### PR TITLE
chore(web): clarify Anarlog macOS support

### DIFF
--- a/apps/web/content/articles/char-is-now-anarlog.mdx
+++ b/apps/web/content/articles/char-is-now-anarlog.mdx
@@ -36,7 +36,7 @@ It's the existing app. Renamed, relicensed (GPL → MIT), kept open source forev
 - Plain markdown files on your device
 - BYOK or local models (Ollama, LM Studio) — your AI, your keys
 - 45+ languages, works with Zoom / Meet / Teams / phone / in-person
-- macOS and Linux. Windows is on the roadmap.
+- macOS only. We are not planning Linux or Windows support.
 
 If you're already running Char (the desktop app), it'll keep working. The next update will rename itself to Anarlog. Your local files don't move. Your stack doesn't change. We're keeping the pro AI models and the calendar integration in Anarlog through the migration window — nothing gets ripped out from under you.
 


### PR DESCRIPTION
Update the rebrand article to state Anarlog will only support macOS going forward.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only change that updates product messaging; low engineering risk, with only potential risk of user-facing confusion if the platform statement is incorrect.
> 
> **Overview**
> Clarifies platform support in `char-is-now-anarlog.mdx` by changing the Anarlog feature list from *macOS and Linux (Windows roadmap)* to **macOS-only**, explicitly stating there are no plans for Linux or Windows support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65226479fad6bd201bce3a818535a6de75d03c5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->