### PR TITLE
chore(changelog): draft 1.0.28 release notes

### DIFF
--- a/packages/changelog/content/1.0.28.md
+++ b/packages/changelog/content/1.0.28.md
@@ -1,0 +1,29 @@
+---
+date: "2026-05-19"
+summary: "Editor recovery, task checkboxes, transcription persistence, speaker detection, browser meeting auto-stop, note deletion, and audio cleanup were improved."
+---
+
+## Editor
+
+- Editor crashes are handled more safely so a bad node view or failed transaction is less likely to bring down the app
+- Simple task checkboxes are back, with direct todo/done toggling while preserving existing task status data
+- Floating editor menus now have clearer borders and more consistent shadows
+
+## Transcription
+
+- Interrupted batch transcriptions now save progress more reliably so recovered sessions keep completed transcript text
+- Speaker count hints are passed through live and batch transcription providers to improve diarization where supported
+- Long cloud batch uploads can wait for the final provider response instead of timing out too early
+- Browser-based meetings are now detected during active listening so recording can stop automatically when the meeting ends
+
+## Data & Cleanup
+
+- Deleted notes now stay deleted after restart once undo is no longer available
+- Retained recorder artifacts are cleaned up in the background, and cached audio state refreshes after deletion
+- When audio retention is set to delete recordings, audio is preserved until transcript words exist so unprocessed sessions can still be transcribed
+
+## UI & Changelog
+
+- Sidebar and tab chrome now share a more stable layout, including a consistent sidebar toggle position
+- Main language settings now use localized display text
+- Changelog pages are now available on the Anarlog website, with cleaner release summaries


### PR DESCRIPTION
Add the desktop 1.0.28 changelog covering editor, transcription, cleanup, and UI updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a new markdown changelog entry; no production code paths or behavior are modified.
> 
> **Overview**
> Adds a new release note entry `packages/changelog/content/1.0.28.md` for version **1.0.28** (dated 2026-05-19), summarizing user-facing improvements across editor stability and task checkboxes, transcription persistence/diarization and meeting auto-stop, note deletion and audio cleanup/retention behavior, plus a few UI and changelog page updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0f67c2db771c48c82559ef9947a165d6fe50f52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->