### PR TITLE
fix(desktop): normalize Soniqo live partials

### DIFF
--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -73,6 +73,306 @@ pub(super) async fn spawn_rx_task(
     Ok((result.0, result.1, result.2, adapter_kind.to_string()))
 }
 
+fn soniqo_model_for_args(
+    args: &ListenerArgs,
+) -> Result<Option<hypr_transcribe_soniqo::SoniqoModel>, ActorProcessingErr> {
+    if let Some(model) =
+        hypr_transcribe_soniqo::local_model_from_request(&args.base_url, &args.model)
+    {
+        return Ok(Some(model));
+    }
+
+    if hypr_transcribe_soniqo::is_local_base_url(&args.base_url) {
+        return hypr_transcribe_soniqo::SoniqoModel::from_str(&args.model)
+            .map(Some)
+            .map_err(|e| actor_error(format!("soniqo_model_invalid: {e}")));
+    }
+
+    Ok(None)
+}
+
+async fn spawn_soniqo_rx_task(
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    args: ListenerArgs,
+    myself: ActorRef<ListenerMsg>,
+) -> Result<
+    (
+        ChannelSender,
+        tokio::task::JoinHandle<()>,
+        tokio::sync::oneshot::Sender<()>,
+    ),
+    ActorProcessingErr,
+> {
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let (session_offset_secs, extra) = build_extra(&args);
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<SoniqoAudioMsg>(32);
+
+    let session = tokio::task::spawn_blocking(move || {
+        hypr_transcribe_soniqo::LiveTranscriptionSession::start(model)
+    })
+    .await
+    .map_err(|e| actor_error(format!("soniqo_live_start_join_failed: {e}")))?
+    .map_err(|e| actor_error(format!("soniqo_live_start_failed: {e}")))?;
+
+    let rx_task = tokio::spawn(async move {
+        let mut session = session;
+        let mut mic_buffer = Vec::<f32>::new();
+        let mut spk_buffer = Vec::<f32>::new();
+        let mut mic_cursor = 0.0;
+        let mut spk_cursor = 0.0;
+        let mut interval = tokio::time::interval(Duration::from_millis(250));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                _ = &mut shutdown_rx => {
+                    break;
+                }
+                maybe_msg = rx.recv() => {
+                    let Some(msg) = maybe_msg else {
+                        break;
+                    };
+
+                    match msg {
+                        SoniqoAudioMsg::Single(source, audio) => {
+                            match source {
+                                hypr_transcribe_soniqo::TranscriptSource::Microphone => {
+                                    mic_buffer.extend(i16_bytes_to_f32(&audio));
+                                }
+                                hypr_transcribe_soniqo::TranscriptSource::System => {
+                                    spk_buffer.extend(i16_bytes_to_f32(&audio));
+                                }
+                            }
+                        }
+                        SoniqoAudioMsg::Dual(mic, spk) => {
+                            mic_buffer.extend(i16_bytes_to_f32(&mic));
+                            spk_buffer.extend(i16_bytes_to_f32(&spk));
+                        }
+                    }
+                }
+                _ = interval.tick() => {
+                    if !mic_buffer.is_empty() {
+                        let samples = std::mem::take(&mut mic_buffer);
+                        let duration = samples.len() as f64 / super::super::SAMPLE_RATE as f64;
+                        let start = mic_cursor;
+                        mic_cursor += duration;
+
+                        match flush_soniqo_source(
+                            session,
+                            model,
+                            hypr_transcribe_soniqo::TranscriptSource::Microphone,
+                            samples,
+                            start,
+                            duration,
+                            myself.clone(),
+                            session_offset_secs,
+                            extra.clone(),
+                        )
+                        .await
+                        {
+                            Ok(next_session) => session = next_session,
+                            Err(error) => {
+                                let _ = myself.cast(ListenerMsg::StreamError(error));
+                                return;
+                            }
+                        }
+                    }
+
+                    if !spk_buffer.is_empty() {
+                        let samples = std::mem::take(&mut spk_buffer);
+                        let duration = samples.len() as f64 / super::super::SAMPLE_RATE as f64;
+                        let start = spk_cursor;
+                        spk_cursor += duration;
+
+                        match flush_soniqo_source(
+                            session,
+                            model,
+                            hypr_transcribe_soniqo::TranscriptSource::System,
+                            samples,
+                            start,
+                            duration,
+                            myself.clone(),
+                            session_offset_secs,
+                            extra.clone(),
+                        )
+                        .await
+                        {
+                            Ok(next_session) => session = next_session,
+                            Err(error) => {
+                                let _ = myself.cast(ListenerMsg::StreamError(error));
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if !mic_buffer.is_empty() {
+            let samples = std::mem::take(&mut mic_buffer);
+            let duration = samples.len() as f64 / super::super::SAMPLE_RATE as f64;
+            let start = mic_cursor;
+            mic_cursor += duration;
+            match flush_soniqo_source(
+                session,
+                model,
+                hypr_transcribe_soniqo::TranscriptSource::Microphone,
+                samples,
+                start,
+                duration,
+                myself.clone(),
+                session_offset_secs,
+                extra.clone(),
+            )
+            .await
+            {
+                Ok(next_session) => session = next_session,
+                Err(error) => {
+                    tracing::warn!(%error, "soniqo_final_mic_flush_failed");
+                    return;
+                }
+            }
+        }
+
+        if !spk_buffer.is_empty() {
+            let samples = std::mem::take(&mut spk_buffer);
+            let duration = samples.len() as f64 / super::super::SAMPLE_RATE as f64;
+            let start = spk_cursor;
+            spk_cursor += duration;
+            match flush_soniqo_source(
+                session,
+                model,
+                hypr_transcribe_soniqo::TranscriptSource::System,
+                samples,
+                start,
+                duration,
+                myself.clone(),
+                session_offset_secs,
+                extra.clone(),
+            )
+            .await
+            {
+                Ok(next_session) => session = next_session,
+                Err(error) => {
+                    tracing::warn!(%error, "soniqo_final_system_flush_failed");
+                    return;
+                }
+            }
+        }
+
+        match finalize_soniqo_source(
+            session,
+            model,
+            hypr_transcribe_soniqo::TranscriptSource::Microphone,
+            mic_cursor,
+            myself.clone(),
+            session_offset_secs,
+            extra.clone(),
+        )
+        .await
+        {
+            Ok(next_session) => session = next_session,
+            Err(error) => {
+                tracing::warn!(%error, "soniqo_final_mic_finalize_failed");
+                return;
+            }
+        }
+
+        match finalize_soniqo_source(
+            session,
+            model,
+            hypr_transcribe_soniqo::TranscriptSource::System,
+            spk_cursor,
+            myself,
+            session_offset_secs,
+            extra,
+        )
+        .await
+        {
+            Ok(next_session) => session = next_session,
+            Err(error) => {
+                tracing::warn!(%error, "soniqo_final_system_finalize_failed");
+                return;
+            }
+        }
+
+        let _ = tokio::task::spawn_blocking(move || session.stop()).await;
+    });
+
+    Ok((ChannelSender::Soniqo(tx), rx_task, shutdown_tx))
+}
+
+async fn flush_soniqo_source(
+    session: hypr_transcribe_soniqo::LiveTranscriptionSession,
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    source: hypr_transcribe_soniqo::TranscriptSource,
+    samples: Vec<f32>,
+    start: f64,
+    duration: f64,
+    myself: ActorRef<ListenerMsg>,
+    session_offset_secs: f64,
+    extra: Extra,
+) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, String> {
+    let joined = tokio::task::spawn_blocking(move || {
+        let mut session = session;
+        let result = session.append(source, &samples);
+        (session, result)
+    })
+    .await
+    .map_err(|e| format!("soniqo_live_append_join_failed: {e}"))?;
+
+    let (session, partials) = joined;
+    let partials = partials.map_err(|e| format!("soniqo_live_append_failed: {e}"))?;
+
+    for partial in partials {
+        let mut response = partial.into_stream_response(model, start, duration);
+        response.apply_offset(session_offset_secs);
+        response.set_extra(&extra);
+
+        let _ = myself.cast(ListenerMsg::StreamResponse(response));
+    }
+
+    Ok(session)
+}
+
+async fn finalize_soniqo_source(
+    session: hypr_transcribe_soniqo::LiveTranscriptionSession,
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    source: hypr_transcribe_soniqo::TranscriptSource,
+    start: f64,
+    myself: ActorRef<ListenerMsg>,
+    session_offset_secs: f64,
+    extra: Extra,
+) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, String> {
+    let joined = tokio::task::spawn_blocking(move || {
+        let mut session = session;
+        let result = session.finalize(source);
+        (session, result)
+    })
+    .await
+    .map_err(|e| format!("soniqo_live_finalize_join_failed: {e}"))?;
+
+    let (session, partials) = joined;
+    let partials = partials.map_err(|e| format!("soniqo_live_finalize_failed: {e}"))?;
+
+    for partial in partials {
+        let mut response = partial.into_stream_response(model, start, 0.05);
+        response.apply_offset(session_offset_secs);
+        response.set_extra(&extra);
+
+        let _ = myself.cast(ListenerMsg::StreamResponse(response));
+    }
+
+    Ok(session)
+}
+
+fn i16_bytes_to_f32(bytes: &Bytes) -> Vec<f32> {
+    bytes
+        .chunks_exact(2)
+        .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / i16::MAX as f32)
+        .collect()
+}
+
 fn build_listen_params(args: &ListenerArgs) -> owhisper_interface::ListenParams {
     let adapter_kind =
         AdapterKind::from_url_and_languages(&args.base_url, &args.languages, Some(&args.model));

--- a/crates/listener-core/src/live_transcript.rs
+++ b/crates/listener-core/src/live_transcript.rs
@@ -5,9 +5,12 @@ use hypr_transcript::{
     TranscriptDelta, TranscriptProcessor, build_segments, channel_assignments_for_participants,
     normalize_rendered_segment_words, segment_options_for_participants, stable_segment_id,
 };
-use owhisper_interface::stream::{StreamResponse, Word};
+use owhisper_interface::stream::{Alternatives, StreamResponse, Word};
 
 const CACTUS_OVERLAP_MAX_GAP_MS: i64 = 500;
+const SONIQO_HISTORY_TOKEN_LIMIT: usize = 160;
+const SONIQO_REPEAT_MIN_TOKENS: usize = 4;
+const SONIQO_INTERNAL_REPEAT_MIN_TOKENS: usize = 6;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
@@ -184,22 +187,24 @@ impl RenderedSegmentState {
 #[derive(Default)]
 enum TranscriptNormalizer {
     Cactus(CactusTranscriptNormalizer),
+    Soniqo(SoniqoTranscriptNormalizer),
     #[default]
     Passthrough,
 }
 
 impl TranscriptNormalizer {
     fn for_provider(provider_name: &str) -> Self {
-        if provider_name == "cactus" {
-            Self::Cactus(CactusTranscriptNormalizer::default())
-        } else {
-            Self::Passthrough
+        match provider_name {
+            "cactus" => Self::Cactus(CactusTranscriptNormalizer::default()),
+            "soniqo" => Self::Soniqo(SoniqoTranscriptNormalizer::default()),
+            _ => Self::Passthrough,
         }
     }
 
     fn normalize(&mut self, response: &mut StreamResponse) {
         match self {
             Self::Cactus(normalizer) => normalizer.normalize(response),
+            Self::Soniqo(normalizer) => normalizer.normalize(response),
             Self::Passthrough => {}
         }
     }
@@ -214,6 +219,18 @@ struct CactusTranscriptNormalizer {
 struct CactusChannelState {
     last_final_tokens: Vec<String>,
     last_final_end_ms: i64,
+}
+
+#[derive(Default)]
+struct SoniqoTranscriptNormalizer {
+    channels: BTreeMap<i32, SoniqoChannelState>,
+}
+
+#[derive(Default)]
+struct SoniqoChannelState {
+    active_start_ms: Option<i64>,
+    active_tokens: Vec<String>,
+    committed_tokens: Vec<String>,
 }
 
 impl CactusTranscriptNormalizer {
@@ -255,6 +272,87 @@ impl CactusTranscriptNormalizer {
     }
 }
 
+impl SoniqoTranscriptNormalizer {
+    fn normalize(&mut self, response: &mut StreamResponse) {
+        let StreamResponse::TranscriptResponse {
+            start,
+            duration,
+            channel,
+            channel_index,
+            is_final,
+            ..
+        } = response
+        else {
+            return;
+        };
+
+        let Some(alternative) = channel.alternatives.first_mut() else {
+            return;
+        };
+        if alternative.words.is_empty() {
+            return;
+        }
+
+        let channel_idx = channel_index.first().copied().unwrap_or_default();
+        let state = self.channels.entry(channel_idx).or_default();
+        let mut current_tokens = normalize_tokens_for_overlap(&alternative.words);
+        let mut current_start_ms = (*start * 1000.0).round() as i64;
+        let mut current_end_ms = ((*start + *duration) * 1000.0).round() as i64;
+
+        collapse_soniqo_internal_repeats(alternative, &mut current_tokens);
+        if alternative.words.is_empty() {
+            return;
+        }
+
+        let committed_overlap =
+            find_soniqo_committed_prefix(&current_tokens, &state.committed_tokens);
+        if committed_overlap > 0 {
+            drain_soniqo_prefix(alternative, &mut current_tokens, committed_overlap);
+
+            if alternative.words.is_empty() {
+                if *is_final {
+                    state.active_start_ms = None;
+                    state.active_tokens.clear();
+                }
+                return;
+            }
+
+            sync_soniqo_timing(start, duration, &alternative.words);
+            current_start_ms = word_start_ms(alternative.words.first().expect("checked non-empty"));
+            current_end_ms = word_end_ms(alternative.words.last().expect("checked non-empty"));
+        }
+
+        if is_soniqo_cumulative_update(&state.active_tokens, &current_tokens) {
+            let active_start_ms = state.active_start_ms.unwrap_or(current_start_ms);
+            retime_words(&mut alternative.words, active_start_ms, current_end_ms);
+            *start = active_start_ms as f64 / 1000.0;
+            *duration = ((current_end_ms - active_start_ms).max(50)) as f64 / 1000.0;
+        } else {
+            let overlap = find_soniqo_overlap_prefix(&current_tokens, &state.active_tokens);
+            if overlap > 0 {
+                drain_soniqo_prefix(alternative, &mut current_tokens, overlap);
+
+                if alternative.words.is_empty() {
+                    return;
+                }
+
+                sync_soniqo_timing(start, duration, &alternative.words);
+                current_start_ms =
+                    word_start_ms(alternative.words.first().expect("checked non-empty"));
+            }
+            state.active_start_ms = Some(current_start_ms);
+        }
+
+        if *is_final {
+            extend_soniqo_committed_tokens(&mut state.committed_tokens, current_tokens);
+            state.active_start_ms = None;
+            state.active_tokens.clear();
+        } else {
+            state.active_tokens = current_tokens;
+        }
+    }
+}
+
 fn find_cactus_overlap_prefix(
     words: &[Word],
     last_final_tokens: &[String],
@@ -282,12 +380,192 @@ fn find_cactus_overlap_prefix(
     0
 }
 
+fn find_soniqo_overlap_prefix(current_tokens: &[String], previous_tokens: &[String]) -> usize {
+    if current_tokens.is_empty() || previous_tokens.is_empty() {
+        return 0;
+    }
+
+    let max_overlap = previous_tokens.len().min(current_tokens.len());
+
+    for overlap in (1..=max_overlap).rev() {
+        let previous_suffix = &previous_tokens[previous_tokens.len() - overlap..];
+        let current_prefix = &current_tokens[..overlap];
+
+        if previous_suffix == current_prefix {
+            return overlap;
+        }
+    }
+
+    0
+}
+
+fn find_soniqo_committed_prefix(current_tokens: &[String], committed_tokens: &[String]) -> usize {
+    if current_tokens.len() < SONIQO_REPEAT_MIN_TOKENS
+        || committed_tokens.len() < SONIQO_REPEAT_MIN_TOKENS
+    {
+        return 0;
+    }
+
+    let max_overlap = committed_tokens.len().min(current_tokens.len());
+
+    for overlap in (SONIQO_REPEAT_MIN_TOKENS..=max_overlap).rev() {
+        let current_prefix = &current_tokens[..overlap];
+        if committed_tokens
+            .windows(overlap)
+            .any(|tokens| tokens == current_prefix)
+        {
+            return overlap;
+        }
+    }
+
+    0
+}
+
+fn find_soniqo_history_prefix(
+    current_tokens: &[String],
+    history_tokens: &[String],
+    min_tokens: usize,
+) -> usize {
+    if current_tokens.len() < min_tokens || history_tokens.len() < min_tokens {
+        return 0;
+    }
+
+    let max_overlap = history_tokens.len().min(current_tokens.len());
+
+    for overlap in (min_tokens..=max_overlap).rev() {
+        let current_prefix = &current_tokens[..overlap];
+        if history_tokens
+            .windows(overlap)
+            .any(|tokens| tokens == current_prefix)
+        {
+            return overlap;
+        }
+    }
+
+    0
+}
+
+fn is_soniqo_cumulative_update(previous_tokens: &[String], current_tokens: &[String]) -> bool {
+    if previous_tokens.is_empty() || current_tokens.is_empty() {
+        return false;
+    }
+
+    current_tokens.starts_with(previous_tokens) || previous_tokens.starts_with(current_tokens)
+}
+
+fn collapse_soniqo_internal_repeats(
+    alternative: &mut Alternatives,
+    current_tokens: &mut Vec<String>,
+) {
+    let mut next_words = Vec::with_capacity(alternative.words.len());
+    let mut next_tokens = Vec::with_capacity(current_tokens.len());
+    let word_tokens = alternative
+        .words
+        .iter()
+        .map(normalize_word_token)
+        .collect::<Vec<_>>();
+    let mut index = 0;
+
+    while index < alternative.words.len() {
+        if word_tokens[index].is_empty() {
+            next_words.push(alternative.words[index].clone());
+            index += 1;
+            continue;
+        }
+
+        let overlap = find_soniqo_history_prefix(
+            &word_tokens[index..],
+            &next_tokens,
+            SONIQO_INTERNAL_REPEAT_MIN_TOKENS,
+        );
+
+        if overlap > 0 {
+            index += overlap;
+            continue;
+        }
+
+        next_tokens.push(word_tokens[index].clone());
+        next_words.push(alternative.words[index].clone());
+        index += 1;
+    }
+
+    if next_words.len() == alternative.words.len() {
+        return;
+    }
+
+    alternative.words = next_words;
+    alternative.transcript = transcript_from_words(&alternative.words);
+    *current_tokens = normalize_tokens_for_overlap(&alternative.words);
+}
+
+fn drain_soniqo_prefix(
+    alternative: &mut Alternatives,
+    current_tokens: &mut Vec<String>,
+    count: usize,
+) {
+    alternative.words.drain(..count);
+    current_tokens.drain(..count);
+    alternative.transcript = transcript_from_words(&alternative.words);
+}
+
+fn extend_soniqo_committed_tokens(committed_tokens: &mut Vec<String>, tokens: Vec<String>) {
+    committed_tokens.extend(tokens);
+
+    if committed_tokens.len() > SONIQO_HISTORY_TOKEN_LIMIT {
+        committed_tokens.drain(..committed_tokens.len() - SONIQO_HISTORY_TOKEN_LIMIT);
+    }
+}
+
+fn sync_soniqo_timing(start: &mut f64, duration: &mut f64, words: &[Word]) {
+    let (Some(first), Some(last)) = (words.first(), words.last()) else {
+        return;
+    };
+
+    *start = first.start;
+    *duration = (last.end - first.start).max(0.05);
+}
+
 fn normalize_tokens_for_overlap(words: &[Word]) -> Vec<String> {
     words
         .iter()
         .map(normalize_word_token)
         .filter(|token| !token.is_empty())
         .collect()
+}
+
+fn retime_words(words: &mut [Word], start_ms: i64, end_ms: i64) {
+    let count = words.len();
+    if count == 0 {
+        return;
+    }
+
+    let duration_ms = (end_ms - start_ms).max(50);
+
+    for (index, word) in words.iter_mut().enumerate() {
+        let word_start_ms = start_ms + (index as i64 * duration_ms / count as i64);
+        let word_end_ms = if index + 1 == count {
+            (start_ms + duration_ms - 50).max(word_start_ms + 50)
+        } else {
+            start_ms + ((index + 1) as i64 * duration_ms / count as i64)
+        };
+
+        word.start = word_start_ms as f64 / 1000.0;
+        word.end = word_end_ms as f64 / 1000.0;
+    }
+}
+
+fn transcript_from_words(words: &[Word]) -> String {
+    words
+        .iter()
+        .map(|word| {
+            word.punctuated_word
+                .as_deref()
+                .unwrap_or(word.word.as_str())
+                .trim()
+        })
+        .filter(|word| !word.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn build_live_segments(
@@ -358,9 +636,20 @@ mod tests {
         is_final: bool,
         channel_idx: i32,
     ) -> StreamResponse {
+        transcript_response_at(transcript, words, is_final, channel_idx, 0.0, 0.0)
+    }
+
+    fn transcript_response_at(
+        transcript: &str,
+        words: Vec<Word>,
+        is_final: bool,
+        channel_idx: i32,
+        start: f64,
+        duration: f64,
+    ) -> StreamResponse {
         StreamResponse::TranscriptResponse {
-            start: 0.0,
-            duration: 0.0,
+            start,
+            duration,
             is_final,
             speech_final: is_final,
             from_finalize: false,
@@ -396,6 +685,21 @@ mod tests {
             punctuated_word: Some(text.to_string()),
             language: None,
         }
+    }
+
+    fn words_from_text(text: &str, start: f64, duration: f64) -> Vec<Word> {
+        let parts = text.split_whitespace().collect::<Vec<_>>();
+        let count = parts.len();
+
+        parts
+            .into_iter()
+            .enumerate()
+            .map(|(index, part)| {
+                let word_start = start + (index as f64 / count as f64) * duration;
+                let word_end = start + ((index + 1) as f64 / count as f64) * duration;
+                word(part, word_start, word_end)
+            })
+            .collect()
     }
 
     #[test]
@@ -447,6 +751,308 @@ mod tests {
         let words = &channel.alternatives[0].words;
         assert_eq!(words.len(), 2);
         assert_eq!(words[0].word, "Mark");
+    }
+
+    #[test]
+    fn soniqo_normalizer_retimes_cumulative_partials() {
+        let mut normalizer = SoniqoTranscriptNormalizer::default();
+
+        let mut first =
+            transcript_response_at("see", vec![word("see", 0.0, 0.25)], false, 0, 0.0, 0.25);
+        normalizer.normalize(&mut first);
+
+        let mut second = transcript_response_at(
+            "see the need",
+            vec![
+                word("see", 0.25, 0.33),
+                word("the", 0.33, 0.41),
+                word("need", 0.41, 0.50),
+            ],
+            false,
+            0,
+            0.25,
+            0.25,
+        );
+        normalizer.normalize(&mut second);
+
+        let StreamResponse::TranscriptResponse {
+            start,
+            duration,
+            channel,
+            ..
+        } = second
+        else {
+            panic!("expected transcript response");
+        };
+        let words = &channel.alternatives[0].words;
+
+        assert_eq!(start, 0.0);
+        assert_eq!(duration, 0.5);
+        assert_eq!(words.len(), 3);
+        assert_eq!(words[0].word, "see");
+        assert_eq!(words[0].start, 0.0);
+        assert_eq!(words[2].end, 0.45);
+    }
+
+    #[test]
+    fn soniqo_normalizer_trims_sliding_overlap() {
+        let mut normalizer = SoniqoTranscriptNormalizer::default();
+
+        let mut first = transcript_response_at(
+            "see the need",
+            vec![
+                word("see", 0.0, 0.20),
+                word("the", 0.20, 0.40),
+                word("need", 0.40, 0.60),
+            ],
+            false,
+            0,
+            0.0,
+            0.60,
+        );
+        normalizer.normalize(&mut first);
+
+        let mut second = transcript_response_at(
+            "the need now",
+            vec![
+                word("the", 0.60, 0.70),
+                word("need", 0.70, 0.80),
+                word("now", 0.80, 0.90),
+            ],
+            false,
+            0,
+            0.60,
+            0.30,
+        );
+        normalizer.normalize(&mut second);
+
+        let StreamResponse::TranscriptResponse { channel, .. } = second else {
+            panic!("expected transcript response");
+        };
+        let alternative = &channel.alternatives[0];
+
+        assert_eq!(alternative.transcript, "now");
+        assert_eq!(
+            alternative
+                .words
+                .iter()
+                .map(|word| word.word.as_str())
+                .collect::<Vec<_>>(),
+            vec!["now"],
+        );
+    }
+
+    #[test]
+    fn soniqo_normalizer_drops_repeated_committed_history() {
+        let mut normalizer = SoniqoTranscriptNormalizer::default();
+        let repeated = "and it tested if you feel";
+
+        let mut first = transcript_response_at(
+            repeated,
+            words_from_text(repeated, 0.0, 1.0),
+            true,
+            0,
+            0.0,
+            1.0,
+        );
+        normalizer.normalize(&mut first);
+
+        let mut second = transcript_response_at(
+            repeated,
+            words_from_text(repeated, 10.0, 1.0),
+            true,
+            0,
+            10.0,
+            1.0,
+        );
+        normalizer.normalize(&mut second);
+
+        let StreamResponse::TranscriptResponse { channel, .. } = second else {
+            panic!("expected transcript response");
+        };
+        let alternative = &channel.alternatives[0];
+
+        assert!(alternative.words.is_empty());
+        assert_eq!(alternative.transcript, "");
+    }
+
+    #[test]
+    fn soniqo_normalizer_trims_repeated_committed_prefix_from_later_update() {
+        let mut normalizer = SoniqoTranscriptNormalizer::default();
+        let repeated = "and it tested if you feel";
+        let filler = "centralized online url for";
+        let repeated_with_tail = "and it tested if you feel like new material";
+
+        let mut first = transcript_response_at(
+            repeated,
+            words_from_text(repeated, 0.0, 1.0),
+            true,
+            0,
+            0.0,
+            1.0,
+        );
+        normalizer.normalize(&mut first);
+
+        let mut second =
+            transcript_response_at(filler, words_from_text(filler, 2.0, 1.0), true, 0, 2.0, 1.0);
+        normalizer.normalize(&mut second);
+
+        let mut third = transcript_response_at(
+            repeated_with_tail,
+            words_from_text(repeated_with_tail, 10.0, 1.0),
+            false,
+            0,
+            10.0,
+            1.0,
+        );
+        normalizer.normalize(&mut third);
+
+        let StreamResponse::TranscriptResponse { channel, .. } = third else {
+            panic!("expected transcript response");
+        };
+        let alternative = &channel.alternatives[0];
+
+        assert_eq!(alternative.transcript, "like new material");
+        assert_eq!(
+            alternative
+                .words
+                .iter()
+                .map(|word| word.word.as_str())
+                .collect::<Vec<_>>(),
+            vec!["like", "new", "material"],
+        );
+    }
+
+    #[test]
+    fn soniqo_normalizer_collapses_internal_partial_loop() {
+        let mut normalizer = SoniqoTranscriptNormalizer::default();
+        let looped = concat!(
+            "yeah but but there's super valuable information in there right ",
+            "it's just like it's a little bit like extracting it out of this like junior develop ",
+            "yeah but but there's super valuable information in there right ",
+            "it's just like it's a little bit like extracting it out of this like junior developer's ",
+            "kind of like private freak out it's it's a very difficult problem set because ",
+            "it's so you know yeah but but there's super valuable information in there right ",
+            "it's just like it's a little bit like extracting it out of this like junior developer's ",
+            "kind of like private freak out it's it's a very"
+        );
+
+        let mut response = transcript_response_at(
+            looped,
+            words_from_text(looped, 0.0, 10.0),
+            false,
+            0,
+            0.0,
+            10.0,
+        );
+        normalizer.normalize(&mut response);
+
+        let StreamResponse::TranscriptResponse { channel, .. } = response else {
+            panic!("expected transcript response");
+        };
+        let transcript = &channel.alternatives[0].transcript;
+
+        assert_eq!(transcript.matches("yeah but but").count(), 1);
+        assert!(transcript.contains("private freak out"));
+    }
+
+    #[test]
+    fn soniqo_engine_replaces_cumulative_live_partials() {
+        let mut engine = LiveTranscriptEngine::new("soniqo", &[], None);
+
+        let first =
+            transcript_response_at("see", vec![word("see", 0.0, 0.25)], false, 0, 0.0, 0.25);
+        engine.process(&first).expect("first update");
+
+        let second = transcript_response_at(
+            "see the need",
+            vec![
+                word("see", 0.25, 0.33),
+                word("the", 0.33, 0.41),
+                word("need", 0.41, 0.50),
+            ],
+            false,
+            0,
+            0.25,
+            0.25,
+        );
+        let update = engine.process(&second).expect("second update");
+        let segment_delta = update.segment_delta.expect("segment delta");
+
+        assert_eq!(segment_delta.upserts.len(), 1);
+        assert_eq!(segment_delta.upserts[0].text, "see the need");
+    }
+
+    #[test]
+    fn soniqo_engine_does_not_persist_repeated_final_history() {
+        let mut engine = LiveTranscriptEngine::new("soniqo", &[], None);
+        let repeated = "and it tested if you feel";
+
+        let first = transcript_response_at(
+            repeated,
+            words_from_text(repeated, 0.0, 1.0),
+            true,
+            0,
+            0.0,
+            1.0,
+        );
+        let first_update = engine.process(&first).expect("first update");
+
+        let second = transcript_response_at(
+            repeated,
+            words_from_text(repeated, 10.0, 1.0),
+            true,
+            0,
+            10.0,
+            1.0,
+        );
+        assert!(engine.process(&second).is_none());
+
+        let flush_update = engine.flush().expect("flush update");
+        let final_text = first_update
+            .transcript_delta
+            .new_words
+            .iter()
+            .chain(flush_update.transcript_delta.new_words.iter())
+            .map(|word| word.text.as_str())
+            .collect::<String>();
+
+        assert_eq!(final_text.trim(), repeated);
+    }
+
+    #[test]
+    fn soniqo_engine_does_not_persist_internal_partial_loop() {
+        let mut engine = LiveTranscriptEngine::new("soniqo", &[], None);
+        let looped = concat!(
+            "yeah but but there's super valuable information in there right ",
+            "it's just like it's a little bit like extracting it out of this like junior develop ",
+            "yeah but but there's super valuable information in there right ",
+            "it's just like it's a little bit like extracting it out of this like junior developer's ",
+            "kind of like private freak out it's it's a very difficult problem set because ",
+            "it's so you know yeah but but there's super valuable information in there right ",
+            "it's just like it's a little bit like extracting it out of this like junior developer's ",
+            "kind of like private freak out it's it's a very"
+        );
+        let response = transcript_response_at(
+            looped,
+            words_from_text(looped, 0.0, 10.0),
+            false,
+            0,
+            0.0,
+            10.0,
+        );
+
+        engine.process(&response).expect("partial update");
+        let flush_update = engine.flush().expect("flush update");
+        let final_text = flush_update
+            .transcript_delta
+            .new_words
+            .iter()
+            .map(|word| word.text.as_str())
+            .collect::<String>();
+
+        assert_eq!(final_text.matches("yeah but but").count(), 1);
+        assert!(final_text.contains("private freak out"));
     }
 
     #[test]

--- a/crates/listener-core/src/live_transcript.rs
+++ b/crates/listener-core/src/live_transcript.rs
@@ -8,6 +8,7 @@ use hypr_transcript::{
 use owhisper_interface::stream::{Alternatives, StreamResponse, Word};
 
 const CACTUS_OVERLAP_MAX_GAP_MS: i64 = 500;
+const SONIQO_CUMULATIVE_PREFIX_MIN_TOKENS: usize = 4;
 const SONIQO_HISTORY_TOKEN_LIMIT: usize = 160;
 const SONIQO_REPEAT_MIN_TOKENS: usize = 4;
 const SONIQO_INTERNAL_REPEAT_MIN_TOKENS: usize = 6;
@@ -79,9 +80,12 @@ impl LiveTranscriptEngine {
         let segment_options =
             segment_options_for_participants(participant_human_ids, self_human_id);
 
+        let normalizer = TranscriptNormalizer::for_provider(provider_name);
+
         Self {
-            processor: TranscriptProcessor::new(),
-            normalizer: TranscriptNormalizer::for_provider(provider_name),
+            processor: TranscriptProcessor::new()
+                .with_partial_finalization(normalizer.finalize_partials()),
+            normalizer,
             rendered_segments: RenderedSegmentState {
                 channel_assignments,
                 segment_options: Some(segment_options),
@@ -103,11 +107,11 @@ impl LiveTranscriptEngine {
 
     pub fn flush(&mut self) -> Option<LiveTranscriptUpdate> {
         let transcript_delta: LiveTranscriptDelta = self.processor.flush().into();
-        if transcript_delta.is_empty() {
+        let segment_delta = self.rendered_segments.apply_delta(&transcript_delta);
+        if transcript_delta.is_empty() && segment_delta.is_none() {
             return None;
         }
 
-        let segment_delta = self.rendered_segments.apply_delta(&transcript_delta);
         Some(LiveTranscriptUpdate {
             transcript_delta,
             segment_delta,
@@ -207,6 +211,10 @@ impl TranscriptNormalizer {
             Self::Soniqo(normalizer) => normalizer.normalize(response),
             Self::Passthrough => {}
         }
+    }
+
+    fn finalize_partials(&self) -> bool {
+        !matches!(self, Self::Soniqo(_))
     }
 }
 
@@ -450,7 +458,34 @@ fn is_soniqo_cumulative_update(previous_tokens: &[String], current_tokens: &[Str
         return false;
     }
 
-    current_tokens.starts_with(previous_tokens) || previous_tokens.starts_with(current_tokens)
+    if current_tokens.starts_with(previous_tokens) || previous_tokens.starts_with(current_tokens) {
+        return true;
+    }
+
+    let common_prefix_len = common_prefix_len(previous_tokens, current_tokens);
+    let shorter_len = previous_tokens.len().min(current_tokens.len());
+    if common_prefix_len < SONIQO_CUMULATIVE_PREFIX_MIN_TOKENS
+        || common_prefix_len + 1 < shorter_len
+    {
+        return false;
+    }
+
+    match (
+        previous_tokens.get(common_prefix_len),
+        current_tokens.get(common_prefix_len),
+    ) {
+        (Some(previous), Some(current)) => {
+            previous.starts_with(current) || current.starts_with(previous)
+        }
+        _ => true,
+    }
+}
+
+fn common_prefix_len(left: &[String], right: &[String]) -> usize {
+    left.iter()
+        .zip(right)
+        .take_while(|(left, right)| left == right)
+        .count()
 }
 
 fn collapse_soniqo_internal_repeats(
@@ -1044,15 +1079,38 @@ mod tests {
 
         engine.process(&response).expect("partial update");
         let flush_update = engine.flush().expect("flush update");
-        let final_text = flush_update
+        let segment_delta = flush_update.segment_delta.expect("segment delta");
+
+        assert!(flush_update.transcript_delta.new_words.is_empty());
+        assert!(flush_update.transcript_delta.partials.is_empty());
+        assert!(segment_delta.upserts.is_empty());
+        assert!(!segment_delta.removed_ids.is_empty());
+    }
+
+    #[test]
+    fn soniqo_engine_persists_model_final_words_on_flush() {
+        let mut engine = LiveTranscriptEngine::new("soniqo", &[], None);
+        let response = transcript_response_at(
+            "hello world",
+            words_from_text("hello world", 0.0, 1.0),
+            true,
+            0,
+            0.0,
+            1.0,
+        );
+
+        let first_update = engine.process(&response).expect("first update");
+        let flush_update = engine.flush().expect("flush update");
+        let final_text = first_update
             .transcript_delta
             .new_words
             .iter()
+            .chain(flush_update.transcript_delta.new_words.iter())
             .map(|word| word.text.as_str())
             .collect::<String>();
 
-        assert_eq!(final_text.matches("yeah but but").count(), 1);
-        assert!(final_text.contains("private freak out"));
+        assert_eq!(final_text.trim(), "hello world");
+        assert!(flush_update.transcript_delta.partials.is_empty());
     }
 
     #[test]

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -1,0 +1,805 @@
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use owhisper_interface::{batch, stream};
+
+pub const LOCAL_BASE_URL: &str = "soniqo://local";
+
+pub fn is_local_base_url(base_url: &str) -> bool {
+    base_url.trim_end_matches('/') == LOCAL_BASE_URL
+}
+
+pub fn is_loopback_http_base_url(base_url: &str) -> bool {
+    let Some(rest) = base_url
+        .trim()
+        .strip_prefix("http://")
+        .or_else(|| base_url.trim().strip_prefix("https://"))
+    else {
+        return false;
+    };
+
+    let authority = rest
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or_default()
+        .rsplit('@')
+        .next()
+        .unwrap_or_default();
+
+    let host = authority
+        .strip_prefix('[')
+        .and_then(|value| value.split(']').next())
+        .unwrap_or_else(|| authority.split(':').next().unwrap_or_default());
+
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|addr| addr.is_loopback())
+}
+
+pub fn local_model_from_request(base_url: &str, model: &str) -> Option<SoniqoModel> {
+    let model = model.parse().ok()?;
+
+    if is_local_base_url(base_url) || is_loopback_http_base_url(base_url) {
+        Some(model)
+    } else {
+        None
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, serde::Serialize, serde::Deserialize, specta::Type, Eq, Hash, PartialEq,
+)]
+pub enum SoniqoModel {
+    #[serde(rename = "soniqo-parakeet-streaming")]
+    ParakeetStreaming,
+    #[serde(rename = "soniqo-parakeet-batch")]
+    ParakeetBatch,
+    #[serde(rename = "soniqo-omnilingual")]
+    Omnilingual,
+    #[serde(rename = "soniqo-qwen3-small")]
+    Qwen3Small,
+    #[serde(rename = "soniqo-qwen3-large")]
+    Qwen3Large,
+}
+
+impl SoniqoModel {
+    pub const fn all() -> &'static [Self] {
+        &[
+            Self::ParakeetStreaming,
+            Self::ParakeetBatch,
+            Self::Omnilingual,
+            Self::Qwen3Small,
+            Self::Qwen3Large,
+        ]
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ParakeetStreaming => "soniqo-parakeet-streaming",
+            Self::ParakeetBatch => "soniqo-parakeet-batch",
+            Self::Omnilingual => "soniqo-omnilingual",
+            Self::Qwen3Small => "soniqo-qwen3-small",
+            Self::Qwen3Large => "soniqo-qwen3-large",
+        }
+    }
+
+    pub const fn repo(self) -> &'static str {
+        match self {
+            Self::ParakeetStreaming => "aufklarer/Parakeet-EOU-120M-CoreML-INT8",
+            Self::ParakeetBatch => "aufklarer/Parakeet-TDT-v3-CoreML-INT8",
+            Self::Omnilingual => "aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s",
+            Self::Qwen3Small => "aufklarer/Qwen3-ASR-0.6B-MLX-4bit",
+            Self::Qwen3Large => "aufklarer/Qwen3-ASR-1.7B-MLX-8bit",
+        }
+    }
+
+    pub const fn display_name(self) -> &'static str {
+        match self {
+            Self::ParakeetStreaming => "Soniqo Parakeet Streaming",
+            Self::ParakeetBatch => "Soniqo Parakeet Batch",
+            Self::Omnilingual => "Soniqo Omnilingual",
+            Self::Qwen3Small => "Soniqo Qwen3 0.6B",
+            Self::Qwen3Large => "Soniqo Qwen3 1.7B",
+        }
+    }
+
+    pub const fn description(self) -> &'static str {
+        match self {
+            Self::ParakeetStreaming => "Realtime transcription for 25 European languages.",
+            Self::ParakeetBatch => "Batch transcription for 25 European languages.",
+            Self::Omnilingual => "Multilingual batch transcription.",
+            Self::Qwen3Small => "Multilingual batch transcription.",
+            Self::Qwen3Large => "Multilingual batch transcription.",
+        }
+    }
+
+    pub const fn size_bytes(self) -> u64 {
+        match self {
+            Self::ParakeetStreaming => 120 * 1024 * 1024,
+            Self::ParakeetBatch => 600 * 1024 * 1024,
+            Self::Omnilingual => 300 * 1024 * 1024,
+            Self::Qwen3Small => 600 * 1024 * 1024,
+            Self::Qwen3Large => 1_700 * 1024 * 1024,
+        }
+    }
+
+    pub const fn supports_live(self) -> bool {
+        matches!(self, Self::ParakeetStreaming)
+    }
+
+    pub const fn is_available_on_current_platform(self) -> bool {
+        cfg!(all(target_os = "macos", target_arch = "aarch64"))
+    }
+
+    pub const fn supports_live_on_current_platform(self) -> bool {
+        self.supports_live() && self.is_available_on_current_platform()
+    }
+
+    pub fn supports_language(self, language: &hypr_language::Language) -> bool {
+        match self {
+            Self::ParakeetStreaming | Self::ParakeetBatch => {
+                hypr_language::is_parakeet_tdt_v3_language(language)
+            }
+            Self::Omnilingual | Self::Qwen3Small | Self::Qwen3Large => true,
+        }
+    }
+
+    pub fn supports_languages(self, languages: &[hypr_language::Language]) -> bool {
+        languages
+            .iter()
+            .all(|language| self.supports_language(language))
+    }
+}
+
+impl std::fmt::Display for SoniqoModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for SoniqoModel {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        Self::all()
+            .iter()
+            .copied()
+            .find(|model| value == model.as_str() || value == model.repo())
+            .ok_or_else(|| Error::UnsupportedModel(value.to_string()))
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelDownloadState {
+    pub status: String,
+    pub current_file: Option<String>,
+    pub progress_percent: Option<u8>,
+    pub local_path: String,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileTranscript {
+    pub text: String,
+    pub duration_seconds: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TranscriptSource {
+    Microphone,
+    System,
+}
+
+impl TranscriptSource {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Microphone => "microphone",
+            Self::System => "system",
+        }
+    }
+
+    pub const fn channel_index(self) -> i32 {
+        match self {
+            Self::Microphone => 0,
+            Self::System => 1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LivePartial {
+    pub source: String,
+    pub text: String,
+    pub is_final: bool,
+}
+
+impl LivePartial {
+    pub fn source(&self) -> TranscriptSource {
+        match self.source.as_str() {
+            "system" => TranscriptSource::System,
+            _ => TranscriptSource::Microphone,
+        }
+    }
+
+    pub fn into_stream_response(
+        self,
+        model: SoniqoModel,
+        start: f64,
+        duration: f64,
+    ) -> stream::StreamResponse {
+        let source = self.source();
+        stream_response_from_text(
+            model,
+            self.text,
+            start,
+            duration,
+            self.is_final,
+            &[source.channel_index(), 2],
+        )
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("unsupported Soniqo model: {0}")]
+    UnsupportedModel(String),
+    #[error("Soniqo is only available on macOS Apple Silicon")]
+    UnsupportedPlatform,
+    #[error("Soniqo bridge failed: {0}")]
+    Bridge(String),
+    #[error("failed to parse Soniqo bridge response: {0}")]
+    ResponseParse(#[from] serde_json::Error),
+    #[error("failed to delete Soniqo model: {0}")]
+    Delete(std::io::Error),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+fn ensure_supported_platform(model: SoniqoModel) -> Result<()> {
+    if model.is_available_on_current_platform() {
+        Ok(())
+    } else {
+        Err(Error::UnsupportedPlatform)
+    }
+}
+
+pub fn model_cache_dir(model: SoniqoModel) -> Result<PathBuf> {
+    ensure_supported_platform(model)?;
+    platform::model_cache_dir(model)
+}
+
+pub fn model_download_state(model: SoniqoModel) -> Result<ModelDownloadState> {
+    ensure_supported_platform(model)?;
+    platform::model_download_state(model)
+}
+
+pub fn start_model_download(model: SoniqoModel) -> Result<()> {
+    ensure_supported_platform(model)?;
+    platform::start_model_download(model)
+}
+
+pub fn reset_model(model: SoniqoModel) -> Result<()> {
+    ensure_supported_platform(model)?;
+    platform::reset_model(model)
+}
+
+pub fn is_model_downloaded(model: SoniqoModel) -> Result<bool> {
+    Ok(model_download_state(model)?.status == "ready")
+}
+
+pub fn is_model_downloading(model: SoniqoModel) -> Result<bool> {
+    Ok(model_download_state(model)?.status == "downloading")
+}
+
+pub fn delete_model(model: SoniqoModel) -> Result<()> {
+    reset_model(model)?;
+
+    let cache_dir = model_cache_dir(model)?;
+    if cache_dir.exists() {
+        std::fs::remove_dir_all(&cache_dir).map_err(Error::Delete)?;
+    }
+
+    Ok(())
+}
+
+pub fn transcribe_file(
+    model: SoniqoModel,
+    path: impl AsRef<Path>,
+    language: Option<&str>,
+) -> Result<FileTranscript> {
+    ensure_supported_platform(model)?;
+    platform::transcribe_file(model, path.as_ref(), language.unwrap_or_default())
+}
+
+pub struct LiveTranscriptionSession {
+    model: SoniqoModel,
+    stopped: bool,
+}
+
+impl LiveTranscriptionSession {
+    pub fn start(model: SoniqoModel) -> Result<Self> {
+        ensure_supported_platform(model)?;
+
+        if !model.supports_live() {
+            return Err(Error::Bridge(format!(
+                "{} does not support realtime transcription",
+                model.display_name()
+            )));
+        }
+
+        platform::live_start(model)?;
+        Ok(Self {
+            model,
+            stopped: false,
+        })
+    }
+
+    pub fn append(
+        &mut self,
+        source: TranscriptSource,
+        samples: &[f32],
+    ) -> Result<Vec<LivePartial>> {
+        platform::live_append(source, samples)
+    }
+
+    pub fn finalize(&mut self, source: TranscriptSource) -> Result<Vec<LivePartial>> {
+        platform::live_finalize(source)
+    }
+
+    pub fn model(&self) -> SoniqoModel {
+        self.model
+    }
+
+    pub fn stop(mut self) -> Result<()> {
+        self.stopped = true;
+        platform::live_stop()
+    }
+}
+
+impl Drop for LiveTranscriptionSession {
+    fn drop(&mut self) {
+        if !self.stopped {
+            let _ = platform::live_stop();
+        }
+    }
+}
+
+pub fn stream_response_from_text(
+    model: SoniqoModel,
+    text: String,
+    start: f64,
+    duration: f64,
+    is_final: bool,
+    channel_index: &[i32],
+) -> stream::StreamResponse {
+    let duration = duration.max(0.05);
+    let words = stream_words_from_text(&text, start, duration);
+
+    stream::StreamResponse::TranscriptResponse {
+        start,
+        duration,
+        is_final,
+        speech_final: is_final,
+        from_finalize: false,
+        channel: stream::Channel {
+            alternatives: vec![stream::Alternatives {
+                transcript: text,
+                words,
+                confidence: 1.0,
+                languages: vec![],
+            }],
+        },
+        metadata: metadata(model),
+        channel_index: channel_index.to_vec(),
+    }
+}
+
+pub fn batch_response_from_text(
+    model: SoniqoModel,
+    text: String,
+    duration_seconds: f64,
+) -> batch::Response {
+    let duration_seconds = duration_seconds.max(0.05);
+    let metadata = metadata_json(model, duration_seconds, 1);
+    let words = batch_words_from_text(&text, duration_seconds, 0);
+
+    batch::Response {
+        metadata,
+        results: batch::Results {
+            channels: vec![batch::Channel {
+                alternatives: vec![batch::Alternatives {
+                    transcript: text,
+                    confidence: 1.0,
+                    words,
+                }],
+            }],
+        },
+    }
+}
+
+fn metadata(model: SoniqoModel) -> stream::Metadata {
+    stream::Metadata {
+        model_info: stream::ModelInfo {
+            name: model.as_str().to_string(),
+            version: "0.0.9".to_string(),
+            arch: "soniqo".to_string(),
+        },
+        extra: Some(stream::Extra::default().into()),
+        ..Default::default()
+    }
+}
+
+fn metadata_json(model: SoniqoModel, duration_seconds: f64, channels: u32) -> serde_json::Value {
+    let mut value = serde_json::to_value(metadata(model)).unwrap_or_else(|_| serde_json::json!({}));
+    if let Some(object) = value.as_object_mut() {
+        object.insert("duration".to_string(), serde_json::json!(duration_seconds));
+        object.insert("channels".to_string(), serde_json::json!(channels));
+    }
+    value
+}
+
+fn stream_words_from_text(text: &str, start: f64, duration: f64) -> Vec<stream::Word> {
+    let word_strs = split_words(text);
+    let count = word_strs.len();
+
+    if count == 0 {
+        return Vec::new();
+    }
+
+    word_strs
+        .into_iter()
+        .enumerate()
+        .map(|(index, word)| {
+            let word_start = start + (index as f64 / count as f64) * duration;
+            let word_end = if index + 1 == count {
+                (start + duration - 0.05).max(word_start + 0.05)
+            } else {
+                start + ((index + 1) as f64 / count as f64) * duration
+            };
+
+            stream::Word {
+                word: word.to_string(),
+                start: word_start,
+                end: word_end,
+                confidence: 1.0,
+                speaker: None,
+                punctuated_word: Some(word.to_string()),
+                language: None,
+            }
+        })
+        .collect()
+}
+
+fn batch_words_from_text(text: &str, duration: f64, channel: i32) -> Vec<batch::Word> {
+    let word_strs = split_words(text);
+    let count = word_strs.len();
+
+    if count == 0 {
+        return Vec::new();
+    }
+
+    word_strs
+        .into_iter()
+        .enumerate()
+        .map(|(index, word)| batch::Word {
+            word: word.to_string(),
+            start: (index as f64 / count as f64) * duration,
+            end: ((index + 1) as f64 / count as f64) * duration,
+            confidence: 1.0,
+            channel,
+            speaker: None,
+            punctuated_word: Some(word.to_string()),
+        })
+        .collect()
+}
+
+fn split_words(text: &str) -> Vec<&str> {
+    text.split_whitespace()
+        .filter(|word| !word.is_empty())
+        .collect()
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use super::*;
+    use swift_rs::{Bool, SRData, SRString, swift};
+
+    swift!(fn _soniqo_model_cache_dir(model_id: &SRString) -> SRString);
+    swift!(fn _soniqo_model_download_state(model_id: &SRString) -> SRString);
+    swift!(fn _soniqo_model_start_download(model_id: &SRString) -> Bool);
+    swift!(fn _soniqo_model_reset(model_id: &SRString) -> Bool);
+    swift!(fn _soniqo_transcribe_audio_file(
+        model_id: &SRString,
+        audio_path: &SRString,
+        language: &SRString
+    ) -> SRString);
+    swift!(fn _soniqo_live_start(model_id: &SRString) -> SRString);
+    swift!(fn _soniqo_live_append(source: &SRString, samples: &SRData) -> SRString);
+    swift!(fn _soniqo_live_finalize(source: &SRString) -> SRString);
+    swift!(fn _soniqo_live_stop() -> SRString);
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct FileTranscriptionPayload {
+        text: String,
+        duration_seconds: f64,
+        error: Option<String>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct LiveAppendPayload {
+        partials: Vec<LivePartial>,
+        error: Option<String>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct StatusPayload {
+        running: bool,
+        error: Option<String>,
+    }
+
+    pub(super) fn model_cache_dir(model: SoniqoModel) -> Result<PathBuf> {
+        let model_id = sr_string(model.as_str());
+        let path = unsafe { _soniqo_model_cache_dir(&model_id) };
+        let path = path.as_str().to_string();
+
+        if path.is_empty() {
+            return Err(Error::Bridge(format!(
+                "cache path unavailable for {}",
+                model.as_str()
+            )));
+        }
+
+        Ok(PathBuf::from(path))
+    }
+
+    pub(super) fn model_download_state(model: SoniqoModel) -> Result<ModelDownloadState> {
+        let model_id = sr_string(model.as_str());
+        let payload = unsafe { _soniqo_model_download_state(&model_id) };
+        let state: ModelDownloadState = serde_json::from_str(payload.as_str())?;
+
+        Ok(state)
+    }
+
+    pub(super) fn start_model_download(model: SoniqoModel) -> Result<()> {
+        let model_id = sr_string(model.as_str());
+        if unsafe { _soniqo_model_start_download(&model_id) } {
+            Ok(())
+        } else {
+            Err(Error::Bridge(format!(
+                "failed to start Soniqo download for {}",
+                model.as_str()
+            )))
+        }
+    }
+
+    pub(super) fn reset_model(model: SoniqoModel) -> Result<()> {
+        let model_id = sr_string(model.as_str());
+        if unsafe { _soniqo_model_reset(&model_id) } {
+            Ok(())
+        } else {
+            Err(Error::Bridge(format!(
+                "failed to reset Soniqo model {}",
+                model.as_str()
+            )))
+        }
+    }
+
+    pub(super) fn transcribe_file(
+        model: SoniqoModel,
+        path: &Path,
+        language: &str,
+    ) -> Result<FileTranscript> {
+        let model_id = sr_string(model.as_str());
+        let audio_path = sr_string(&path.to_string_lossy());
+        let language = sr_string(language);
+        let payload = unsafe { _soniqo_transcribe_audio_file(&model_id, &audio_path, &language) };
+        let result: FileTranscriptionPayload = serde_json::from_str(payload.as_str())?;
+
+        if let Some(error) = result.error {
+            return Err(Error::Bridge(error));
+        }
+
+        Ok(FileTranscript {
+            text: result.text,
+            duration_seconds: result.duration_seconds,
+        })
+    }
+
+    pub(super) fn live_start(model: SoniqoModel) -> Result<()> {
+        let model_id = sr_string(model.as_str());
+        let payload = unsafe { _soniqo_live_start(&model_id) };
+        let result: StatusPayload = serde_json::from_str(payload.as_str())?;
+
+        if result.running {
+            Ok(())
+        } else {
+            Err(Error::Bridge(result.error.unwrap_or_else(|| {
+                "failed to start Soniqo live session".to_string()
+            })))
+        }
+    }
+
+    pub(super) fn live_append(
+        source: TranscriptSource,
+        samples: &[f32],
+    ) -> Result<Vec<LivePartial>> {
+        let source = sr_string(source.as_str());
+        let samples = floats_to_sr_data(samples);
+        let payload = unsafe { _soniqo_live_append(&source, &samples) };
+        let result: LiveAppendPayload = serde_json::from_str(payload.as_str())?;
+
+        if let Some(error) = result.error {
+            return Err(Error::Bridge(error));
+        }
+
+        Ok(result.partials)
+    }
+
+    pub(super) fn live_finalize(source: TranscriptSource) -> Result<Vec<LivePartial>> {
+        let source = sr_string(source.as_str());
+        let payload = unsafe { _soniqo_live_finalize(&source) };
+        let result: LiveAppendPayload = serde_json::from_str(payload.as_str())?;
+
+        if let Some(error) = result.error {
+            return Err(Error::Bridge(error));
+        }
+
+        Ok(result.partials)
+    }
+
+    pub(super) fn live_stop() -> Result<()> {
+        let payload = unsafe { _soniqo_live_stop() };
+        let result: StatusPayload = serde_json::from_str(payload.as_str())?;
+
+        if let Some(error) = result.error {
+            return Err(Error::Bridge(error));
+        }
+
+        Ok(())
+    }
+
+    fn sr_string(value: &str) -> SRString {
+        SRString::from(value)
+    }
+
+    fn floats_to_sr_data(samples: &[f32]) -> SRData {
+        let bytes = samples
+            .iter()
+            .flat_map(|sample| sample.to_bits().to_le_bytes())
+            .collect::<Vec<_>>();
+        SRData::from(bytes.as_slice())
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+mod platform {
+    use super::*;
+
+    pub(super) fn model_cache_dir(_model: SoniqoModel) -> Result<PathBuf> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn model_download_state(_model: SoniqoModel) -> Result<ModelDownloadState> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn start_model_download(_model: SoniqoModel) -> Result<()> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn reset_model(_model: SoniqoModel) -> Result<()> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn transcribe_file(
+        _model: SoniqoModel,
+        _path: &Path,
+        _language: &str,
+    ) -> Result<FileTranscript> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn live_start(_model: SoniqoModel) -> Result<()> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn live_append(
+        _source: TranscriptSource,
+        _samples: &[f32],
+    ) -> Result<Vec<LivePartial>> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn live_finalize(_source: TranscriptSource) -> Result<Vec<LivePartial>> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn live_stop() -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_model_ids() {
+        assert_eq!(
+            "soniqo-parakeet-streaming".parse::<SoniqoModel>().unwrap(),
+            SoniqoModel::ParakeetStreaming
+        );
+    }
+
+    #[test]
+    fn parakeet_models_support_documented_european_languages() {
+        let english = "en-US".parse().unwrap();
+        let french = "fr".parse().unwrap();
+
+        assert!(SoniqoModel::ParakeetStreaming.supports_language(&english));
+        assert!(SoniqoModel::ParakeetBatch.supports_language(&english));
+        assert!(SoniqoModel::ParakeetStreaming.supports_language(&french));
+        assert!(SoniqoModel::ParakeetBatch.supports_language(&french));
+    }
+
+    #[test]
+    fn parakeet_models_reject_unsupported_languages() {
+        let korean = "ko".parse().unwrap();
+
+        assert!(!SoniqoModel::ParakeetStreaming.supports_language(&korean));
+        assert!(!SoniqoModel::ParakeetBatch.supports_language(&korean));
+    }
+
+    #[test]
+    fn multilingual_models_support_non_english_languages() {
+        let french = "fr".parse().unwrap();
+
+        assert!(SoniqoModel::Omnilingual.supports_language(&french));
+        assert!(SoniqoModel::Qwen3Small.supports_language(&french));
+        assert!(SoniqoModel::Qwen3Large.supports_language(&french));
+    }
+
+    #[test]
+    fn live_support_is_gated_by_platform() {
+        assert_eq!(
+            SoniqoModel::ParakeetStreaming.supports_live_on_current_platform(),
+            cfg!(all(target_os = "macos", target_arch = "aarch64")),
+        );
+        assert!(!SoniqoModel::ParakeetBatch.supports_live_on_current_platform());
+    }
+
+    #[test]
+    fn batch_response_has_deepgram_shape() {
+        let response =
+            batch_response_from_text(SoniqoModel::ParakeetBatch, "hello world".to_string(), 2.0);
+
+        assert_eq!(
+            response.results.channels[0].alternatives[0].transcript,
+            "hello world"
+        );
+        assert_eq!(response.results.channels[0].alternatives[0].words.len(), 2);
+        assert_eq!(response.metadata["model_info"]["arch"], "soniqo");
+        assert_eq!(response.metadata["duration"], 2.0);
+    }
+
+    #[test]
+    fn live_response_keeps_source_channel() {
+        let partial = LivePartial {
+            source: "system".to_string(),
+            text: "hello".to_string(),
+            is_final: true,
+        };
+
+        let response = partial.into_stream_response(SoniqoModel::ParakeetStreaming, 0.0, 0.5);
+        let stream::StreamResponse::TranscriptResponse { channel_index, .. } = response else {
+            panic!("expected transcript response");
+        };
+
+        assert_eq!(channel_index, vec![1, 2]);
+    }
+}

--- a/crates/transcribe-soniqo/swift-lib/Package.resolved
+++ b/crates/transcribe-soniqo/swift-lib/Package.resolved
@@ -1,0 +1,328 @@
+{
+  "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
+    {
+      "identity" : "compress-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/adam-fowler/compress-nio.git",
+      "state" : {
+        "revision" : "e1caa19077dda4b00441142ef57da3db02acd466",
+        "version" : "1.4.2"
+      }
+    },
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "hummingbird",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hummingbird-project/hummingbird.git",
+      "state" : {
+        "revision" : "3ae359b1bb1e72378ed43b59fdcd4d44cac5d7a4",
+        "version" : "2.16.0"
+      }
+    },
+    {
+      "identity" : "hummingbird-websocket",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hummingbird-project/hummingbird-websocket.git",
+      "state" : {
+        "revision" : "716c54294152c6d3301a6239a1d74db57cbcd6dc",
+        "version" : "2.6.0"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
+      }
+    },
+    {
+      "identity" : "speech-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/soniqo/speech-swift",
+      "state" : {
+        "revision" : "03920e17671fc79d59da1573923958304e233c42",
+        "version" : "0.0.9"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
+        "version" : "2.3.5"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "d51c8d13fa366eec807eedb4e37daa60ff5bfdd5",
+        "version" : "2.10.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
+        "version" : "1.34.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
+        "version" : "1.43.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-rs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Brendonovich/swift-rs",
+      "state" : {
+        "revision" : "01980f981bc642a6da382cc0788f18fdd4cde6df"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "b38443e44d93eca770f2eb68e2a4d0fa100f9aa2",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-websocket",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hummingbird-project/swift-websocket.git",
+      "state" : {
+        "revision" : "ca48d46c25f8fa948d37eaa480c73172182cf90f",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/crates/transcribe-soniqo/swift-lib/src/lib.swift
+++ b/crates/transcribe-soniqo/swift-lib/src/lib.swift
@@ -1,0 +1,703 @@
+import AudioCommon
+import Foundation
+import OmnilingualASR
+import ParakeetASR
+import ParakeetStreamingASR
+import Qwen3ASR
+import SwiftRs
+
+private enum SoniqoBridgeError: LocalizedError {
+  case message(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .message(let message):
+      return message
+    }
+  }
+}
+
+private enum SpeechModelKind: String, CaseIterable {
+  case parakeetStreaming = "soniqo-parakeet-streaming"
+  case parakeetBatch = "soniqo-parakeet-batch"
+  case omnilingual = "soniqo-omnilingual"
+  case qwen3Small = "soniqo-qwen3-small"
+  case qwen3Large = "soniqo-qwen3-large"
+
+  static func resolve(_ identifier: String) -> Self? {
+    Self(rawValue: identifier) ?? Self.allCases.first(where: { $0.repo == identifier })
+  }
+
+  var label: String {
+    switch self {
+    case .parakeetStreaming:
+      return "Soniqo Parakeet Streaming"
+    case .parakeetBatch:
+      return "Soniqo Parakeet Batch"
+    case .omnilingual:
+      return "Soniqo Omnilingual"
+    case .qwen3Small:
+      return "Soniqo Qwen3 0.6B"
+    case .qwen3Large:
+      return "Soniqo Qwen3 1.7B"
+    }
+  }
+
+  var repo: String {
+    switch self {
+    case .parakeetStreaming:
+      return "aufklarer/Parakeet-EOU-120M-CoreML-INT8"
+    case .parakeetBatch:
+      return "aufklarer/Parakeet-TDT-v3-CoreML-INT8"
+    case .omnilingual:
+      return "aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s"
+    case .qwen3Small:
+      return "aufklarer/Qwen3-ASR-0.6B-MLX-4bit"
+    case .qwen3Large:
+      return "aufklarer/Qwen3-ASR-1.7B-MLX-8bit"
+    }
+  }
+
+  var isStreamingCapable: Bool {
+    self == .parakeetStreaming
+  }
+
+  func cacheDirectoryURL() throws -> URL {
+    try HuggingFaceDownloader.getCacheDirectory(for: repo)
+  }
+
+  func cacheDirectoryPath() -> String {
+    (try? cacheDirectoryURL().path) ?? ""
+  }
+
+  func filesReady() -> Bool {
+    guard let directory = try? cacheDirectoryURL() else {
+      return false
+    }
+
+    switch self {
+    case .parakeetStreaming, .parakeetBatch:
+      return Self.regularFileExists(at: directory.appendingPathComponent("config.json"))
+        && Self.regularFileExists(at: directory.appendingPathComponent("vocab.json"))
+        && Self.compiledCoreMLModelReady(at: directory.appendingPathComponent("encoder.mlmodelc"))
+        && Self.compiledCoreMLModelReady(at: directory.appendingPathComponent("decoder.mlmodelc"))
+        && Self.compiledCoreMLModelReady(at: directory.appendingPathComponent("joint.mlmodelc"))
+    case .omnilingual:
+      return Self.regularFileExists(at: directory.appendingPathComponent("config.json"))
+        && Self.regularFileExists(at: directory.appendingPathComponent("tokenizer.model"))
+        && Self.directoryContainsRegularFile(
+          at: directory.appendingPathComponent("omnilingual-ctc-300m-int8.mlpackage")
+        )
+    case .qwen3Small, .qwen3Large:
+      return Self.regularFileExists(at: directory.appendingPathComponent("vocab.json"))
+        && Self.regularFileExists(at: directory.appendingPathComponent("merges.txt"))
+        && Self.regularFileExists(at: directory.appendingPathComponent("tokenizer_config.json"))
+        && Self.directoryContainsFile(withExtension: "safetensors", in: directory)
+    }
+  }
+
+  func load(progressHandler: ((Double, String) -> Void)?) async throws -> LoadedSpeechModel {
+    let offlineMode = filesReady()
+
+    switch self {
+    case .parakeetStreaming:
+      return .streaming(
+        try await ParakeetStreamingASRModel.fromPretrained(
+          modelId: repo,
+          progressHandler: progressHandler
+        )
+      )
+    case .parakeetBatch:
+      return .parakeetBatch(
+        try await ParakeetASRModel.fromPretrained(
+          modelId: repo,
+          offlineMode: offlineMode,
+          progressHandler: progressHandler
+        )
+      )
+    case .omnilingual:
+      return .omnilingual(
+        try await OmnilingualASRModel.fromPretrained(
+          modelId: repo,
+          offlineMode: offlineMode,
+          progressHandler: progressHandler
+        )
+      )
+    case .qwen3Small, .qwen3Large:
+      return .qwen3(
+        try await Qwen3ASRModel.fromPretrained(
+          modelId: repo,
+          offlineMode: offlineMode,
+          progressHandler: progressHandler
+        )
+      )
+    }
+  }
+
+  private static func regularFileExists(at url: URL) -> Bool {
+    var isDirectory = ObjCBool(false)
+    return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+      && !isDirectory.boolValue
+  }
+
+  private static func compiledCoreMLModelReady(at directory: URL) -> Bool {
+    var isDirectory = ObjCBool(false)
+    guard FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+      isDirectory.boolValue
+    else {
+      return false
+    }
+
+    return regularFileExists(at: directory.appendingPathComponent("model.mil"))
+      && directoryContainsRegularFile(at: directory.appendingPathComponent("weights"))
+  }
+
+  private static func directoryContainsFile(withExtension pathExtension: String, in directory: URL)
+    -> Bool
+  {
+    guard
+      let contents = try? FileManager.default.contentsOfDirectory(
+        at: directory,
+        includingPropertiesForKeys: [.isRegularFileKey]
+      )
+    else {
+      return false
+    }
+
+    return contents.contains { candidate in
+      guard
+        candidate.pathExtension == pathExtension,
+        let values = try? candidate.resourceValues(forKeys: [.isRegularFileKey])
+      else {
+        return false
+      }
+
+      return values.isRegularFile == true
+    }
+  }
+
+  private static func directoryContainsRegularFile(at directory: URL) -> Bool {
+    guard
+      let enumerator = FileManager.default.enumerator(
+        at: directory,
+        includingPropertiesForKeys: [.isRegularFileKey],
+        options: [.skipsHiddenFiles]
+      )
+    else {
+      return false
+    }
+
+    for case let candidate as URL in enumerator {
+      guard let values = try? candidate.resourceValues(forKeys: [.isRegularFileKey]) else {
+        continue
+      }
+
+      if values.isRegularFile == true {
+        return true
+      }
+    }
+
+    return false
+  }
+}
+
+private enum LoadedSpeechModel {
+  case streaming(ParakeetStreamingASRModel)
+  case parakeetBatch(ParakeetASRModel)
+  case omnilingual(OmnilingualASRModel)
+  case qwen3(Qwen3ASRModel)
+
+  func asStreamingModel() throws -> ParakeetStreamingASRModel {
+    guard case .streaming(let model) = self else {
+      throw SoniqoBridgeError.message(
+        "The selected Soniqo model does not support realtime transcription.")
+    }
+
+    return model
+  }
+
+  func transcribe(audio: [Float], sampleRate: Int, language: String?) throws -> String {
+    let normalizedLanguage = language?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let languageHint = (normalizedLanguage?.isEmpty == false) ? normalizedLanguage : nil
+
+    switch self {
+    case .streaming(let model):
+      return try model.transcribeAudio(audio, sampleRate: sampleRate)
+    case .parakeetBatch(let model):
+      return try model.transcribeAudio(audio, sampleRate: sampleRate, language: languageHint)
+    case .omnilingual(let model):
+      return try model.transcribeAudio(audio, sampleRate: sampleRate)
+    case .qwen3(let model):
+      return model.transcribe(audio: audio, sampleRate: sampleRate, language: languageHint)
+    }
+  }
+}
+
+private enum TranscriptSource: String, Codable, CaseIterable {
+  case microphone
+  case system
+}
+
+private struct ModelDownloadPayload: Codable {
+  var status: String
+  var currentFile: String?
+  var progressPercent: Int?
+  var localPath: String
+  var error: String?
+}
+
+private struct FileTranscriptionPayload: Codable {
+  var text: String
+  var durationSeconds: Double
+  var error: String?
+}
+
+private struct LivePartialPayload: Codable {
+  var source: String
+  var text: String
+  var isFinal: Bool
+}
+
+private struct LiveAppendPayload: Codable {
+  var partials: [LivePartialPayload]
+  var error: String?
+}
+
+private struct StatusPayload: Codable {
+  var running: Bool
+  var error: String?
+}
+
+private func encodeJSON<T: Encodable>(_ value: T) -> String {
+  guard let data = try? JSONEncoder().encode(value),
+    let string = String(data: data, encoding: .utf8)
+  else {
+    return "{}"
+  }
+
+  return string
+}
+
+private func waitForValue<T>(_ operation: @escaping () async -> T) -> T {
+  let semaphore = DispatchSemaphore(value: 0)
+  var result: T!
+
+  Task {
+    result = await operation()
+    semaphore.signal()
+  }
+
+  semaphore.wait()
+  return result
+}
+
+private func decodeFloatSamples(from data: Data) throws -> [Float] {
+  let stride = MemoryLayout<Float>.size
+  guard data.count.isMultiple(of: stride) else {
+    throw SoniqoBridgeError.message("Invalid audio chunk received by Soniqo.")
+  }
+
+  let count = data.count / stride
+  var samples = [Float]()
+  samples.reserveCapacity(count)
+
+  data.withUnsafeBytes { bytes in
+    for index in 0..<count {
+      let bits = bytes.loadUnaligned(fromByteOffset: index * stride, as: UInt32.self)
+      samples.append(Float(bitPattern: UInt32(littleEndian: bits)))
+    }
+  }
+
+  return samples
+}
+
+private actor SoniqoBridge {
+  static let shared = SoniqoBridge()
+
+  private var loadedModels: [SpeechModelKind: LoadedSpeechModel] = [:]
+  private var modelTasks: [SpeechModelKind: Task<LoadedSpeechModel, Error>] = [:]
+  private var downloadStates: [SpeechModelKind: ModelDownloadPayload] = [:]
+  private var activeStreamingSessions: [TranscriptSource: StreamingSession] = [:]
+
+  func cacheDirectory(modelId: String) -> String {
+    guard let kind = SpeechModelKind.resolve(modelId) else {
+      return ""
+    }
+
+    refreshReadyState(for: kind)
+    return kind.cacheDirectoryPath()
+  }
+
+  func modelDownloadStateJSON(modelId: String) -> String {
+    guard let kind = SpeechModelKind.resolve(modelId) else {
+      return encodeJSON(
+        ModelDownloadPayload(
+          status: "error",
+          currentFile: nil,
+          progressPercent: nil,
+          localPath: "",
+          error: "Unsupported Soniqo model."
+        )
+      )
+    }
+
+    refreshReadyState(for: kind)
+    return encodeJSON(downloadState(for: kind))
+  }
+
+  func startModelDownload(modelId: String) {
+    guard let kind = SpeechModelKind.resolve(modelId) else {
+      return
+    }
+
+    refreshReadyState(for: kind)
+    if kind.filesReady(), modelTasks[kind] == nil {
+      var state = downloadState(for: kind)
+      state.status = "ready"
+      state.currentFile = nil
+      state.error = nil
+      downloadStates[kind] = state
+      return
+    }
+
+    if modelTasks[kind] != nil {
+      var state = downloadState(for: kind)
+      state.status = "downloading"
+      downloadStates[kind] = state
+      return
+    }
+
+    var state = downloadState(for: kind)
+    state.status = "downloading"
+    state.currentFile = "Preparing \(kind.label)..."
+    state.progressPercent = nil
+    state.error = nil
+    downloadStates[kind] = state
+
+    let task = Task.detached(priority: .utility) {
+      try await kind.load { fraction, status in
+        Task {
+          await SoniqoBridge.shared.updateDownloadProgress(
+            kind: kind,
+            fraction: fraction,
+            status: status
+          )
+        }
+      }
+    }
+
+    modelTasks[kind] = task
+
+    Task.detached {
+      do {
+        let model = try await task.value
+        await SoniqoBridge.shared.finishModelLoad(kind: kind, model: model)
+      } catch {
+        await SoniqoBridge.shared.finishModelLoad(kind: kind, error: error)
+      }
+    }
+  }
+
+  func resetModel(modelId: String) {
+    guard let kind = SpeechModelKind.resolve(modelId) else {
+      return
+    }
+
+    loadedModels[kind] = nil
+    modelTasks[kind] = nil
+    refreshReadyState(for: kind)
+
+    var state = downloadState(for: kind)
+    if state.status != "ready" {
+      state.status = "idle"
+    }
+    state.currentFile = nil
+    state.progressPercent = nil
+    state.error = nil
+    downloadStates[kind] = state
+  }
+
+  func startLiveJSON(modelId: String) async -> String {
+    do {
+      guard let kind = SpeechModelKind.resolve(modelId) else {
+        throw SoniqoBridgeError.message("Unsupported Soniqo model: \(modelId)")
+      }
+      guard kind.isStreamingCapable else {
+        throw SoniqoBridgeError.message("\(kind.label) does not support realtime transcription.")
+      }
+
+      let model = try await ensureModelLoaded(kind).asStreamingModel()
+      activeStreamingSessions = [
+        .microphone: try model.createSession(),
+        .system: try model.createSession(),
+      ]
+      return encodeJSON(StatusPayload(running: true, error: nil))
+    } catch {
+      activeStreamingSessions = [:]
+      return encodeJSON(StatusPayload(running: false, error: error.localizedDescription))
+    }
+  }
+
+  func stopLiveJSON() -> String {
+    activeStreamingSessions = [:]
+    return encodeJSON(StatusPayload(running: false, error: nil))
+  }
+
+  func appendLiveJSON(source: String, samplesData: Data) -> String {
+    do {
+      guard let transcriptSource = TranscriptSource(rawValue: source) else {
+        throw SoniqoBridgeError.message("Unsupported Soniqo transcript source: \(source)")
+      }
+      guard let session = activeStreamingSessions[transcriptSource] else {
+        throw SoniqoBridgeError.message("No active Soniqo transcription session.")
+      }
+
+      let samples = try decodeFloatSamples(from: samplesData)
+      let partials = try session.pushAudio(samples).map { partial in
+        LivePartialPayload(
+          source: transcriptSource.rawValue,
+          text: partial.text,
+          isFinal: partial.isFinal
+        )
+      }
+      return encodeJSON(LiveAppendPayload(partials: partials, error: nil))
+    } catch {
+      return encodeJSON(LiveAppendPayload(partials: [], error: error.localizedDescription))
+    }
+  }
+
+  func finalizeLiveJSON(source: String) -> String {
+    do {
+      guard let transcriptSource = TranscriptSource(rawValue: source) else {
+        throw SoniqoBridgeError.message("Unsupported Soniqo transcript source: \(source)")
+      }
+      guard let session = activeStreamingSessions[transcriptSource] else {
+        throw SoniqoBridgeError.message("No active Soniqo transcription session.")
+      }
+
+      let partials = try session.finalize().map { partial in
+        LivePartialPayload(
+          source: transcriptSource.rawValue,
+          text: partial.text,
+          isFinal: partial.isFinal
+        )
+      }
+      return encodeJSON(LiveAppendPayload(partials: partials, error: nil))
+    } catch {
+      return encodeJSON(LiveAppendPayload(partials: [], error: error.localizedDescription))
+    }
+  }
+
+  func transcribeAudioFileJSON(modelId: String, audioPath: String, language: String) async -> String
+  {
+    do {
+      guard let kind = SpeechModelKind.resolve(modelId) else {
+        throw SoniqoBridgeError.message("Unsupported Soniqo model: \(modelId)")
+      }
+
+      let trimmedLanguage = language.trimmingCharacters(in: .whitespacesAndNewlines)
+      let url = URL(fileURLWithPath: audioPath)
+      let audio = try AudioFileLoader.load(url: url, targetSampleRate: 16000)
+      let model = try await ensureModelLoaded(kind)
+      let text = try model.transcribe(
+        audio: audio,
+        sampleRate: 16000,
+        language: trimmedLanguage.isEmpty ? nil : trimmedLanguage
+      )
+
+      return encodeJSON(
+        FileTranscriptionPayload(
+          text: text,
+          durationSeconds: Double(audio.count) / 16000.0,
+          error: nil
+        )
+      )
+    } catch {
+      return encodeJSON(
+        FileTranscriptionPayload(
+          text: "",
+          durationSeconds: 0,
+          error: error.localizedDescription
+        )
+      )
+    }
+  }
+
+  private func ensureModelLoaded(_ kind: SpeechModelKind) async throws -> LoadedSpeechModel {
+    refreshReadyState(for: kind)
+
+    if let model = loadedModels[kind] {
+      return model
+    }
+
+    if let task = modelTasks[kind] {
+      let loaded = try await task.value
+      loadedModels[kind] = loaded
+      return loaded
+    }
+
+    let loaded = try await kind.load(progressHandler: nil)
+    loadedModels[kind] = loaded
+    refreshReadyState(for: kind)
+    return loaded
+  }
+
+  private func updateDownloadProgress(kind: SpeechModelKind, fraction: Double, status: String) {
+    var state = downloadState(for: kind)
+    state.status = "downloading"
+    state.localPath = kind.cacheDirectoryPath()
+    state.error = nil
+
+    let percent = Int(max(0.0, min(1.0, fraction)) * 100.0)
+    let statusText = status.trimmingCharacters(in: .whitespacesAndNewlines)
+    state.progressPercent = percent
+    state.currentFile = statusText.isEmpty ? "Preparing \(kind.label)..." : statusText
+    downloadStates[kind] = state
+  }
+
+  private func finishModelLoad(kind: SpeechModelKind, model: LoadedSpeechModel) {
+    loadedModels[kind] = model
+    modelTasks[kind] = nil
+
+    var state = downloadState(for: kind)
+    state.localPath = kind.cacheDirectoryPath()
+    state.status = "ready"
+    state.currentFile = nil
+    state.progressPercent = nil
+    state.error = nil
+    downloadStates[kind] = state
+  }
+
+  private func finishModelLoad(kind: SpeechModelKind, error: Error) {
+    modelTasks[kind] = nil
+
+    var state = downloadState(for: kind)
+    state.localPath = kind.cacheDirectoryPath()
+    state.status = "error"
+    state.currentFile = nil
+    state.progressPercent = nil
+    state.error = error.localizedDescription
+    downloadStates[kind] = state
+  }
+
+  private func refreshReadyState(for kind: SpeechModelKind) {
+    var state = downloadState(for: kind)
+    state.localPath = kind.cacheDirectoryPath()
+
+    guard modelTasks[kind] == nil else {
+      downloadStates[kind] = state
+      return
+    }
+
+    if kind.filesReady() {
+      state.status = "ready"
+      state.error = nil
+      state.currentFile = nil
+      state.progressPercent = nil
+    } else if state.status == "ready" {
+      state.status = "idle"
+      state.currentFile = nil
+      state.progressPercent = nil
+      state.error = nil
+      loadedModels[kind] = nil
+    } else if state.localPath.isEmpty {
+      state.status = "idle"
+    }
+
+    downloadStates[kind] = state
+  }
+
+  private func downloadState(for kind: SpeechModelKind) -> ModelDownloadPayload {
+    if let state = downloadStates[kind] {
+      return state
+    }
+
+    return ModelDownloadPayload(
+      status: "idle",
+      currentFile: nil,
+      progressPercent: nil,
+      localPath: kind.cacheDirectoryPath(),
+      error: nil
+    )
+  }
+}
+
+@_cdecl("_soniqo_model_cache_dir")
+public func _soniqo_model_cache_dir(modelId: SRString) -> SRString {
+  SRString(
+    waitForValue {
+      await SoniqoBridge.shared.cacheDirectory(modelId: modelId.toString())
+    })
+}
+
+@_cdecl("_soniqo_model_download_state")
+public func _soniqo_model_download_state(modelId: SRString) -> SRString {
+  SRString(
+    waitForValue {
+      await SoniqoBridge.shared.modelDownloadStateJSON(modelId: modelId.toString())
+    })
+}
+
+@_cdecl("_soniqo_model_start_download")
+public func _soniqo_model_start_download(modelId: SRString) -> Bool {
+  waitForValue {
+    await SoniqoBridge.shared.startModelDownload(modelId: modelId.toString())
+    return true
+  }
+}
+
+@_cdecl("_soniqo_model_reset")
+public func _soniqo_model_reset(modelId: SRString) -> Bool {
+  waitForValue {
+    await SoniqoBridge.shared.resetModel(modelId: modelId.toString())
+    return true
+  }
+}
+
+@_cdecl("_soniqo_transcribe_audio_file")
+public func _soniqo_transcribe_audio_file(
+  modelId: SRString,
+  audioPath: SRString,
+  language: SRString
+) -> SRString {
+  SRString(
+    waitForValue {
+      await SoniqoBridge.shared.transcribeAudioFileJSON(
+        modelId: modelId.toString(),
+        audioPath: audioPath.toString(),
+        language: language.toString()
+      )
+    })
+}
+
+@_cdecl("_soniqo_live_start")
+public func _soniqo_live_start(modelId: SRString) -> SRString {
+  SRString(
+    waitForValue {
+      await SoniqoBridge.shared.startLiveJSON(modelId: modelId.toString())
+    })
+}
+
+@_cdecl("_soniqo_live_append")
+public func _soniqo_live_append(source: SRString, samples: SRData) -> SRString {
+  SRString(
+    waitForValue {
+      await SoniqoBridge.shared.appendLiveJSON(
+        source: source.toString(),
+        samplesData: Data(samples.toArray())
+      )
+    })
+}
+
+@_cdecl("_soniqo_live_finalize")
+public func _soniqo_live_finalize(source: SRString) -> SRString {
+  SRString(
+    waitForValue {
+      await SoniqoBridge.shared.finalizeLiveJSON(source: source.toString())
+    })
+}
+
+@_cdecl("_soniqo_live_stop")
+public func _soniqo_live_stop() -> SRString {
+  SRString(waitForValue { await SoniqoBridge.shared.stopLiveJSON() })
+}

--- a/crates/transcript/src/channel_state.rs
+++ b/crates/transcript/src/channel_state.rs
@@ -18,12 +18,14 @@ impl ChannelState {
 
     /// Process a confirmed final batch.
     ///
-    /// Partials that end before this batch starts are promoted to final.
+    /// When partial finalization is enabled, partials that end before this
+    /// batch starts are promoted to final.
     /// Partials overlapping the final range are dropped.
     pub(super) fn apply_final(
         &mut self,
         words: Vec<RawWord>,
         state: WordState,
+        finalize_partials: bool,
     ) -> Vec<FinalizedWord> {
         let new_words = dedup(words, self.watermark);
         if new_words.is_empty() {
@@ -33,9 +35,12 @@ impl ChannelState {
         let final_start = new_words.first().map_or(0, |w| w.start_ms);
         let final_end = new_words.last().map_or(0, |w| w.end_ms);
 
-        let (pre_final, rest): (Vec<_>, Vec<_>) = std::mem::take(&mut self.partials)
-            .into_iter()
-            .partition(|w| w.end_ms <= final_start);
+        let partials = std::mem::take(&mut self.partials);
+        let (pre_final, rest): (Vec<_>, Vec<_>) = if finalize_partials {
+            partials.into_iter().partition(|w| w.end_ms <= final_start)
+        } else {
+            (Vec::new(), partials)
+        };
 
         self.partials = rest
             .into_iter()
@@ -82,6 +87,12 @@ impl ChannelState {
     pub(super) fn drain(&mut self) -> Vec<FinalizedWord> {
         let mut raw: Vec<RawWord> = self.held.take().into_iter().collect();
         raw.extend(std::mem::take(&mut self.partials));
+        finalize_words(raw, WordState::Final)
+    }
+
+    pub(super) fn drain_final_words(&mut self) -> Vec<FinalizedWord> {
+        let raw: Vec<RawWord> = self.held.take().into_iter().collect();
+        self.partials.clear();
         finalize_words(raw, WordState::Final)
     }
 

--- a/crates/transcript/src/processor.rs
+++ b/crates/transcript/src/processor.rs
@@ -33,6 +33,7 @@ pub struct TranscriptProcessor {
     channels: BTreeMap<i32, ChannelState>,
     pending_corrections: HashMap<u64, Vec<String>>,
     next_job_id: u64,
+    finalize_partials: bool,
 }
 
 struct ParsedStreamResponse<'a> {
@@ -60,7 +61,15 @@ impl TranscriptProcessor {
             channels: BTreeMap::new(),
             pending_corrections: HashMap::new(),
             next_job_id: 1,
+            finalize_partials: true,
         }
+    }
+
+    /// Disable this for providers whose partials are UI snapshots rather than
+    /// commit-worthy transcript words.
+    pub fn with_partial_finalization(mut self, finalize_partials: bool) -> Self {
+        self.finalize_partials = finalize_partials;
+        self
     }
 
     pub fn process(&mut self, response: &StreamResponse) -> Option<TranscriptDelta> {
@@ -82,7 +91,8 @@ impl TranscriptProcessor {
                 WordState::Final
             };
 
-            let new_words = channel_state.apply_final(raw_words, word_state);
+            let new_words =
+                channel_state.apply_final(raw_words, word_state, self.finalize_partials);
 
             let replaced_ids = if parsed.correction.is_corrected_job() {
                 self.resolve_job(parsed.correction.cloud_job_id)
@@ -147,7 +157,11 @@ impl TranscriptProcessor {
         let mut new_words = vec![];
 
         for state in self.channels.values_mut() {
-            new_words.extend(state.drain());
+            if self.finalize_partials {
+                new_words.extend(state.drain());
+            } else {
+                new_words.extend(state.drain_final_words());
+            }
         }
 
         self.channels.clear();
@@ -341,5 +355,43 @@ mod tests {
         assert_eq!(snapshot.partials[0].speaker_index, Some(4));
         assert_eq!(snapshot.partials[1].speaker_index, None);
         assert_eq!(snapshot.partials[2].speaker_index, Some(7));
+    }
+
+    #[test]
+    fn flush_can_discard_partials_without_losing_held_finals() {
+        let mut processor = TranscriptProcessor::new().with_partial_finalization(false);
+        let channel = processor
+            .channels
+            .entry(0)
+            .or_insert_with(ChannelState::new);
+
+        channel.apply_partial(vec![RawWord {
+            text: " repeated".to_string(),
+            start_ms: 0,
+            end_ms: 100,
+            channel: 0,
+            speaker: None,
+        }]);
+        channel.apply_final(
+            vec![RawWord {
+                text: " final".to_string(),
+                start_ms: 1_000,
+                end_ms: 1_100,
+                channel: 0,
+                speaker: None,
+            }],
+            WordState::Final,
+            false,
+        );
+
+        let delta = processor.flush();
+        let text = delta
+            .new_words
+            .iter()
+            .map(|word| word.text.as_str())
+            .collect::<String>();
+
+        assert_eq!(text, " final");
+        assert!(delta.partials.is_empty());
     }
 }


### PR DESCRIPTION
Retimes cumulative Soniqo realtime partials so live transcript rows replace previous text instead of appending duplicates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core live transcript processing (normalization, partial finalization, and flush semantics) and introduces a new local Swift/Rust bridge, so regressions could affect realtime transcript rendering across providers if assumptions change.
> 
> **Overview**
> Adds a new `hypr_transcribe_soniqo` crate (with a macOS Swift bridge) to support local Soniqo model download/status management, file transcription, and live streaming partials.
> 
> Updates `LiveTranscriptEngine` to apply provider-specific normalization for `soniqo`, including retiming cumulative partial updates, trimming overlapping/repeated tokens (including internal looping), and suppressing committing Soniqo partial snapshots into final words.
> 
> Extends `TranscriptProcessor`/`ChannelState` with a configurable *partial finalization* mode and adjusts `flush()` behavior so providers like Soniqo can discard partial buffers while still emitting held final words; adds targeted tests for the new Soniqo normalization and flush behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a89a6eaa40fbef37e9b3d809fb271625ca87ceff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->