### PR TITLE
chore(web): add changelog pages to footer

### DIFF
--- a/apps/desktop/src/changelog/index.tsx
+++ b/apps/desktop/src/changelog/index.tsx
@@ -154,7 +154,7 @@ function ChangelogHeader({
   date: string | null;
 }) {
   const formattedDate = date ? safeFormat(date, "MMM d, yyyy") : null;
-  const webUrl = `https://char.com/changelog/${version}`;
+  const webUrl = `https://anarlog.so/changelog/${version}`;
 
   return (
     <div className="w-full pt-1">

--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -14,6 +14,9 @@ export function SiteFooter() {
         <Link to="/blog/" className="hover:text-[#181613]">
           Blog
         </Link>
+        <Link to="/changelog/" className="hover:text-[#181613]">
+          Changelog
+        </Link>
         <a href="mailto:founders@fastrepl.com" className="hover:text-[#181613]">
           Contact
         </a>

--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -1,0 +1,60 @@
+import { processContent } from "@hypr/changelog";
+
+const rawEntries = import.meta.glob(
+  "../../../../packages/changelog/content/*.md",
+  {
+    eager: true,
+    import: "default",
+    query: "?raw",
+  },
+) as Record<string, string>;
+
+export const changelogEntries = Object.entries(rawEntries)
+  .map(([filePath, raw]) => {
+    const version = filePath.split("/").pop()?.replace(/\.md$/, "") ?? "";
+    const { content, date } = processContent(raw);
+
+    return {
+      version,
+      content,
+      date: normalizeDate(date),
+    };
+  })
+  .filter((entry) => entry.version)
+  .sort((a, b) => compareVersionsDesc(a.version, b.version));
+
+export function getChangelogEntry(version: string) {
+  return changelogEntries.find((entry) => entry.version === version);
+}
+
+function normalizeDate(date: string | null) {
+  return date?.replace(/^["']|["']$/g, "") ?? null;
+}
+
+function compareVersionsDesc(a: string, b: string) {
+  const left = a.split(".").map(Number);
+  const right = b.split(".").map(Number);
+  const length = Math.max(left.length, right.length);
+
+  for (let i = 0; i < length; i++) {
+    const diff = (right[i] ?? 0) - (left[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+
+  return b.localeCompare(a);
+}
+
+export function formatChangelogDate(date: string) {
+  const parsed = new Date(`${date}T00:00:00Z`);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return date;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(parsed);
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -15,8 +15,10 @@ import { Route as FoundersRouteImport } from './routes/founders'
 import { Route as AuthRouteImport } from './routes/auth'
 import { Route as ViewRouteRouteImport } from './routes/_view/route'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ChangelogIndexRouteImport } from './routes/changelog/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
 import { Route as LegalSlugRouteImport } from './routes/legal/$slug'
+import { Route as ChangelogVersionRouteImport } from './routes/changelog/$version'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as ApiTemplatesRouteImport } from './routes/api/templates'
 import { Route as ApiShortcutsRouteImport } from './routes/api/shortcuts'
@@ -103,6 +105,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ChangelogIndexRoute = ChangelogIndexRouteImport.update({
+  id: '/changelog/',
+  path: '/changelog/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BlogIndexRoute = BlogIndexRouteImport.update({
   id: '/blog/',
   path: '/blog/',
@@ -111,6 +118,11 @@ const BlogIndexRoute = BlogIndexRouteImport.update({
 const LegalSlugRoute = LegalSlugRouteImport.update({
   id: '/legal/$slug',
   path: '/legal/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ChangelogVersionRoute = ChangelogVersionRouteImport.update({
+  id: '/changelog/$version',
+  path: '/changelog/$version',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BlogSlugRoute = BlogSlugRouteImport.update({
@@ -415,8 +427,10 @@ export interface FileRoutesByFullPath {
   '/api/shortcuts': typeof ApiShortcutsRoute
   '/api/templates': typeof ApiTemplatesRoute
   '/blog/$slug': typeof BlogSlugRoute
+  '/changelog/$version': typeof ChangelogVersionRoute
   '/legal/$slug': typeof LegalSlugRoute
   '/blog/': typeof BlogIndexRoute
+  '/changelog/': typeof ChangelogIndexRoute
   '/app/account': typeof ViewAppAccountRoute
   '/app/checkout': typeof ViewAppCheckoutRoute
   '/app/integration': typeof ViewAppIntegrationRoute
@@ -479,8 +493,10 @@ export interface FileRoutesByTo {
   '/api/shortcuts': typeof ApiShortcutsRoute
   '/api/templates': typeof ApiTemplatesRoute
   '/blog/$slug': typeof BlogSlugRoute
+  '/changelog/$version': typeof ChangelogVersionRoute
   '/legal/$slug': typeof LegalSlugRoute
   '/blog': typeof BlogIndexRoute
+  '/changelog': typeof ChangelogIndexRoute
   '/app/account': typeof ViewAppAccountRoute
   '/app/checkout': typeof ViewAppCheckoutRoute
   '/app/integration': typeof ViewAppIntegrationRoute
@@ -546,8 +562,10 @@ export interface FileRoutesById {
   '/api/shortcuts': typeof ApiShortcutsRoute
   '/api/templates': typeof ApiTemplatesRoute
   '/blog/$slug': typeof BlogSlugRoute
+  '/changelog/$version': typeof ChangelogVersionRoute
   '/legal/$slug': typeof LegalSlugRoute
   '/blog/': typeof BlogIndexRoute
+  '/changelog/': typeof ChangelogIndexRoute
   '/_view/app/account': typeof ViewAppAccountRoute
   '/_view/app/checkout': typeof ViewAppCheckoutRoute
   '/_view/app/integration': typeof ViewAppIntegrationRoute
@@ -613,8 +631,10 @@ export interface FileRouteTypes {
     | '/api/shortcuts'
     | '/api/templates'
     | '/blog/$slug'
+    | '/changelog/$version'
     | '/legal/$slug'
     | '/blog/'
+    | '/changelog/'
     | '/app/account'
     | '/app/checkout'
     | '/app/integration'
@@ -677,8 +697,10 @@ export interface FileRouteTypes {
     | '/api/shortcuts'
     | '/api/templates'
     | '/blog/$slug'
+    | '/changelog/$version'
     | '/legal/$slug'
     | '/blog'
+    | '/changelog'
     | '/app/account'
     | '/app/checkout'
     | '/app/integration'
@@ -743,8 +765,10 @@ export interface FileRouteTypes {
     | '/api/shortcuts'
     | '/api/templates'
     | '/blog/$slug'
+    | '/changelog/$version'
     | '/legal/$slug'
     | '/blog/'
+    | '/changelog/'
     | '/_view/app/account'
     | '/_view/app/checkout'
     | '/_view/app/integration'
@@ -808,8 +832,10 @@ export interface RootRouteChildren {
   ApiShortcutsRoute: typeof ApiShortcutsRoute
   ApiTemplatesRoute: typeof ApiTemplatesRoute
   BlogSlugRoute: typeof BlogSlugRoute
+  ChangelogVersionRoute: typeof ChangelogVersionRoute
   LegalSlugRoute: typeof LegalSlugRoute
   BlogIndexRoute: typeof BlogIndexRoute
+  ChangelogIndexRoute: typeof ChangelogIndexRoute
   ApiAssetsSplatRoute: typeof ApiAssetsSplatRoute
   ApiTweetIdRoute: typeof ApiTweetIdRoute
   ApiWebhooksSlackInteractiveRoute: typeof ApiWebhooksSlackInteractiveRoute
@@ -890,6 +916,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/changelog/': {
+      id: '/changelog/'
+      path: '/changelog'
+      fullPath: '/changelog/'
+      preLoaderRoute: typeof ChangelogIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/blog/': {
       id: '/blog/'
       path: '/blog'
@@ -902,6 +935,13 @@ declare module '@tanstack/react-router' {
       path: '/legal/$slug'
       fullPath: '/legal/$slug'
       preLoaderRoute: typeof LegalSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/changelog/$version': {
+      id: '/changelog/$version'
+      path: '/changelog/$version'
+      fullPath: '/changelog/$version'
+      preLoaderRoute: typeof ChangelogVersionRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/blog/$slug': {
@@ -1366,8 +1406,10 @@ const rootRouteChildren: RootRouteChildren = {
   ApiShortcutsRoute: ApiShortcutsRoute,
   ApiTemplatesRoute: ApiTemplatesRoute,
   BlogSlugRoute: BlogSlugRoute,
+  ChangelogVersionRoute: ChangelogVersionRoute,
   LegalSlugRoute: LegalSlugRoute,
   BlogIndexRoute: BlogIndexRoute,
+  ChangelogIndexRoute: ChangelogIndexRoute,
   ApiAssetsSplatRoute: ApiAssetsSplatRoute,
   ApiTweetIdRoute: ApiTweetIdRoute,
   ApiWebhooksSlackInteractiveRoute: ApiWebhooksSlackInteractiveRoute,

--- a/apps/web/src/routes/changelog/$version.tsx
+++ b/apps/web/src/routes/changelog/$version.tsx
@@ -1,0 +1,89 @@
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+
+import { ChangelogContent } from "@hypr/changelog";
+
+import { SiteFooter } from "@/components/site-footer";
+import { formatChangelogDate, getChangelogEntry } from "@/lib/changelog";
+import { ANARLOG_SITE_URL } from "@/lib/seo";
+
+export const Route = createFileRoute("/changelog/$version")({
+  component: Component,
+  loader: async ({ params }) => {
+    const entry = getChangelogEntry(params.version);
+    if (!entry) {
+      throw notFound();
+    }
+    return { entry };
+  },
+  head: ({ loaderData }) => {
+    const entry = loaderData?.entry;
+    if (!entry) return {};
+
+    const url = `${ANARLOG_SITE_URL}/changelog/${entry.version}`;
+    return {
+      links: [{ rel: "canonical", href: url }],
+      meta: [
+        { title: `Anarlog v${entry.version} Changelog` },
+        {
+          name: "description",
+          content: `Release notes for Anarlog v${entry.version}.`,
+        },
+        {
+          property: "og:title",
+          content: `Anarlog v${entry.version} Changelog`,
+        },
+        {
+          property: "og:description",
+          content: `Release notes for Anarlog v${entry.version}.`,
+        },
+        { property: "og:url", content: url },
+      ],
+    };
+  },
+});
+
+function Component() {
+  const { entry } = Route.useLoaderData();
+
+  return (
+    <main className="min-h-screen bg-white text-[#181613]">
+      <div className="mx-auto w-full max-w-[700px] px-5 py-8 md:px-8 md:py-12">
+        <header className="flex items-center justify-between gap-6">
+          <Link to="/" aria-label="Anarlog home">
+            <img src="/logo.svg" alt="Anarlog" className="h-9 w-auto" />
+          </Link>
+        </header>
+
+        <Link
+          to="/changelog/"
+          className="mt-16 inline-block text-sm text-[#756b5d] hover:text-[#181613]"
+        >
+          ← Changelog
+        </Link>
+
+        <header className="pt-10 pb-12">
+          <h1 className="font-hand text-5xl leading-[1.02] font-semibold tracking-normal text-balance text-black md:text-7xl">
+            v{entry.version}
+          </h1>
+          {entry.date && (
+            <time
+              dateTime={entry.date}
+              className="mt-6 block text-sm text-[#756b5d]"
+            >
+              {formatChangelogDate(entry.date)}
+            </time>
+          )}
+        </header>
+
+        <article className="border-t border-[#eee8df] pt-8">
+          <ChangelogContent
+            content={entry.content}
+            className="text-sm leading-7"
+          />
+        </article>
+      </div>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/apps/web/src/routes/changelog/index.tsx
+++ b/apps/web/src/routes/changelog/index.tsx
@@ -1,0 +1,106 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+import { SiteFooter } from "@/components/site-footer";
+import { changelogEntries, formatChangelogDate } from "@/lib/changelog";
+import { ANARLOG_SITE_URL } from "@/lib/seo";
+
+export const Route = createFileRoute("/changelog/")({
+  component: Component,
+  head: () => ({
+    links: [{ rel: "canonical", href: `${ANARLOG_SITE_URL}/changelog` }],
+    meta: [
+      { title: "Anarlog Changelog" },
+      {
+        name: "description",
+        content:
+          "See the latest Anarlog desktop app updates, fixes, and product changes.",
+      },
+      { property: "og:title", content: "Anarlog Changelog" },
+      { property: "og:url", content: `${ANARLOG_SITE_URL}/changelog` },
+    ],
+  }),
+});
+
+function Component() {
+  return (
+    <main className="min-h-screen bg-white text-[#181613]">
+      <div className="mx-auto w-full max-w-[700px] px-5 py-8 md:px-8 md:py-12">
+        <header className="flex items-center justify-between gap-6">
+          <Link to="/" aria-label="Anarlog home">
+            <img src="/logo.svg" alt="Anarlog" className="h-9 w-auto" />
+          </Link>
+        </header>
+
+        <section className="pt-24 pb-16 md:pt-32">
+          <h1 className="font-hand text-6xl leading-[0.98] font-semibold tracking-normal text-balance text-black md:text-8xl">
+            Changelog
+          </h1>
+          <p className="mt-6 max-w-2xl text-xl leading-9 text-[#363029]">
+            Product updates, fixes, and release notes for Anarlog.
+          </p>
+        </section>
+
+        {changelogEntries.length > 0 ? (
+          <ol className="grid gap-12">
+            {changelogEntries.map((entry) => (
+              <li
+                key={entry.version}
+                id={entry.version}
+                className="scroll-mt-8 border-t border-[#eee8df] pt-8"
+              >
+                <article className="grid gap-4">
+                  <header className="flex flex-wrap items-baseline justify-between gap-x-5 gap-y-2">
+                    <Link
+                      to="/changelog/$version/"
+                      params={{ version: entry.version }}
+                      className="group"
+                    >
+                      <h2 className="font-hand text-4xl leading-none font-semibold tracking-normal text-[#756b5d] group-hover:text-[#4f4940]">
+                        v{entry.version}
+                      </h2>
+                    </Link>
+                    {entry.date && (
+                      <time
+                        dateTime={entry.date}
+                        className="text-sm text-[#756b5d]"
+                      >
+                        {formatChangelogDate(entry.date)}
+                      </time>
+                    )}
+                  </header>
+                  <p className="leading-7 text-[#4f4940]">
+                    {getEntrySummary(entry.content)}
+                  </p>
+                  <Link
+                    to="/changelog/$version/"
+                    params={{ version: entry.version }}
+                    className="text-sm font-medium text-[#756b5d] hover:text-[#181613]"
+                  >
+                    Read release notes
+                  </Link>
+                </article>
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <p className="border-t border-[#eee8df] pt-8 text-[#4f4940]">
+            No changelog entries yet.
+          </p>
+        )}
+      </div>
+
+      <SiteFooter />
+    </main>
+  );
+}
+
+function getEntrySummary(content: string) {
+  return (
+    content
+      .split("\n")
+      .map((line) => line.trim())
+      .find(
+        (line) => line && !line.startsWith("#") && !line.startsWith("!["),
+      ) ?? "See what changed in this release."
+  );
+}

--- a/apps/web/src/utils/sitemap.ts
+++ b/apps/web/src/utils/sitemap.ts
@@ -18,8 +18,21 @@ function getArticleSlugs(): string[] {
   }
 }
 
+function getChangelogVersions(): string[] {
+  const dir = path.resolve(process.cwd(), "../../packages/changelog/content");
+  try {
+    return fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith(".md"))
+      .map((f) => f.replace(/\.md$/, ""));
+  } catch {
+    return [];
+  }
+}
+
 export function getSitemap(): Sitemap<TRoutes> {
   const slugs = getArticleSlugs();
+  const changelogVersions = getChangelogVersions();
 
   return {
     siteUrl: "https://anarlog.so",
@@ -34,6 +47,15 @@ export function getSitemap(): Sitemap<TRoutes> {
         priority: 0.8,
         changeFrequency: "weekly",
       },
+      "/changelog/": {
+        priority: 0.7,
+        changeFrequency: "weekly",
+      },
+      "/changelog/$version": changelogVersions.map((version) => ({
+        path: `/changelog/${version}`,
+        priority: 0.5,
+        changeFrequency: "monthly" as const,
+      })),
       "/blog/$slug": slugs.map((slug) => ({
         path: `/blog/${slug}`,
         priority: 0.6,


### PR DESCRIPTION
Add a website changelog index and individual release pages backed by existing changelog markdown. Update sitemap entries and desktop external changelog links to the Anarlog domain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new public, read-only changelog routes and link updates, with no auth or data mutations. Main risk is broken routing/build if markdown glob/import paths or version parsing are incorrect.
> 
> **Overview**
> Adds **public changelog pages** on the web app: a `/changelog/` index listing releases and a `/changelog/$version` detail page rendering the markdown release notes with canonical/OG metadata.
> 
> Introduces `apps/web/src/lib/changelog.ts` to load and sort entries from `packages/changelog/content/*.md`, format dates, and fetch a specific version; updates the footer to link to the changelog and extends sitemap generation to include `/changelog/` plus per-version URLs.
> 
> Updates the desktop changelog’s “Open in web” link to point at `https://anarlog.so/changelog/{version}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42af48868b4f6471b39a8f58b91f81ed4cb71e23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->