### PR TITLE
fix(desktop): unify sidebar and tab chrome

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -1,5 +1,6 @@
 import { useShallow } from "zustand/shallow";
 
+import { ClassicMainSidebar } from "./shell-sidebar";
 import { ClassicMainTabChrome } from "./tab-chrome";
 import { ClassicMainTabContent } from "./tab-content";
 
@@ -18,13 +19,16 @@ export function ClassicMainBody() {
   }
 
   return (
-    <div className="relative flex h-full flex-1 flex-col">
+    <div className="relative flex h-full min-w-0 flex-1 flex-col">
       <ClassicMainTabChrome tabs={tabs} />
-      <div className="min-h-0 flex-1 overflow-auto">
-        <ClassicMainTabContent
-          key={uniqueIdfromTab(currentTab)}
-          tab={currentTab as Tab}
-        />
+      <div className="flex min-h-0 min-w-0 flex-1 gap-1">
+        <ClassicMainSidebar />
+        <div className="min-h-0 min-w-0 flex-1 overflow-auto">
+          <ClassicMainTabContent
+            key={uniqueIdfromTab(currentTab)}
+            tab={currentTab as Tab}
+          />
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/main/shell-frame.tsx
+++ b/apps/desktop/src/main/shell-frame.tsx
@@ -1,12 +1,10 @@
 import { ClassicMainBody } from "./body";
-import { ClassicMainSidebar } from "./shell-sidebar";
 
 import { MainShellBodyFrame, MainShellScaffold } from "~/shared/main";
 
 export function ClassicMainShellFrame() {
   return (
     <MainShellScaffold>
-      <ClassicMainSidebar />
       <MainShellBodyFrame autoSaveId="main-chat">
         <ClassicMainBody />
       </MainShellBodyFrame>

--- a/apps/desktop/src/main/tab-chrome.tsx
+++ b/apps/desktop/src/main/tab-chrome.tsx
@@ -3,7 +3,9 @@ import { platform } from "@tauri-apps/plugin-os";
 import {
   ArrowLeftIcon,
   ArrowRightIcon,
+  AxeIcon,
   MessageCircleIcon,
+  PanelLeftCloseIcon,
   PanelLeftOpenIcon,
   PlusIcon,
 } from "lucide-react";
@@ -33,6 +35,7 @@ import { useNewNote, useNewNoteAndListen } from "~/shared/useNewNote";
 import { Update } from "~/sidebar/update";
 import { type Tab, uniqueIdfromTab, useTabs } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
+import { commands as tauriCommands } from "~/types/tauri.gen";
 
 export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
   const { leftsidebar } = useShell();
@@ -42,7 +45,7 @@ export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
   const notifications = useNotifications();
   const currentTab = useTabs((state) => state.currentTab);
   const isOnboarding = currentTab?.type === "onboarding";
-  const isSidebarHidden = isOnboarding || !leftsidebar.expanded;
+  const showSidebarToggle = !isOnboarding && !leftsidebar.locked;
   const {
     select,
     close,
@@ -120,27 +123,36 @@ export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
   const setTabRef = useScrollActiveTabIntoView(regularTabs);
   useClassicMainTabsShortcuts();
 
+  const { data: showDevtoolButton = false } = useQuery({
+    queryKey: ["show_devtool"],
+    queryFn: () => tauriCommands.showDevtool(),
+  });
+
   return (
     <div
       data-tauri-drag-region
       className={cn([
         "flex h-10 w-full items-center",
-        isSidebarHidden && (isLinux ? "pl-3" : "pl-20"),
+        isLinux ? "pl-3" : "pl-[72px]",
       ])}
       data-testid="main-tab-chrome"
     >
-      {isSidebarHidden && isLinux && <TrafficLights className="mr-2" />}
-      {!leftsidebar.expanded && !isOnboarding && (
-        <div className="relative">
+      {isLinux && <TrafficLights className="mr-2" />}
+      {showSidebarToggle && (
+        <div className="relative shrink-0">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
                 size="icon"
                 variant="ghost"
                 className="shrink-0"
-                onClick={() => leftsidebar.setExpanded(true)}
+                onClick={leftsidebar.toggleExpanded}
               >
-                <PanelLeftOpenIcon size={16} className="text-neutral-600" />
+                {leftsidebar.expanded ? (
+                  <PanelLeftCloseIcon size={16} className="text-neutral-600" />
+                ) : (
+                  <PanelLeftOpenIcon size={16} className="text-neutral-600" />
+                )}
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom" className="flex items-center gap-2">
@@ -148,8 +160,16 @@ export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
               <Kbd className="animate-kbd-press">⌘ \</Kbd>
             </TooltipContent>
           </Tooltip>
-          <NotificationBadge show={notifications.shouldShowBadge} />
+          <NotificationBadge
+            show={!leftsidebar.expanded && notifications.shouldShowBadge}
+          />
         </div>
+      )}
+
+      {!isOnboarding && leftsidebar.expanded && showDevtoolButton && (
+        <Button size="icon" variant="ghost" onClick={leftsidebar.toggleDevtool}>
+          <AxeIcon size={16} />
+        </Button>
       )}
 
       {!isOnboarding && (

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -11,6 +11,10 @@ vi.mock("~/main/tab-content", () => ({
   ),
 }));
 
+vi.mock("~/main/shell-sidebar", () => ({
+  ClassicMainSidebar: () => <div data-testid="main-sidebar" />,
+}));
+
 vi.mock("~/store/zustand/tabs", () => ({
   uniqueIdfromTab: vi.fn(() => "empty-slot"),
   useTabs: vi.fn((selector: (state: unknown) => unknown) =>
@@ -33,6 +37,7 @@ describe("ClassicMainBody", () => {
     render(<ClassicMainBody />);
 
     expect(screen.getByTestId("main-tab-chrome")).toBeTruthy();
+    expect(screen.getByTestId("main-sidebar")).toBeTruthy();
     expect(screen.getByTestId("main-tab-content").textContent).toContain(
       "empty",
     );

--- a/apps/desktop/src/sidebar/index.tsx
+++ b/apps/desktop/src/sidebar/index.tsx
@@ -1,16 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
-import { platform } from "@tauri-apps/plugin-os";
-import { AxeIcon, PanelLeftCloseIcon } from "lucide-react";
 import { lazy, Suspense, useState } from "react";
-
-import { Button } from "@hypr/ui/components/ui/button";
-import { Kbd } from "@hypr/ui/components/ui/kbd";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@hypr/ui/components/ui/tooltip";
-import { cn } from "@hypr/utils";
 
 import { CalendarNav } from "./calendar";
 import { ContactsNav } from "./contacts";
@@ -24,9 +12,7 @@ import { ToastArea } from "./toast";
 import { useShell } from "~/contexts/shell";
 import { SearchResults } from "~/search/components/sidebar";
 import { useSearch } from "~/search/contexts/ui";
-import { TrafficLights } from "~/shared/ui/traffic-lights";
 import { useTabs } from "~/store/zustand/tabs";
-import { commands } from "~/types/tauri.gen";
 
 const DevtoolView = lazy(() =>
   import("./devtool").then((m) => ({ default: m.DevtoolView })),
@@ -37,12 +23,6 @@ export function LeftSidebar() {
   const { query } = useSearch();
   const currentTab = useTabs((state) => state.currentTab);
   const [isProfileExpanded, setIsProfileExpanded] = useState(false);
-  const isLinux = platform() === "linux";
-
-  const { data: showDevtoolButton = false } = useQuery({
-    queryKey: ["show_devtool"],
-    queryFn: () => commands.showDevtool(),
-  });
 
   const isSettingsMode = currentTab?.type === "settings";
   const isCalendarMode = currentTab?.type === "calendar";
@@ -50,52 +30,10 @@ export function LeftSidebar() {
   const isTemplatesMode = currentTab?.type === "templates";
   const isSpecialMode =
     isSettingsMode || isCalendarMode || isContactsMode || isTemplatesMode;
-  const showCollapseButton = !isSpecialMode;
   const showSearchResults = !isSpecialMode && query.trim() !== "";
 
   return (
-    <div className="flex h-full w-70 shrink-0 flex-col gap-1 overflow-hidden">
-      <header
-        data-tauri-drag-region
-        className={cn([
-          "flex flex-row items-center",
-          "h-10 w-full",
-          isLinux ? "justify-between pl-3" : "justify-end pl-20",
-          "shrink-0",
-        ])}
-      >
-        {isLinux && <TrafficLights />}
-        <div className="flex items-center">
-          {showDevtoolButton && (
-            <Button
-              size="icon"
-              variant="ghost"
-              onClick={leftsidebar.toggleDevtool}
-            >
-              <AxeIcon size={16} />
-            </Button>
-          )}
-          {showCollapseButton && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  disabled={leftsidebar.locked}
-                  onClick={leftsidebar.toggleExpanded}
-                >
-                  <PanelLeftCloseIcon size={16} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="flex items-center gap-2">
-                <span>Toggle sidebar</span>
-                <Kbd className="animate-kbd-press">⌘ \</Kbd>
-              </TooltipContent>
-            </Tooltip>
-          )}
-        </div>
-      </header>
-
+    <div className="flex h-full w-70 shrink-0 flex-col gap-1 overflow-hidden pt-1">
       {!isSpecialMode && <SidebarSearchInput />}
 
       <div className="flex flex-1 flex-col gap-1 overflow-hidden">

--- a/plugins/windows/src/window/v1.rs
+++ b/plugins/windows/src/window/v1.rs
@@ -66,9 +66,9 @@ impl AppWindow {
                 };
 
                 if major >= 26 && cfg!(debug_assertions) {
-                    24.0
+                    22.0
                 } else {
-                    18.0
+                    16.0
                 }
             };
 


### PR DESCRIPTION
Render the tab chrome above the sidebar/content split and move the sidebar toggle into the shared chrome so it keeps a stable position.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout refactor that moves sidebar controls into the shared tab chrome; main risk is minor regressions in sidebar visibility/toggling and window titlebar positioning across platforms.
> 
> **Overview**
> **Unifies the top chrome and sidebar layout.** The main view now renders `ClassicMainTabChrome` above a sidebar/content split, and `ClassicMainShellFrame` no longer mounts the sidebar separately.
> 
> **Centralizes sidebar controls in the tab chrome.** The sidebar toggle (with updated icons/badge behavior) and the devtool button/query were moved out of `LeftSidebar` into `ClassicMainTabChrome`, while `LeftSidebar` drops its custom header and adds minor spacing tweaks.
> 
> Adjusts macOS window traffic-light Y offsets in `plugins/windows` to better align with the updated chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b5f80645b60dd4f9037284e4f4b7e66eefb6f29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->