### PR TITLE
fix(editor): recover from editor render failures

### DIFF
--- a/apps/desktop/src/editor-bridge/app-link-view.tsx
+++ b/apps/desktop/src/editor-bridge/app-link-view.tsx
@@ -12,6 +12,7 @@ import {
   type GitHubAttrs,
   type AppLinkAttrs,
 } from "@hypr/editor/app-link";
+import { getSafeNodePos } from "@hypr/editor/node-views";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { commands as todoCommands } from "@hypr/plugin-todo";
 import { cn } from "@hypr/utils";
@@ -104,10 +105,12 @@ export const AppLinkView = forwardRef<HTMLSpanElement, NodeViewComponentProps>(
         attrs.repo &&
         attrs.number
       ) {
-        const pos = nodeProps.getPos();
-        const resources = collectSiblingResources(view.state.doc, pos);
-        openTaskTab(resources);
-        return;
+        const pos = getSafeNodePos(nodeProps.getPos);
+        if (pos !== null) {
+          const resources = collectSiblingResources(view.state.doc, pos);
+          openTaskTab(resources);
+          return;
+        }
       }
 
       await openerCommands.openUrl(href, null);

--- a/apps/desktop/src/editor-bridge/session-view.tsx
+++ b/apps/desktop/src/editor-bridge/session-view.tsx
@@ -5,7 +5,7 @@ import {
 import { format } from "date-fns";
 import { forwardRef, type ReactNode, useCallback, useMemo } from "react";
 
-import { TaskCheckbox } from "@hypr/editor/node-views";
+import { getSafeNodePos, TaskCheckbox } from "@hypr/editor/node-views";
 import { useLinkedItemOpenBehavior } from "@hypr/editor/note";
 import {
   createTaskStatusAttrs,
@@ -91,7 +91,9 @@ export const SessionNodeView = forwardRef<
 
   const handleToggle = useEditorEventCallback((view) => {
     if (!view) return;
-    const pos = getPos();
+    const pos = getSafeNodePos(getPos);
+    if (pos === null) return;
+
     const nextStatus = getNextTaskStatus(status);
     const tr = view.state.tr.setNodeMarkup(pos, undefined, {
       ...node.attrs,

--- a/packages/editor/src/chat/index.tsx
+++ b/packages/editor/src/chat/index.tsx
@@ -30,7 +30,11 @@ import "@hypr/tiptap/styles.css";
 import { cn } from "@hypr/utils";
 
 import { EditorErrorBoundary } from "../editor-error-boundary";
-import { AttachmentChipView, MentionNodeView } from "../node-views";
+import {
+  AttachmentChipView,
+  MentionNodeView,
+  withNodeViewErrorBoundary,
+} from "../node-views";
 import { type PlaceholderFunction, placeholderPlugin } from "../plugins";
 import { dispatchEditorTransaction } from "../transaction-guard";
 import {
@@ -68,8 +72,12 @@ interface ChatEditorProps {
 }
 
 const nodeViews = {
-  "mention-@": MentionNodeView,
-  attachment: AttachmentChipView,
+  "mention-@": withNodeViewErrorBoundary<HTMLElement>(MentionNodeView, {
+    name: "mention-@",
+  }),
+  attachment: withNodeViewErrorBoundary<HTMLSpanElement>(AttachmentChipView, {
+    name: "attachment",
+  }),
 };
 
 function ViewCapture({

--- a/packages/editor/src/editor-error-boundary.test.tsx
+++ b/packages/editor/src/editor-error-boundary.test.tsx
@@ -1,0 +1,99 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+
+import { EditorErrorBoundary } from "./editor-error-boundary";
+
+const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+const renderOptions = {
+  onCaughtError: () => {},
+  onRecoverableError: () => {},
+} satisfies Parameters<typeof render>[1];
+
+afterEach(() => {
+  cleanup();
+  consoleError.mockClear();
+});
+
+afterAll(() => {
+  consoleError.mockRestore();
+});
+
+describe("EditorErrorBoundary", () => {
+  it("automatically remounts the editor once after a render failure", async () => {
+    let renderCount = 0;
+
+    function FlakyEditor() {
+      renderCount += 1;
+      if (renderCount === 1) {
+        throw new Error("first render failed");
+      }
+
+      return <div>editor ready</div>;
+    }
+
+    render(
+      <EditorErrorBoundary>
+        <FlakyEditor />
+      </EditorErrorBoundary>,
+      renderOptions,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("editor ready")).toBeTruthy();
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("keeps a manual reload path after repeated render failures", async () => {
+    function BrokenEditor() {
+      throw new Error("render failed");
+    }
+
+    render(
+      <EditorErrorBoundary>
+        <BrokenEditor />
+      </EditorErrorBoundary>,
+      renderOptions,
+    );
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("The editor failed to render");
+
+    fireEvent.click(screen.getByRole("button", { name: "Reload editor" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+    });
+  });
+
+  it("resets after the editor identity changes", async () => {
+    function BrokenEditor() {
+      throw new Error("render failed");
+    }
+
+    const view = render(
+      <EditorErrorBoundary resetKey="session-a">
+        <BrokenEditor />
+      </EditorErrorBoundary>,
+      renderOptions,
+    );
+
+    await screen.findByRole("alert");
+
+    view.rerender(
+      <EditorErrorBoundary resetKey="session-b">
+        <div>new editor</div>
+      </EditorErrorBoundary>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("new editor")).toBeTruthy();
+    });
+  });
+});

--- a/packages/editor/src/editor-error-boundary.tsx
+++ b/packages/editor/src/editor-error-boundary.tsx
@@ -1,12 +1,17 @@
-import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Component, Fragment, type ErrorInfo, type ReactNode } from "react";
 
 type EditorErrorBoundaryProps = {
   children: ReactNode;
+  resetKey?: string;
 };
 
 type EditorErrorBoundaryState = {
   hasError: boolean;
+  recoveryAttempts: number;
+  recoveryKey: number;
 };
+
+const MAX_AUTO_RECOVERY_ATTEMPTS = 1;
 
 export class EditorErrorBoundary extends Component<
   EditorErrorBoundaryProps,
@@ -14,29 +19,68 @@ export class EditorErrorBoundary extends Component<
 > {
   constructor(props: EditorErrorBoundaryProps) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { hasError: false, recoveryAttempts: 0, recoveryKey: 0 };
   }
 
-  static getDerivedStateFromError(): EditorErrorBoundaryState {
+  static getDerivedStateFromError(): Partial<EditorErrorBoundaryState> {
     return { hasError: true };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error("Editor render failed", error, info);
+
+    if (this.state.recoveryAttempts < MAX_AUTO_RECOVERY_ATTEMPTS) {
+      this.setState((state) => ({
+        hasError: false,
+        recoveryAttempts: state.recoveryAttempts + 1,
+        recoveryKey: state.recoveryKey + 1,
+      }));
+    }
   }
+
+  componentDidUpdate(prevProps: EditorErrorBoundaryProps) {
+    if (prevProps.resetKey === this.props.resetKey) {
+      return;
+    }
+
+    this.setState((state) => ({
+      hasError: false,
+      recoveryAttempts: 0,
+      recoveryKey: state.recoveryKey + 1,
+    }));
+  }
+
+  private retry = () => {
+    this.setState((state) => ({
+      hasError: false,
+      recoveryAttempts: 0,
+      recoveryKey: state.recoveryKey + 1,
+    }));
+  };
 
   render() {
     if (this.state.hasError) {
       return (
         <div
           role="alert"
-          className="rounded-md border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-600"
+          className="flex items-center justify-between gap-3 rounded-md border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-600"
         >
-          The editor hit an error. Your recording is still running.
+          <span>
+            The editor failed to render. Your recording is still running.
+          </span>
+          <button
+            type="button"
+            onClick={this.retry}
+            className="shrink-0 rounded-md border border-neutral-200 bg-white px-2 py-1 text-xs font-medium text-neutral-700 hover:bg-neutral-100"
+          >
+            Reload editor
+          </button>
         </div>
       );
     }
 
-    return this.props.children;
+    return (
+      <Fragment key={this.state.recoveryKey}>{this.props.children}</Fragment>
+    );
   }
 }

--- a/packages/editor/src/node-views/attachment-view.tsx
+++ b/packages/editor/src/node-views/attachment-view.tsx
@@ -6,6 +6,8 @@ import { FileIcon, XIcon } from "lucide-react";
 import type { NodeSpec } from "prosemirror-model";
 import { forwardRef } from "react";
 
+import { getSafeNodePos } from "./error-boundary";
+
 export const attachmentNodeSpec: NodeSpec = {
   group: "inline",
   inline: true,
@@ -58,7 +60,9 @@ export const AttachmentChipView = forwardRef<
 
   const handleRemove = useEditorEventCallback((view) => {
     if (!view) return;
-    const pos = getPos();
+    const pos = getSafeNodePos(getPos);
+    if (pos === null) return;
+
     view.dispatch(view.state.tr.delete(pos, pos + node.nodeSize));
     view.focus();
   });

--- a/packages/editor/src/node-views/error-boundary.test.tsx
+++ b/packages/editor/src/node-views/error-boundary.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+
+import { getSafeNodePos, withNodeViewErrorBoundary } from "./error-boundary";
+
+const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+const renderOptions = {
+  onCaughtError: () => {},
+  onRecoverableError: () => {},
+} satisfies Parameters<typeof render>[1];
+
+afterEach(() => {
+  cleanup();
+  consoleError.mockClear();
+});
+
+afterAll(() => {
+  consoleError.mockRestore();
+});
+
+describe("getSafeNodePos", () => {
+  it("returns null when ProseMirror no longer has a node position", () => {
+    expect(
+      getSafeNodePos(() => {
+        throw new Error("detached node");
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("withNodeViewErrorBoundary", () => {
+  it("contains node view render failures to a local fallback", () => {
+    function BrokenNodeView() {
+      throw new Error("node view failed");
+    }
+
+    const Wrapped = withNodeViewErrorBoundary<HTMLSpanElement>(BrokenNodeView, {
+      name: "attachment",
+    });
+
+    render(
+      <Wrapped
+        nodeProps={
+          {
+            node: {
+              attrs: {},
+              textContent: "attachment.txt",
+            },
+          } as any
+        }
+      />,
+      renderOptions,
+    );
+
+    const fallback = screen.getByText("attachment.txt");
+    expect(fallback.getAttribute("data-node-view-error")).toBe("attachment");
+  });
+});

--- a/packages/editor/src/node-views/error-boundary.tsx
+++ b/packages/editor/src/node-views/error-boundary.tsx
@@ -1,0 +1,154 @@
+import type { NodeViewComponentProps } from "@handlewithcare/react-prosemirror";
+import {
+  Component,
+  createElement,
+  forwardRef,
+  type ComponentType,
+  type ErrorInfo,
+  type ForwardedRef,
+  type ReactNode,
+} from "react";
+
+type FallbackTag = "div" | "li" | "span";
+
+type NodeViewErrorBoundaryProps = {
+  children: ReactNode;
+  fallbackAttrs: Record<string, unknown>;
+  fallbackTag: FallbackTag;
+  fallbackText: string;
+  forwardedRef: ForwardedRef<HTMLElement>;
+  name: string;
+  resetKey: unknown;
+};
+
+type NodeViewErrorBoundaryState = {
+  hasError: boolean;
+};
+
+class NodeViewErrorBoundary extends Component<
+  NodeViewErrorBoundaryProps,
+  NodeViewErrorBoundaryState
+> {
+  constructor(props: NodeViewErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): NodeViewErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Editor node view render failed", {
+      error,
+      info,
+      nodeView: this.props.name,
+    });
+  }
+
+  componentDidUpdate(prevProps: NodeViewErrorBoundaryProps) {
+    if (prevProps.resetKey === this.props.resetKey || !this.state.hasError) {
+      return;
+    }
+
+    this.setState({ hasError: false });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      const { className, ...attrs } = this.props.fallbackAttrs;
+      return createElement(
+        this.props.fallbackTag,
+        {
+          ...attrs,
+          ref: this.props.forwardedRef,
+          contentEditable: false,
+          suppressContentEditableWarning: true,
+          "data-node-view-error": this.props.name,
+          className: [
+            "rounded-md border border-neutral-200 bg-neutral-50 px-2 py-1 text-sm text-neutral-600",
+            typeof className === "string" ? className : "",
+          ]
+            .filter(Boolean)
+            .join(" "),
+        },
+        this.props.fallbackText,
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+function getFallbackAttrs(props: Record<string, unknown>) {
+  const { children: _children, nodeProps: _nodeProps, ...attrs } = props;
+  return attrs;
+}
+
+function getFallbackText(props: Partial<NodeViewComponentProps>) {
+  const node = props.nodeProps?.node;
+  const text = node?.textContent?.trim();
+  if (text) {
+    return text;
+  }
+
+  const attrs = node?.attrs ?? {};
+  if (typeof attrs.name === "string" && attrs.name.trim()) {
+    return attrs.name;
+  }
+  if (typeof attrs.url === "string" && attrs.url.trim()) {
+    return attrs.url;
+  }
+
+  return "Unsupported content";
+}
+
+export function getNodeViewFallbackTag(name: string): FallbackTag {
+  if (name === "taskItem") {
+    return "li";
+  }
+  if (
+    name === "attachment" ||
+    name === "appLink" ||
+    name.startsWith("mention")
+  ) {
+    return "span";
+  }
+  return "div";
+}
+
+export function getSafeNodePos(getPos: () => number | undefined) {
+  try {
+    const pos = getPos();
+    return typeof pos === "number" && Number.isFinite(pos) ? pos : null;
+  } catch {
+    return null;
+  }
+}
+
+export function withNodeViewErrorBoundary<E extends HTMLElement>(
+  Component: ComponentType<any>,
+  {
+    fallbackTag,
+    name,
+  }: {
+    fallbackTag?: FallbackTag;
+    name: string;
+  },
+) {
+  const Wrapped = forwardRef<E, any>((props, ref) => (
+    <NodeViewErrorBoundary
+      fallbackAttrs={getFallbackAttrs(props)}
+      fallbackTag={fallbackTag ?? getNodeViewFallbackTag(name)}
+      fallbackText={getFallbackText(props)}
+      forwardedRef={ref as ForwardedRef<HTMLElement>}
+      name={name}
+      resetKey={props.nodeProps?.node}
+    >
+      <Component {...props} ref={ref} />
+    </NodeViewErrorBoundary>
+  ));
+
+  Wrapped.displayName = `NodeViewErrorBoundary(${name})`;
+  return Wrapped;
+}

--- a/packages/editor/src/node-views/file-attachment-view.tsx
+++ b/packages/editor/src/node-views/file-attachment-view.tsx
@@ -16,6 +16,8 @@ import { forwardRef } from "react";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { cn } from "@hypr/utils";
 
+import { getSafeNodePos } from "./error-boundary";
+
 const MIME_ICON_MAP: Record<string, typeof FileIcon> = {
   "application/pdf": FileTextIcon,
   "text/plain": FileTextIcon,
@@ -99,7 +101,9 @@ export const FileAttachmentView = forwardRef<
 
   const handleRemove = useEditorEventCallback((view) => {
     if (!view) return;
-    const pos = getPos();
+    const pos = getSafeNodePos(getPos);
+    if (pos === null) return;
+
     view.dispatch(view.state.tr.delete(pos, pos + node.nodeSize));
     view.focus();
   });

--- a/packages/editor/src/node-views/image-view.tsx
+++ b/packages/editor/src/node-views/image-view.tsx
@@ -8,6 +8,8 @@ import { forwardRef, useCallback, useRef, useState } from "react";
 
 import { cn } from "@hypr/utils";
 
+import { getSafeNodePos } from "./error-boundary";
+
 const MIN_IMAGE_WIDTH = 15;
 const MAX_IMAGE_WIDTH = 100;
 const DEFAULT_IMAGE_WIDTH = 80;
@@ -92,7 +94,9 @@ export const ResizableImageView = forwardRef<
   const updateAttributes = useEditorEventCallback(
     (view, attrs: Record<string, unknown>) => {
       if (!view) return;
-      const pos = getPos();
+      const pos = getSafeNodePos(getPos);
+      if (pos === null) return;
+
       const tr = view.state.tr.setNodeMarkup(pos, undefined, {
         ...node.attrs,
         ...attrs,
@@ -104,10 +108,12 @@ export const ResizableImageView = forwardRef<
   // to detect whether a nodeview is selected:
   // see: https://discuss.prosemirror.net/t/is-this-the-right-way-to-determine-if-a-nodeview-is-selected/2208/2
   // also: https://github.com/handlewithcarecollective/react-prosemirror/issues/161
-  const pos = getPos();
+  const pos = getSafeNodePos(getPos);
   const { selection } = useEditorState();
   const isSelected =
-    pos >= selection.from && pos + node.nodeSize <= selection.to;
+    pos !== null &&
+    pos >= selection.from &&
+    pos + node.nodeSize <= selection.to;
 
   // we register all resize event handlers during resize start and unregister them on resize end.
   // all drag state lives inside this callback scope.

--- a/packages/editor/src/node-views/index.ts
+++ b/packages/editor/src/node-views/index.ts
@@ -1,6 +1,11 @@
 export { appLinkNodeSpec } from "./app-link-spec";
 export { attachmentNodeSpec, AttachmentChipView } from "./attachment-view";
 export {
+  getNodeViewFallbackTag,
+  getSafeNodePos,
+  withNodeViewErrorBoundary,
+} from "./error-boundary";
+export {
   fileAttachmentNodeSpec,
   FileAttachmentView,
 } from "./file-attachment-view";

--- a/packages/editor/src/node-views/task-item-view.test.tsx
+++ b/packages/editor/src/node-views/task-item-view.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => {
   const transaction = {
@@ -25,11 +25,19 @@ vi.mock("@handlewithcare/react-prosemirror", () => ({
 import { TaskItemView } from "./task-item-view";
 
 describe("TaskItemView", () => {
+  beforeEach(() => {
+    hoisted.transaction.setNodeMarkup.mockClear();
+    hoisted.view.dispatch.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
   it("toggles the task status when the checkbox is clicked", () => {
     hoisted.transaction.setNodeMarkup.mockImplementation(
       (_pos, _type, attrs) => ({ attrs }),
     );
-    hoisted.view.dispatch.mockClear();
 
     render(
       <TaskItemView
@@ -72,5 +80,37 @@ describe("TaskItemView", () => {
         taskItemId: null,
       },
     });
+  });
+
+  it("renders when ProseMirror no longer has a node position", () => {
+    expect(() =>
+      render(
+        <TaskItemView
+          nodeProps={
+            {
+              node: {
+                attrs: {
+                  status: "todo",
+                  checked: false,
+                  taskId: null,
+                  taskItemId: null,
+                },
+                nodeSize: 2,
+              },
+              getPos: () => {
+                throw new Error("detached node");
+              },
+            } as any
+          }
+        >
+          <p>All hands</p>
+        </TaskItemView>,
+      ),
+    ).not.toThrow();
+
+    fireEvent.click(screen.getByRole("checkbox"));
+
+    expect(hoisted.transaction.setNodeMarkup).not.toHaveBeenCalled();
+    expect(hoisted.view.dispatch).not.toHaveBeenCalled();
   });
 });

--- a/packages/editor/src/node-views/task-item-view.tsx
+++ b/packages/editor/src/node-views/task-item-view.tsx
@@ -11,6 +11,7 @@ import {
   getNextTaskStatus,
   normalizeTaskStatus,
 } from "../tasks";
+import { getSafeNodePos } from "./error-boundary";
 import { TaskCheckbox } from "./task-checkbox";
 
 export const taskListNodeSpec: NodeSpec = {
@@ -72,14 +73,18 @@ export const TaskItemView = forwardRef<
   const status = normalizeTaskStatus(node.attrs.status, node.attrs.checked);
   const taskId = node.attrs.taskId as string | null;
 
-  const pos = getPos();
+  const pos = getSafeNodePos(getPos);
   const { selection } = useEditorState();
   const isSelected =
-    pos >= selection.from && pos + node.nodeSize <= selection.to - 1;
+    pos !== null &&
+    pos >= selection.from &&
+    pos + node.nodeSize <= selection.to - 1;
 
   const handleToggle = useEditorEventCallback((view) => {
     if (!view) return;
-    const pos = getPos();
+    const pos = getSafeNodePos(getPos);
+    if (pos === null) return;
+
     const nextStatus = getNextTaskStatus(status);
     const tr = view.state.tr.setNodeMarkup(pos, undefined, {
       ...node.attrs,

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -35,9 +35,11 @@ import "@hypr/tiptap/styles.css";
 import { EditorErrorBoundary } from "../editor-error-boundary";
 import {
   FileAttachmentView,
+  getNodeViewFallbackTag,
   MentionNodeView,
   ResizableImageView,
   TaskItemView,
+  withNodeViewErrorBoundary,
 } from "../node-views";
 import {
   appLinkPastePlugin,
@@ -134,11 +136,36 @@ export interface NoteEditorProps {
 }
 
 const baseNodeViews = {
-  fileAttachment: FileAttachmentView,
-  image: ResizableImageView,
-  "mention-@": MentionNodeView,
-  taskItem: TaskItemView,
+  fileAttachment: withNodeViewErrorBoundary<HTMLDivElement>(
+    FileAttachmentView,
+    { name: "fileAttachment" },
+  ),
+  image: withNodeViewErrorBoundary<HTMLDivElement>(ResizableImageView, {
+    name: "image",
+  }),
+  "mention-@": withNodeViewErrorBoundary<HTMLElement>(MentionNodeView, {
+    name: "mention-@",
+  }),
+  taskItem: withNodeViewErrorBoundary<HTMLLIElement>(TaskItemView, {
+    name: "taskItem",
+  }),
 };
+
+function wrapNodeViewComponents(nodeViews?: NodeViewComponents) {
+  if (!nodeViews) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(nodeViews).map(([name, Component]) => [
+      name,
+      withNodeViewErrorBoundary(Component, {
+        fallbackTag: getNodeViewFallbackTag(name),
+        name,
+      }),
+    ]),
+  ) as NodeViewComponents;
+}
 
 function ViewCapture({
   viewRef,
@@ -419,7 +446,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       ],
     );
     const nodeViews = useMemo(
-      () => ({ ...baseNodeViews, ...extraNodeViews }),
+      () => ({ ...baseNodeViews, ...wrapNodeViewComponents(extraNodeViews) }),
       [extraNodeViews],
     );
 
@@ -473,7 +500,11 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
     return (
       <TaskSourceProvider source={taskSource ?? null}>
         <LinkedItemOpenBehaviorContext.Provider value={linkedItemOpenBehavior}>
-          <EditorErrorBoundary>
+          <EditorErrorBoundary
+            resetKey={
+              taskSource ? `${taskSource.type}:${taskSource.id}` : "note"
+            }
+          >
             <ProseMirror
               defaultState={defaultState}
               nodeViewComponents={nodeViews}


### PR DESCRIPTION
Add node-view error boundaries, guard stale ProseMirror positions, and let the editor boundary remount after crashes.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5247 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5242 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core editor rendering and node-view wiring; mistakes could hide errors, drop interactions, or cause unexpected remounts in active sessions, though changes are defensive and well-tested.
> 
> **Overview**
> **Editor crashes now recover more gracefully.** `EditorErrorBoundary` auto-remounts the editor once after a render failure, adds a manual *Reload editor* action, and supports `resetKey` to fully reset the boundary when the editor identity changes (used in `NoteEditor`).
> 
> **Node views are hardened.** Adds `withNodeViewErrorBoundary` to locally contain node-view render crashes with a minimal fallback UI, and introduces `getSafeNodePos` to avoid throwing/dispatching transactions when `getPos()` is stale; this guard is applied across multiple node views (tasks, attachments, images, app links, sessions) and chat/note node-view registrations now wrap built-ins and `extraNodeViews`. Added unit tests cover the new recovery and node-view error handling paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 002ad533ea8ce9f73223843791bfab035cd47c27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->