### PR TITLE
fix(stt): auto-stop browser meetings

### DIFF
--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -1,7 +1,12 @@
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { AUTO_STOP_CONFIRM_DELAY_MS, ListenerProvider } from "./contexts";
+import {
+  AUTO_STOP_BROWSER_CONFIRM_DELAY_MS,
+  AUTO_STOP_BROWSER_CALENDAR_CONFIRM_DELAY_MS,
+  AUTO_STOP_CONFIRM_DELAY_MS,
+  ListenerProvider,
+} from "./contexts";
 
 import { createListenerStore } from "~/store/zustand/listener";
 
@@ -50,10 +55,36 @@ vi.mock("~/store/tinybase/store/settings", () => ({
   },
 }));
 
-function setStoreActive(store: ReturnType<typeof createListenerStore>) {
+function setStoreActive(
+  store: ReturnType<typeof createListenerStore>,
+  sessionId = "session-1",
+) {
   store.setState((state) => ({
-    live: { ...state.live, status: "active" },
+    live: { ...state.live, sessionId, status: "active" },
   }));
+}
+
+function mockSessionEventStore(event: {
+  started_at: string;
+  ended_at: string;
+  is_all_day?: boolean;
+}) {
+  return {
+    getRow: vi.fn((table: string, rowId: string) =>
+      table === "sessions" && rowId === "session-1"
+        ? {
+            event_json: JSON.stringify({
+              tracking_id: "tracking-1",
+              calendar_id: "calendar-1",
+              title: "Design sync",
+              has_recurrence_rules: false,
+              ...event,
+            }),
+          }
+        : undefined,
+    ),
+    forEachRow: vi.fn(),
+  };
 }
 
 describe("ListenerProvider detect events", () => {
@@ -283,6 +314,215 @@ describe("ListenerProvider detect events", () => {
         icon: null,
       }),
     );
+  });
+
+  test("records trigger app ids from micDetected while already listening", async () => {
+    const store = createListenerStore();
+
+    setStoreActive(store);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "micDetected",
+        key: "mic-1",
+        apps: [
+          { id: "pid:42", name: "Chrome Helper" },
+          { id: "com.google.Chrome", name: "Google Chrome" },
+        ],
+        duration_secs: 15,
+      },
+    });
+
+    expect(showNotificationMock).not.toHaveBeenCalled();
+    expect(store.getState().live.triggerAppIds).toEqual(["com.google.Chrome"]);
+  });
+
+  test("auto-stops after a trigger app learned during active listening stops", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    setStoreActive(store);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+    listMicUsingApplicationsMock.mockClear();
+
+    handler({
+      payload: {
+        type: "micDetected",
+        key: "mic-1",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
+        duration_secs: 15,
+      },
+    });
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+
+    expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses a longer auto-stop grace period for browser meeting triggers", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["com.google.Chrome"]);
+    setStoreActive(store);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "com.google.Chrome", name: "Google Chrome" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+    expect(stopSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(
+      AUTO_STOP_BROWSER_CONFIRM_DELAY_MS - AUTO_STOP_CONFIRM_DELAY_MS,
+    );
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses calendar context to extend browser auto-stop during an active scheduled meeting", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+    const now = new Date("2026-05-19T10:05:00.000Z");
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["com.google.Chrome"]);
+    setStoreActive(store);
+    (useStoreMock as any).mockReturnValue(
+      mockSessionEventStore({
+        started_at: "2026-05-19T10:00:00.000Z",
+        ended_at: "2026-05-19T10:30:00.000Z",
+      }),
+    );
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    listMicUsingApplicationsMock.mockClear();
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "com.google.Chrome", name: "Google Chrome" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_BROWSER_CONFIRM_DELAY_MS);
+    expect(stopSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(
+      AUTO_STOP_BROWSER_CALENDAR_CONFIRM_DELAY_MS -
+        AUTO_STOP_BROWSER_CONFIRM_DELAY_MS,
+    );
+
+    expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("cancels pending auto-stop when a browser trigger restarts", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["com.google.Chrome"]);
+    setStoreActive(store);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+    listMicUsingApplicationsMock.mockClear();
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "com.google.Chrome", name: "Google Chrome" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+
+    handler({
+      payload: {
+        type: "micDetected",
+        key: "mic-1",
+        apps: [{ id: "com.google.Chrome", name: "Google Chrome" }],
+        duration_secs: 15,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(
+      AUTO_STOP_BROWSER_CONFIRM_DELAY_MS - AUTO_STOP_CONFIRM_DELAY_MS,
+    );
+
+    expect(listMicUsingApplicationsMock).not.toHaveBeenCalled();
+    expect(stopSpy).not.toHaveBeenCalled();
   });
 
   test("stops listening when sleep starts", async () => {

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -8,6 +8,7 @@ import {
 } from "@hypr/plugin-detect";
 import { commands as notificationCommands } from "@hypr/plugin-notification";
 
+import { getSessionEventById } from "~/session/utils";
 import * as main from "~/store/tinybase/store/main";
 import * as settings from "~/store/tinybase/store/settings";
 import {
@@ -17,6 +18,26 @@ import {
 
 const ListenerContext = createContext<ListenerStore | null>(null);
 export const AUTO_STOP_CONFIRM_DELAY_MS = 5_000;
+export const AUTO_STOP_BROWSER_CONFIRM_DELAY_MS = 30_000;
+export const AUTO_STOP_BROWSER_CALENDAR_CONFIRM_DELAY_MS = 10 * 60_000;
+export const AUTO_STOP_CALENDAR_END_BUFFER_MS = 2 * 60_000;
+export const AUTO_STOP_CALENDAR_EARLY_START_BUFFER_MS = 5 * 60_000;
+
+const BROWSER_MEETING_APP_IDS = new Set([
+  "app.zen-browser.zen",
+  "com.apple.Safari",
+  "com.brave.Browser",
+  "com.google.Chrome",
+  "com.google.Chrome.canary",
+  "com.microsoft.edgemac",
+  "com.microsoft.edgemac.Canary",
+  "com.operasoftware.Opera",
+  "com.vivaldi.Vivaldi",
+  "company.thebrowser.Browser",
+  "org.mozilla.firefox",
+]);
+
+type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
 
 function getIgnorableAppIds(apps: { id: string }[]) {
   return [
@@ -24,6 +45,72 @@ function getIgnorableAppIds(apps: { id: string }[]) {
       apps.map((app) => app.id).filter((id) => id && !id.startsWith("pid:")),
     ),
   ];
+}
+
+function parseEventTimeMs(value: string | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const ms = new Date(value).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}
+
+function getCalendarAwareBrowserDelayMs({
+  tinybaseStore,
+  sessionId,
+  nowMs,
+}: {
+  tinybaseStore: MainStore | null | undefined;
+  sessionId: string | null;
+  nowMs: number;
+}): number | null {
+  if (!tinybaseStore || !sessionId) {
+    return null;
+  }
+
+  const event = getSessionEventById(tinybaseStore, sessionId);
+  if (!event || event.is_all_day) {
+    return null;
+  }
+
+  const endMs = parseEventTimeMs(event.ended_at);
+  if (!endMs) {
+    return null;
+  }
+
+  const startMs = parseEventTimeMs(event.started_at);
+  if (startMs && nowMs < startMs - AUTO_STOP_CALENDAR_EARLY_START_BUFFER_MS) {
+    return null;
+  }
+
+  const guardUntilMs = endMs + AUTO_STOP_CALENDAR_END_BUFFER_MS;
+  if (guardUntilMs <= nowMs) {
+    return null;
+  }
+
+  return Math.min(
+    Math.max(guardUntilMs - nowMs, AUTO_STOP_BROWSER_CONFIRM_DELAY_MS),
+    AUTO_STOP_BROWSER_CALENDAR_CONFIRM_DELAY_MS,
+  );
+}
+
+function getAutoStopConfirmDelayMs(
+  appIds: string[],
+  options: {
+    tinybaseStore: MainStore | null | undefined;
+    sessionId: string | null;
+    nowMs: number;
+  },
+) {
+  if (!appIds.some((id) => BROWSER_MEETING_APP_IDS.has(id))) {
+    return AUTO_STOP_CONFIRM_DELAY_MS;
+  }
+
+  return (
+    getCalendarAwareBrowserDelayMs(options) ??
+    AUTO_STOP_BROWSER_CONFIRM_DELAY_MS
+  );
 }
 
 export const ListenerProvider = ({
@@ -140,7 +227,18 @@ const useHandleDetectEvents = (store: ListenerStore) => {
     detectEvents.detectEvent
       .listen(({ payload }) => {
         if (payload.type === "micDetected") {
+          const appIds = getIgnorableAppIds(payload.apps);
+
           if (store.getState().live.status === "active") {
+            if (appIds.length > 0) {
+              const currentTrigger = store.getState().live.triggerAppIds ?? [];
+              if (appIds.some((id) => currentTrigger.includes(id))) {
+                clearPendingAutoStop();
+              }
+              store
+                .getState()
+                .setTriggerAppIds([...new Set([...currentTrigger, ...appIds])]);
+            }
             return;
           }
 
@@ -148,15 +246,14 @@ const useHandleDetectEvents = (store: ListenerStore) => {
           const nearbyEvents = currentTinybaseStore
             ? getNearbyEvents(currentTinybaseStore)
             : [];
-          const ignorableAppIds = getIgnorableAppIds(payload.apps);
 
           const options =
             nearbyEvents.length > 0 ? nearbyEvents.map((e) => e.title) : null;
           const footer =
-            ignorableAppIds.length > 0
+            appIds.length > 0
               ? {
                   text:
-                    ignorableAppIds.length === 1
+                    appIds.length === 1
                       ? "Ignore this app?"
                       : "Ignore these apps?",
                   actionLabel: "Yes",
@@ -171,7 +268,7 @@ const useHandleDetectEvents = (store: ListenerStore) => {
             source: {
               type: "mic_detected",
               app_names: payload.apps.map((a) => a.name),
-              app_ids: ignorableAppIds,
+              app_ids: appIds,
               event_ids: nearbyEvents.map((e) => e.id),
             },
             start_time: null,
@@ -196,10 +293,19 @@ const useHandleDetectEvents = (store: ListenerStore) => {
             ) ?? [];
           if (stoppedTriggerAppIds.length > 0) {
             clearPendingAutoStop();
+            const confirmDelayMs = getAutoStopConfirmDelayMs(
+              stoppedTriggerAppIds,
+              {
+                tinybaseStore: tinybaseStoreRef.current,
+                sessionId: store.getState().live.sessionId,
+                nowMs: Date.now(),
+              },
+            );
+
             pendingAutoStopRef.current = setTimeout(() => {
               pendingAutoStopRef.current = null;
               void confirmAutoStop(stoppedTriggerAppIds);
-            }, AUTO_STOP_CONFIRM_DELAY_MS);
+            }, confirmDelayMs);
           }
         } else if (payload.type === "sleepStateChanged") {
           if (payload.value) {


### PR DESCRIPTION
Remember detected meeting apps while already listening so browser-based calls can stop recording after the external mic source ends.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-stop timing/trigger behavior during active recording, including new calendar-based grace periods; mistakes could cause premature stops or recordings that run long.
> 
> **Overview**
> **Auto-stop behavior is updated to better handle browser-based meetings.** While already `active`, `micDetected` events now *learn and persist* trigger app IDs (and cancel pending auto-stop if a trigger restarts) instead of only showing a notification.
> 
> **Auto-stop confirmation delays are now app- and calendar-aware.** `micStopped` uses a longer grace period for known browser meeting app IDs, and can extend that delay up to 10 minutes when the current session is within an upcoming/ongoing scheduled (non-all-day) calendar event (with start/end buffers).
> 
> **Tests are expanded** to cover learning trigger apps mid-session, browser-specific delays, calendar-extended delays, and cancelling pending auto-stop when mic activity resumes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c524e72d386ca1914f39dbffb981e5b4f2a1641d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->