### PR TITLE
fix(audio): clean up retained recordings

### DIFF
--- a/apps/desktop/src/services/audio-retention.test.ts
+++ b/apps/desktop/src/services/audio-retention.test.ts
@@ -1,11 +1,63 @@
-import { describe, expect, test } from "vitest";
+import { createMergeableStore } from "tinybase/with-schemas";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { SCHEMA as MAIN_SCHEMA } from "@hypr/store";
 
 import {
+  cleanupExpiredAudio,
   normalizeAudioRetention,
   sessionAudioExpired,
 } from "./audio-retention";
 
+import type * as main from "~/store/tinybase/store/main";
+import { SCHEMA as SETTINGS_SCHEMA } from "~/store/tinybase/store/settings";
+import type * as settings from "~/store/tinybase/store/settings";
+
+const { audioDeleteMock, audioDeleteOrphanedExpiredMock, getSessionModeMock } =
+  vi.hoisted(() => ({
+    audioDeleteMock: vi.fn(),
+    audioDeleteOrphanedExpiredMock: vi.fn(),
+    getSessionModeMock: vi.fn(),
+  }));
+
+vi.mock("@hypr/plugin-fs-sync", () => ({
+  commands: {
+    audioDelete: audioDeleteMock,
+    audioDeleteOrphanedExpired: audioDeleteOrphanedExpiredMock,
+  },
+}));
+
+vi.mock("~/store/zustand/listener/instance", () => ({
+  listenerStore: {
+    getState: () => ({
+      getSessionMode: getSessionModeMock,
+    }),
+  },
+}));
+
+function createMainStore() {
+  return createMergeableStore()
+    .setTablesSchema(MAIN_SCHEMA.table)
+    .setValuesSchema(MAIN_SCHEMA.value) as main.Store;
+}
+
+function createSettingsStore() {
+  return createMergeableStore()
+    .setTablesSchema(SETTINGS_SCHEMA.table)
+    .setValuesSchema(SETTINGS_SCHEMA.value) as settings.Store;
+}
+
 describe("audio retention", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    audioDeleteMock.mockResolvedValue({ status: "ok", data: null });
+    audioDeleteOrphanedExpiredMock.mockResolvedValue({
+      status: "ok",
+      data: [],
+    });
+    getSessionModeMock.mockReturnValue("inactive");
+  });
+
   test("normalizes current and legacy values", () => {
     expect(normalizeAudioRetention("none")).toBe("none");
     expect(normalizeAudioRetention("oneWeek")).toBe("oneWeek");
@@ -28,10 +80,73 @@ describe("audio retention", () => {
     expect(sessionAudioExpired("2026-05-12T00:00:00.001Z", "oneDay", now)).toBe(
       false,
     );
+    expect(
+      sessionAudioExpired("2026-05-09T23:59:59.999Z", "threeDays", now),
+    ).toBe(true);
+    expect(
+      sessionAudioExpired("2026-05-10T00:00:00.001Z", "threeDays", now),
+    ).toBe(false);
+    expect(
+      sessionAudioExpired("2026-05-05T23:59:59.999Z", "oneWeek", now),
+    ).toBe(true);
+    expect(
+      sessionAudioExpired("2026-05-06T00:00:00.001Z", "oneWeek", now),
+    ).toBe(false);
+    expect(
+      sessionAudioExpired("2026-04-12T23:59:59.999Z", "oneMonth", now),
+    ).toBe(true);
+    expect(
+      sessionAudioExpired("2026-04-13T00:00:00.001Z", "oneMonth", now),
+    ).toBe(false);
   });
 
   test("does not expire sessions with invalid creation dates", () => {
     expect(sessionAudioExpired(null, "oneDay")).toBe(false);
     expect(sessionAudioExpired("not-a-date", "oneDay")).toBe(false);
+  });
+
+  test("deletes expired inactive audio and orphaned expired audio", async () => {
+    const now = Date.parse("2026-05-13T00:00:00.000Z");
+    const store = createMainStore();
+    const settingsStore = createSettingsStore();
+
+    settingsStore.setValue("audio_retention", "oneDay");
+    store.setRow("sessions", "expired", {
+      user_id: "user",
+      created_at: "2026-05-11T23:59:59.999Z",
+      title: "",
+      raw_md: "",
+    });
+    store.setRow("sessions", "fresh", {
+      user_id: "user",
+      created_at: "2026-05-12T00:00:00.001Z",
+      title: "",
+      raw_md: "",
+    });
+    store.setRow("sessions", "active", {
+      user_id: "user",
+      created_at: "2026-05-11T23:59:59.999Z",
+      title: "",
+      raw_md: "",
+    });
+
+    getSessionModeMock.mockImplementation((sessionId) =>
+      sessionId === "active" ? "active" : "inactive",
+    );
+    audioDeleteOrphanedExpiredMock.mockResolvedValue({
+      status: "ok",
+      data: ["orphan"],
+    });
+
+    const deleted = await cleanupExpiredAudio(store, settingsStore, now);
+
+    expect(audioDeleteMock).toHaveBeenCalledTimes(1);
+    expect(audioDeleteMock).toHaveBeenCalledWith("expired");
+    expect(audioDeleteOrphanedExpiredMock).toHaveBeenCalledWith(
+      ["expired", "fresh", "active"],
+      24 * 60 * 60 * 1000,
+      now,
+    );
+    expect(deleted).toEqual(["expired", "orphan"]);
   });
 });

