### PR TITLE
fix(web): keep changelog summaries concise

### DIFF
--- a/apps/web/src/lib/changelog-summary.test.ts
+++ b/apps/web/src/lib/changelog-summary.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getEntrySummary } from "./changelog-summary.ts";
+
+test("uses the first sentence from explicit summaries", () => {
+  assert.equal(
+    getEntrySummary("Recording improved. Follow-up details stay hidden."),
+    "Recording improved.",
+  );
+});
+
+test("skips custom tags and strips markdown from fallback content", () => {
+  const content = `
+<banner title="Local STT models are back!" variant="info">
+- **Parakeet V3** and Whisper Small should work smoothly.
+- Local STT processing is now batch only.
+</banner>
+`;
+
+  assert.equal(
+    getEntrySummary(content),
+    "Parakeet V3 and Whisper Small should work smoothly.",
+  );
+});
+
+test("ignores headings and images when building fallback content", () => {
+  const content = `
+# Changelog
+![hero](/api/assets/example.png)
+## Transcript
+- \`Cmd/Ctrl+W\` now closes the desktop window when no tab is open
+`;
+
+  assert.equal(
+    getEntrySummary(content),
+    "Cmd/Ctrl+W now closes the desktop window when no tab is open",
+  );
+});

--- a/apps/web/src/lib/changelog-summary.ts
+++ b/apps/web/src/lib/changelog-summary.ts
@@ -1,0 +1,42 @@
+const FALLBACK_SUMMARY = "See what changed in this release.";
+
+export function getEntrySummary(content: string) {
+  const summary = content.split("\n").map(cleanSummaryLine).find(Boolean);
+
+  if (!summary) {
+    return FALLBACK_SUMMARY;
+  }
+
+  return firstSentence(summary);
+}
+
+function cleanSummaryLine(line: string) {
+  const trimmed = line.trim();
+
+  if (
+    !trimmed ||
+    trimmed.startsWith("#") ||
+    trimmed.startsWith("![") ||
+    /^<\/?[a-z][^>]*>$/i.test(trimmed)
+  ) {
+    return "";
+  }
+
+  return trimmed
+    .replace(/^[-*]\s+/, "")
+    .replace(/^\d+\.\s+/, "")
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/_([^_]+)_/g, "$1")
+    .replace(/<\/?[a-z][^>]*>/gi, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function firstSentence(value: string) {
+  return value.match(/^.*?[.!?](?=\s|$)/)?.[0] ?? value;
+}

--- a/apps/web/src/routes/changelog/index.tsx
+++ b/apps/web/src/routes/changelog/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { SiteFooter } from "@/components/site-footer";
 import { changelogEntries, formatChangelogDate } from "@/lib/changelog";
+import { getEntrySummary } from "@/lib/changelog-summary";
 import { ANARLOG_SITE_URL } from "@/lib/seo";
 
 export const Route = createFileRoute("/changelog/")({
@@ -69,7 +70,7 @@ function Component() {
                     )}
                   </header>
                   <p className="leading-7 text-[#4f4940]">
-                    {entry.summary ?? getEntrySummary(entry.content)}
+                    {getEntrySummary(entry.summary ?? entry.content)}
                   </p>
                   <Link
                     to="/changelog/$version/"
@@ -91,16 +92,5 @@ function Component() {
 
       <SiteFooter />
     </main>
-  );
-}
-
-function getEntrySummary(content: string) {
-  return (
-    content
-      .split("\n")
-      .map((line) => line.trim())
-      .find(
-        (line) => line && !line.startsWith("#") && !line.startsWith("!["),
-      ) ?? "See what changed in this release."
   );
 }

--- a/packages/changelog/content/1.0.0.md
+++ b/packages/changelog/content/1.0.0.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-01-04"
+summary: "Initial desktop release with core recording, transcription, AI notes, search, export, and cross-platform distribution."
 ---
 
 ![v1.0.0](/api/assets/changelog/v1.0.0.jpg)

--- a/packages/changelog/content/1.0.1.md
+++ b/packages/changelog/content/1.0.1.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-01-08"
+summary: "Calendar metadata, automatic summaries, storage improvements, search, imports, and app stability received a broad set of fixes."
 ---
 
 Char 1.0.1 brings significant improvements to plugin architecture, data management, and overall user experience.

--- a/packages/changelog/content/1.0.10.md
+++ b/packages/changelog/content/1.0.10.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-02-27"
+summary: "Pre-meeting notes now inform AI summaries, with Azure provider support, persistent chat, richer previews, export consolidation, and playback speed controls."
 ---
 
 ## AI

--- a/packages/changelog/content/1.0.11.md
+++ b/packages/changelog/content/1.0.11.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-03-04"
+summary: "Calendar links, contextual chat edits, code blocks, Org export, AI generation tips, and batch transcription resilience were improved."
 ---
 
 ## Calendar

--- a/packages/changelog/content/1.0.12.md
+++ b/packages/changelog/content/1.0.12.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-03-07"
+summary: "Google Calendar sync, note search, chat starter prompts, batch transcription, Parakeet support, and folder placeholders were improved."
 ---
 
 ## Calendar

--- a/packages/changelog/content/1.0.13.md
+++ b/packages/changelog/content/1.0.13.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-03-09"
+summary: "Live and batch transcription, sidebar search, custom storage locations, chat resizing, folder changes, and timeline accuracy were improved."
 ---
 
 ## Transcription

--- a/packages/changelog/content/1.0.14.md
+++ b/packages/changelog/content/1.0.14.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-03-13"
+summary: "Hyprnote was renamed to Char, with better recording, chat search, multi-account Google Calendar, custom storage moves, note images, and UI polish."
 ---
 
 <banner title="Hyprnote is now Char">

--- a/packages/changelog/content/1.0.15.md
+++ b/packages/changelog/content/1.0.15.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-03-17"
+summary: "Sign-in skipping, audio uploads, audio player controls, note images, notification placement, and quit behavior were improved."
 ---
 
 ## Onboarding

--- a/packages/changelog/content/1.0.16.md
+++ b/packages/changelog/content/1.0.16.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-03-19"
+summary: "Transcript copying, recording deletion, image attachment actions, session previews, and calendar sync resilience were improved."
 ---
 
 ## Transcript

--- a/packages/changelog/content/1.0.17.md
+++ b/packages/changelog/content/1.0.17.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-03-21"
+summary: "The AI assistant, chat layout, app icons, recording waveform, raw note placeholder, and language persistence were updated."
 ---
 
 ## Chat

--- a/packages/changelog/content/1.0.18.md
+++ b/packages/changelog/content/1.0.18.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-03-25"
+summary: "Calendar management, empty-note recording, chat access, transcript speaker assignment, settings navigation, and macOS distribution were improved."
 ---
 
 ## Calendar

--- a/packages/changelog/content/1.0.19.md
+++ b/packages/changelog/content/1.0.19.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-03-30"
+summary: "Outlook Calendar beta, template workflows, chat polish, export options, editable note dates, Lite plan messaging, and settings cleanup were added."
 ---
 
 ## Calendar

--- a/packages/changelog/content/1.0.2.md
+++ b/packages/changelog/content/1.0.2.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-01-30"
+summary: "Recording, transcription, note editing, exports, contacts, calendar behavior, and app settings were expanded across the desktop app."
 ---
 
 ## Audio & Recording

--- a/packages/changelog/content/1.0.20.md
+++ b/packages/changelog/content/1.0.20.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-04-01"
+summary: "Local transcription was migrated to the new provider, alongside richer note editing, template actions, notifications, and billing handoff improvements."
 ---
 
 <banner title="MIGRATION REQUIRED" variant="warning">

--- a/packages/changelog/content/1.0.21.md
+++ b/packages/changelog/content/1.0.21.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-04-07"
+summary: "Local STT models returned with record-only sessions, stronger AssemblyAI transcription, redesigned transcript chat UI, editor formatting, and UI polish."
 ---
 
 <banner title="Local STT models are back!" variant="info">

--- a/packages/changelog/content/1.0.22.md
+++ b/packages/changelog/content/1.0.22.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-04-09"
+summary: "Live transcription now falls back to batch capture when needed, with refreshed calendar controls, window resizing, ad-hoc sessions, and update handling."
 ---
 
 ## Recording, Transcription & Audio

--- a/packages/changelog/content/1.0.23.md
+++ b/packages/changelog/content/1.0.23.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-04-14"
+summary: "Transcript controls, recording deletion, AquaVoice STT, calendar redirect handling, and tab bar polish were improved."
 ---
 
 ## Transcript & Session

--- a/packages/changelog/content/1.0.24.md
+++ b/packages/changelog/content/1.0.24.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-04-16"
+summary: "Update progress, update banner actions, note row timing, help routing, editor focus, live transcript styling, avatar fallback, and template editing were cleaned up."
 ---
 
 ## Updates

--- a/packages/changelog/content/1.0.27.md
+++ b/packages/changelog/content/1.0.27.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-05-16"
+summary: "Scheduled meeting recording, auto-stop, echo cancellation, local transcription, summary generation, settings navigation, app branding, and notification behavior were improved."
 ---
 
 ## Recording

--- a/packages/changelog/content/1.0.3.md
+++ b/packages/changelog/content/1.0.3.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-02-02"
+summary: "Pinned tabs, quick note opening, transcript empty states, feedback options, and startup reliability were improved."
 ---
 
 ## Navigation

--- a/packages/changelog/content/1.0.4.md
+++ b/packages/changelog/content/1.0.4.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-02-04"
+summary: "Undo delete, timezone settings, recurring calendar events, auto-enhance, dropdowns, and transcript migration were improved."
 ---
 
 ## Note Management

--- a/packages/changelog/content/1.0.5.md
+++ b/packages/changelog/content/1.0.5.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-02-08"
+summary: "Calendar view, note creation shortcuts, mentions, microphone reminders, and note-opening behavior were refined."
 ---
 
 ## Keyboard Shortcuts

--- a/packages/changelog/content/1.0.6.md
+++ b/packages/changelog/content/1.0.6.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-02-11"
+summary: "Support chat, advanced search, settings polish, local transcription fixes, and startup reliability were improved."
 ---
 
 ## Chat

--- a/packages/changelog/content/1.0.7.md
+++ b/packages/changelog/content/1.0.7.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-02-14"
+summary: "Mic-use notifications, Mistral transcription, Tantivy search, experimental chat, live transcription recovery, and bulk note actions were added."
 ---
 
 ## Notification

--- a/packages/changelog/content/1.0.8.md
+++ b/packages/changelog/content/1.0.8.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-02-22"
+summary: "Local Whisper transcription, smarter provider selection, default AI templates, transcript search, calendar polish, and onboarding updates were added."
 ---
 
 ## Transcription

--- a/packages/changelog/content/1.0.9.md
+++ b/packages/changelog/content/1.0.9.md
@@ -1,5 +1,6 @@
 ---
 date: "2026-02-25"
+summary: "Transcript segmentation, link editing, MP3 recordings, calendar participant handling, onboarding, and sign-in reliability were improved."
 ---
 
 ## Transcription


### PR DESCRIPTION
Add one-sentence changelog summaries and sanitize index fallback text to avoid raw markdown or custom tags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI-only text formatting changes plus added tests; main risk is edge-case summary parsing producing unexpected snippets for some markdown/custom tag content.
> 
> **Overview**
> Changelog index summaries are now generated via a shared `getEntrySummary` helper that **strips markdown/custom tags**, skips headings/images, and truncates to the *first sentence* with a stable fallback string.
> 
> The changelog content files add explicit `summary` frontmatter for many versions so the index can show concise release blurbs, and a small Node test suite was added to lock in the parsing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 883404e18b2b101169812e5d6312ffc0b45cd63b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->