### PR TITLE
fix: balance header new meeting button layout

### DIFF
--- a/apps/desktop/src/shared/main/header-listen-button.tsx
+++ b/apps/desktop/src/shared/main/header-listen-button.tsx
@@ -230,11 +230,12 @@ function HeaderListenButtonInner() {
           )}
         </div>
       ) : (
-        <span className="flex w-full items-center justify-center px-7">
+        <span className="flex w-full items-center justify-between pr-8 pl-5">
           <span className="inline-flex shrink-0 items-center gap-2">
             <RecordingIcon />
             <span className="whitespace-nowrap">New meeting</span>
           </span>
+          <span aria-hidden className="size-3.5 shrink-0" />
         </span>
       )}
     </button>


### PR DESCRIPTION
- switch the idle header button content to a distributed layout
- reserve space for the chevron so the label no longer looks right-heavy