### PR TITLE
fix(desktop): break changelog HMR import cycle

### DIFF
--- a/apps/desktop/src/main/tab-content.tsx
+++ b/apps/desktop/src/main/tab-content.tsx
@@ -1,6 +1,6 @@
 import { TabContentEmpty } from "./empty";
 
-import { MainTabContent } from "~/shared/main";
+import { MainTabContent } from "~/shared/main/tab-content";
 import { type Tab } from "~/store/zustand/tabs";
 
 export function ClassicMainTabContent({ tab }: { tab: Tab }) {

--- a/apps/desktop/src/main/tab-item.tsx
+++ b/apps/desktop/src/main/tab-item.tsx
@@ -1,6 +1,6 @@
 import { TabItemEmpty } from "./empty";
 
-import { MainTabItem } from "~/shared/main";
+import { MainTabItem } from "~/shared/main/tab-item";
 import { type Tab } from "~/store/zustand/tabs";
 
 export function ClassicMainTabItem({

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -19,8 +19,6 @@ export {
   useSessionStatusBanner,
 } from "./session-status-banner";
 export { MainShellScaffold } from "./shell-scaffold";
-export { MainTabItem } from "./tab-item";
-export { MainTabContent } from "./tab-content";
 export { useScrollActiveTabIntoView } from "./tab-scroll";
 
 export function StandardTabWrapper({


### PR DESCRIPTION
Stop exporting tab routers from the shared main barrel and import them directly so changelog can use shared layout components without re-entering itself during HMR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes module export/import boundaries; behavior should be unchanged aside from potential HMR/module resolution effects.
> 
> **Overview**
> Stops re-exporting `MainTabItem` and `MainTabContent` from the `~/shared/main` barrel and updates classic main components to import them directly from `~/shared/main/tab-item` and `~/shared/main/tab-content`.
> 
> This reduces coupling in `shared/main` to help avoid an import cycle during HMR (notably when `changelog` consumes shared layout components).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57bfb29c9d36837366240f7d143ea43a9f61526f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->