### PR TITLE
fix(editor): refine floating menu surfaces

### DIFF
--- a/packages/editor/src/widgets/format-toolbar.tsx
+++ b/packages/editor/src/widgets/format-toolbar.tsx
@@ -109,7 +109,7 @@ export function FormatToolbar() {
       ref={toolbarRef}
       className={cn([
         "absolute z-[9999] flex items-center gap-0.5 rounded-lg border border-neutral-200 bg-white/95 p-1",
-        "shadow-[0_10px_30px_-14px_rgba(0,0,0,0.35),0_4px_12px_-6px_rgba(0,0,0,0.18)] backdrop-blur-sm",
+        "shadow-[0_2px_8px_rgba(0,0,0,0.08),0_18px_42px_-16px_rgba(0,0,0,0.34)] backdrop-blur-sm",
       ])}
       style={{ top: 0, left: 0 }}
       onMouseDown={(e) => e.preventDefault()}

--- a/packages/editor/src/widgets/slash-command.tsx
+++ b/packages/editor/src/widgets/slash-command.tsx
@@ -355,9 +355,9 @@ export function SlashCommandMenu() {
     <div
       ref={popupRef}
       className={cn([
-        "absolute z-[9999] max-h-80 max-w-[280px] min-w-[220px]",
-        "overflow-y-auto rounded-lg bg-white p-1",
-        "shadow-[0_0_0_1px_rgba(0,0,0,0.05),0_6px_12px_-3px_rgba(0,0,0,0.08)]",
+        "absolute z-[9999] max-h-80 w-[280px]",
+        "overflow-y-auto rounded-lg border border-neutral-200 bg-white/95 p-1",
+        "shadow-[0_2px_8px_rgba(0,0,0,0.08),0_18px_42px_-16px_rgba(0,0,0,0.34)] backdrop-blur-sm",
       ])}
       style={{ top: 0, left: 0 }}
     >


### PR DESCRIPTION
Add an explicit border to the slash command menu and align editor floating menu shadows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Styling-only changes to editor floating UI (shadows/borders/sizing) with no logic or data-flow changes, so the main risk is minor visual regressions across themes/browsers.
> 
> **Overview**
> Aligns the floating UI surfaces in the editor by updating the `FormatToolbar` shadow to match the new design.
> 
> Refines the slash command menu surface by making its width fixed, adding an explicit neutral border, and updating shadow/backdrop styles for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd56781ebe21719a067f3680414d2d1d22d8ab20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->