### PR TITLE
fix: persist and rehydrate draft mention context

### DIFF
--- a/apps/desktop/src/chat/components/body/empty.tsx
+++ b/apps/desktop/src/chat/components/body/empty.tsx
@@ -8,6 +8,7 @@ import { useCallback } from "react";
 
 import { cn } from "@hypr/utils";
 
+import type { ContextRef } from "~/chat/context/entities";
 import { useTabs } from "~/store/zustand/tabs";
 
 const SUGGESTIONS = [
@@ -38,6 +39,7 @@ export function ChatBodyEmpty({
   onSendMessage?: (
     content: string,
     parts: Array<{ type: "text"; text: string }>,
+    contextRefs?: ContextRef[],
   ) => void;
 }) {
   const openNew = useTabs((state) => state.openNew);

--- a/apps/desktop/src/chat/components/body/index.tsx
+++ b/apps/desktop/src/chat/components/body/index.tsx
@@ -8,6 +8,7 @@ import { ChatBodyEmpty } from "./empty";
 import { ChatBodyNonEmpty } from "./non-empty";
 import { useChatAutoScroll } from "./use-chat-auto-scroll";
 
+import type { ContextRef } from "~/chat/context/entities";
 import type { HyprUIMessage } from "~/chat/types";
 import { useShell } from "~/contexts/shell";
 
@@ -29,6 +30,7 @@ export function ChatBody({
   onSendMessage?: (
     content: string,
     parts: Array<{ type: "text"; text: string }>,
+    contextRefs?: ContextRef[],
   ) => void;
 }) {
   const { chat } = useShell();

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 
 import { cn } from "@hypr/utils";
 
@@ -11,28 +11,19 @@ import { useSessionTab } from "./use-session-tab";
 import { useLanguageModel } from "~/ai/hooks";
 import { useChatActions } from "~/chat/store/use-chat-actions";
 import { useShell } from "~/contexts/shell";
-import { id } from "~/shared/utils";
 import * as main from "~/store/tinybase/store/main";
 
 export function ChatView() {
   const { chat } = useShell();
-  const { groupId, setGroupId } = chat;
+  const { groupId, sessionId, setGroupId, startNewChat, selectChat } = chat;
 
   const { currentSessionId } = useSessionTab();
-
-  // sessionId drives the ChatSession key and useChat id.
-  // It is managed explicitly — not derived from groupId — so that we can distinguish:
-  //   handleNewChat:    new random ID → fresh useChat instance
-  //   handleSelectChat: set to groupId → forces ChatSession remount to load history
-  //   onGroupCreated:   groupId changes but sessionId stays stable → keeps useChat alive for the in-flight stream
-  const [sessionId, setSessionId] = useState<string>(() => groupId ?? id());
 
   const model = useLanguageModel("chat");
   const { user_id } = main.UI.useValues(main.STORE_ID);
 
   const handleGroupCreated = useCallback(
     (newGroupId: string) => {
-      // Don't update sessionId — keep current one so useChat stays alive for the in-flight stream
       setGroupId(newGroupId);
     },
     [setGroupId],
@@ -43,19 +34,6 @@ export function ChatView() {
     onGroupCreated: handleGroupCreated,
   });
 
-  const handleNewChat = useCallback(() => {
-    setGroupId(undefined);
-    setSessionId(id());
-  }, [setGroupId]);
-
-  const handleSelectChat = useCallback(
-    (selectedGroupId: string) => {
-      setGroupId(selectedGroupId);
-      setSessionId(selectedGroupId);
-    },
-    [setGroupId],
-  );
-
   return (
     <div
       className={cn([
@@ -65,8 +43,8 @@ export function ChatView() {
     >
       <ChatHeader
         currentChatGroupId={groupId}
-        onNewChat={handleNewChat}
-        onSelectChat={handleSelectChat}
+        onNewChat={startNewChat}
+        onSelectChat={selectChat}
         handleClose={() => chat.sendEvent({ type: "CLOSE" })}
       />
       {user_id && (

--- a/apps/desktop/src/chat/components/content.tsx
+++ b/apps/desktop/src/chat/components/content.tsx
@@ -5,7 +5,7 @@ import { ContextBar } from "./context-bar";
 import { ChatMessageInput, type McpIndicator } from "./input";
 
 import type { useLanguageModel } from "~/ai/hooks";
-import type { ContextRef } from "~/chat/context/entities";
+import { dedupeByKey, type ContextRef } from "~/chat/context/entities";
 import type { DisplayEntity } from "~/chat/context/use-chat-context-pipeline";
 import type { HyprUIMessage } from "~/chat/types";
 
@@ -23,6 +23,7 @@ export function ChatContent({
   pendingRefs,
   onRemoveContextEntity,
   onAddContextEntity,
+  onDraftContextRefsChange,
   isSystemPromptReady,
   mcpIndicator,
   children,
@@ -45,11 +46,14 @@ export function ChatContent({
   pendingRefs: ContextRef[];
   onRemoveContextEntity?: (key: string) => void;
   onAddContextEntity?: (ref: ContextRef) => void;
+  onDraftContextRefsChange?: (refs: ContextRef[]) => void;
   isSystemPromptReady: boolean;
   mcpIndicator?: McpIndicator;
   children?: React.ReactNode;
 }) {
   const disabled = !model || !isSystemPromptReady;
+  const mergeContextRefs = (contextRefs?: ContextRef[]) =>
+    contextRefs ? dedupeByKey([pendingRefs, contextRefs]) : pendingRefs;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -60,8 +64,13 @@ export function ChatContent({
           error={error}
           onReload={regenerate}
           isModelConfigured={!!model}
-          onSendMessage={(content, parts) => {
-            handleSendMessage(content, parts, sendMessage, pendingRefs);
+          onSendMessage={(content, parts, contextRefs) => {
+            handleSendMessage(
+              content,
+              parts,
+              sendMessage,
+              mergeContextRefs(contextRefs),
+            );
           }}
         />
       )}
@@ -74,9 +83,15 @@ export function ChatContent({
         draftKey={sessionId}
         disabled={disabled}
         hasContextBar={contextEntities.length > 0}
-        onSendMessage={(content, parts) => {
-          handleSendMessage(content, parts, sendMessage, pendingRefs);
+        onSendMessage={(content, parts, contextRefs) => {
+          handleSendMessage(
+            content,
+            parts,
+            sendMessage,
+            mergeContextRefs(contextRefs),
+          );
         }}
+        onContextRefsChange={onDraftContextRefsChange}
         isStreaming={status === "streaming" || status === "submitted"}
         onStop={stop}
         mcpIndicator={mcpIndicator}

--- a/apps/desktop/src/chat/components/context-bar.tsx
+++ b/apps/desktop/src/chat/components/context-bar.tsx
@@ -71,17 +71,33 @@ function ContextChip({
 }) {
   const Icon = chip.icon;
   const openNew = useTabs((state) => state.openNew);
-  const isClickable = chip.entityKind === "session" && chip.entityId;
+  const isClickable = !!chip.entityKind && !!chip.entityId;
+
+  const handleClick = () => {
+    if (!chip.entityKind || !chip.entityId) {
+      return;
+    }
+
+    if (chip.entityKind === "session") {
+      openNew({ type: "sessions", id: chip.entityId });
+      return;
+    }
+
+    if (chip.entityKind === "human") {
+      openNew({ type: "humans", id: chip.entityId });
+      return;
+    }
+
+    if (chip.entityKind === "organization") {
+      openNew({ type: "organizations", id: chip.entityId });
+    }
+  };
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <span
-          onClick={() => {
-            if (isClickable) {
-              openNew({ type: "sessions", id: chip.entityId! });
-            }
-          }}
+          onClick={handleClick}
           className={cn([
             "group max-w-48 min-w-0 rounded-md px-1.5 py-0.5 text-xs",
             pending

--- a/apps/desktop/src/chat/components/context-bar.tsx
+++ b/apps/desktop/src/chat/components/context-bar.tsx
@@ -281,7 +281,7 @@ export function ContextBar({
     [entities],
   );
 
-  if (chips.length === 0 && !onAddEntity) {
+  if (chips.length === 0) {
     return null;
   }
 

--- a/apps/desktop/src/chat/components/input/draft.ts
+++ b/apps/desktop/src/chat/components/input/draft.ts
@@ -1,0 +1,132 @@
+import type { JSONContent } from "@hypr/tiptap/chat";
+import { EMPTY_TIPTAP_DOC } from "@hypr/tiptap/shared";
+
+import type { ContextRef } from "~/chat/context/entities";
+
+const draftsByKey = new Map<string, JSONContent>();
+
+export function getDraftContent(draftKey: string): JSONContent {
+  return draftsByKey.get(draftKey) ?? EMPTY_TIPTAP_DOC;
+}
+
+export function setDraftContent(draftKey: string, content: JSONContent) {
+  draftsByKey.set(draftKey, content);
+}
+
+export function clearDraftContent(draftKey: string) {
+  draftsByKey.delete(draftKey);
+}
+
+export function serializeDraftMessage(json: JSONContent | undefined): {
+  text: string;
+  refs: ContextRef[];
+} {
+  const textParts: string[] = [];
+  const refs: ContextRef[] = [];
+  const seen = new Set<string>();
+
+  const visit = (node: JSONContent | undefined) => {
+    if (!node || typeof node !== "object") {
+      return;
+    }
+
+    if (node.type === "text") {
+      textParts.push(node.text || "");
+      return;
+    }
+
+    if (node.type === "hardBreak") {
+      textParts.push("\n");
+      return;
+    }
+
+    if (isMentionNode(node)) {
+      textParts.push(mentionNodeToPlainText(node));
+
+      const mentionType =
+        typeof node.attrs?.type === "string" ? node.attrs.type : null;
+      const mentionId =
+        typeof node.attrs?.id === "string" ? node.attrs.id : null;
+
+      if (!mentionType || !mentionId) {
+        return;
+      }
+
+      let ref: ContextRef | null = null;
+      if (mentionType === "session") {
+        ref = {
+          kind: "session",
+          key: `session:manual:${mentionId}`,
+          label:
+            typeof node.attrs?.label === "string"
+              ? node.attrs.label
+              : undefined,
+          source: "draft",
+          sessionId: mentionId,
+        };
+      } else if (mentionType === "human") {
+        ref = {
+          kind: "human",
+          key: `human:manual:${mentionId}`,
+          label:
+            typeof node.attrs?.label === "string"
+              ? node.attrs.label
+              : undefined,
+          source: "draft",
+          humanId: mentionId,
+        };
+      } else if (mentionType === "organization") {
+        ref = {
+          kind: "organization",
+          key: `organization:manual:${mentionId}`,
+          label:
+            typeof node.attrs?.label === "string"
+              ? node.attrs.label
+              : undefined,
+          source: "draft",
+          organizationId: mentionId,
+        };
+      }
+
+      if (ref && !seen.has(ref.key)) {
+        seen.add(ref.key);
+        refs.push(ref);
+      }
+
+      return;
+    }
+
+    if (Array.isArray(node.content)) {
+      for (const child of node.content) {
+        visit(child);
+      }
+    }
+  };
+
+  visit(json);
+  return { text: textParts.join(""), refs };
+}
+
+export function getDraftContextRefs(draftKey: string): ContextRef[] {
+  return serializeDraftMessage(getDraftContent(draftKey)).refs;
+}
+
+function isMentionNode(
+  node: Pick<JSONContent, "type" | "attrs"> | Record<string, unknown>,
+): boolean {
+  return (
+    typeof node.type === "string" &&
+    (node.type === "mention" || node.type.startsWith("mention-"))
+  );
+}
+
+function mentionNodeToPlainText(node: JSONContent): string {
+  const label =
+    typeof node.attrs?.label === "string" && node.attrs.label.trim()
+      ? node.attrs.label.trim()
+      : typeof node.attrs?.id === "string" && node.attrs.id.trim()
+        ? node.attrs.id.trim()
+        : "";
+
+  return label ? `@${label}` : "";
+}

--- a/apps/desktop/src/chat/components/input/draft.ts
+++ b/apps/desktop/src/chat/components/input/draft.ts
@@ -107,10 +107,6 @@ export function serializeDraftMessage(json: JSONContent | undefined): {
   return { text: textParts.join(""), refs };
 }
 
-export function getDraftContextRefs(draftKey: string): ContextRef[] {
-  return serializeDraftMessage(getDraftContent(draftKey)).refs;
-}
-
 function isMentionNode(
   node: Pick<JSONContent, "type" | "attrs"> | Record<string, unknown>,
 ): boolean {

--- a/apps/desktop/src/chat/components/input/hooks.test.ts
+++ b/apps/desktop/src/chat/components/input/hooks.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import type { JSONContent } from "@hypr/tiptap/chat";
 
-import { serializeDraftMessage } from "./hooks";
+import { serializeDraftMessage } from "./draft";
 
 describe("serializeDraftMessage", () => {
   test("serializes mention labels into plain text and draft refs", () => {

--- a/apps/desktop/src/chat/components/input/hooks.test.ts
+++ b/apps/desktop/src/chat/components/input/hooks.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "vitest";
+
+import type { JSONContent } from "@hypr/tiptap/chat";
+
+import { serializeDraftMessage } from "./hooks";
+
+describe("serializeDraftMessage", () => {
+  test("serializes mention labels into plain text and draft refs", () => {
+    const json: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "mention-@",
+              attrs: {
+                id: "human-1",
+                type: "human",
+                label: "john",
+              },
+            },
+            {
+              type: "text",
+              text: " is this",
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(serializeDraftMessage(json)).toEqual({
+      text: "@john is this",
+      refs: [
+        {
+          kind: "human",
+          key: "human:manual:human-1",
+          source: "draft",
+          humanId: "human-1",
+        },
+      ],
+    });
+  });
+
+  test("dedupes refs while preserving repeated mention text", () => {
+    const json: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "mention",
+              attrs: {
+                id: "org-1",
+                type: "organization",
+                label: "Acme",
+              },
+            },
+            {
+              type: "text",
+              text: " and ",
+            },
+            {
+              type: "mention-@",
+              attrs: {
+                id: "org-1",
+                type: "organization",
+                label: "Acme",
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(serializeDraftMessage(json)).toEqual({
+      text: "@Acme and @Acme",
+      refs: [
+        {
+          kind: "organization",
+          key: "organization:manual:org-1",
+          source: "draft",
+          organizationId: "org-1",
+        },
+      ],
+    });
+  });
+});

--- a/apps/desktop/src/chat/components/input/hooks.test.ts
+++ b/apps/desktop/src/chat/components/input/hooks.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, test } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
+import type { TiptapEditor } from "@hypr/tiptap/chat";
 import type { JSONContent } from "@hypr/tiptap/chat";
 
 import { serializeDraftMessage } from "./draft";
+import { useSyncDraftStateFromEditor } from "./hooks";
 
 describe("serializeDraftMessage", () => {
   test("serializes mention labels into plain text and draft refs", () => {
@@ -82,6 +85,68 @@ describe("serializeDraftMessage", () => {
           key: "organization:manual:org-1",
           source: "draft",
           organizationId: "org-1",
+        },
+      ],
+    });
+  });
+});
+
+describe("useSyncDraftStateFromEditor", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("syncs draft refs from the mounted editor state", async () => {
+    const getJSON = vi.fn(() => ({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "mention",
+              attrs: {
+                id: "human-1",
+                type: "human",
+                label: "John",
+              },
+            },
+          ],
+        },
+      ],
+    }));
+    const handleEditorUpdate = vi.fn();
+    const editorRef = {
+      current: {
+        editor: {
+          isDestroyed: false,
+          isInitialized: true,
+          getJSON,
+        } as unknown as TiptapEditor,
+      },
+    } as React.RefObject<{ editor: TiptapEditor | null } | null>;
+
+    renderHook(() =>
+      useSyncDraftStateFromEditor({ editorRef, handleEditorUpdate }),
+    );
+
+    await vi.waitFor(() => expect(handleEditorUpdate).toHaveBeenCalledTimes(1));
+    expect(getJSON).toHaveBeenCalledTimes(1);
+    expect(handleEditorUpdate).toHaveBeenCalledWith({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "mention",
+              attrs: {
+                id: "human-1",
+                type: "human",
+                label: "John",
+              },
+            },
+          ],
         },
       ],
     });

--- a/apps/desktop/src/chat/components/input/hooks.ts
+++ b/apps/desktop/src/chat/components/input/hooks.ts
@@ -8,22 +8,36 @@ import type {
 } from "@hypr/tiptap/chat";
 import { EMPTY_TIPTAP_DOC } from "@hypr/tiptap/shared";
 
+import type { ContextRef } from "~/chat/context/entities";
 import { useSearchEngine } from "~/search/contexts/engine";
 import * as main from "~/store/tinybase/store/main";
 
 const draftsByKey = new Map<string, JSONContent>();
 
-export function useDraftState({ draftKey }: { draftKey: string }) {
+export function useDraftState({
+  draftKey,
+  onContextRefsChange,
+}: {
+  draftKey: string;
+  onContextRefsChange?: (refs: ContextRef[]) => void;
+}) {
   const [hasContent, setHasContent] = useState(false);
   const initialContent = useRef(draftsByKey.get(draftKey) ?? EMPTY_TIPTAP_DOC);
+
+  useEffect(() => {
+    onContextRefsChange?.(
+      extractContextRefsFromTiptapJson(initialContent.current),
+    );
+  }, [onContextRefsChange]);
 
   const handleEditorUpdate = useCallback(
     (json: JSONContent) => {
       const text = tiptapJsonToText(json).trim();
       setHasContent(text.length > 0);
       draftsByKey.set(draftKey, json);
+      onContextRefsChange?.(extractContextRefsFromTiptapJson(json));
     },
-    [draftKey],
+    [draftKey, onContextRefsChange],
   );
 
   return {
@@ -39,6 +53,7 @@ export function useSubmit({
   disabled,
   isStreaming,
   onSendMessage,
+  onContextRefsChange,
 }: {
   draftKey: string;
   editorRef: React.RefObject<{ editor: TiptapEditor | null } | null>;
@@ -47,21 +62,32 @@ export function useSubmit({
   onSendMessage: (
     content: string,
     parts: Array<{ type: "text"; text: string }>,
+    contextRefs?: ContextRef[],
   ) => void;
+  onContextRefsChange?: (refs: ContextRef[]) => void;
 }) {
   return useCallback(() => {
     const json = editorRef.current?.editor?.getJSON();
     const text = tiptapJsonToText(json).trim();
+    const mentionRefs = extractContextRefsFromTiptapJson(json);
 
     if (!text || disabled || isStreaming) {
       return;
     }
 
     void analyticsCommands.event({ event: "message_sent" });
-    onSendMessage(text, [{ type: "text", text }]);
+    onSendMessage(text, [{ type: "text", text }], mentionRefs);
     editorRef.current?.editor?.commands.clearContent();
     draftsByKey.delete(draftKey);
-  }, [draftKey, editorRef, disabled, isStreaming, onSendMessage]);
+    onContextRefsChange?.([]);
+  }, [
+    draftKey,
+    editorRef,
+    disabled,
+    isStreaming,
+    onSendMessage,
+    onContextRefsChange,
+  ]);
 }
 
 export function useAutoFocusEditor({
@@ -179,7 +205,7 @@ function tiptapJsonToText(json: any): string {
     return json.text || "";
   }
 
-  if (json.type === "mention") {
+  if (typeof json.type === "string" && json.type.startsWith("mention-")) {
     return `@${json.attrs?.label || json.attrs?.id || ""}`;
   }
 
@@ -188,4 +214,66 @@ function tiptapJsonToText(json: any): string {
   }
 
   return "";
+}
+
+function extractContextRefsFromTiptapJson(
+  json: JSONContent | undefined,
+): ContextRef[] {
+  const refs: ContextRef[] = [];
+  const seen = new Set<string>();
+
+  const visit = (node: JSONContent | undefined) => {
+    if (!node || typeof node !== "object") {
+      return;
+    }
+
+    if (typeof node.type === "string" && node.type.startsWith("mention-")) {
+      const mentionType =
+        typeof node.attrs?.type === "string" ? node.attrs.type : null;
+      const mentionId =
+        typeof node.attrs?.id === "string" ? node.attrs.id : null;
+
+      if (!mentionType || !mentionId) {
+        return;
+      }
+
+      let ref: ContextRef | null = null;
+      if (mentionType === "session") {
+        ref = {
+          kind: "session",
+          key: `session:manual:${mentionId}`,
+          source: "manual",
+          sessionId: mentionId,
+        };
+      } else if (mentionType === "human") {
+        ref = {
+          kind: "human",
+          key: `human:manual:${mentionId}`,
+          source: "manual",
+          humanId: mentionId,
+        };
+      } else if (mentionType === "organization") {
+        ref = {
+          kind: "organization",
+          key: `organization:manual:${mentionId}`,
+          source: "manual",
+          organizationId: mentionId,
+        };
+      }
+
+      if (ref && !seen.has(ref.key)) {
+        seen.add(ref.key);
+        refs.push(ref);
+      }
+    }
+
+    if (Array.isArray(node.content)) {
+      for (const child of node.content) {
+        visit(child);
+      }
+    }
+  };
+
+  visit(json);
+  return refs;
 }

--- a/apps/desktop/src/chat/components/input/hooks.ts
+++ b/apps/desktop/src/chat/components/input/hooks.ts
@@ -205,8 +205,12 @@ function tiptapJsonToText(json: any): string {
     return json.text || "";
   }
 
-  if (typeof json.type === "string" && json.type.startsWith("mention-")) {
-    return `@${json.attrs?.label || json.attrs?.id || ""}`;
+  if (json.type === "hardBreak") {
+    return "\n";
+  }
+
+  if (isMentionNode(json)) {
+    return mentionNodeToPlainText(json);
   }
 
   if (json.content && Array.isArray(json.content)) {
@@ -227,7 +231,7 @@ function extractContextRefsFromTiptapJson(
       return;
     }
 
-    if (typeof node.type === "string" && node.type.startsWith("mention-")) {
+    if (isMentionNode(node)) {
       const mentionType =
         typeof node.attrs?.type === "string" ? node.attrs.type : null;
       const mentionId =
@@ -276,4 +280,24 @@ function extractContextRefsFromTiptapJson(
 
   visit(json);
   return refs;
+}
+
+function isMentionNode(
+  node: Pick<JSONContent, "type" | "attrs"> | Record<string, unknown>,
+): boolean {
+  return (
+    typeof node.type === "string" &&
+    (node.type === "mention" || node.type.startsWith("mention-"))
+  );
+}
+
+function mentionNodeToPlainText(node: JSONContent): string {
+  const label =
+    typeof node.attrs?.label === "string" && node.attrs.label.trim()
+      ? node.attrs.label.trim()
+      : typeof node.attrs?.id === "string" && node.attrs.id.trim()
+        ? node.attrs.id.trim()
+        : "";
+
+  return label ? `@${label}` : "";
 }

--- a/apps/desktop/src/chat/components/input/hooks.ts
+++ b/apps/desktop/src/chat/components/input/hooks.ts
@@ -25,17 +25,16 @@ export function useDraftState({
   const initialContent = useRef(draftsByKey.get(draftKey) ?? EMPTY_TIPTAP_DOC);
 
   useEffect(() => {
-    onContextRefsChange?.(
-      extractContextRefsFromTiptapJson(initialContent.current),
-    );
+    onContextRefsChange?.(serializeDraftMessage(initialContent.current).refs);
   }, [onContextRefsChange]);
 
   const handleEditorUpdate = useCallback(
     (json: JSONContent) => {
-      const text = tiptapJsonToText(json).trim();
+      const draft = serializeDraftMessage(json);
+      const text = draft.text.trim();
       setHasContent(text.length > 0);
       draftsByKey.set(draftKey, json);
-      onContextRefsChange?.(extractContextRefsFromTiptapJson(json));
+      onContextRefsChange?.(draft.refs);
     },
     [draftKey, onContextRefsChange],
   );
@@ -68,15 +67,15 @@ export function useSubmit({
 }) {
   return useCallback(() => {
     const json = editorRef.current?.editor?.getJSON();
-    const text = tiptapJsonToText(json).trim();
-    const mentionRefs = extractContextRefsFromTiptapJson(json);
+    const draft = serializeDraftMessage(json);
+    const text = draft.text.trim();
 
     if (!text || disabled || isStreaming) {
       return;
     }
 
     void analyticsCommands.event({ event: "message_sent" });
-    onSendMessage(text, [{ type: "text", text }], mentionRefs);
+    onSendMessage(text, [{ type: "text", text }], draft.refs);
     editorRef.current?.editor?.commands.clearContent();
     draftsByKey.delete(draftKey);
     onContextRefsChange?.([]);
@@ -196,33 +195,11 @@ export function useSlashCommandConfig(): SlashCommandConfig {
   );
 }
 
-function tiptapJsonToText(json: any): string {
-  if (!json || typeof json !== "object") {
-    return "";
-  }
-
-  if (json.type === "text") {
-    return json.text || "";
-  }
-
-  if (json.type === "hardBreak") {
-    return "\n";
-  }
-
-  if (isMentionNode(json)) {
-    return mentionNodeToPlainText(json);
-  }
-
-  if (json.content && Array.isArray(json.content)) {
-    return json.content.map(tiptapJsonToText).join("");
-  }
-
-  return "";
-}
-
-function extractContextRefsFromTiptapJson(
-  json: JSONContent | undefined,
-): ContextRef[] {
+export function serializeDraftMessage(json: JSONContent | undefined): {
+  text: string;
+  refs: ContextRef[];
+} {
+  const textParts: string[] = [];
   const refs: ContextRef[] = [];
   const seen = new Set<string>();
 
@@ -231,7 +208,19 @@ function extractContextRefsFromTiptapJson(
       return;
     }
 
+    if (node.type === "text") {
+      textParts.push(node.text || "");
+      return;
+    }
+
+    if (node.type === "hardBreak") {
+      textParts.push("\n");
+      return;
+    }
+
     if (isMentionNode(node)) {
+      textParts.push(mentionNodeToPlainText(node));
+
       const mentionType =
         typeof node.attrs?.type === "string" ? node.attrs.type : null;
       const mentionId =
@@ -246,21 +235,21 @@ function extractContextRefsFromTiptapJson(
         ref = {
           kind: "session",
           key: `session:manual:${mentionId}`,
-          source: "manual",
+          source: "draft",
           sessionId: mentionId,
         };
       } else if (mentionType === "human") {
         ref = {
           kind: "human",
           key: `human:manual:${mentionId}`,
-          source: "manual",
+          source: "draft",
           humanId: mentionId,
         };
       } else if (mentionType === "organization") {
         ref = {
           kind: "organization",
           key: `organization:manual:${mentionId}`,
-          source: "manual",
+          source: "draft",
           organizationId: mentionId,
         };
       }
@@ -269,6 +258,8 @@ function extractContextRefsFromTiptapJson(
         seen.add(ref.key);
         refs.push(ref);
       }
+
+      return;
     }
 
     if (Array.isArray(node.content)) {
@@ -279,7 +270,7 @@ function extractContextRefsFromTiptapJson(
   };
 
   visit(json);
-  return refs;
+  return { text: textParts.join(""), refs };
 }
 
 function isMentionNode(

--- a/apps/desktop/src/chat/components/input/hooks.ts
+++ b/apps/desktop/src/chat/components/input/hooks.ts
@@ -6,13 +6,17 @@ import type {
   SlashCommandConfig,
   TiptapEditor,
 } from "@hypr/tiptap/chat";
-import { EMPTY_TIPTAP_DOC } from "@hypr/tiptap/shared";
+
+import {
+  clearDraftContent,
+  getDraftContent,
+  serializeDraftMessage,
+  setDraftContent,
+} from "./draft";
 
 import type { ContextRef } from "~/chat/context/entities";
 import { useSearchEngine } from "~/search/contexts/engine";
 import * as main from "~/store/tinybase/store/main";
-
-const draftsByKey = new Map<string, JSONContent>();
 
 export function useDraftState({
   draftKey,
@@ -21,19 +25,18 @@ export function useDraftState({
   draftKey: string;
   onContextRefsChange?: (refs: ContextRef[]) => void;
 }) {
-  const [hasContent, setHasContent] = useState(false);
-  const initialContent = useRef(draftsByKey.get(draftKey) ?? EMPTY_TIPTAP_DOC);
-
-  useEffect(() => {
-    onContextRefsChange?.(serializeDraftMessage(initialContent.current).refs);
-  }, [onContextRefsChange]);
+  const initialContent = useRef(getDraftContent(draftKey));
+  const initialDraft = useRef(serializeDraftMessage(initialContent.current));
+  const [hasContent, setHasContent] = useState(
+    initialDraft.current.text.trim().length > 0,
+  );
 
   const handleEditorUpdate = useCallback(
     (json: JSONContent) => {
       const draft = serializeDraftMessage(json);
       const text = draft.text.trim();
       setHasContent(text.length > 0);
-      draftsByKey.set(draftKey, json);
+      setDraftContent(draftKey, json);
       onContextRefsChange?.(draft.refs);
     },
     [draftKey, onContextRefsChange],
@@ -77,7 +80,7 @@ export function useSubmit({
     void analyticsCommands.event({ event: "message_sent" });
     onSendMessage(text, [{ type: "text", text }], draft.refs);
     editorRef.current?.editor?.commands.clearContent();
-    draftsByKey.delete(draftKey);
+    clearDraftContent(draftKey);
     onContextRefsChange?.([]);
   }, [
     draftKey,
@@ -193,102 +196,4 @@ export function useSlashCommandConfig(): SlashCommandConfig {
     }),
     [sessions, humans, organizations, search],
   );
-}
-
-export function serializeDraftMessage(json: JSONContent | undefined): {
-  text: string;
-  refs: ContextRef[];
-} {
-  const textParts: string[] = [];
-  const refs: ContextRef[] = [];
-  const seen = new Set<string>();
-
-  const visit = (node: JSONContent | undefined) => {
-    if (!node || typeof node !== "object") {
-      return;
-    }
-
-    if (node.type === "text") {
-      textParts.push(node.text || "");
-      return;
-    }
-
-    if (node.type === "hardBreak") {
-      textParts.push("\n");
-      return;
-    }
-
-    if (isMentionNode(node)) {
-      textParts.push(mentionNodeToPlainText(node));
-
-      const mentionType =
-        typeof node.attrs?.type === "string" ? node.attrs.type : null;
-      const mentionId =
-        typeof node.attrs?.id === "string" ? node.attrs.id : null;
-
-      if (!mentionType || !mentionId) {
-        return;
-      }
-
-      let ref: ContextRef | null = null;
-      if (mentionType === "session") {
-        ref = {
-          kind: "session",
-          key: `session:manual:${mentionId}`,
-          source: "draft",
-          sessionId: mentionId,
-        };
-      } else if (mentionType === "human") {
-        ref = {
-          kind: "human",
-          key: `human:manual:${mentionId}`,
-          source: "draft",
-          humanId: mentionId,
-        };
-      } else if (mentionType === "organization") {
-        ref = {
-          kind: "organization",
-          key: `organization:manual:${mentionId}`,
-          source: "draft",
-          organizationId: mentionId,
-        };
-      }
-
-      if (ref && !seen.has(ref.key)) {
-        seen.add(ref.key);
-        refs.push(ref);
-      }
-
-      return;
-    }
-
-    if (Array.isArray(node.content)) {
-      for (const child of node.content) {
-        visit(child);
-      }
-    }
-  };
-
-  visit(json);
-  return { text: textParts.join(""), refs };
-}
-
-function isMentionNode(
-  node: Pick<JSONContent, "type" | "attrs"> | Record<string, unknown>,
-): boolean {
-  return (
-    typeof node.type === "string" &&
-    (node.type === "mention" || node.type.startsWith("mention-"))
-  );
-}
-
-function mentionNodeToPlainText(node: JSONContent): string {
-  const label =
-    typeof node.attrs?.label === "string" && node.attrs.label.trim()
-      ? node.attrs.label.trim()
-      : typeof node.attrs?.id === "string" && node.attrs.id.trim()
-        ? node.attrs.id.trim()
-        : "";
-
-  return label ? `@${label}` : "";
 }

--- a/apps/desktop/src/chat/components/input/hooks.ts
+++ b/apps/desktop/src/chat/components/input/hooks.ts
@@ -135,6 +135,44 @@ export function useAutoFocusEditor({
   }, [editorRef, disabled, shouldFocus]);
 }
 
+export function useSyncDraftStateFromEditor({
+  editorRef,
+  handleEditorUpdate,
+}: {
+  editorRef: React.RefObject<{ editor: TiptapEditor | null } | null>;
+  handleEditorUpdate: (json: JSONContent) => void;
+}) {
+  useEffect(() => {
+    let rafId: number | null = null;
+    let attempts = 0;
+    const maxAttempts = 20;
+
+    const syncWhenReady = () => {
+      const editor = editorRef.current?.editor;
+
+      if (editor && !editor.isDestroyed && editor.isInitialized) {
+        handleEditorUpdate(editor.getJSON());
+        return;
+      }
+
+      if (attempts >= maxAttempts) {
+        return;
+      }
+
+      attempts += 1;
+      rafId = window.requestAnimationFrame(syncWhenReady);
+    };
+
+    syncWhenReady();
+
+    return () => {
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId);
+      }
+    };
+  }, [editorRef, handleEditorUpdate]);
+}
+
 export function useSlashCommandConfig(): SlashCommandConfig {
   const sessions = main.UI.useResultTable(
     main.QUERIES.timelineSessions,

--- a/apps/desktop/src/chat/components/input/hooks.ts
+++ b/apps/desktop/src/chat/components/input/hooks.ts
@@ -26,10 +26,9 @@ export function useDraftState({
   onContextRefsChange?: (refs: ContextRef[]) => void;
 }) {
   const initialContent = useRef(getDraftContent(draftKey));
-  const initialDraft = useRef(serializeDraftMessage(initialContent.current));
-  const [hasContent, setHasContent] = useState(
-    initialDraft.current.text.trim().length > 0,
-  );
+  const [hasContent, setHasContent] = useState(() => {
+    return serializeDraftMessage(initialContent.current).text.trim().length > 0;
+  });
 
   const handleEditorUpdate = useCallback(
     (json: JSONContent) => {

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -65,6 +65,7 @@ export function ChatMessageInput({
       isRightPanel={chat.mode === "RightPanelOpen"}
     >
       <div
+        data-chat-message-input
         className={cn([
           "flex flex-col pt-3 pb-2",
           chat.mode === "RightPanelOpen" ? "px-2" : "px-2",

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -15,6 +15,7 @@ import {
 } from "./hooks";
 import { type McpIndicator, McpIndicatorBadge } from "./mcp";
 
+import type { ContextRef } from "~/chat/context/entities";
 import { useShell } from "~/contexts/shell";
 
 export type { McpIndicator } from "./mcp";
@@ -27,17 +28,20 @@ export function ChatMessageInput({
   isStreaming,
   onStop,
   mcpIndicator,
+  onContextRefsChange,
 }: {
   draftKey: string;
   onSendMessage: (
     content: string,
     parts: Array<{ type: "text"; text: string }>,
+    contextRefs?: ContextRef[],
   ) => void;
   disabled?: boolean | { disabled: boolean; message?: string };
   hasContextBar?: boolean;
   isStreaming?: boolean;
   onStop?: () => void;
   mcpIndicator?: McpIndicator;
+  onContextRefsChange?: (refs: ContextRef[]) => void;
 }) {
   const { chat } = useShell();
   const editorRef = useRef<{ editor: TiptapEditor | null }>(null);
@@ -48,6 +52,7 @@ export function ChatMessageInput({
 
   const { hasContent, initialContent, handleEditorUpdate } = useDraftState({
     draftKey,
+    onContextRefsChange,
   });
   const handleSubmit = useSubmit({
     draftKey,
@@ -55,6 +60,7 @@ export function ChatMessageInput({
     disabled,
     isStreaming,
     onSendMessage,
+    onContextRefsChange,
   });
   useAutoFocusEditor({ editorRef, disabled, shouldFocus });
   const slashCommandConfig = useSlashCommandConfig();

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -12,6 +12,7 @@ import {
   useDraftState,
   useSlashCommandConfig,
   useSubmit,
+  useSyncDraftStateFromEditor,
 } from "./hooks";
 import { type McpIndicator, McpIndicatorBadge } from "./mcp";
 
@@ -63,6 +64,7 @@ export function ChatMessageInput({
     onContextRefsChange,
   });
   useAutoFocusEditor({ editorRef, disabled, shouldFocus });
+  useSyncDraftStateFromEditor({ editorRef, handleEditorUpdate });
   const slashCommandConfig = useSlashCommandConfig();
 
   return (

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -149,7 +149,9 @@ function Container({
         className={cn([
           "flex max-h-full flex-col border border-neutral-200 bg-white",
           isRightPanel
-            ? "rounded-t-xl rounded-b-none"
+            ? hasContextBar
+              ? "rounded-t-none rounded-b-none"
+              : "rounded-t-xl rounded-b-none"
             : hasContextBar
               ? "rounded-t-none rounded-b-xl"
               : "rounded-xl",

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -148,8 +148,12 @@ function Container({
       <div
         className={cn([
           "flex max-h-full flex-col border border-neutral-200 bg-white",
-          isRightPanel ? "rounded-t-xl rounded-b-none" : "rounded-b-xl",
-          hasContextBar && "rounded-t-none border-t-0",
+          isRightPanel
+            ? "rounded-t-xl rounded-b-none"
+            : hasContextBar
+              ? "rounded-t-none rounded-b-xl"
+              : "rounded-xl",
+          hasContextBar && "border-t-0",
         ])}
       >
         {children}

--- a/apps/desktop/src/chat/components/message/normal.tsx
+++ b/apps/desktop/src/chat/components/message/normal.tsx
@@ -113,13 +113,23 @@ function Part({ part }: { part: Part }) {
 }
 
 function Reasoning({ part }: { part: Extract<Part, { type: "reasoning" }> }) {
-  const cleaned = part.text
+  const raw = part.text.trim();
+
+  if (!raw) {
+    return null;
+  }
+
+  const cleaned = raw
     .replace(/[\n`*#"]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
 
   const streaming = part.state !== "done";
   const title = streaming ? cleaned.slice(-150) : cleaned;
+
+  if (!title) {
+    return null;
+  }
 
   return (
     <Disclosure

--- a/apps/desktop/src/chat/components/session-provider.test.tsx
+++ b/apps/desktop/src/chat/components/session-provider.test.tsx
@@ -1,0 +1,112 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { clearDraftContent, setDraftContent } from "./input/draft";
+import { ChatSession } from "./session-provider";
+
+const {
+  useChatMock,
+  useTransportMock,
+  useChatContextPipelineMock,
+  useStoreMock,
+  useValuesMock,
+} = vi.hoisted(() => ({
+  useChatMock: vi.fn(),
+  useTransportMock: vi.fn(),
+  useChatContextPipelineMock: vi.fn(),
+  useStoreMock: vi.fn(),
+  useValuesMock: vi.fn(),
+}));
+
+vi.mock("@ai-sdk/react", () => ({
+  useChat: useChatMock,
+}));
+
+vi.mock("~/chat/transport/use-transport", () => ({
+  useTransport: useTransportMock,
+}));
+
+vi.mock("~/chat/context/use-chat-context-pipeline", () => ({
+  useChatContextPipeline: useChatContextPipelineMock,
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "test-store",
+  UI: {
+    useStore: useStoreMock,
+    useValues: useValuesMock,
+  },
+}));
+
+describe("ChatSession", () => {
+  beforeEach(() => {
+    useStoreMock.mockReturnValue(null);
+    useValuesMock.mockReturnValue({ user_id: "user-1" });
+    useTransportMock.mockReturnValue({
+      transport: null,
+      isSystemPromptReady: true,
+    });
+    useChatMock.mockReturnValue({
+      messages: [],
+      sendMessage: vi.fn(),
+      regenerate: vi.fn(),
+      stop: vi.fn(),
+      status: "ready",
+      error: undefined,
+      setMessages: vi.fn(),
+    });
+    useChatContextPipelineMock.mockImplementation(
+      ({ pendingManualRefs }: { pendingManualRefs: unknown[] }) => ({
+        contextEntities: [],
+        pendingRefs: pendingManualRefs,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    clearDraftContent("draft-session");
+    vi.clearAllMocks();
+  });
+
+  test("keeps restored draft refs after mount effects run", async () => {
+    setDraftContent("draft-session", {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "mention",
+              attrs: {
+                id: "human-1",
+                type: "human",
+                label: "John",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const child = vi.fn(() => null);
+
+    render(
+      <ChatSession sessionId="draft-session">
+        {(props) => child(props)}
+      </ChatSession>,
+    );
+
+    await act(async () => {});
+
+    expect(child).toHaveBeenCalled();
+    expect(child.mock.lastCall?.[0].pendingRefs).toEqual([
+      {
+        kind: "human",
+        key: "human:manual:human-1",
+        label: "John",
+        source: "draft",
+        humanId: "human-1",
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/chat/components/session-provider.tsx
+++ b/apps/desktop/src/chat/components/session-provider.tsx
@@ -4,11 +4,12 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
 
-import type { ContextRef } from "~/chat/context/entities";
+import { dedupeByKey, type ContextRef } from "~/chat/context/entities";
 import {
   type DisplayEntity,
   useChatContextPipeline,
@@ -45,6 +46,7 @@ interface ChatSessionProps {
     pendingRefs: ContextRef[];
     onRemoveContextEntity: (key: string) => void;
     onAddContextEntity: (ref: ContextRef) => void;
+    onDraftContextRefsChange: (refs: ContextRef[]) => void;
     isSystemPromptReady: boolean;
   }) => ReactNode;
 }
@@ -62,6 +64,7 @@ export function ChatSession({
   const { user_id } = main.UI.useValues(main.STORE_ID);
 
   const [pendingManualRefs, setPendingManualRefs] = useState<ContextRef[]>([]);
+  const [pendingDraftRefs, setPendingDraftRefs] = useState<ContextRef[]>([]);
 
   const onAddContextEntity = useCallback((ref: ContextRef) => {
     setPendingManualRefs((prev) =>
@@ -71,10 +74,16 @@ export function ChatSession({
 
   const onRemoveContextEntity = useCallback((key: string) => {
     setPendingManualRefs((prev) => prev.filter((r) => r.key !== key));
+    setPendingDraftRefs((prev) => prev.filter((r) => r.key !== key));
+  }, []);
+
+  const onDraftContextRefsChange = useCallback((refs: ContextRef[]) => {
+    setPendingDraftRefs(refs);
   }, []);
 
   useEffect(() => {
     setPendingManualRefs([]);
+    setPendingDraftRefs([]);
   }, [sessionId, chatGroupId]);
 
   const { transport, isSystemPromptReady } = useTransport(
@@ -156,14 +165,20 @@ export function ChatSession({
     const count = messages.filter((message) => message.role === "user").length;
     if (count > prevUserMsgCountRef.current) {
       setPendingManualRefs([]);
+      setPendingDraftRefs([]);
     }
     prevUserMsgCountRef.current = count;
   }, [messages]);
 
+  const pendingMessageRefs = useMemo(
+    () => dedupeByKey([pendingManualRefs, pendingDraftRefs]),
+    [pendingManualRefs, pendingDraftRefs],
+  );
+
   const { contextEntities, pendingRefs } = useChatContextPipeline({
     messages,
     currentSessionId,
-    pendingManualRefs,
+    pendingManualRefs: pendingMessageRefs,
     store,
   });
 
@@ -182,6 +197,7 @@ export function ChatSession({
         pendingRefs,
         onRemoveContextEntity,
         onAddContextEntity,
+        onDraftContextRefsChange,
         isSystemPromptReady,
       })}
     </div>

--- a/apps/desktop/src/chat/components/session-provider.tsx
+++ b/apps/desktop/src/chat/components/session-provider.tsx
@@ -9,7 +9,10 @@ import {
   useState,
 } from "react";
 
-import { getDraftContextRefs } from "~/chat/components/input/draft";
+import {
+  getDraftContent,
+  serializeDraftMessage,
+} from "~/chat/components/input/draft";
 import { dedupeByKey, type ContextRef } from "~/chat/context/entities";
 import {
   type DisplayEntity,
@@ -65,8 +68,8 @@ export function ChatSession({
   const { user_id } = main.UI.useValues(main.STORE_ID);
 
   const [pendingManualRefs, setPendingManualRefs] = useState<ContextRef[]>([]);
-  const [pendingDraftRefs, setPendingDraftRefs] = useState<ContextRef[]>(() =>
-    getDraftContextRefs(sessionId),
+  const [pendingDraftRefs, setPendingDraftRefs] = useState<ContextRef[]>(
+    () => serializeDraftMessage(getDraftContent(sessionId)).refs,
   );
 
   const onAddContextEntity = useCallback((ref: ContextRef) => {

--- a/apps/desktop/src/chat/components/session-provider.tsx
+++ b/apps/desktop/src/chat/components/session-provider.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 
+import { getDraftContextRefs } from "~/chat/components/input/draft";
 import { dedupeByKey, type ContextRef } from "~/chat/context/entities";
 import {
   type DisplayEntity,
@@ -64,7 +65,9 @@ export function ChatSession({
   const { user_id } = main.UI.useValues(main.STORE_ID);
 
   const [pendingManualRefs, setPendingManualRefs] = useState<ContextRef[]>([]);
-  const [pendingDraftRefs, setPendingDraftRefs] = useState<ContextRef[]>([]);
+  const [pendingDraftRefs, setPendingDraftRefs] = useState<ContextRef[]>(() =>
+    getDraftContextRefs(sessionId),
+  );
 
   const onAddContextEntity = useCallback((ref: ContextRef) => {
     setPendingManualRefs((prev) =>

--- a/apps/desktop/src/chat/components/session-provider.tsx
+++ b/apps/desktop/src/chat/components/session-provider.tsx
@@ -86,11 +86,6 @@ export function ChatSession({
     setPendingDraftRefs(refs);
   }, []);
 
-  useEffect(() => {
-    setPendingManualRefs([]);
-    setPendingDraftRefs([]);
-  }, [sessionId, chatGroupId]);
-
   const { transport, isSystemPromptReady } = useTransport(
     modelOverride,
     extraTools,

--- a/apps/desktop/src/chat/components/session-provider.tsx
+++ b/apps/desktop/src/chat/components/session-provider.tsx
@@ -74,7 +74,6 @@ export function ChatSession({
 
   const onRemoveContextEntity = useCallback((key: string) => {
     setPendingManualRefs((prev) => prev.filter((r) => r.key !== key));
-    setPendingDraftRefs((prev) => prev.filter((r) => r.key !== key));
   }, []);
 
   const onDraftContextRefsChange = useCallback((refs: ContextRef[]) => {

--- a/apps/desktop/src/chat/components/shared.test.ts
+++ b/apps/desktop/src/chat/components/shared.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+
+import { hasRenderableContent } from "./shared";
+
+describe("hasRenderableContent", () => {
+  test("returns false for blank reasoning-only messages", () => {
+    expect(
+      hasRenderableContent({
+        id: "message-1",
+        role: "assistant",
+        parts: [{ type: "reasoning", text: "   ", state: "done" }],
+      }),
+    ).toBe(false);
+  });
+
+  test("returns true for non-empty reasoning messages", () => {
+    expect(
+      hasRenderableContent({
+        id: "message-2",
+        role: "assistant",
+        parts: [{ type: "reasoning", text: "Thinking", state: "done" }],
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/desktop/src/chat/components/shared.ts
+++ b/apps/desktop/src/chat/components/shared.ts
@@ -1,5 +1,15 @@
 import type { HyprUIMessage } from "~/chat/types";
 
 export function hasRenderableContent(message: HyprUIMessage): boolean {
-  return message.parts.some((part) => part.type !== "step-start");
+  return message.parts.some((part) => {
+    if (part.type === "step-start") {
+      return false;
+    }
+
+    if (part.type === "reasoning") {
+      return part.text.trim().length > 0;
+    }
+
+    return true;
+  });
 }

--- a/apps/desktop/src/chat/context/entities.ts
+++ b/apps/desktop/src/chat/context/entities.ts
@@ -14,17 +14,45 @@ export const CONTEXT_ENTITY_SOURCES = [
 ] as const;
 export type ContextEntitySource = (typeof CONTEXT_ENTITY_SOURCES)[number];
 
-export type ContextRef = {
-  kind: "session";
+type BaseContextRef = {
   key: string;
   source?: ContextEntitySource;
+};
+
+export type SessionContextRef = BaseContextRef & {
+  kind: "session";
   sessionId: string;
 };
 
+export type HumanContextRef = BaseContextRef & {
+  kind: "human";
+  humanId: string;
+};
+
+export type OrganizationContextRef = BaseContextRef & {
+  kind: "organization";
+  organizationId: string;
+};
+
+export type ContextRef =
+  | SessionContextRef
+  | HumanContextRef
+  | OrganizationContextRef;
+
 export type ContextEntity =
-  | (ContextRef & {
+  | (SessionContextRef & {
       title?: string | null;
       date?: string | null;
+      removable?: boolean;
+    })
+  | (HumanContextRef & {
+      name?: string | null;
+      email?: string | null;
+      organizationName?: string | null;
+      removable?: boolean;
+    })
+  | (OrganizationContextRef & {
+      name?: string | null;
       removable?: boolean;
     })
   | ({

--- a/apps/desktop/src/chat/context/entities.ts
+++ b/apps/desktop/src/chat/context/entities.ts
@@ -10,6 +10,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export const CONTEXT_ENTITY_SOURCES = [
   "tool",
   "manual",
+  "draft",
   "auto-current",
 ] as const;
 export type ContextEntitySource = (typeof CONTEXT_ENTITY_SOURCES)[number];

--- a/apps/desktop/src/chat/context/refs.ts
+++ b/apps/desktop/src/chat/context/refs.ts
@@ -9,14 +9,30 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 const validSources: ReadonlySet<string> = new Set(CONTEXT_ENTITY_SOURCES);
 
 export function isContextRef(value: unknown): value is ContextRef {
-  return (
-    isRecord(value) &&
-    value.kind === "session" &&
-    typeof value.key === "string" &&
-    typeof value.sessionId === "string" &&
-    (value.source === undefined ||
-      (typeof value.source === "string" && validSources.has(value.source)))
-  );
+  if (!isRecord(value) || typeof value.key !== "string") {
+    return false;
+  }
+
+  if (
+    value.source !== undefined &&
+    (typeof value.source !== "string" || !validSources.has(value.source))
+  ) {
+    return false;
+  }
+
+  if (value.kind === "session") {
+    return typeof value.sessionId === "string";
+  }
+
+  if (value.kind === "human") {
+    return typeof value.humanId === "string";
+  }
+
+  if (value.kind === "organization") {
+    return typeof value.organizationId === "string";
+  }
+
+  return false;
 }
 
 export function getContextRefs(metadata: unknown): ContextRef[] {

--- a/apps/desktop/src/chat/context/registry.ts
+++ b/apps/desktop/src/chat/context/registry.ts
@@ -1,4 +1,10 @@
-import { CalendarIcon, MonitorIcon, SearchIcon, UserIcon } from "lucide-react";
+import {
+  Building2Icon,
+  CalendarIcon,
+  MonitorIcon,
+  SearchIcon,
+  UserIcon,
+} from "lucide-react";
 
 import type { ContextEntity, ContextEntityKind } from "./entities";
 
@@ -38,6 +44,39 @@ const renderers: RendererMap = {
         removable: entity.removable,
         entityKind: "session",
         entityId: entity.sessionId,
+      };
+    },
+  },
+
+  human: {
+    toChip: (entity) => {
+      const label = entity.name || entity.email || "Person";
+      const tooltip = [entity.name, entity.email, entity.organizationName]
+        .filter(Boolean)
+        .join(" • ");
+      return {
+        key: entity.key,
+        icon: UserIcon,
+        label,
+        tooltip: tooltip || label,
+        removable: entity.removable,
+        entityKind: "human",
+        entityId: entity.humanId,
+      };
+    },
+  },
+
+  organization: {
+    toChip: (entity) => {
+      const label = entity.name || "Organization";
+      return {
+        key: entity.key,
+        icon: Building2Icon,
+        label,
+        tooltip: label,
+        removable: entity.removable,
+        entityKind: "organization",
+        entityId: entity.organizationId,
       };
     },
   },

--- a/apps/desktop/src/chat/context/use-chat-context-pipeline.ts
+++ b/apps/desktop/src/chat/context/use-chat-context-pipeline.ts
@@ -28,6 +28,77 @@ function getSessionDisplayData(
   };
 }
 
+function getHumanDisplayData(
+  store: ReturnType<typeof main.UI.useStore>,
+  humanId: string,
+): {
+  name: string | null;
+  email: string | null;
+  organizationName: string | null;
+} {
+  if (!store) {
+    return { name: null, email: null, organizationName: null };
+  }
+
+  const row = store.getRow("humans", humanId);
+  const orgId = typeof row.org_id === "string" ? row.org_id : null;
+  const organization =
+    orgId && store.hasRow("organizations", orgId)
+      ? store.getRow("organizations", orgId)
+      : {};
+
+  return {
+    name: typeof row.name === "string" && row.name.trim() ? row.name : null,
+    email: typeof row.email === "string" && row.email.trim() ? row.email : null,
+    organizationName:
+      typeof organization.name === "string" && organization.name.trim()
+        ? organization.name
+        : null,
+  };
+}
+
+function getOrganizationDisplayData(
+  store: ReturnType<typeof main.UI.useStore>,
+  organizationId: string,
+): { name: string | null } {
+  if (!store) {
+    return { name: null };
+  }
+
+  const row = store.getRow("organizations", organizationId);
+  return {
+    name: typeof row.name === "string" && row.name.trim() ? row.name : null,
+  };
+}
+
+function toDisplayEntity(
+  ref: ContextRef,
+  store: ReturnType<typeof main.UI.useStore>,
+  removable: boolean,
+): ContextEntity {
+  if (ref.kind === "session") {
+    return {
+      ...ref,
+      ...getSessionDisplayData(store, ref.sessionId),
+      removable,
+    };
+  }
+
+  if (ref.kind === "human") {
+    return {
+      ...ref,
+      ...getHumanDisplayData(store, ref.humanId),
+      removable,
+    };
+  }
+
+  return {
+    ...ref,
+    ...getOrganizationDisplayData(store, ref.organizationId),
+    removable,
+  };
+}
+
 type UseChatContextPipelineParams = {
   messages: HyprUIMessage[];
   currentSessionId?: string;
@@ -72,23 +143,16 @@ export function useChatContextPipeline({
   }, [currentSessionId, pendingManualRefs]);
 
   const committedEntities = useMemo(
-    () =>
-      committedRefs.map((ref) => ({
-        ...ref,
-        ...getSessionDisplayData(store, ref.sessionId),
-        removable: false,
-      })),
+    () => committedRefs.map((ref) => toDisplayEntity(ref, store, false)),
     [committedRefs, store],
   );
 
   // Pending manual refs are removable; pending auto-current is not.
   const pendingEntities = useMemo(
     () =>
-      pendingRefs.map((ref) => ({
-        ...ref,
-        ...getSessionDisplayData(store, ref.sessionId),
-        removable: ref.source === "manual",
-      })),
+      pendingRefs.map((ref) =>
+        toDisplayEntity(ref, store, ref.source === "manual"),
+      ),
     [pendingRefs, store],
   );
 

--- a/apps/desktop/src/chat/context/use-chat-context-pipeline.ts
+++ b/apps/desktop/src/chat/context/use-chat-context-pipeline.ts
@@ -147,7 +147,7 @@ export function useChatContextPipeline({
     [committedRefs, store],
   );
 
-  // Pending manual refs are removable; pending auto-current is not.
+  // Only explicit manual refs are removable; draft and auto-current refs are not.
   const pendingEntities = useMemo(
     () =>
       pendingRefs.map((ref) =>

--- a/apps/desktop/src/chat/state/chat-context.test.ts
+++ b/apps/desktop/src/chat/state/chat-context.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { useChatContext } from "./chat-context";
+
+describe("chat context", () => {
+  beforeEach(() => {
+    useChatContext.setState({
+      groupId: undefined,
+      sessionId: "session-initial",
+    });
+  });
+
+  test("startNewChat resets the group and rotates the session id", () => {
+    useChatContext.setState({
+      groupId: "group-1",
+      sessionId: "session-1",
+    });
+
+    useChatContext.getState().startNewChat();
+
+    const state = useChatContext.getState();
+    expect(state.groupId).toBeUndefined();
+    expect(state.sessionId).not.toBe("session-1");
+  });
+
+  test("selectChat syncs the selected group and session id", () => {
+    useChatContext.getState().selectChat("group-2");
+
+    const state = useChatContext.getState();
+    expect(state.groupId).toBe("group-2");
+    expect(state.sessionId).toBe("group-2");
+  });
+});

--- a/apps/desktop/src/chat/state/chat-context.ts
+++ b/apps/desktop/src/chat/state/chat-context.ts
@@ -1,16 +1,24 @@
 import { create } from "zustand";
 
+import { id } from "~/shared/utils";
+
 interface ChatContextState {
   groupId: string | undefined;
+  sessionId: string;
 }
 
 interface ChatContextActions {
   setGroupId: (groupId: string | undefined) => void;
+  startNewChat: () => void;
+  selectChat: (groupId: string) => void;
 }
 
 export const useChatContext = create<ChatContextState & ChatContextActions>(
   (set) => ({
     groupId: undefined,
+    sessionId: id(),
     setGroupId: (groupId) => set({ groupId }),
+    startNewChat: () => set({ groupId: undefined, sessionId: id() }),
+    selectChat: (groupId) => set({ groupId, sessionId: groupId }),
   }),
 );

--- a/apps/desktop/src/chat/state/use-chat-mode.ts
+++ b/apps/desktop/src/chat/state/use-chat-mode.ts
@@ -11,7 +11,10 @@ export function useChatMode() {
   const transitionChatMode = useTabs((state) => state.transitionChatMode);
 
   const groupId = useChatContext((state) => state.groupId);
+  const sessionId = useChatContext((state) => state.sessionId);
   const setGroupId = useChatContext((state) => state.setGroupId);
+  const startNewChat = useChatContext((state) => state.startNewChat);
+  const selectChat = useChatContext((state) => state.selectChat);
 
   useHotkeys(
     "mod+j",
@@ -28,6 +31,9 @@ export function useChatMode() {
     mode,
     sendEvent: transitionChatMode,
     groupId,
+    sessionId,
     setGroupId,
+    startNewChat,
+    selectChat,
   };
 }

--- a/apps/desktop/src/chat/transport/index.ts
+++ b/apps/desktop/src/chat/transport/index.ts
@@ -28,6 +28,10 @@ import {
   type ToolOutputPart,
 } from "./helpers";
 
+export type ResolvedChatContext =
+  | { kind: "session"; context: SessionContext }
+  | { kind: "text"; text: string };
+
 export class CustomChatTransport implements ChatTransport<HyprUIMessage> {
   constructor(
     private model: LanguageModel,
@@ -35,7 +39,7 @@ export class CustomChatTransport implements ChatTransport<HyprUIMessage> {
     private systemPrompt?: string,
     private resolveContextRef?: (
       ref: ContextRef,
-    ) => Promise<SessionContext | null>,
+    ) => Promise<ResolvedChatContext | null>,
   ) {}
 
   private async renderContextBlock(
@@ -52,24 +56,45 @@ export class CustomChatTransport implements ChatTransport<HyprUIMessage> {
     }
 
     const seen = new Set<string>();
-    const contexts: SessionContext[] = [];
+    const sessionContexts: SessionContext[] = [];
+    const textContexts: string[] = [];
     for (const ref of contextRefs) {
       if (seen.has(ref.key)) continue;
       seen.add(ref.key);
       const context = await this.resolveContextRef(ref);
-      if (context) contexts.push(context);
+      if (!context) {
+        continue;
+      }
+
+      if (context.kind === "session") {
+        sessionContexts.push(context.context);
+      } else if (context.text.trim()) {
+        textContexts.push(context.text.trim());
+      }
     }
 
-    if (contexts.length === 0) {
+    if (sessionContexts.length === 0 && textContexts.length === 0) {
       cache.set(cacheKey, null);
       return null;
     }
 
-    // Rendered by Rust-side template engine via Tauri plugin
-    const rendered = await templateCommands.render({
-      contextBlock: { contexts },
-    });
-    const result = rendered.status === "ok" ? rendered.data : null;
+    const blocks: string[] = [];
+
+    if (sessionContexts.length > 0) {
+      // Rendered by Rust-side template engine via Tauri plugin
+      const rendered = await templateCommands.render({
+        contextBlock: { contexts: sessionContexts },
+      });
+      if (rendered.status === "ok" && rendered.data.trim()) {
+        blocks.push(rendered.data.trim());
+      }
+    }
+
+    if (textContexts.length > 0) {
+      blocks.push(textContexts.join("\n\n"));
+    }
+
+    const result = blocks.length > 0 ? blocks.join("\n\n") : null;
     cache.set(cacheKey, result);
     return result;
   }

--- a/apps/desktop/src/chat/transport/use-transport.ts
+++ b/apps/desktop/src/chat/transport/use-transport.ts
@@ -4,12 +4,74 @@ import { useEffect, useMemo, useState } from "react";
 import { commands as templateCommands } from "@hypr/plugin-template";
 
 import { CustomChatTransport } from "./index";
+import type { ResolvedChatContext } from "./index";
 
 import { useLanguageModel } from "~/ai/hooks";
 import type { ContextRef } from "~/chat/context/entities";
 import { hydrateSessionContextFromFs } from "~/chat/context/session-context-hydrator";
 import { useToolRegistry } from "~/contexts/tool";
 import * as main from "~/store/tinybase/store/main";
+
+function renderHumanContext(
+  store: ReturnType<typeof main.UI.useStore>,
+  humanId: string,
+): string | null {
+  if (!store) {
+    return null;
+  }
+
+  const human = store.getRow("humans", humanId);
+  const orgId = typeof human.org_id === "string" ? human.org_id : "";
+  const organization =
+    orgId && store.hasRow("organizations", orgId)
+      ? store.getRow("organizations", orgId)
+      : {};
+
+  const name =
+    typeof human.name === "string" && human.name.trim() ? human.name : null;
+  const email =
+    typeof human.email === "string" && human.email.trim() ? human.email : null;
+  const jobTitle =
+    typeof human.job_title === "string" && human.job_title.trim()
+      ? human.job_title
+      : null;
+  const organizationName =
+    typeof organization.name === "string" && organization.name.trim()
+      ? organization.name
+      : null;
+  const memo =
+    typeof human.memo === "string" && human.memo.trim() ? human.memo : null;
+
+  if (!name && !email) {
+    return null;
+  }
+
+  const details = [
+    jobTitle,
+    organizationName ? `Organization: ${organizationName}` : null,
+    email ? `Email: ${email}` : null,
+    memo ? `Notes: ${memo}` : null,
+  ].filter(Boolean);
+
+  return [`Referenced contact: ${name ?? email}`, ...details].join("\n");
+}
+
+function renderOrganizationContext(
+  store: ReturnType<typeof main.UI.useStore>,
+  organizationId: string,
+): string | null {
+  if (!store) {
+    return null;
+  }
+
+  const organization = store.getRow("organizations", organizationId);
+  const name =
+    typeof organization.name === "string" && organization.name.trim()
+      ? organization.name
+      : null;
+
+  return name ? `Referenced organization: ${name}` : null;
+}
 
 export function useTransport(
   modelOverride?: LanguageModel,
@@ -96,7 +158,27 @@ export function useTransport(
         if (!store) {
           return null;
         }
-        return hydrateSessionContextFromFs(store, ref.sessionId);
+        if (ref.kind === "session") {
+          const context = await hydrateSessionContextFromFs(
+            store,
+            ref.sessionId,
+          );
+          return context
+            ? ({ kind: "session", context } satisfies ResolvedChatContext)
+            : null;
+        }
+
+        if (ref.kind === "human") {
+          const text = renderHumanContext(store, ref.humanId);
+          return text
+            ? ({ kind: "text", text } satisfies ResolvedChatContext)
+            : null;
+        }
+
+        const text = renderOrganizationContext(store, ref.organizationId);
+        return text
+          ? ({ kind: "text", text } satisfies ResolvedChatContext)
+          : null;
       },
     );
   }, [model, tools, effectiveSystemPrompt, store]);

--- a/apps/desktop/src/chat/types.ts
+++ b/apps/desktop/src/chat/types.ts
@@ -8,12 +8,26 @@ const messageMetadataSchema = z.object({
   createdAt: z.number().optional(),
   contextRefs: z
     .array(
-      z.object({
-        kind: z.literal("session"),
-        key: z.string(),
-        source: z.enum(CONTEXT_ENTITY_SOURCES).optional(),
-        sessionId: z.string(),
-      }),
+      z.discriminatedUnion("kind", [
+        z.object({
+          kind: z.literal("session"),
+          key: z.string(),
+          source: z.enum(CONTEXT_ENTITY_SOURCES).optional(),
+          sessionId: z.string(),
+        }),
+        z.object({
+          kind: z.literal("human"),
+          key: z.string(),
+          source: z.enum(CONTEXT_ENTITY_SOURCES).optional(),
+          humanId: z.string(),
+        }),
+        z.object({
+          kind: z.literal("organization"),
+          key: z.string(),
+          source: z.enum(CONTEXT_ENTITY_SOURCES).optional(),
+          organizationId: z.string(),
+        }),
+      ]),
     )
     .optional(),
 });

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -937,6 +937,11 @@ function useTabsShortcuts() {
   useHotkeys(
     "mod+n",
     () => {
+      if (isPersistentChatInputFocused(chat.mode)) {
+        chat.startNewChat();
+        return;
+      }
+
       if (currentTab?.type === "empty") {
         newNoteCurrent();
       } else {
@@ -948,7 +953,7 @@ function useTabsShortcuts() {
       enableOnFormTags: true,
       enableOnContentEditable: true,
     },
-    [currentTab, newNote, newNoteCurrent],
+    [chat, currentTab, newNote, newNoteCurrent],
   );
 
   useHotkeys(
@@ -1128,4 +1133,23 @@ function useNewEmptyTab() {
   }, [openNew]);
 
   return handler;
+}
+
+function isPersistentChatInputFocused(
+  mode: ReturnType<typeof useShell>["chat"]["mode"],
+) {
+  if (mode !== "FloatingOpen" && mode !== "RightPanelOpen") {
+    return false;
+  }
+
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  const activeElement = document.activeElement;
+  if (!(activeElement instanceof HTMLElement)) {
+    return false;
+  }
+
+  return activeElement.closest("[data-chat-message-input]") !== null;
 }


### PR DESCRIPTION
- centralize draft serialization and storage in the shared chat draft module
- derive pending draft mention refs from stored editor state instead of effect-based sync
- preserve restored draft refs and rehydrate draft context from the editor once it is initialized