--- a/apps/desktop/src/services/audio-retention.ts
+++ b/apps/desktop/src/services/audio-retention.ts
@@ -48,8 +48,12 @@ export async function cleanupExpiredAudio(
     settingsStore.getValue("audio_retention"),
   );
   const deletes: Promise<void>[] = [];
+  const knownSessionIds: string[] = [];
+  const deletedSessionIds: string[] = [];
 
   store.forEachRow("sessions", (sessionId, _forEachCell) => {
+    knownSessionIds.push(sessionId);
+
     if (listenerStore.getState().getSessionMode(sessionId) !== "inactive") {
       return;
     }
@@ -68,7 +72,10 @@ export async function cleanupExpiredAudio(
               sessionId,
               error: result.error,
             });
+            return;
           }
+
+          deletedSessionIds.push(sessionId);
         })
         .catch((error) => {
           console.error("[audio-retention] failed to delete audio", {
@@ -80,4 +87,26 @@ export async function cleanupExpiredAudio(
   });
 
   await Promise.all(deletes);
+
+  try {
+    const orphanedResult = await fsSyncCommands.audioDeleteOrphanedExpired(
+      knownSessionIds,
+      AUDIO_RETENTION_DURATION_MS[policy],
+      nowMs,
+    );
+
+    if (orphanedResult.status === "error") {
+      console.error("[audio-retention] failed to delete orphaned audio", {
+        error: orphanedResult.error,
+      });
+    } else {
+      deletedSessionIds.push(...orphanedResult.data);
+    }
+  } catch (error) {
+    console.error("[audio-retention] failed to delete orphaned audio", {
+      error,
+    });
+  }
+
+  return deletedSessionIds;
 }

--- a/apps/desktop/src/services/task-manager.tsx
+++ b/apps/desktop/src/services/task-manager.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import type { Queries } from "tinybase/with-schemas";
 import {
@@ -27,6 +28,7 @@ import * as settings from "~/store/tinybase/store/settings";
 const CALENDAR_SYNC_INTERVAL = 60 * 1000; // 60 sec
 
 export function TaskManager() {
+  const queryClient = useQueryClient();
   const store = main.UI.useStore(main.STORE_ID);
   const queries = main.UI.useQueries(main.STORE_ID);
 
@@ -75,11 +77,19 @@ export function TaskManager() {
 
   useSetTask(AUDIO_RETENTION_TASK_ID, async () => {
     if (!store || !settingsStore) return;
-    await cleanupExpiredAudio(
+    const deletedSessionIds = await cleanupExpiredAudio(
       store as main.Store,
       settingsStore as settings.Store,
     );
-  }, [store, settingsStore]);
+    for (const sessionId of deletedSessionIds) {
+      void queryClient.invalidateQueries({
+        queryKey: ["audio", sessionId, "exist"],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["audio", sessionId, "url"],
+      });
+    }
+  }, [store, settingsStore, queryClient]);
 
   useScheduleTaskRun(AUDIO_RETENTION_TASK_ID, undefined, 0, {
     repeatDelay: AUDIO_RETENTION_INTERVAL,

--- a/crates/fs-sync-core/src/audio/mod.rs
+++ b/crates/fs-sync-core/src/audio/mod.rs
@@ -1,10 +1,21 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, UNIX_EPOCH};
 
 use crate::error::AudioImportError;
+use crate::path::is_uuid;
 use crate::runtime::{AudioImportEvent, AudioImportRuntime};
 use chrono::{DateTime, Utc};
 
 const AUDIO_FORMATS: [&str; 3] = ["audio.mp3", "audio.wav", "audio.ogg"];
+const AUDIO_ARTIFACTS: [&str; 6] = [
+    "audio.mp3",
+    "audio.wav",
+    "audio.ogg",
+    "audio.mp3.tmp",
+    "audio_mic.wav",
+    "audio_spk.wav",
+];
 
 #[derive(Clone, serde::Serialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
@@ -24,8 +35,8 @@ pub fn exists(session_dir: &Path) -> std::io::Result<bool> {
 }
 
 pub fn delete(session_dir: &Path) -> std::io::Result<()> {
-    for format in AUDIO_FORMATS {
-        let path = session_dir.join(format);
+    for artifact in AUDIO_ARTIFACTS {
+        let path = session_dir.join(artifact);
         if std::fs::exists(&path).unwrap_or(false) {
             std::fs::remove_file(&path)?;
         }
@@ -38,6 +49,30 @@ pub fn path(session_dir: &Path) -> Option<PathBuf> {
         .iter()
         .map(|format| session_dir.join(format))
         .find(|path| path.exists())
+}
+
+pub fn delete_orphaned_expired(
+    sessions_dir: &Path,
+    known_session_ids: &[String],
+    retention_ms: u64,
+    now_ms: u64,
+) -> std::io::Result<Vec<String>> {
+    if !sessions_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let known_session_ids: HashSet<&str> = known_session_ids.iter().map(String::as_str).collect();
+    let expires_before_ms = now_ms.saturating_sub(retention_ms);
+    let mut deleted = Vec::new();
+
+    delete_orphaned_expired_in_dir(
+        sessions_dir,
+        &known_session_ids,
+        expires_before_ms,
+        &mut deleted,
+    )?;
+
+    Ok(deleted)
 }
 
 pub fn source_metadata(source_path: &Path) -> std::io::Result<AudioSourceMetadata> {
@@ -56,6 +91,73 @@ pub fn source_metadata(source_path: &Path) -> std::io::Result<AudioSourceMetadat
         modified_at,
         duration_ms,
     })
+}
+
+fn delete_orphaned_expired_in_dir(
+    dir: &Path,
+    known_session_ids: &HashSet<&str>,
+    expires_before_ms: u64,
+    deleted: &mut Vec<String>,
+) -> std::io::Result<()> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+
+        if is_uuid(name) {
+            if known_session_ids.contains(name) || path.join("_meta.json").exists() {
+                continue;
+            }
+
+            if orphan_audio_expired(&path, expires_before_ms)? {
+                delete(&path)?;
+                deleted.push(name.to_string());
+            }
+            continue;
+        }
+
+        delete_orphaned_expired_in_dir(&path, known_session_ids, expires_before_ms, deleted)?;
+    }
+
+    Ok(())
+}
+
+fn orphan_audio_expired(session_dir: &Path, expires_before_ms: u64) -> std::io::Result<bool> {
+    let mut latest_modified_ms: Option<u64> = None;
+
+    for artifact in AUDIO_ARTIFACTS {
+        let path = session_dir.join(artifact);
+        let metadata = match std::fs::metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error),
+        };
+
+        let modified_ms = metadata
+            .modified()?
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
+
+        latest_modified_ms =
+            Some(latest_modified_ms.map_or(modified_ms, |latest| latest.max(modified_ms)));
+    }
+
+    Ok(latest_modified_ms.is_some_and(|modified_ms| modified_ms <= expires_before_ms))
 }
 
 pub fn import_to_session(
@@ -138,8 +240,85 @@ mod tests {
     use super::*;
     use assert_fs::TempDir;
     use hypr_audio_utils::Source;
+    use std::time::SystemTime;
 
     const MIN_MP3_BYTES: u64 = 1024;
+    const KNOWN_SESSION_ID: &str = "11111111-1111-4111-8111-111111111111";
+    const ORPHAN_SESSION_ID: &str = "22222222-2222-4222-8222-222222222222";
+    const META_SESSION_ID: &str = "33333333-3333-4333-8333-333333333333";
+    const FRESH_ORPHAN_SESSION_ID: &str = "44444444-4444-4444-8444-444444444444";
+
+    fn now_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+            .try_into()
+            .unwrap()
+    }
+
+    fn write_audio(path: &Path) {
+        std::fs::write(path, b"audio").unwrap();
+    }
+
+    #[test]
+    fn test_delete_removes_audio_artifacts() {
+        let temp = TempDir::new().unwrap();
+        let session_dir = temp.path();
+        for artifact in AUDIO_ARTIFACTS {
+            write_audio(&session_dir.join(artifact));
+        }
+        let note_path = session_dir.join("note.md");
+        std::fs::write(&note_path, b"keep").unwrap();
+
+        delete(session_dir).unwrap();
+
+        for artifact in AUDIO_ARTIFACTS {
+            assert!(!session_dir.join(artifact).exists());
+        }
+        assert!(note_path.exists());
+    }
+
+    #[test]
+    fn test_delete_orphaned_expired_removes_nested_orphan_audio() {
+        let temp = TempDir::new().unwrap();
+        let sessions_dir = temp.path();
+        let orphan_dir = sessions_dir.join("folder").join(ORPHAN_SESSION_ID);
+        let known_dir = sessions_dir.join(KNOWN_SESSION_ID);
+        let meta_dir = sessions_dir.join(META_SESSION_ID);
+        std::fs::create_dir_all(&orphan_dir).unwrap();
+        std::fs::create_dir_all(&known_dir).unwrap();
+        std::fs::create_dir_all(&meta_dir).unwrap();
+        write_audio(&orphan_dir.join("audio.wav"));
+        write_audio(&orphan_dir.join("audio_mic.wav"));
+        write_audio(&known_dir.join("audio.wav"));
+        write_audio(&meta_dir.join("audio.wav"));
+        std::fs::write(meta_dir.join("_meta.json"), b"{}").unwrap();
+
+        let deleted =
+            delete_orphaned_expired(sessions_dir, &[KNOWN_SESSION_ID.to_string()], 0, now_ms())
+                .unwrap();
+
+        assert_eq!(deleted, vec![ORPHAN_SESSION_ID.to_string()]);
+        assert!(!orphan_dir.join("audio.wav").exists());
+        assert!(!orphan_dir.join("audio_mic.wav").exists());
+        assert!(known_dir.join("audio.wav").exists());
+        assert!(meta_dir.join("audio.wav").exists());
+    }
+
+    #[test]
+    fn test_delete_orphaned_expired_keeps_fresh_orphan_audio() {
+        let temp = TempDir::new().unwrap();
+        let sessions_dir = temp.path();
+        let orphan_dir = sessions_dir.join(FRESH_ORPHAN_SESSION_ID);
+        std::fs::create_dir_all(&orphan_dir).unwrap();
+        write_audio(&orphan_dir.join("audio.wav"));
+
+        let deleted = delete_orphaned_expired(sessions_dir, &[], u64::MAX, now_ms()).unwrap();
+
+        assert!(deleted.is_empty());
+        assert!(orphan_dir.join("audio.wav").exists());
+    }
 
     macro_rules! test_import_audio {
         ($($name:ident: $path:expr),* $(,)?) => {

--- a/plugins/fs-sync/build.rs
+++ b/plugins/fs-sync/build.rs
@@ -10,6 +10,7 @@ const COMMANDS: &[&str] = &[
     "delete_folder",
     "audio_exist",
     "audio_delete",
+    "audio_delete_orphaned_expired",
     "audio_import",
     "audio_source_metadata",
     "audio_path",

--- a/plugins/fs-sync/js/bindings.gen.ts
+++ b/plugins/fs-sync/js/bindings.gen.ts
@@ -94,6 +94,14 @@ async audioDelete(sessionId: string) : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async audioDeleteOrphanedExpired(knownSessionIds: string[], retentionMs: number, nowMs: number) : Promise<Result<string[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:fs-sync|audio_delete_orphaned_expired", { knownSessionIds, retentionMs, nowMs }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async audioImport(sessionId: string, sourcePath: string) : Promise<Result<string, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("plugin:fs-sync|audio_import", { sessionId, sourcePath }) };

--- a/plugins/fs-sync/permissions/autogenerated/commands/audio_delete_orphaned_expired.toml
+++ b/plugins/fs-sync/permissions/autogenerated/commands/audio_delete_orphaned_expired.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-audio-delete-orphaned-expired"
+description = "Enables the audio_delete_orphaned_expired command without any pre-configured scope."
+commands.allow = ["audio_delete_orphaned_expired"]
+
+[[permission]]
+identifier = "deny-audio-delete-orphaned-expired"
+description = "Denies the audio_delete_orphaned_expired command without any pre-configured scope."
+commands.deny = ["audio_delete_orphaned_expired"]

--- a/plugins/fs-sync/permissions/autogenerated/reference.md
+++ b/plugins/fs-sync/permissions/autogenerated/reference.md
@@ -15,6 +15,7 @@ Default permissions for the fs-sync plugin
 - `allow-delete-folder`
 - `allow-audio-exist`
 - `allow-audio-delete`
+- `allow-audio-delete-orphaned-expired`
 - `allow-audio-import`
 - `allow-audio-source-metadata`
 - `allow-audio-path`
@@ -137,6 +138,32 @@ Enables the audio_delete command without any pre-configured scope.
 <td>
 
 Denies the audio_delete command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`fs-sync:allow-audio-delete-orphaned-expired`
+
+</td>
+<td>
+
+Enables the audio_delete_orphaned_expired command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`fs-sync:deny-audio-delete-orphaned-expired`
+
+</td>
+<td>
+
+Denies the audio_delete_orphaned_expired command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/fs-sync/permissions/default.toml
+++ b/plugins/fs-sync/permissions/default.toml
@@ -12,6 +12,7 @@ permissions = [
     "allow-delete-folder",
     "allow-audio-exist",
     "allow-audio-delete",
+    "allow-audio-delete-orphaned-expired",
     "allow-audio-import",
     "allow-audio-source-metadata",
     "allow-audio-path",

--- a/plugins/fs-sync/permissions/schemas/schema.json
+++ b/plugins/fs-sync/permissions/schemas/schema.json
@@ -343,6 +343,18 @@
           "markdownDescription": "Denies the audio_delete command without any pre-configured scope."
         },
         {
+          "description": "Enables the audio_delete_orphaned_expired command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-audio-delete-orphaned-expired",
+          "markdownDescription": "Enables the audio_delete_orphaned_expired command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the audio_delete_orphaned_expired command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-audio-delete-orphaned-expired",
+          "markdownDescription": "Denies the audio_delete_orphaned_expired command without any pre-configured scope."
+        },
+        {
           "description": "Enables the audio_exist command without any pre-configured scope.",
           "type": "string",
           "const": "allow-audio-exist",
@@ -583,10 +595,10 @@
           "markdownDescription": "Denies the write_json_batch command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the fs-sync plugin\n#### This default permission set includes:\n\n- `allow-deserialize`\n- `allow-write-json-batch`\n- `allow-write-document-batch`\n- `allow-read-document-batch`\n- `allow-list-folders`\n- `allow-move-session`\n- `allow-create-folder`\n- `allow-rename-folder`\n- `allow-delete-folder`\n- `allow-audio-exist`\n- `allow-audio-delete`\n- `allow-audio-import`\n- `allow-audio-source-metadata`\n- `allow-audio-path`\n- `allow-session-dir`\n- `allow-load-session-content`\n- `allow-delete-session-folder`\n- `allow-scan-and-read`\n- `allow-chat-dir`\n- `allow-entity-dir`\n- `allow-attachment-save`\n- `allow-attachment-list`\n- `allow-attachment-remove`",
+          "description": "Default permissions for the fs-sync plugin\n#### This default permission set includes:\n\n- `allow-deserialize`\n- `allow-write-json-batch`\n- `allow-write-document-batch`\n- `allow-read-document-batch`\n- `allow-list-folders`\n- `allow-move-session`\n- `allow-create-folder`\n- `allow-rename-folder`\n- `allow-delete-folder`\n- `allow-audio-exist`\n- `allow-audio-delete`\n- `allow-audio-delete-orphaned-expired`\n- `allow-audio-import`\n- `allow-audio-source-metadata`\n- `allow-audio-path`\n- `allow-session-dir`\n- `allow-load-session-content`\n- `allow-delete-session-folder`\n- `allow-scan-and-read`\n- `allow-chat-dir`\n- `allow-entity-dir`\n- `allow-attachment-save`\n- `allow-attachment-list`\n- `allow-attachment-remove`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the fs-sync plugin\n#### This default permission set includes:\n\n- `allow-deserialize`\n- `allow-write-json-batch`\n- `allow-write-document-batch`\n- `allow-read-document-batch`\n- `allow-list-folders`\n- `allow-move-session`\n- `allow-create-folder`\n- `allow-rename-folder`\n- `allow-delete-folder`\n- `allow-audio-exist`\n- `allow-audio-delete`\n- `allow-audio-import`\n- `allow-audio-source-metadata`\n- `allow-audio-path`\n- `allow-session-dir`\n- `allow-load-session-content`\n- `allow-delete-session-folder`\n- `allow-scan-and-read`\n- `allow-chat-dir`\n- `allow-entity-dir`\n- `allow-attachment-save`\n- `allow-attachment-list`\n- `allow-attachment-remove`"
+          "markdownDescription": "Default permissions for the fs-sync plugin\n#### This default permission set includes:\n\n- `allow-deserialize`\n- `allow-write-json-batch`\n- `allow-write-document-batch`\n- `allow-read-document-batch`\n- `allow-list-folders`\n- `allow-move-session`\n- `allow-create-folder`\n- `allow-rename-folder`\n- `allow-delete-folder`\n- `allow-audio-exist`\n- `allow-audio-delete`\n- `allow-audio-delete-orphaned-expired`\n- `allow-audio-import`\n- `allow-audio-source-metadata`\n- `allow-audio-path`\n- `allow-session-dir`\n- `allow-load-session-content`\n- `allow-delete-session-folder`\n- `allow-scan-and-read`\n- `allow-chat-dir`\n- `allow-entity-dir`\n- `allow-attachment-save`\n- `allow-attachment-list`\n- `allow-attachment-remove`"
         }
       ]
     }

--- a/plugins/fs-sync/src/commands.rs
+++ b/plugins/fs-sync/src/commands.rs
@@ -202,6 +202,27 @@ pub(crate) async fn audio_delete<R: tauri::Runtime>(
 
 #[tauri::command]
 #[specta::specta]
+pub(crate) async fn audio_delete_orphaned_expired<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    known_session_ids: Vec<String>,
+    retention_ms: u64,
+    now_ms: u64,
+) -> Result<Vec<String>, String> {
+    let base = app.settings().vault_base().map_err(|e| e.to_string())?;
+    let sessions_dir = base.join("sessions").into_std_path_buf();
+    spawn_blocking!({
+        crate::audio::delete_orphaned_expired(
+            &sessions_dir,
+            &known_session_ids,
+            retention_ms,
+            now_ms,
+        )
+        .map_err(|e| e.to_string())
+    })
+}
+
+#[tauri::command]
+#[specta::specta]
 pub(crate) async fn audio_import<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
     session_id: String,

--- a/plugins/fs-sync/src/lib.rs
+++ b/plugins/fs-sync/src/lib.rs
@@ -22,6 +22,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::delete_folder::<tauri::Wry>,
             commands::audio_exist::<tauri::Wry>,
             commands::audio_delete::<tauri::Wry>,
+            commands::audio_delete_orphaned_expired::<tauri::Wry>,
             commands::audio_import::<tauri::Wry>,
             commands::audio_source_metadata,
             commands::audio_path::<tauri::Wry>,


### PR DESCRIPTION
Delete orphaned recorder artifacts during retention cleanup and refresh cached audio state after background deletion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new background deletion paths (including recursive filesystem cleanup) and invalidates cached audio queries, which could affect user recordings if retention logic is wrong, but changes are scoped and covered by tests.
> 
> **Overview**
> **Audio retention cleanup now removes more than just session-linked recordings.** `cleanupExpiredAudio` tracks known session IDs, returns the list of deleted session IDs, and invokes a new `audioDeleteOrphanedExpired` command to delete expired audio directories that no longer map to any known session.
> 
> **FS plugin adds orphan cleanup support and broader artifact deletion.** `fs-sync-core` expands `audio::delete` to remove temp/mic/speaker artifacts and introduces recursive `delete_orphaned_expired` (skipping known sessions and dirs with `_meta.json`) exposed via a new Tauri command, JS bindings, and permissions; `TaskManager` invalidates `react-query` audio caches for any deleted sessions so the UI refreshes after background cleanup.
> 
> **Tests updated/added** to cover retention windows and combined deletion of expired inactive sessions plus orphaned audio.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 573c613b65e601f7b3bad0b9d5cbc5f1e221c3a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->