### PR TITLE
fix(stt): persist interrupted batch transcripts

### DIFF
--- a/apps/desktop/src/store/zustand/listener/batch.ts
+++ b/apps/desktop/src/store/zustand/listener/batch.ts
@@ -115,7 +115,7 @@ export const createBatchSlice = <T extends BatchState>(
       return;
     }
 
-    persist?.(words, hints);
+    persist?.(words, hints, { mode: "replace" });
 
     set((state) => {
       if (!state.batch[sessionId]) {
@@ -135,6 +135,17 @@ export const createBatchSlice = <T extends BatchState>(
   handleBatchResponseStreamed: (sessionId, event) => {
     const percentage = getBatchStreamPercentage(event);
     const isComplete = event.type === "result" || event.type === "terminal";
+    const currentPreview = get().batchPreview[sessionId] ?? {
+      wordsByChannel: {},
+      hintsByChannel: {},
+    };
+    const nextPreview = mergeBatchPreview(currentPreview, event);
+    const persist = get().batchPersist[sessionId];
+    const [words, hints] = flattenBatchPreview(nextPreview);
+
+    if (event.type === "segment" && words.length > 0) {
+      persist?.(words, hints, { mode: "replace" });
+    }
 
     set((state) => ({
       ...state,
@@ -151,13 +162,7 @@ export const createBatchSlice = <T extends BatchState>(
       },
       batchPreview: {
         ...state.batchPreview,
-        [sessionId]: mergeBatchPreview(
-          state.batchPreview[sessionId] ?? {
-            wordsByChannel: {},
-            hintsByChannel: {},
-          },
-          event,
-        ),
+        [sessionId]: nextPreview,
       },
     }));
   },
@@ -298,6 +303,34 @@ function transformBatch(
     allWords.push(...words);
     wordOffset += words.length;
   });
+
+  return [allWords, allHints];
+}
+
+function flattenBatchPreview(preview: {
+  wordsByChannel: Record<number, WordLike[]>;
+  hintsByChannel: Record<number, RuntimeSpeakerHint[]>;
+}): [WordLike[], RuntimeSpeakerHint[]] {
+  const allWords: WordLike[] = [];
+  const allHints: RuntimeSpeakerHint[] = [];
+  let wordOffset = 0;
+
+  Object.keys(preview.wordsByChannel)
+    .map(Number)
+    .sort((a, b) => a - b)
+    .forEach((channel) => {
+      const words = preview.wordsByChannel[channel] ?? [];
+      const hints = preview.hintsByChannel[channel] ?? [];
+
+      hints.forEach((hint) => {
+        allHints.push({
+          ...hint,
+          wordIndex: hint.wordIndex + wordOffset,
+        });
+      });
+      allWords.push(...words);
+      wordOffset += words.length;
+    });
 
   return [allWords, allHints];
 }

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -1,5 +1,5 @@
 import { create as mutate } from "mutative";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { createListenerStore } from ".";
 import { getLiveCaptureUiMode } from "./general-shared";
@@ -142,6 +142,78 @@ describe("General Listener Slice", () => {
       clearBatchSession(sessionId);
       expect(store.getState().batch[sessionId]).toBeUndefined();
       expect(store.getState().batchPreview[sessionId]).toBeUndefined();
+    });
+
+    test("handleBatchResponseStreamed persists streamed transcript snapshots", () => {
+      const sessionId = "session-streamed-persist";
+      const persist = vi.fn();
+      const { handleBatchResponseStreamed, setBatchPersist } = store.getState();
+
+      setBatchPersist(sessionId, persist);
+
+      handleBatchResponseStreamed(sessionId, {
+        type: "segment",
+        percentage: 0.5,
+        response: {
+          type: "Results",
+          start: 0,
+          duration: 5,
+          is_final: false,
+          speech_final: false,
+          from_finalize: false,
+          channel: {
+            alternatives: [
+              {
+                transcript: "hello",
+                languages: [],
+                words: [
+                  {
+                    word: "hello",
+                    punctuated_word: "hello",
+                    start: 0,
+                    end: 0.5,
+                    confidence: 0.9,
+                    speaker: 1,
+                    language: null,
+                  },
+                ],
+                confidence: 0.9,
+              },
+            ],
+          },
+          metadata: {
+            request_id: "test-request",
+            model_info: {
+              name: "test-model",
+              version: "1.0",
+              arch: "test-arch",
+            },
+            model_uuid: "test-uuid",
+          },
+          channel_index: [0],
+        },
+      });
+
+      expect(persist).toHaveBeenCalledWith(
+        [
+          {
+            text: " hello",
+            start_ms: 0,
+            end_ms: 500,
+            channel: 0,
+          },
+        ],
+        [
+          {
+            wordIndex: 0,
+            data: {
+              type: "provider_speaker_index",
+              speaker_index: 1,
+            },
+          },
+        ],
+        { mode: "replace" },
+      );
     });
 
     test("handleBatchFailed preserves batch error for UI surfaces", () => {

--- a/apps/desktop/src/store/zustand/listener/transcript.ts
+++ b/apps/desktop/src/store/zustand/listener/transcript.ts
@@ -14,6 +14,7 @@ type WordsByChannel = Record<number, WordLike[]>;
 export type BatchPersistCallback = (
   words: WordLike[],
   hints: RuntimeSpeakerHint[],
+  options?: { mode?: "append" | "replace" },
 ) => void;
 
 export type LiveTranscriptPersistCallback = (

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { getBatchProvider } from "./useRunBatch";
+import { getBatchProvider, getSessionSpeakerCount } from "./useRunBatch";
 
 describe("getBatchProvider", () => {
   test("maps pyannote to the batch transcription provider", () => {
@@ -16,6 +16,43 @@ describe("getBatchProvider", () => {
   test("maps local soniqo models to soniqo batch provider", () => {
     expect(getBatchProvider("hyprnote", "soniqo-parakeet-batch")).toBe(
       "soniqo",
+    );
+  });
+});
+
+describe("getSessionSpeakerCount", () => {
+  test("counts distinct session participants plus the current user", () => {
+    const rows = new Map([
+      ["mapping-1", { session_id: "session-1", human_id: "human-a" }],
+      ["mapping-2", { session_id: "session-1", human_id: "human-a" }],
+      ["mapping-3", { session_id: "session-1", human_id: "human-b" }],
+      ["mapping-4", { session_id: "other-session", human_id: "human-c" }],
+    ]);
+    const store = {
+      forEachRow: (_table: string, callback: (rowId: string) => void) => {
+        for (const rowId of rows.keys()) callback(rowId);
+      },
+      getCell: (_table: string, rowId: string, cellId: string) =>
+        rows.get(rowId)?.[cellId as "session_id" | "human_id"],
+    };
+
+    expect(getSessionSpeakerCount(store as any, "session-1", "self")).toBe(3);
+  });
+
+  test("returns undefined until at least two speakers are known", () => {
+    const rows = new Map([
+      ["mapping-1", { session_id: "session-1", human_id: "human-a" }],
+    ]);
+    const store = {
+      forEachRow: (_table: string, callback: (rowId: string) => void) => {
+        for (const rowId of rows.keys()) callback(rowId);
+      },
+      getCell: (_table: string, rowId: string, cellId: string) =>
+        rows.get(rowId)?.[cellId as "session_id" | "human_id"],
+    };
+
+    expect(getSessionSpeakerCount(store as any, "session-1", null)).toBe(
+      undefined,
     );
   });
 });

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -32,6 +32,8 @@ type RunOptions = {
   maxSpeakers?: number;
 };
 
+type Store = NonNullable<ReturnType<typeof main.UI.useStore>>;
+
 const DIRECT_BATCH_PROVIDERS: Set<TranscriptionParams["provider"]> = new Set([
   "deepgram",
   "soniox",
@@ -81,6 +83,38 @@ export function isStoppedTranscriptionError(error: unknown) {
   );
 }
 
+export function getSessionSpeakerCount(
+  store: Store,
+  sessionId: string,
+  selfHumanId?: string | null,
+): number | undefined {
+  const humanIds = new Set<string>();
+
+  store.forEachRow("mapping_session_participant", (mappingId, _forEachCell) => {
+    const sid = store.getCell(
+      "mapping_session_participant",
+      mappingId,
+      "session_id",
+    );
+    if (sid !== sessionId) return;
+
+    const humanId = store.getCell(
+      "mapping_session_participant",
+      mappingId,
+      "human_id",
+    );
+    if (typeof humanId === "string" && humanId) {
+      humanIds.add(humanId);
+    }
+  });
+
+  if (typeof selfHumanId === "string" && selfHumanId) {
+    humanIds.add(selfHumanId);
+  }
+
+  return humanIds.size > 1 ? humanIds.size : undefined;
+}
+
 export const useRunBatch = (sessionId: string) => {
   const store = main.UI.useStore(main.STORE_ID);
   const indexes = main.UI.useIndexes(main.STORE_ID);
@@ -114,6 +148,12 @@ export const useRunBatch = (sessionId: string) => {
       const createdAt = new Date().toISOString();
       const memoMd = store.getCell("sessions", sessionId, "raw_md");
       let transcriptId: string | null = null;
+      const inferredNumSpeakers =
+        options?.numSpeakers === undefined &&
+        options?.minSpeakers === undefined &&
+        options?.maxSpeakers === undefined
+          ? getSessionSpeakerCount(store, sessionId, user_id)
+          : undefined;
 
       const handlePersist: BatchPersistCallback | undefined =
         options?.handlePersist;
@@ -232,7 +272,7 @@ export const useRunBatch = (sessionId: string) => {
         languages:
           options?.languages ??
           getTranscriptionLanguages(aiLanguage, spokenLanguages),
-        num_speakers: options?.numSpeakers,
+        num_speakers: options?.numSpeakers ?? inferredNumSpeakers,
         min_speakers: options?.minSpeakers,
         max_speakers: options?.maxSpeakers,
       };

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -160,7 +160,7 @@ export const useRunBatch = (sessionId: string) => {
 
       const persist =
         handlePersist ??
-        ((words, hints) => {
+        ((words, hints, persistOptions) => {
           if (words.length === 0) {
             return;
           }
@@ -199,14 +199,13 @@ export const useRunBatch = (sessionId: string) => {
             return;
           }
 
-          const existingWords = parseTranscriptWords(
-            store,
-            currentTranscriptId,
-          );
-          const existingHints = parseTranscriptHints(
-            store,
-            currentTranscriptId,
-          );
+          const shouldReplace = persistOptions?.mode === "replace";
+          const existingWords = shouldReplace
+            ? []
+            : parseTranscriptWords(store, currentTranscriptId);
+          const existingHints = shouldReplace
+            ? []
+            : parseTranscriptHints(store, currentTranscriptId);
 
           const newWords: WordWithId[] = [];
           const newWordIds: string[] = [];
@@ -251,14 +250,25 @@ export const useRunBatch = (sessionId: string) => {
             });
           });
 
-          updateTranscriptWords(store, currentTranscriptId, [
-            ...existingWords,
-            ...newWords,
-          ]);
-          updateTranscriptHints(store, currentTranscriptId, [
-            ...existingHints,
-            ...newHints,
-          ]);
+          store.transaction(() => {
+            updateTranscriptWords(store, currentTranscriptId, [
+              ...existingWords,
+              ...newWords,
+            ]);
+            updateTranscriptHints(store, currentTranscriptId, [
+              ...existingHints,
+              ...newHints,
+            ]);
+          });
+
+          void import("~/store/tinybase/store/save")
+            .then(({ save }) => save())
+            .catch((error) => {
+              console.error(
+                "[runBatch] failed to save streamed transcript",
+                error,
+              );
+            });
         });
 
       const params: TranscriptionParams = {

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -410,32 +410,25 @@ fn i16_bytes_to_f32(bytes: &Bytes) -> Vec<f32> {
 }
 
 fn build_listen_params(args: &ListenerArgs) -> owhisper_interface::ListenParams {
-    let adapter_kind =
-        AdapterKind::from_url_and_languages(&args.base_url, &args.languages, Some(&args.model));
     let redemption_time_ms = if args.onboarding { "60" } else { "400" };
-    let mut custom_query = std::collections::HashMap::from([(
+    let custom_query = std::collections::HashMap::from([(
         "redemption_time_ms".to_string(),
         redemption_time_ms.to_string(),
     )]);
-
-    if adapter_kind == AdapterKind::AssemblyAI
-        && let Some(expected_speakers) = assemblyai_expected_speakers(args)
-    {
-        custom_query.insert("speaker_labels".to_string(), "true".to_string());
-        custom_query.insert("max_speakers".to_string(), expected_speakers.to_string());
-    }
+    let num_speakers = expected_speakers(args);
 
     owhisper_interface::ListenParams {
         model: Some(args.model.clone()),
         languages: args.languages.clone(),
         sample_rate: super::super::SAMPLE_RATE,
         keywords: args.keywords.clone(),
+        num_speakers,
         custom_query: Some(custom_query),
         ..Default::default()
     }
 }
 
-fn assemblyai_expected_speakers(args: &ListenerArgs) -> Option<u32> {
+fn expected_speakers(args: &ListenerArgs) -> Option<u32> {
     let mut participants = args.participant_human_ids.clone();
 
     if let Some(self_human_id) = &args.self_human_id
@@ -655,16 +648,16 @@ mod tests {
     }
 
     #[test]
-    fn assemblyai_expected_speakers_counts_distinct_participants() {
+    fn expected_speakers_counts_distinct_participants() {
         let mut args = listener_args("https://api.assemblyai.com", "u3-rt-pro");
         args.participant_human_ids = vec!["remote".to_string(), "self".to_string()];
         args.self_human_id = Some("self".to_string());
 
-        assert_eq!(assemblyai_expected_speakers(&args), Some(2));
+        assert_eq!(expected_speakers(&args), Some(2));
     }
 
     #[test]
-    fn build_listen_params_adds_assemblyai_diarization_hints() {
+    fn build_listen_params_sets_num_speakers_without_assemblyai_custom_query() {
         let mut args = listener_args("https://api.assemblyai.com", "u3-rt-pro");
         args.participant_human_ids = vec!["remote".to_string()];
         args.self_human_id = Some("self".to_string());
@@ -672,14 +665,9 @@ mod tests {
         let params = build_listen_params(&args);
         let custom_query = params.custom_query.expect("custom query");
 
-        assert_eq!(
-            custom_query.get("speaker_labels").map(String::as_str),
-            Some("true")
-        );
-        assert_eq!(
-            custom_query.get("max_speakers").map(String::as_str),
-            Some("2")
-        );
+        assert_eq!(params.num_speakers, Some(2));
+        assert!(!custom_query.contains_key("speaker_labels"));
+        assert!(!custom_query.contains_key("max_speakers"));
     }
 
     #[test]
@@ -691,6 +679,7 @@ mod tests {
         let params = build_listen_params(&args);
         let custom_query = params.custom_query.expect("custom query");
 
+        assert_eq!(params.num_speakers, Some(2));
         assert!(!custom_query.contains_key("speaker_labels"));
         assert!(!custom_query.contains_key("max_speakers"));
     }

--- a/crates/listener2-core/src/batch/mod.rs
+++ b/crates/listener2-core/src/batch/mod.rs
@@ -133,6 +133,28 @@ pub async fn run_batch(
     result
 }
 
+pub fn expects_progressive_batch(params: &BatchParams) -> bool {
+    match params.provider {
+        BatchProvider::Am => {
+            let listen_params = owhisper_interface::ListenParams {
+                model: params.model.clone(),
+                languages: params.languages.clone(),
+                ..Default::default()
+            };
+
+            supports_progressive_batch(
+                resolve_batch_adapter_kind(params, &listen_params),
+                listen_params.model.as_deref(),
+            )
+        }
+        BatchProvider::WhisperLocal | BatchProvider::Cactus => true,
+        BatchProvider::OpenAI => {
+            OpenAIAdapter::supports_progressive_batch_model(params.model.as_deref())
+        }
+        _ => false,
+    }
+}
+
 async fn run_batch_inner(
     runtime: Arc<dyn BatchRuntime>,
     params: BatchParams,
@@ -398,5 +420,26 @@ mod tests {
             adapter_kind,
             Some("gpt-4o-transcribe-diarize"),
         ));
+    }
+
+    #[test]
+    fn cloud_hyprnote_batch_is_not_progressive() {
+        let params = batch_params(BatchProvider::Hyprnote, "https://api.char.com/stt");
+
+        assert!(!expects_progressive_batch(&params));
+    }
+
+    #[test]
+    fn cloud_am_batch_is_not_progressive() {
+        let params = batch_params(BatchProvider::Am, "https://api.char.com/stt");
+
+        assert!(!expects_progressive_batch(&params));
+    }
+
+    #[test]
+    fn local_am_batch_is_progressive() {
+        let params = batch_params(BatchProvider::Am, "http://localhost:50060/v1");
+
+        assert!(expects_progressive_batch(&params));
     }
 }

--- a/crates/listener2-core/src/lib.rs
+++ b/crates/listener2-core/src/lib.rs
@@ -5,7 +5,9 @@ mod events;
 mod runtime;
 mod subtitle;
 
-pub use batch::{BatchParams, BatchProvider, BatchRunMode, BatchRunOutput, run_batch};
+pub use batch::{
+    BatchParams, BatchProvider, BatchRunMode, BatchRunOutput, expects_progressive_batch, run_batch,
+};
 pub use denoise::{DenoiseParams, run_denoise};
 pub use error::*;
 pub use events::*;

--- a/crates/owhisper-client/src/adapter/assemblyai/live.rs
+++ b/crates/owhisper-client/src/adapter/assemblyai/live.rs
@@ -57,18 +57,13 @@ impl RealtimeSttAdapter for AssemblyAIAdapter {
                 query_pairs.append_pair("max_turn_silence", max_silence);
             }
 
-            if matches!(resolved_model, ResolvedLiveModel::U3RtPro)
-                && let Some(custom) = &params.custom_query
-            {
-                if custom
-                    .get("speaker_labels")
-                    .is_some_and(|value| value == "true")
-                {
+            if matches!(resolved_model, ResolvedLiveModel::U3RtPro) {
+                if Self::streaming_speaker_labels_enabled(params) {
                     query_pairs.append_pair("speaker_labels", "true");
                 }
 
-                if let Some(max_speakers) = custom.get("max_speakers") {
-                    query_pairs.append_pair("max_speakers", max_speakers);
+                if let Some(max_speakers) = Self::streaming_max_speakers(params) {
+                    query_pairs.append_pair("max_speakers", &max_speakers.to_string());
                 }
             }
 
@@ -232,6 +227,27 @@ impl AssemblyAIAdapter {
         }
     }
 
+    fn streaming_speaker_labels_enabled(params: &ListenParams) -> bool {
+        params.num_speakers.is_some()
+            || params.min_speakers.is_some()
+            || params.max_speakers.is_some()
+            || params
+                .custom_query
+                .as_ref()
+                .and_then(|custom| custom.get("speaker_labels"))
+                .is_some_and(|value| value == "true")
+    }
+
+    fn streaming_max_speakers(params: &ListenParams) -> Option<u32> {
+        params.max_speakers.or(params.num_speakers).or_else(|| {
+            params
+                .custom_query
+                .as_ref()
+                .and_then(|custom| custom.get("max_speakers"))
+                .and_then(|value| value.parse().ok())
+        })
+    }
+
     fn parse_speaker_label(label: Option<&str>) -> Option<i32> {
         let label = label?.trim();
         if label.is_empty() || label.eq_ignore_ascii_case("unknown") {
@@ -339,8 +355,6 @@ impl ResolvedLiveModel {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use hypr_language::ISO639;
     use owhisper_interface::ListenParams;
     use owhisper_interface::stream::StreamResponse;
@@ -424,10 +438,7 @@ mod tests {
             API_BASE,
             &owhisper_interface::ListenParams {
                 model: Some("u3-rt-pro".to_string()),
-                custom_query: Some(HashMap::from([
-                    ("speaker_labels".to_string(), "true".to_string()),
-                    ("max_speakers".to_string(), "3".to_string()),
-                ])),
+                num_speakers: Some(3),
                 ..Default::default()
             },
             1,
@@ -439,14 +450,28 @@ mod tests {
     }
 
     #[test]
-    fn test_whisper_fallback_omits_streaming_diarization_hints() {
+    fn test_streaming_min_speakers_enables_diarization() {
         let url = AssemblyAIAdapter.build_ws_url(
             API_BASE,
             &owhisper_interface::ListenParams {
-                custom_query: Some(HashMap::from([
-                    ("speaker_labels".to_string(), "true".to_string()),
-                    ("max_speakers".to_string(), "3".to_string()),
-                ])),
+                model: Some("u3-rt-pro".to_string()),
+                min_speakers: Some(2),
+                ..Default::default()
+            },
+            1,
+        );
+
+        let query = url.query().expect("query string");
+        assert!(query.contains("speaker_labels=true"));
+        assert!(!query.contains("max_speakers"));
+    }
+
+    #[test]
+    fn test_streaming_diarization_hints_skip_whisper_fallback() {
+        let url = AssemblyAIAdapter.build_ws_url(
+            API_BASE,
+            &owhisper_interface::ListenParams {
+                num_speakers: Some(3),
                 languages: vec![ISO639::Ko.into()],
                 ..Default::default()
             },
@@ -455,8 +480,8 @@ mod tests {
 
         let query = url.query().expect("query string");
         assert!(query.contains("speech_model=whisper-rt"));
-        assert!(!query.contains("speaker_labels=true"));
-        assert!(!query.contains("max_speakers=3"));
+        assert!(!query.contains("speaker_labels"));
+        assert!(!query.contains("max_speakers"));
     }
 
     #[test]

--- a/crates/owhisper-client/src/adapter/elevenlabs/batch.rs
+++ b/crates/owhisper-client/src/adapter/elevenlabs/batch.rs
@@ -86,6 +86,10 @@ impl ElevenLabsAdapter {
             .text("diarize", "true")
             .text("timestamps_granularity", "word");
 
+        if let Some(num_speakers) = Self::num_speakers_hint(params) {
+            form = form.text("num_speakers", num_speakers.to_string());
+        }
+
         if let Some(lang) = params.languages.first() {
             form = form.text("language_code", lang.iso639().code().to_string());
         }
@@ -114,6 +118,10 @@ impl ElevenLabsAdapter {
         tracing::info!("transcript fetched successfully from ElevenLabs");
 
         Ok(Self::convert_to_batch_response(transcript))
+    }
+
+    fn num_speakers_hint(params: &ListenParams) -> Option<u32> {
+        params.num_speakers.or(params.max_speakers)
     }
 
     fn convert_to_batch_response(response: TranscriptResponse) -> BatchResponse {
@@ -163,6 +171,26 @@ impl ElevenLabsAdapter {
 mod tests {
     use super::*;
     use crate::http_client::create_client;
+
+    #[test]
+    fn num_speakers_hint_prefers_exact_count_then_max() {
+        let exact = ListenParams {
+            num_speakers: Some(3),
+            max_speakers: Some(5),
+            ..Default::default()
+        };
+        let ranged = ListenParams {
+            max_speakers: Some(5),
+            ..Default::default()
+        };
+
+        assert_eq!(ElevenLabsAdapter::num_speakers_hint(&exact), Some(3));
+        assert_eq!(ElevenLabsAdapter::num_speakers_hint(&ranged), Some(5));
+        assert_eq!(
+            ElevenLabsAdapter::num_speakers_hint(&ListenParams::default()),
+            None
+        );
+    }
 
     #[test]
     fn speaker_labeled_words_use_mixed_capture_channel() {

--- a/crates/owhisper-client/src/adapter/gladia/batch.rs
+++ b/crates/owhisper-client/src/adapter/gladia/batch.rs
@@ -53,9 +53,21 @@ struct TranscriptRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     diarization: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    diarization_config: Option<DiarizationConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     custom_vocabulary: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name_consistency: Option<bool>,
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+struct DiarizationConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    number_of_speakers: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    min_speakers: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_speakers: Option<u32>,
 }
 
 #[derive(Debug, Serialize)]
@@ -226,6 +238,7 @@ impl GladiaAdapter {
             model,
             language_config,
             diarization: Some(true),
+            diarization_config: Self::diarization_config(params),
             custom_vocabulary,
             name_consistency: Some(true),
         };
@@ -297,6 +310,19 @@ impl GladiaAdapter {
         .await
     }
 
+    fn diarization_config(params: &ListenParams) -> Option<DiarizationConfig> {
+        let config = DiarizationConfig {
+            number_of_speakers: params.num_speakers,
+            min_speakers: params.min_speakers,
+            max_speakers: params.max_speakers,
+        };
+
+        (config.number_of_speakers.is_some()
+            || config.min_speakers.is_some()
+            || config.max_speakers.is_some())
+        .then_some(config)
+    }
+
     fn convert_to_batch_response(response: TranscriptResponse) -> BatchResponse {
         let result = response.result.unwrap_or_default();
         let transcription = result.transcription.unwrap_or_default();
@@ -356,6 +382,33 @@ impl GladiaAdapter {
 mod tests {
     use super::*;
     use crate::http_client::create_client;
+
+    #[test]
+    fn diarization_config_uses_speaker_count_hints() {
+        let params = ListenParams {
+            num_speakers: Some(3),
+            min_speakers: Some(2),
+            max_speakers: Some(4),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            GladiaAdapter::diarization_config(&params),
+            Some(DiarizationConfig {
+                number_of_speakers: Some(3),
+                min_speakers: Some(2),
+                max_speakers: Some(4),
+            })
+        );
+    }
+
+    #[test]
+    fn diarization_config_is_omitted_without_speaker_hints() {
+        assert_eq!(
+            GladiaAdapter::diarization_config(&ListenParams::default()),
+            None
+        );
+    }
 
     #[tokio::test]
     #[ignore]

--- a/crates/owhisper-client/src/adapter/hyprnote/batch.rs
+++ b/crates/owhisper-client/src/adapter/hyprnote/batch.rs
@@ -56,6 +56,15 @@ async fn do_transcribe_file(
         for kw in &params.keywords {
             q.append_pair("keyword", kw);
         }
+        if let Some(num_speakers) = params.num_speakers {
+            q.append_pair("num_speakers", &num_speakers.to_string());
+        }
+        if let Some(min_speakers) = params.min_speakers {
+            q.append_pair("min_speakers", &min_speakers.to_string());
+        }
+        if let Some(max_speakers) = params.max_speakers {
+            q.append_pair("max_speakers", &max_speakers.to_string());
+        }
         if let Some(custom) = &params.custom_query {
             for (key, value) in custom {
                 q.append_pair(key, value);

--- a/crates/owhisper-client/src/adapter/hyprnote/live.rs
+++ b/crates/owhisper-client/src/adapter/hyprnote/live.rs
@@ -46,6 +46,16 @@ impl RealtimeSttAdapter for HyprnoteAdapter {
                 query.append_pair("keyword", keyword);
             }
 
+            if let Some(num_speakers) = params.num_speakers {
+                query.append_pair("num_speakers", &num_speakers.to_string());
+            }
+            if let Some(min_speakers) = params.min_speakers {
+                query.append_pair("min_speakers", &min_speakers.to_string());
+            }
+            if let Some(max_speakers) = params.max_speakers {
+                query.append_pair("max_speakers", &max_speakers.to_string());
+            }
+
             if let Some(custom) = &params.custom_query {
                 for (key, value) in custom {
                     query.append_pair(key, value);
@@ -135,6 +145,24 @@ mod tests {
 
         assert!(url_str.contains("keyword=Hyprnote"));
         assert!(url_str.contains("keyword=transcription"));
+    }
+
+    #[test]
+    fn test_url_with_speaker_counts() {
+        let adapter = HyprnoteAdapter::default();
+        let params = owhisper_interface::ListenParams {
+            num_speakers: Some(3),
+            min_speakers: Some(2),
+            max_speakers: Some(4),
+            ..Default::default()
+        };
+
+        let url = adapter.build_ws_url(API_BASE, &params, 1);
+        let url_str = url.as_str();
+
+        assert!(url_str.contains("num_speakers=3"));
+        assert!(url_str.contains("min_speakers=2"));
+        assert!(url_str.contains("max_speakers=4"));
     }
 
     #[test]

--- a/crates/owhisper-interface/src/openapi.rs
+++ b/crates/owhisper-interface/src/openapi.rs
@@ -16,6 +16,15 @@ pub struct CommonListenParams {
     /// Keyword boosting. Comma-separated or repeated query params
     #[allow(dead_code)]
     keywords: Option<String>,
+    /// Expected exact number of speakers, when supported by the selected provider
+    #[allow(dead_code)]
+    num_speakers: Option<u32>,
+    /// Minimum expected number of speakers, when supported by the selected provider
+    #[allow(dead_code)]
+    min_speakers: Option<u32>,
+    /// Maximum expected number of speakers, when supported by the selected provider
+    #[allow(dead_code)]
+    max_speakers: Option<u32>,
 }
 
 #[derive(utoipa::IntoParams)]

--- a/crates/transcribe-proxy/src/query_params.rs
+++ b/crates/transcribe-proxy/src/query_params.rs
@@ -89,6 +89,12 @@ impl QueryParams {
             })
             .unwrap_or_default()
     }
+
+    pub fn parse_optional_u32(&self, key: &str) -> Option<u32> {
+        self.get_first(key)
+            .and_then(|value| value.parse::<u32>().ok())
+            .filter(|value| *value > 0)
+    }
 }
 
 impl Deref for QueryParams {
@@ -276,5 +282,15 @@ mod tests {
         assert_eq!(languages.len(), 2);
         assert_eq!(languages[0].iso639(), ISO639::En);
         assert_eq!(languages[1].iso639(), ISO639::Ko);
+    }
+
+    #[test]
+    fn parse_optional_u32_ignores_missing_invalid_and_zero_values() {
+        let params = parse_query("?num_speakers=3&min_speakers=0&max_speakers=nope");
+
+        assert_eq!(params.parse_optional_u32("num_speakers"), Some(3));
+        assert_eq!(params.parse_optional_u32("min_speakers"), None);
+        assert_eq!(params.parse_optional_u32("max_speakers"), None);
+        assert_eq!(params.parse_optional_u32("missing"), None);
     }
 }

--- a/crates/transcribe-proxy/src/routes/batch/mod.rs
+++ b/crates/transcribe-proxy/src/routes/batch/mod.rs
@@ -105,6 +105,9 @@ pub(super) fn build_listen_params(params: &QueryParams) -> ListenParams {
         model: params.get_first("model").map(|s| s.to_string()),
         languages: params.get_languages(),
         keywords: params.parse_keywords(),
+        num_speakers: params.parse_optional_u32("num_speakers"),
+        min_speakers: params.parse_optional_u32("min_speakers"),
+        max_speakers: params.parse_optional_u32("max_speakers"),
         ..Default::default()
     })
 }
@@ -151,5 +154,28 @@ mod tests {
         assert_eq!(listen_params.languages[0].region(), None);
         assert_eq!(listen_params.languages[1].iso639(), ISO639::Ko);
         assert_eq!(listen_params.languages[1].region(), Some("KR"));
+    }
+
+    #[test]
+    fn test_build_listen_params_with_speaker_counts() {
+        let mut params = QueryParams::default();
+        params.insert(
+            "num_speakers".to_string(),
+            QueryValue::Single("3".to_string()),
+        );
+        params.insert(
+            "min_speakers".to_string(),
+            QueryValue::Single("2".to_string()),
+        );
+        params.insert(
+            "max_speakers".to_string(),
+            QueryValue::Single("4".to_string()),
+        );
+
+        let listen_params = build_listen_params(&params);
+
+        assert_eq!(listen_params.num_speakers, Some(3));
+        assert_eq!(listen_params.min_speakers, Some(2));
+        assert_eq!(listen_params.max_speakers, Some(4));
     }
 }

--- a/crates/transcribe-proxy/src/routes/streaming/hyprnote.rs
+++ b/crates/transcribe-proxy/src/routes/streaming/hyprnote.rs
@@ -24,6 +24,9 @@ fn build_listen_params(params: &QueryParams) -> ListenParams {
         sample_rate: parse_param(params, "sample_rate", 16000),
         channels: parse_param(params, "channels", 1),
         keywords: params.parse_keywords(),
+        num_speakers: params.parse_optional_u32("num_speakers"),
+        min_speakers: params.parse_optional_u32("min_speakers"),
+        max_speakers: params.parse_optional_u32("max_speakers"),
         ..Default::default()
     })
 }
@@ -291,6 +294,29 @@ mod tests {
         assert_eq!(listen_params.languages[0].iso639(), ISO639::En);
         assert_eq!(listen_params.sample_rate, 16000);
         assert_eq!(listen_params.channels, 1);
+    }
+
+    #[test]
+    fn test_build_listen_params_with_speaker_counts() {
+        let mut params = QueryParams::default();
+        params.insert(
+            "num_speakers".to_string(),
+            QueryValue::Single("3".to_string()),
+        );
+        params.insert(
+            "min_speakers".to_string(),
+            QueryValue::Single("2".to_string()),
+        );
+        params.insert(
+            "max_speakers".to_string(),
+            QueryValue::Single("4".to_string()),
+        );
+
+        let listen_params = build_listen_params(&params);
+
+        assert_eq!(listen_params.num_speakers, Some(3));
+        assert_eq!(listen_params.min_speakers, Some(2));
+        assert_eq!(listen_params.max_speakers, Some(4));
     }
 
     #[test]

--- a/plugins/transcription/src/listener2/ext.rs
+++ b/plugins/transcription/src/listener2/ext.rs
@@ -33,6 +33,7 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Listener2<'a, R, M> {
             .inner()
             .clone();
         let session_id = params.session_id.clone();
+        let idle_timeout = batch_idle_timeout(&params);
 
         {
             let mut sessions = registry
@@ -124,7 +125,16 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Listener2<'a, R, M> {
             return Ok(());
         }
 
-        spawn_idle_timeout_monitor(app, registry, session_id, control, abort_handle);
+        if let Some(idle_timeout) = idle_timeout {
+            spawn_idle_timeout_monitor(
+                app,
+                registry,
+                session_id,
+                control,
+                abort_handle,
+                idle_timeout,
+            );
+        }
 
         Ok(())
     }
@@ -326,18 +336,25 @@ fn stop_batch_session(
     }
 }
 
+fn batch_idle_timeout(params: &TranscriptionParams) -> Option<Duration> {
+    let batch_params: core::BatchParams = params.clone().into();
+
+    core::expects_progressive_batch(&batch_params).then_some(BATCH_IDLE_TIMEOUT)
+}
+
 fn spawn_idle_timeout_monitor(
     app: tauri::AppHandle,
     registry: Arc<BatchSessionRegistry>,
     session_id: String,
     control: Arc<BatchSessionControl>,
     abort_handle: tokio::task::AbortHandle,
+    idle_timeout: Duration,
 ) -> JoinHandle<()> {
     let mut activity_rx = control.last_activity_tx.subscribe();
 
     tokio::spawn(async move {
         loop {
-            let deadline = *activity_rx.borrow() + BATCH_IDLE_TIMEOUT;
+            let deadline = *activity_rx.borrow() + idle_timeout;
             let sleep = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline));
             tokio::pin!(sleep);
 
@@ -352,7 +369,10 @@ fn spawn_idle_timeout_monitor(
                     let _ = TranscriptionEvent::Failed {
                         session_id: session_id.clone(),
                         code: core::BatchErrorCode::TimedOut,
-                        error: "Transcription timed out after 60 seconds without progress.".to_string(),
+                        error: format!(
+                            "Transcription timed out after {} seconds without progress.",
+                            idle_timeout.as_secs()
+                        ),
                     }
                     .emit(&app);
                     abort_handle.abort();
@@ -379,6 +399,26 @@ mod tests {
             last_activity_tx,
             terminal_state: std::sync::Mutex::new(BatchTerminalState::Running),
         })
+    }
+
+    fn transcription_params(
+        provider: core::BatchProvider,
+        base_url: &str,
+        model: Option<&str>,
+    ) -> TranscriptionParams {
+        TranscriptionParams {
+            session_id: "session-1".to_string(),
+            provider,
+            file_path: "/tmp/audio.wav".to_string(),
+            model: model.map(ToOwned::to_owned),
+            base_url: base_url.to_string(),
+            api_key: "key".to_string(),
+            languages: vec![hypr_language::ISO639::En.into()],
+            keywords: vec![],
+            num_speakers: None,
+            min_speakers: None,
+            max_speakers: None,
+        }
     }
 
     #[test]
@@ -430,5 +470,32 @@ mod tests {
                 .expect("batch session registry poisoned")
                 .contains_key("session-1")
         );
+    }
+
+    #[test]
+    fn batch_idle_timeout_skips_direct_cloud_batch() {
+        let params = transcription_params(
+            core::BatchProvider::Hyprnote,
+            "https://api.char.com/stt",
+            None,
+        );
+
+        assert_eq!(batch_idle_timeout(&params), None);
+    }
+
+    #[test]
+    fn batch_idle_timeout_skips_cloud_am_batch() {
+        let params =
+            transcription_params(core::BatchProvider::Am, "https://api.char.com/stt", None);
+
+        assert_eq!(batch_idle_timeout(&params), None);
+    }
+
+    #[test]
+    fn batch_idle_timeout_applies_to_local_am_batch() {
+        let params =
+            transcription_params(core::BatchProvider::Am, "http://localhost:50060/v1", None);
+
+        assert_eq!(batch_idle_timeout(&params), Some(BATCH_IDLE_TIMEOUT));
     }
 }


### PR DESCRIPTION
Persist streamed batch transcript snapshots and flush them so interrupted batch jobs can recover transcript progress.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5246 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5241 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how progressive batch transcripts are persisted (replace-mode snapshots + explicit store flush), which could affect transcript integrity/duplication and write frequency. Also alters timeout behavior by disabling idle timeouts for non-progressive/cloud batch runs, which may change failure modes for those providers.
> 
> **Overview**
> **Progressive batch runs now persist recoverable transcript snapshots.** Streamed `BatchResponseStreamed` `segment` events are flattened across channels and persisted as full *replace-mode* snapshots, and final `handleBatchResponse` also writes via `replace`.
> 
> **Batch persistence is made safer/more durable.** `BatchPersistCallback` gains an optional `{ mode: "append" | "replace" }`, the default batch persist in `useRunBatch` honors `replace` (avoiding re-reading existing words/hints), wraps updates in a single transaction, and triggers a `save()` flush after streamed writes.
> 
> **Idle-timeout monitoring is gated to progressive batches.** A new core helper `expects_progressive_batch` (exported from `listener2-core`) is used by the plugin to only start the 60s idle timeout monitor when a provider/model should emit progressive batch events; tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf94153aae8eedf3f5f62e87b4acea0b2e3b6197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->