### PR TITLE
fix(desktop): persist note deletions

### DIFF
--- a/apps/desktop/src/session/components/outer-header/overflow/delete.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/delete.tsx
@@ -2,7 +2,6 @@ import { Loader2Icon, TrashIcon } from "lucide-react";
 import { useCallback } from "react";
 
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
-import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { DropdownMenuItem } from "@hypr/ui/components/ui/dropdown-menu";
 import { cn } from "@hypr/utils";
 
@@ -10,6 +9,7 @@ import { useAudioPlayer } from "~/audio-player";
 import {
   captureSessionData,
   deleteSessionCascade,
+  finalizeSessionDeletion,
 } from "~/store/tinybase/store/deleteSession";
 import * as main from "~/store/tinybase/store/main";
 import { useTabs } from "~/store/zustand/tabs";
@@ -63,12 +63,12 @@ export function DeleteNote({ sessionId }: { sessionId: string }) {
 
     invalidateResource("sessions", sessionId);
     void deleteSessionCascade(store, indexes, sessionId, {
-      skipAudio: true,
+      deferFilesystemDelete: true,
     });
 
     if (capturedData) {
       addDeletion(capturedData, () => {
-        void fsSyncCommands.audioDelete(sessionId);
+        void finalizeSessionDeletion(sessionId);
       });
     }
 

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -7,7 +7,6 @@ import {
   useState,
 } from "react";
 
-import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { Button } from "@hypr/ui/components/ui/button";
 import { cn, startOfDay } from "@hypr/utils";
 
@@ -38,6 +37,7 @@ import { useIgnoredEvents } from "~/store/tinybase/hooks";
 import {
   captureSessionData,
   deleteSessionCascade,
+  finalizeSessionDeletion,
 } from "~/store/tinybase/store/deleteSession";
 import * as main from "~/store/tinybase/store/main";
 import { useTabs } from "~/store/zustand/tabs";
@@ -228,14 +228,14 @@ export function TimelineView() {
 
       invalidateResource("sessions", sessionId);
       void deleteSessionCascade(store, indexes, sessionId, {
-        skipAudio: true,
+        deferFilesystemDelete: true,
       });
 
       if (capturedData) {
         addDeletion(
           capturedData,
           () => {
-            void fsSyncCommands.audioDelete(sessionId);
+            void finalizeSessionDeletion(sessionId);
           },
           batchId,
         );

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -27,6 +27,7 @@ import { useIgnoredEvents } from "~/store/tinybase/hooks";
 import {
   captureSessionData,
   deleteSessionCascade,
+  finalizeSessionDeletion,
 } from "~/store/tinybase/store/deleteSession";
 import * as main from "~/store/tinybase/store/main";
 import { getOrCreateSessionForEventId } from "~/store/tinybase/store/sessions";
@@ -400,12 +401,12 @@ const SessionItem = memo(
 
       invalidateResource("sessions", sessionId);
       void deleteSessionCascade(store, indexes, sessionId, {
-        skipAudio: true,
+        deferFilesystemDelete: true,
       });
 
       if (capturedData) {
         addDeletion(capturedData, () => {
-          void fsSyncCommands.audioDelete(sessionId);
+          void finalizeSessionDeletion(sessionId);
         });
       }
     }, [

--- a/apps/desktop/src/store/tinybase/store/deleteSession.test.ts
+++ b/apps/desktop/src/store/tinybase/store/deleteSession.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { deleteSessionCascade, finalizeSessionDeletion } from "./deleteSession";
+
+import { createTestMainStore } from "~/store/tinybase/persister/testing/mocks";
+
+const fsSyncMocks = vi.hoisted(() => ({
+  audioDelete: vi.fn(),
+  deleteSessionFolder: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-fs-sync", () => ({ commands: fsSyncMocks }));
+
+describe("deleteSessionCascade", () => {
+  let store: ReturnType<typeof createTestMainStore>;
+
+  beforeEach(() => {
+    store = createTestMainStore();
+    store.setRow("sessions", "session-1", {
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:00Z",
+      folder_id: "",
+      event_json: "",
+      title: "Meeting notes",
+      raw_md: "",
+    });
+
+    fsSyncMocks.deleteSessionFolder.mockResolvedValue({
+      status: "ok",
+      data: null,
+    });
+    vi.clearAllMocks();
+  });
+
+  test("deletes the persisted session folder by default", () => {
+    deleteSessionCascade(store, undefined, "session-1");
+
+    expect(store.getRow("sessions", "session-1")).toEqual({});
+    expect(fsSyncMocks.deleteSessionFolder).toHaveBeenCalledWith("session-1");
+    expect(fsSyncMocks.audioDelete).not.toHaveBeenCalled();
+  });
+
+  test("defers filesystem deletion while undo is pending", () => {
+    deleteSessionCascade(store, undefined, "session-1", {
+      deferFilesystemDelete: true,
+    });
+
+    expect(store.getRow("sessions", "session-1")).toEqual({});
+    expect(fsSyncMocks.deleteSessionFolder).not.toHaveBeenCalled();
+  });
+
+  test("finalizes deletion by removing the session folder", async () => {
+    await finalizeSessionDeletion("session-1");
+
+    expect(fsSyncMocks.deleteSessionFolder).toHaveBeenCalledWith("session-1");
+  });
+});

--- a/apps/desktop/src/store/tinybase/store/deleteSession.ts
+++ b/apps/desktop/src/store/tinybase/store/deleteSession.ts
@@ -8,6 +8,27 @@ import type { DeletedSessionData } from "~/store/zustand/undo-delete";
 type Store = NonNullable<ReturnType<typeof main.UI.useStore>>;
 type Indexes = NonNullable<ReturnType<typeof main.UI.useIndexes>>;
 
+export async function finalizeSessionDeletion(
+  sessionId: string,
+): Promise<void> {
+  try {
+    const result = await fsSyncCommands.deleteSessionFolder(sessionId);
+    if (result.status !== "error") {
+      return;
+    }
+
+    console.error("[delete-session] failed to delete session folder", {
+      sessionId,
+      error: result.error,
+    });
+  } catch (error) {
+    console.error("[delete-session] failed to delete session folder", {
+      sessionId,
+      error,
+    });
+  }
+}
+
 function deleteByIndex(
   store: Store,
   indexes: Indexes,
@@ -197,7 +218,7 @@ export function deleteSessionCascade(
   store: Store,
   indexes: ReturnType<typeof main.UI.useIndexes>,
   sessionId: string,
-  options?: { skipAudio?: boolean },
+  options?: { deferFilesystemDelete?: boolean },
 ): void {
   if (!indexes) {
     store.delRow("sessions", sessionId);
@@ -238,7 +259,7 @@ export function deleteSessionCascade(
     });
   }
 
-  if (!options?.skipAudio) {
-    void fsSyncCommands.audioDelete(sessionId);
+  if (!options?.deferFilesystemDelete) {
+    void finalizeSessionDeletion(sessionId);
   }
 }


### PR DESCRIPTION
Remove session folders when delete undo is confirmed so deleted notes do not reload from disk on restart.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session deletion behavior to delay on-disk folder removal until the undo window expires/confirmation, which affects data retention and could cause unexpected permanent deletions or orphaned files if the callback timing or fs-sync command fails.
> 
> **Overview**
> **Session deletion now supports undo without resurrecting notes on restart.** `deleteSessionCascade` no longer deletes audio immediately; instead it can *defer filesystem deletion* and a new `finalizeSessionDeletion` performs `deleteSessionFolder` with error logging.
> 
> Deletion entry points (note delete menu and timeline single/multi-delete) now call `deleteSessionCascade(..., { deferFilesystemDelete: true })` and register `finalizeSessionDeletion` as the undo-confirm callback, and new unit tests cover default vs deferred deletion and finalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aefc96a450851d35429d5128f58de3b0153a3d3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->