### PR TITLE
fix: keep audio until transcript words exist for none policy

### DIFF
--- a/apps/desktop/src/services/audio-retention.test.ts
+++ b/apps/desktop/src/services/audio-retention.test.ts
@@ -149,4 +149,39 @@ describe("audio retention", () => {
     );
     expect(deleted).toEqual(["expired", "orphan"]);
   });
+
+  test("keeps unsaved audio when retention is none until transcript words exist", async () => {
+    const now = Date.parse("2026-05-13T00:00:00.000Z");
+    const store = createMainStore();
+    const settingsStore = createSettingsStore();
+
+    settingsStore.setValue("audio_retention", "none");
+    store.setRow("sessions", "unprocessed", {
+      user_id: "user",
+      created_at: "2026-05-13T00:00:00.000Z",
+      title: "",
+      raw_md: "",
+    });
+    store.setRow("sessions", "processed", {
+      user_id: "user",
+      created_at: "2026-05-13T00:00:00.000Z",
+      title: "",
+      raw_md: "",
+    });
+    store.setRow("transcripts", "processed-transcript", {
+      user_id: "user",
+      created_at: "2026-05-13T00:00:00.000Z",
+      session_id: "processed",
+      started_at: now,
+      words: JSON.stringify([{ text: " saved" }]),
+      speaker_hints: "[]",
+      memo_md: "",
+    });
+
+    const deleted = await cleanupExpiredAudio(store, settingsStore, now);
+
+    expect(audioDeleteMock).toHaveBeenCalledTimes(1);
+    expect(audioDeleteMock).toHaveBeenCalledWith("processed");
+    expect(deleted).toEqual(["processed"]);
+  });
 });

--- a/apps/desktop/src/services/audio-retention.ts
+++ b/apps/desktop/src/services/audio-retention.ts
@@ -39,6 +39,36 @@ export function sessionAudioExpired(
   return nowMs >= createdAtMs + AUDIO_RETENTION_DURATION_MS[policy];
 }
 
+function sessionHasTranscriptWords(store: main.Store, sessionId: string) {
+  let hasWords = false;
+
+  store.forEachRow("transcripts", (transcriptId, _forEachCell) => {
+    if (hasWords) {
+      return;
+    }
+
+    if (
+      store.getCell("transcripts", transcriptId, "session_id") !== sessionId
+    ) {
+      return;
+    }
+
+    const wordsJson = store.getCell("transcripts", transcriptId, "words");
+    if (typeof wordsJson !== "string" || !wordsJson) {
+      return;
+    }
+
+    try {
+      const words = JSON.parse(wordsJson);
+      hasWords = Array.isArray(words) && words.length > 0;
+    } catch {
+      hasWords = false;
+    }
+  });
+
+  return hasWords;
+}
+
 export async function cleanupExpiredAudio(
   store: main.Store,
   settingsStore: settings.Store,
@@ -55,6 +85,10 @@ export async function cleanupExpiredAudio(
     knownSessionIds.push(sessionId);
 
     if (listenerStore.getState().getSessionMode(sessionId) !== "inactive") {
+      return;
+    }
+
+    if (policy === "none" && !sessionHasTranscriptWords(store, sessionId)) {
       return;
     }
 


### PR DESCRIPTION
When audio retention is set to "none", audio files are now preserved until the associated session has transcript words. This prevents deletion of audio for sessions that have not
yet been processed, ensuring transcription can still occur.

Add a `sessionHasTranscriptWords` function that checks the store for any transcript belonging to the session with a
non-empty words array. The cleanup logic skips deletion when the policy is "none" and no transcript words are found.

Add a test to verify that only sessions with transcript words are cleaned up when the retention policy is "none".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes audio deletion behavior for the `none` retention policy and could impact storage usage or deletion expectations if the transcript/words state is misdetected.
> 
> **Overview**
> Adjusts `cleanupExpiredAudio` so that when `audio_retention` is `none`, inactive sessions are **not** deleted until a transcript row for that session contains a non-empty `words` array (via new `sessionHasTranscriptWords`).
> 
> Adds a Vitest case to ensure only sessions with transcript words are cleaned up under the `none` policy, preventing premature deletion for unprocessed sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffbaa2a93d87f6de80cbf41cb3d80a4619eb9e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->