### PR TITLE
chore(web): read changelog summaries from frontmatter

### DIFF
--- a/.agents/skills/new-changelog/SKILL.md
+++ b/.agents/skills/new-changelog/SKILL.md
@@ -10,3 +10,17 @@ doxxer --config doxxer.desktop.toml
 ```
 
 Create the new markdown file in `packages/changelog/content` for that version.
+
+Each changelog file must start with frontmatter that includes both `date` and
+`summary`:
+
+```md
+---
+date: "YYYY-MM-DD"
+summary: "One concise, user-facing sentence for the changelog index preview."
+---
+```
+
+Keep `summary` plain text. Do not use markdown or custom tags in it. The web
+changelog index renders this field directly, so it should describe the release
+at a glance without leaking implementation details.

--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -12,12 +12,13 @@ const rawEntries = import.meta.glob(
 export const changelogEntries = Object.entries(rawEntries)
   .map(([filePath, raw]) => {
     const version = filePath.split("/").pop()?.replace(/\.md$/, "") ?? "";
-    const { content, date } = processContent(raw);
+    const { content, date, summary } = processContent(raw);
 
     return {
       version,
       content,
       date: normalizeDate(date),
+      summary,
     };
   })
   .filter((entry) => entry.version)

--- a/apps/web/src/routes/changelog/$version.tsx
+++ b/apps/web/src/routes/changelog/$version.tsx
@@ -20,13 +20,16 @@ export const Route = createFileRoute("/changelog/$version")({
     if (!entry) return {};
 
     const url = `${ANARLOG_SITE_URL}/changelog/${entry.version}`;
+    const description =
+      entry.summary ?? `Release notes for Anarlog v${entry.version}.`;
+
     return {
       links: [{ rel: "canonical", href: url }],
       meta: [
         { title: `Anarlog v${entry.version} Changelog` },
         {
           name: "description",
-          content: `Release notes for Anarlog v${entry.version}.`,
+          content: description,
         },
         {
           property: "og:title",
@@ -34,7 +37,7 @@ export const Route = createFileRoute("/changelog/$version")({
         },
         {
           property: "og:description",
-          content: `Release notes for Anarlog v${entry.version}.`,
+          content: description,
         },
         { property: "og:url", content: url },
       ],

--- a/apps/web/src/routes/changelog/index.tsx
+++ b/apps/web/src/routes/changelog/index.tsx
@@ -69,7 +69,7 @@ function Component() {
                     )}
                   </header>
                   <p className="leading-7 text-[#4f4940]">
-                    {getEntrySummary(entry.content)}
+                    {entry.summary ?? getEntrySummary(entry.content)}
                   </p>
                   <Link
                     to="/changelog/$version/"

--- a/packages/changelog/content/1.0.25.md
+++ b/packages/changelog/content/1.0.25.md
@@ -1,14 +1,6 @@
 ---
 date: "2026-04-30"
----
-
-<banner title="Char is now Anarlog">
-We've renamed the app from Char to Anarlog for legal reasons. Nothing changes on your end — your data, settings, and updates all carry over.
-
-Read more: [/blog/char-is-now-anarlog](https://char.com/blog/char-is-now-anarlog)
-</banner>
----
-date: "2026-04-30"
+summary: "Char has been renamed to Anarlog; existing data, settings, and updates carry over unchanged."
 ---
 
 <banner title="Char is now Anarlog">

--- a/packages/changelog/content/AGENTS.md
+++ b/packages/changelog/content/AGENTS.md
@@ -2,6 +2,14 @@
 
 - Read through the commits, and most of the diffs, but only keep the desktop-related thing to the changelog.
 - All changelogs should "worth reading" for app users. No internal changes or infra updates.
+- Each changelog must include `date` and `summary` frontmatter. `summary` is shown on the web changelog index, so keep it to one concise, plain-text, user-facing sentence with no markdown or custom tags.
+
+```md
+---
+date: "YYYY-MM-DD"
+summary: "One concise, user-facing sentence for the changelog index preview."
+---
+```
 
 # Scripts
 

--- a/packages/changelog/src/process.ts
+++ b/packages/changelog/src/process.ts
@@ -1,5 +1,6 @@
 export function parseFrontmatter(content: string): {
   date: string | null;
+  summary: string | null;
   body: string;
 } {
   const trimmed = content.trim();
@@ -8,16 +9,29 @@ export function parseFrontmatter(content: string): {
   );
 
   if (!frontmatterMatch) {
-    return { date: null, body: trimmed };
+    return { date: null, summary: null, body: trimmed };
   }
 
   const frontmatterBlock = frontmatterMatch[1];
   const body = frontmatterMatch[2];
 
-  const dateMatch = frontmatterBlock.match(/^date:\s*(.+)$/m);
-  const date = dateMatch ? dateMatch[1].trim() : null;
+  const date = readFrontmatterValue(frontmatterBlock, "date");
+  const summary = readFrontmatterValue(frontmatterBlock, "summary");
 
-  return { date, body };
+  return { date, summary, body };
+}
+
+function readFrontmatterValue(block: string, key: string) {
+  const match = block.match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
+  if (!match) return null;
+
+  const value = match[1].trim();
+  const quote = value[0];
+  if ((quote === `"` || quote === `'`) && value.endsWith(quote)) {
+    return value.slice(1, -1);
+  }
+
+  return value;
 }
 
 export function fixImageUrls(content: string): string {
@@ -30,8 +44,9 @@ export function fixImageUrls(content: string): string {
 export function processContent(raw: string): {
   content: string;
   date: string | null;
+  summary: string | null;
 } {
-  const { date, body } = parseFrontmatter(raw);
+  const { date, summary, body } = parseFrontmatter(raw);
   const markdown = fixImageUrls(body);
-  return { content: markdown, date };
+  return { content: markdown, date, summary };
 }


### PR DESCRIPTION
Parse changelog summary metadata, use it for web previews and page descriptions, and add a summary for the Anarlog rename entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds optional `summary` metadata parsing for changelog entries and uses it for preview/SEO text; fallbacks preserve current behavior when missing.
> 
> **Overview**
> **Adds `summary` frontmatter support for changelog entries** and wires it through the shared `@hypr/changelog` parser so each entry can expose `{date, summary, content}`.
> 
> The web changelog index and per-version page now prefer `entry.summary` for the list preview and meta/OG descriptions, falling back to the previous derived text when absent. Documentation is updated to require `date` + `summary` frontmatter, and `1.0.25` is updated to include a plain-text `summary`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2beb1f58de43c3cdf3170f0d37155952736f90f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->