### PR TITLE
fix(editor): restore simple task checkboxes

### DIFF
--- a/apps/desktop/src/editor-bridge/session-view.test.tsx
+++ b/apps/desktop/src/editor-bridge/session-view.test.tsx
@@ -68,7 +68,7 @@ vi.mock("@hypr/editor/note", () => ({
 import { SessionNodeView } from "./session-view";
 
 describe("SessionNodeView", () => {
-  it("cycles the linked session status when clicked", () => {
+  it("toggles the linked session status when clicked", () => {
     hoisted.transaction.setNodeMarkup.mockImplementation(
       (_pos, _type, attrs) => ({ attrs }),
     );

--- a/packages/editor/src/node-views/task-checkbox.test.tsx
+++ b/packages/editor/src/node-views/task-checkbox.test.tsx
@@ -14,22 +14,27 @@ describe("TaskCheckbox", () => {
     expect(onToggle).toHaveBeenCalledTimes(1);
   });
 
-  it("exposes the mixed state for in-progress tasks", () => {
-    const view = render(<TaskCheckbox status="in_progress" />);
+  it("renders as checked only for done tasks", () => {
+    const done = render(<TaskCheckbox status="done" />);
 
     expect(
-      view.container
-        .querySelector('[role="checkbox"]')
-        ?.getAttribute("aria-checked"),
-    ).toBe("mixed");
+      (done.container.querySelector("input") as HTMLInputElement).checked,
+    ).toBe(true);
+    done.unmount();
+
+    const inProgress = render(<TaskCheckbox status="in_progress" />);
+
+    expect(
+      (inProgress.container.querySelector("input") as HTMLInputElement).checked,
+    ).toBe(false);
   });
 
   it("does not call onToggle when read-only", () => {
     const view = render(<TaskCheckbox status="done" />);
 
     const checkbox = view.container.querySelector(
-      '[role="checkbox"]',
-    ) as HTMLButtonElement | null;
+      'input[type="checkbox"]',
+    ) as HTMLInputElement | null;
 
     expect(checkbox).not.toBeNull();
     if (!checkbox) {

--- a/packages/editor/src/node-views/task-checkbox.tsx
+++ b/packages/editor/src/node-views/task-checkbox.tsx
@@ -1,7 +1,3 @@
-import { CheckIcon, MinusIcon } from "lucide-react";
-
-import { cn } from "@hypr/utils";
-
 import type { TaskStatus } from "../tasks";
 
 type TaskCheckboxProps = {
@@ -17,8 +13,7 @@ export function TaskCheckbox({
   isSelected = false,
   onToggle,
 }: TaskCheckboxProps) {
-  const ariaChecked =
-    status === "done" ? true : status === "in_progress" ? "mixed" : false;
+  const checked = status === "done";
 
   return (
     <label
@@ -26,12 +21,11 @@ export function TaskCheckbox({
       contentEditable={false}
       suppressContentEditableWarning
     >
-      <button
-        type="button"
-        role="checkbox"
-        aria-checked={ariaChecked}
+      <input
+        type="checkbox"
         className="task-checkbox"
-        data-status={status}
+        checked={checked}
+        readOnly
         data-interactive={isInteractive ? "true" : "false"}
         data-selected={isSelected ? "true" : undefined}
         onClick={(event) => {
@@ -46,20 +40,7 @@ export function TaskCheckbox({
           event.preventDefault();
           event.stopPropagation();
         }}
-      >
-        <span
-          className={cn([
-            "pointer-events-none flex size-full items-center justify-center text-white",
-            status === "todo" && "text-transparent",
-          ])}
-        >
-          {status === "done" ? (
-            <CheckIcon size={12} strokeWidth={3} />
-          ) : status === "in_progress" ? (
-            <MinusIcon size={12} strokeWidth={3} />
-          ) : null}
-        </span>
-      </button>
+      />
     </label>
   );
 }

--- a/packages/editor/src/node-views/task-item-view.test.tsx
+++ b/packages/editor/src/node-views/task-item-view.test.tsx
@@ -22,19 +22,10 @@ vi.mock("@handlewithcare/react-prosemirror", () => ({
   }),
 }));
 
-vi.mock("../task-source", () => ({
-  useTaskSourceOptional: () => null,
-}));
-
-vi.mock("../task-storage", () => ({
-  useTaskRecord: () => null,
-  useTaskStorageOptional: () => null,
-}));
-
 import { TaskItemView } from "./task-item-view";
 
 describe("TaskItemView", () => {
-  it("advances the task status when the checkbox is clicked", () => {
+  it("toggles the task status when the checkbox is clicked", () => {
     hoisted.transaction.setNodeMarkup.mockImplementation(
       (_pos, _type, attrs) => ({ attrs }),
     );
@@ -67,16 +58,16 @@ describe("TaskItemView", () => {
       4,
       undefined,
       {
-        status: "in_progress",
-        checked: false,
+        status: "done",
+        checked: true,
         taskId: null,
         taskItemId: null,
       },
     );
     expect(hoisted.view.dispatch).toHaveBeenCalledWith({
       attrs: {
-        status: "in_progress",
-        checked: false,
+        status: "done",
+        checked: true,
         taskId: null,
         taskItemId: null,
       },

--- a/packages/editor/src/node-views/task-item-view.tsx
+++ b/packages/editor/src/node-views/task-item-view.tsx
@@ -4,12 +4,8 @@ import {
   useEditorState,
 } from "@handlewithcare/react-prosemirror";
 import type { NodeSpec } from "prosemirror-model";
-import { forwardRef, type ReactNode, useMemo, useState } from "react";
+import { forwardRef, type ReactNode } from "react";
 
-import { cn, format, parseISO } from "@hypr/utils";
-
-import { useTaskSourceOptional } from "../task-source";
-import { useTaskRecord, useTaskStorageOptional } from "../task-storage";
 import {
   createTaskStatusAttrs,
   getNextTaskStatus,
@@ -75,28 +71,11 @@ export const TaskItemView = forwardRef<
   const { node, getPos } = nodeProps;
   const status = normalizeTaskStatus(node.attrs.status, node.attrs.checked);
   const taskId = node.attrs.taskId as string | null;
-  const taskSource = useTaskSourceOptional();
-  const taskStorage = useTaskStorageOptional();
-  const taskRecord = useTaskRecord(taskSource, taskId);
-  const dueDate = taskRecord?.dueDate ?? "";
-  const [isEditingDueDate, setIsEditingDueDate] = useState(false);
 
   const pos = getPos();
   const { selection } = useEditorState();
   const isSelected =
     pos >= selection.from && pos + node.nodeSize <= selection.to - 1;
-  const showDueDateInput = isEditingDueDate || isSelected;
-  const formattedDueDate = useMemo(() => {
-    if (!dueDate) {
-      return "";
-    }
-
-    try {
-      return format(parseISO(`${dueDate}T00:00:00`), "MMM d");
-    } catch {
-      return dueDate;
-    }
-  }, [dueDate]);
 
   const handleToggle = useEditorEventCallback((view) => {
     if (!view) return;
@@ -108,22 +87,6 @@ export const TaskItemView = forwardRef<
     });
     view.dispatch(tr);
   });
-
-  const handleDueDateChange = (value: string) => {
-    if (!taskSource || !taskId || !taskStorage) {
-      return;
-    }
-
-    const sourceTasks = taskStorage.getTasksForSource(taskSource);
-    taskStorage.upsertTasksForSource(
-      taskSource,
-      sourceTasks.map((task) =>
-        task.taskId === taskId
-          ? { ...task, dueDate: value || undefined }
-          : task,
-      ),
-    );
-  };
 
   return (
     <li
@@ -143,39 +106,7 @@ export const TaskItemView = forwardRef<
         isSelected={isSelected}
         onToggle={handleToggle}
       />
-      <div className="flex min-w-0 flex-1 flex-wrap items-start gap-2">
-        <div ref={nodeProps.contentDOMRef} className="min-w-0 flex-1">
-          {children}
-        </div>
-        {taskSource && taskId ? (
-          <div contentEditable={false} suppressContentEditableWarning>
-            {showDueDateInput ? (
-              <input
-                type="date"
-                value={dueDate}
-                onChange={(event) => handleDueDateChange(event.target.value)}
-                onBlur={() => setIsEditingDueDate(false)}
-                onMouseDown={(event) => event.stopPropagation()}
-                className={cn([
-                  "rounded border border-neutral-200 bg-transparent px-2 py-1 text-xs text-neutral-600 transition outline-none",
-                  "focus:border-neutral-400",
-                ])}
-              />
-            ) : (
-              <button
-                type="button"
-                onClick={() => setIsEditingDueDate(true)}
-                onMouseDown={(event) => event.stopPropagation()}
-                className={cn([
-                  "rounded-full border border-neutral-200 px-2 py-1 text-xs text-neutral-600 transition hover:border-neutral-300 hover:text-neutral-800",
-                ])}
-              >
-                {formattedDueDate || "Due"}
-              </button>
-            )}
-          </div>
-        ) : null}
-      </div>
+      <div ref={nodeProps.contentDOMRef}>{children}</div>
     </li>
   );
 });

--- a/packages/editor/src/note/keymap.test.ts
+++ b/packages/editor/src/note/keymap.test.ts
@@ -1,8 +1,13 @@
-import { EditorState, Selection, type Transaction } from "prosemirror-state";
+import {
+  EditorState,
+  Selection,
+  TextSelection,
+  type Transaction,
+} from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import { describe, expect, it } from "vitest";
 
-import { buildInputRules } from "./keymap";
+import { buildInputRules, buildKeymap } from "./keymap";
 import { schema } from "./schema";
 
 describe("buildInputRules", () => {
@@ -69,3 +74,208 @@ describe("buildInputRules", () => {
     });
   });
 });
+
+describe("buildKeymap", () => {
+  it("merges task item text backward without changing the list structure", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("taskList", null, [
+        schema.node(
+          "taskItem",
+          {
+            status: "todo",
+            checked: false,
+            taskId: "task-1",
+            taskItemId: "task-item-1",
+          },
+          [schema.node("paragraph", null, [schema.text("one")])],
+        ),
+        schema.node(
+          "taskItem",
+          {
+            status: "todo",
+            checked: false,
+            taskId: "task-2",
+            taskItemId: "task-item-2",
+          },
+          [schema.node("paragraph", null, [schema.text("two")])],
+        ),
+      ]),
+    ]);
+    const { state } = runBackspaceAtTextStart(doc, "two");
+
+    expect(state.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "taskList",
+          content: [
+            {
+              type: "taskItem",
+              attrs: {
+                status: "todo",
+                checked: false,
+                taskId: "task-1",
+                taskItemId: "task-item-1",
+              },
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "onetwo" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("keeps the first task item separate from a previous bullet list", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("bulletList", null, [
+        schema.node("listItem", null, [
+          schema.node("paragraph", null, [schema.text("one")]),
+        ]),
+      ]),
+      schema.node("taskList", null, [
+        schema.node(
+          "taskItem",
+          {
+            status: "todo",
+            checked: false,
+            taskId: "task-1",
+            taskItemId: "task-item-1",
+          },
+          [schema.node("paragraph", null, [schema.text("two")])],
+        ),
+      ]),
+    ]);
+    const { state } = runBackspaceAtTextStart(doc, "two");
+
+    expect(state.doc.toJSON()).toEqual(doc.toJSON());
+  });
+
+  it("joins later task item paragraphs within the same task item", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("taskList", null, [
+        schema.node(
+          "taskItem",
+          {
+            status: "todo",
+            checked: false,
+            taskId: "task-1",
+            taskItemId: "task-item-1",
+          },
+          [schema.node("paragraph", null, [schema.text("one")])],
+        ),
+        schema.node(
+          "taskItem",
+          {
+            status: "todo",
+            checked: false,
+            taskId: "task-2",
+            taskItemId: "task-item-2",
+          },
+          [
+            schema.node("paragraph", null, [schema.text("two")]),
+            schema.node("paragraph", null, [schema.text("three")]),
+          ],
+        ),
+      ]),
+    ]);
+    const { state } = runBackspaceAtTextStart(doc, "three", true);
+
+    expect(state.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "taskList",
+          content: [
+            {
+              type: "taskItem",
+              attrs: {
+                status: "todo",
+                checked: false,
+                taskId: "task-1",
+                taskItemId: "task-item-1",
+              },
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "one" }],
+                },
+              ],
+            },
+            {
+              type: "taskItem",
+              attrs: {
+                status: "todo",
+                checked: false,
+                taskId: "task-2",
+                taskItemId: "task-item-2",
+              },
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "twothree" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+});
+
+function runBackspaceAtTextStart(
+  doc: ReturnType<typeof schema.node>,
+  text: string,
+  isEndOfTextblock = false,
+) {
+  const keymap = buildKeymap();
+  const textPos = getTextStartPos(doc, text);
+  let state = EditorState.create({
+    schema,
+    doc,
+    selection: TextSelection.create(doc, textPos),
+    plugins: [keymap],
+  });
+  const view = {
+    get state() {
+      return state;
+    },
+    dispatch(tr: Transaction) {
+      state = state.apply(tr);
+    },
+    endOfTextblock: () => isEndOfTextblock,
+  } as Pick<EditorView, "dispatch" | "endOfTextblock" | "state"> as EditorView;
+  const handleKeyDown = keymap.props.handleKeyDown;
+
+  const handled = handleKeyDown?.(
+    view,
+    new KeyboardEvent("keydown", { key: "Backspace" }),
+  );
+
+  expect(handled).toBe(true);
+  return { state };
+}
+
+function getTextStartPos(doc: ReturnType<typeof schema.node>, text: string) {
+  let textPos = -1;
+
+  doc.descendants((node, pos) => {
+    if (node.isText && node.text === text) {
+      textPos = pos;
+      return false;
+    }
+
+    return undefined;
+  });
+
+  if (textPos === -1) {
+    throw new Error(`Missing text node: ${text}`);
+  }
+
+  return textPos;
+}

--- a/packages/editor/src/note/keymap.ts
+++ b/packages/editor/src/note/keymap.ts
@@ -35,6 +35,7 @@ import {
   TextSelection,
   type Command,
   type EditorState,
+  type Transaction,
 } from "prosemirror-state";
 
 import { createTaskItemAttrs } from "../tasks";
@@ -161,6 +162,101 @@ function moveListItem(direction: "up" | "down"): Command {
     }
     return true;
   };
+}
+
+function joinTaskItemBackward(
+  state: EditorState,
+  dispatch?: (tr: Transaction) => void,
+) {
+  const { selection } = state;
+  const { $from } = selection;
+
+  if (!selection.empty || $from.parentOffset !== 0) {
+    return false;
+  }
+
+  let itemDepth = -1;
+  for (let depth = $from.depth; depth > 0; depth--) {
+    if ($from.node(depth).type === schema.nodes.taskItem) {
+      itemDepth = depth;
+      break;
+    }
+  }
+
+  if (itemDepth === -1 || $from.parent.type !== schema.nodes.paragraph) {
+    return false;
+  }
+
+  const list = $from.node(itemDepth - 1);
+  if (list.type !== schema.nodes.taskList) {
+    return false;
+  }
+
+  if ($from.index(itemDepth) !== 0) {
+    return false;
+  }
+
+  const itemIndex = $from.index(itemDepth - 1);
+  const currentItem = list.child(itemIndex);
+  if (itemIndex === 0) {
+    return currentItem.firstChild?.content.size ? true : false;
+  }
+
+  const previousItem = list.child(itemIndex - 1);
+  const previousParagraphIndex = previousItem.childCount - 1;
+  const previousParagraph = previousItem.child(previousParagraphIndex);
+  const currentParagraph = currentItem.firstChild;
+
+  if (
+    previousParagraph.type !== schema.nodes.paragraph ||
+    currentParagraph?.type !== schema.nodes.paragraph
+  ) {
+    return false;
+  }
+
+  if (!dispatch) {
+    return true;
+  }
+
+  const mergedParagraph = previousParagraph.type.create(
+    previousParagraph.attrs,
+    previousParagraph.content.append(currentParagraph.content),
+    previousParagraph.marks,
+  );
+
+  const mergedPreviousContent = [
+    ...Array.from({ length: previousParagraphIndex }, (_, index) =>
+      previousItem.child(index),
+    ),
+    mergedParagraph,
+    ...Array.from({ length: currentItem.childCount - 1 }, (_, index) =>
+      currentItem.child(index + 1),
+    ),
+  ];
+  const mergedPreviousItem = previousItem.type.create(
+    previousItem.attrs,
+    Fragment.from(mergedPreviousContent),
+    previousItem.marks,
+  );
+
+  const currentStart = $from.before(itemDepth);
+  const currentEnd = $from.after(itemDepth);
+  const previousStart = currentStart - previousItem.nodeSize;
+  let paragraphOffset = 0;
+  for (let index = 0; index < previousParagraphIndex; index++) {
+    paragraphOffset += previousItem.child(index).nodeSize;
+  }
+  const selectionPos =
+    previousStart + 1 + paragraphOffset + 1 + previousParagraph.content.size;
+
+  const tr = state.tr.replaceWith(
+    previousStart,
+    currentEnd,
+    mergedPreviousItem,
+  );
+  tr.setSelection(TextSelection.create(tr.doc, selectionPos));
+  dispatch(tr.scrollIntoView());
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -376,6 +472,7 @@ export function buildKeymap(onNavigateToTitle?: (pixelWidth?: number) => void) {
       return false;
     },
     revertBlockToParagraph,
+    joinTaskItemBackward,
     joinBackward,
     selectNodeBackward,
   );

--- a/packages/editor/src/tasks.test.ts
+++ b/packages/editor/src/tasks.test.ts
@@ -4,12 +4,19 @@ import { createInMemoryTaskStorage } from "./task-storage";
 import {
   createTaskItemNode,
   extractTasksFromContent,
+  getNextTaskStatus,
   hydrateTaskContent,
   moveOpenTasksBetweenContents,
   normalizeTaskContent,
 } from "./tasks";
 
 describe("task content", () => {
+  it("toggles task status through the simple checked state", () => {
+    expect(getNextTaskStatus("todo")).toBe("done");
+    expect(getNextTaskStatus("in_progress")).toBe("done");
+    expect(getNextTaskStatus("done")).toBe("todo");
+  });
+
   it("assigns unique task ids and task item ids to missing and duplicated task items", () => {
     const content = normalizeTaskContent({
       type: "doc",

--- a/packages/editor/src/tasks.ts
+++ b/packages/editor/src/tasks.ts
@@ -105,14 +105,7 @@ export function createTaskItemAttrs(
 }
 
 export function getNextTaskStatus(status: TaskStatus): TaskStatus {
-  switch (status) {
-    case "todo":
-      return "in_progress";
-    case "in_progress":
-      return "done";
-    case "done":
-      return "todo";
-  }
+  return status === "done" ? "todo" : "done";
 }
 
 export function isTaskDone(status: TaskStatus): boolean {

--- a/packages/tiptap/src/shared/extensions/task-item.test.ts
+++ b/packages/tiptap/src/shared/extensions/task-item.test.ts
@@ -68,4 +68,27 @@ describe("task item node view", () => {
     expect(checkboxWrapper).not.toBeNull();
     expect(checkboxWrapper?.getAttribute("contenteditable")).toBeNull();
   });
+
+  test("uses shared task checkbox styling hooks", () => {
+    const editor = createEditor();
+    const taskItemNode = editor.state.doc.firstChild?.firstChild;
+
+    expect(taskItemNode).not.toBeNull();
+
+    const nodeView = editor.extensionManager.nodeViews.taskItem(
+      taskItemNode!,
+      {} as any,
+      () => 1,
+      [] as any,
+      {} as any,
+    );
+    const checkboxWrapper = nodeView.dom.querySelector("label");
+    const checkbox = nodeView.dom.querySelector("input[type='checkbox']");
+
+    expect(checkboxWrapper?.classList.contains("task-checkbox-label")).toBe(
+      true,
+    );
+    expect(checkbox?.classList.contains("task-checkbox")).toBe(true);
+    expect(checkbox?.getAttribute("data-interactive")).toBe("true");
+  });
 });

--- a/packages/tiptap/src/shared/extensions/task-item.ts
+++ b/packages/tiptap/src/shared/extensions/task-item.ts
@@ -16,12 +16,21 @@ const TaskItem = BaseTaskItem.extend({
           this.options.a11y?.checkboxLabel?.(currentNode, checkbox.checked) ||
           `Task item checkbox for ${currentNode.textContent || "empty task item"}`;
       };
+      const updateInteractivity = () => {
+        checkbox.dataset.interactive =
+          editor.isEditable || this.options.onReadOnlyChecked
+            ? "true"
+            : "false";
+      };
 
       updateA11Y(node);
+      updateInteractivity();
 
       // Chrome can fail to paint full-document selections across task items when
       // the checkbox wrapper is marked contenteditable="false".
       checkbox.type = "checkbox";
+      checkbox.className = "task-checkbox";
+      checkboxWrapper.className = "task-checkbox-label";
       checkbox.addEventListener("mousedown", (event) => event.preventDefault());
       checkbox.addEventListener("change", (event) => {
         if (!editor.isEditable && !this.options.onReadOnlyChecked) {
@@ -87,6 +96,7 @@ const TaskItem = BaseTaskItem.extend({
           listItem.dataset.checked = updatedNode.attrs.checked;
           checkbox.checked = updatedNode.attrs.checked;
           updateA11Y(updatedNode);
+          updateInteractivity();
 
           const extensionAttributes = editor.extensionManager.attributes;
           const newHTMLAttributes = getRenderedAttributes(

--- a/packages/tiptap/src/styles/nodes/task-list.css
+++ b/packages/tiptap/src/styles/nodes/task-list.css
@@ -10,22 +10,16 @@
     align-items: center;
   }
 
-  .task-checkbox {
+  input.task-checkbox {
     appearance: none;
     -webkit-appearance: none;
     width: 18px;
     height: 18px;
-    border: 1.5px solid #000000;
+    border: 2px solid #ccc;
     border-radius: 4px;
-    background: transparent;
-    padding: 0;
     margin: 0;
     transition: all 0.2s ease;
     position: relative;
-    margin-top: 1px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
 
     &[data-interactive="true"] {
       cursor: pointer;
@@ -40,42 +34,31 @@
       box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
     }
 
-    &[data-status="done"],
     &:checked {
       background-color: #3b82f6;
       border-color: #3b82f6;
     }
 
-    &[data-status="in_progress"] {
-      background-color: #f59e0b;
-      border-color: #f59e0b;
+    &:checked::after {
+      content: "";
+      position: absolute;
+      left: 4.5px;
+      top: 1px;
+      width: 5px;
+      height: 10px;
+      border: solid white;
+      border-width: 0 2px 2px 0;
+      transform: rotate(45deg);
     }
 
-    &:focus,
-    &:focus-visible {
+    &:focus {
       outline: none;
       box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
     }
 
-    &[data-interactive="true"]:hover:not([data-status="done"]):not([data-status="in_progress"]) {
+    &[data-interactive="true"]:hover:not(:checked) {
       border-color: #9ca3af;
     }
-  }
-
-  input.task-checkbox:checked::after {
-    content: "";
-    position: absolute;
-    left: 4.5px;
-    top: 1px;
-    width: 5px;
-    height: 10px;
-    border: solid white;
-    border-width: 0 2px 2px 0;
-    transform: rotate(45deg);
-  }
-
-  input.task-checkbox[data-interactive="true"]:hover:not(:checked) {
-    border-color: #9ca3af;
   }
 
   /* task list */
@@ -89,13 +72,17 @@
     }
 
     li {
-      align-items: flex-start;
+      align-items: center;
       display: flex;
       margin-bottom: 0.25rem;
 
       > div {
         flex: 1 1 auto;
         margin-top: 0;
+
+        > p {
+          margin: 0;
+        }
       }
     }
 


### PR DESCRIPTION
Use the native checkbox rendering again and make task clicks toggle directly between todo and done while preserving existing task status metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task item UI, interaction, and backspace-join behavior in the editor; regressions could affect task editing and document structure but doesn’t touch auth or external data flows.
> 
> **Overview**
> Restores *native* task checkbox rendering by replacing the custom icon/button checkbox with a read-only `input[type="checkbox"]`, and updates shared CSS hooks (`task-checkbox`, `task-checkbox-label`) to style the native control.
> 
> Simplifies status transitions so clicking a task/session checkbox now toggles **only** between `todo` and `done` (no cycling through `in_progress`), with tests updated accordingly.
> 
> Adds a `Backspace` keymap handler (`joinTaskItemBackward`) to merge task text across adjacent task items *without* collapsing/rewiring the surrounding list structure, with new keymap tests covering task-list and mixed list boundaries.
> 
> Removes task due-date UI/state from `TaskItemView`, leaving only the checkbox and editable content container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d77122ee3e70e02a8b121cab4dae8beaf7c3b10b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5247 
- <kbd>&nbsp;1&nbsp;</kbd> #5242 👈 
<!-- GitButler Footer Boundary Bottom -->

