### PR TITLE
Define session file migration target

### DIFF
--- a/apps/desktop/src/session/file-format.test.ts
+++ b/apps/desktop/src/session/file-format.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  parseSessionMarkdown,
+  renderSessionMarkdown,
+  SESSION_MARKDOWN_SCHEMA_VERSION,
+  type SessionMarkdownDocument,
+} from "./file-format";
+
+const baseDocument = {
+  schemaVersion: SESSION_MARKDOWN_SCHEMA_VERSION,
+  id: "session-1",
+  createdAt: "2026-05-19T00:00:00.000Z",
+  updatedAt: "2026-05-19T00:05:00.000Z",
+  title: "Weekly sync",
+  folderId: "work",
+  eventId: "event-1",
+  event: { tracking_id: "event-1", title: "Weekly sync" },
+  participants: [
+    {
+      person_id: "person-1",
+      legacy_human_id: "human-1",
+      name: "Jane Doe",
+      email: "jane@example.com",
+      source: "manual",
+    },
+  ],
+  tags: ["work", "sync"],
+  notes: "Raw notes.\n\n- follow up",
+  summary: "Summary text.",
+  transcript: "Jane: Hello.\nSam: Hi.",
+} satisfies SessionMarkdownDocument;
+
+describe("session file format", () => {
+  test("roundtrips the canonical session markdown shape", () => {
+    const markdown = renderSessionMarkdown(baseDocument);
+
+    expect(parseSessionMarkdown(markdown)).toEqual(baseDocument);
+  });
+
+  test("parses unsectioned body as notes for hand-authored compatibility", () => {
+    const parsed = parseSessionMarkdown(`---
+schema_version: 1
+id: "session-1"
+created_at: "2026-05-19T00:00:00.000Z"
+title: "Loose note"
+---
+Loose markdown body.
+`);
+
+    expect(parsed.notes).toBe("Loose markdown body.");
+    expect(parsed.summary).toBe("");
+    expect(parsed.transcript).toBe("");
+  });
+
+  test("keeps unknown headings inside the active section", () => {
+    const parsed = parseSessionMarkdown(`---
+schema_version: 1
+id: "session-1"
+created_at: "2026-05-19T00:00:00.000Z"
+---
+
+# Notes
+
+## Nested heading
+
+Body.
+
+# Summary
+
+Done.
+`);
+
+    expect(parsed.notes).toBe("## Nested heading\n\nBody.");
+    expect(parsed.summary).toBe("Done.");
+  });
+
+  test("requires stable identity metadata", () => {
+    expect(() =>
+      parseSessionMarkdown(`---
+created_at: "2026-05-19T00:00:00.000Z"
+---
+Body
+`),
+    ).toThrow("session_markdown_missing_id");
+  });
+});

--- a/apps/desktop/src/session/file-format.ts
+++ b/apps/desktop/src/session/file-format.ts
@@ -1,0 +1,243 @@
+export const SESSION_MARKDOWN_SCHEMA_VERSION = 1;
+export const SESSION_MARKDOWN_FILE = "session.md";
+
+export type SessionMarkdownParticipant = {
+  person_id?: string;
+  legacy_human_id?: string;
+  name?: string;
+  email?: string;
+  source?: string;
+};
+
+export type SessionMarkdownDocument = {
+  schemaVersion: typeof SESSION_MARKDOWN_SCHEMA_VERSION;
+  id: string;
+  createdAt: string;
+  updatedAt?: string;
+  title: string;
+  folderId?: string;
+  eventId?: string;
+  event?: Record<string, unknown>;
+  participants: SessionMarkdownParticipant[];
+  tags: string[];
+  notes: string;
+  summary: string;
+  transcript: string;
+};
+
+type SectionKey = "notes" | "summary" | "transcript";
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+const SECTION_TITLES: Record<SectionKey, string> = {
+  notes: "Notes",
+  summary: "Summary",
+  transcript: "Transcript",
+};
+
+const SECTION_KEYS_BY_TITLE = new Map<string, SectionKey>(
+  Object.entries(SECTION_TITLES).map(([key, title]) => [
+    title,
+    key as SectionKey,
+  ]),
+);
+
+function parseFrontmatter(markdown: string): {
+  frontmatter: Record<string, unknown>;
+  body: string;
+} {
+  const match = markdown.match(FRONTMATTER_RE);
+  if (!match) {
+    return { frontmatter: {}, body: markdown };
+  }
+
+  const frontmatter: Record<string, unknown> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const separator = trimmed.indexOf(":");
+    if (separator === -1) continue;
+
+    const key = trimmed.slice(0, separator).trim();
+    const rawValue = trimmed.slice(separator + 1).trim();
+    if (!key) continue;
+    frontmatter[key] = parseFrontmatterValue(rawValue);
+  }
+
+  return {
+    frontmatter,
+    body: markdown.slice(match[0].length),
+  };
+}
+
+function parseFrontmatterValue(rawValue: string): unknown {
+  if (!rawValue) return "";
+
+  try {
+    return JSON.parse(rawValue);
+  } catch {
+    return rawValue;
+  }
+}
+
+function stringifyFrontmatterValue(value: unknown): string {
+  if (value === undefined) return "";
+  return JSON.stringify(value);
+}
+
+function addFrontmatterLine(
+  lines: string[],
+  key: string,
+  value: unknown,
+): void {
+  if (value === undefined) return;
+  if (typeof value === "string" && !value) return;
+  if (Array.isArray(value) && value.length === 0) return;
+  lines.push(`${key}: ${stringifyFrontmatterValue(value)}`);
+}
+
+function renderFrontmatter(document: SessionMarkdownDocument): string {
+  const lines = ["---"];
+  addFrontmatterLine(lines, "schema_version", document.schemaVersion);
+  addFrontmatterLine(lines, "id", document.id);
+  addFrontmatterLine(lines, "created_at", document.createdAt);
+  addFrontmatterLine(lines, "updated_at", document.updatedAt);
+  addFrontmatterLine(lines, "title", document.title);
+  addFrontmatterLine(lines, "folder_id", document.folderId);
+  addFrontmatterLine(lines, "event_id", document.eventId);
+  addFrontmatterLine(lines, "event_json", document.event);
+  addFrontmatterLine(lines, "participants_json", document.participants);
+  addFrontmatterLine(lines, "tags_json", document.tags);
+  lines.push("---");
+  return lines.join("\n");
+}
+
+function sectionHeading(key: SectionKey): string {
+  return `# ${SECTION_TITLES[key]}`;
+}
+
+function normalizeSectionContent(content: string): string {
+  return content.replace(/^\r?\n/, "").trimEnd();
+}
+
+function parseSections(
+  body: string,
+): Pick<SessionMarkdownDocument, "notes" | "summary" | "transcript"> {
+  const sections: Record<SectionKey, string> = {
+    notes: "",
+    summary: "",
+    transcript: "",
+  };
+
+  const matches = Array.from(
+    body.matchAll(/^# (Notes|Summary|Transcript)\s*$/gm),
+  );
+  if (matches.length === 0) {
+    return {
+      notes: body.trim(),
+      summary: "",
+      transcript: "",
+    };
+  }
+
+  const preamble = body.slice(0, matches[0].index).trim();
+  if (preamble) {
+    sections.notes = preamble;
+  }
+
+  for (let index = 0; index < matches.length; index += 1) {
+    const match = matches[index];
+    const title = match[1];
+    const key = SECTION_KEYS_BY_TITLE.get(title);
+    if (!key) continue;
+
+    const start = (match.index ?? 0) + match[0].length;
+    const end = matches[index + 1]?.index ?? body.length;
+    const content = normalizeSectionContent(body.slice(start, end));
+    sections[key] = sections[key] ? `${sections[key]}\n\n${content}` : content;
+  }
+
+  return sections;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function asParticipants(value: unknown): SessionMarkdownParticipant[] {
+  if (!Array.isArray(value)) return [];
+
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      return [];
+    }
+
+    const record = item as Record<string, unknown>;
+    return [
+      {
+        person_id: asString(record.person_id),
+        legacy_human_id: asString(record.legacy_human_id),
+        name: asString(record.name),
+        email: asString(record.email),
+        source: asString(record.source),
+      },
+    ];
+  });
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export function parseSessionMarkdown(
+  markdown: string,
+): SessionMarkdownDocument {
+  const { frontmatter, body } = parseFrontmatter(markdown);
+  const id = asString(frontmatter.id);
+  const createdAt = asString(frontmatter.created_at);
+
+  if (!id) {
+    throw new Error("session_markdown_missing_id");
+  }
+  if (!createdAt) {
+    throw new Error("session_markdown_missing_created_at");
+  }
+
+  return {
+    schemaVersion: SESSION_MARKDOWN_SCHEMA_VERSION,
+    id,
+    createdAt,
+    updatedAt: asString(frontmatter.updated_at),
+    title: asString(frontmatter.title) ?? "",
+    folderId: asString(frontmatter.folder_id),
+    eventId: asString(frontmatter.event_id),
+    event: asObject(frontmatter.event_json),
+    participants: asParticipants(frontmatter.participants_json),
+    tags: asStringArray(frontmatter.tags_json),
+    ...parseSections(body),
+  };
+}
+
+export function renderSessionMarkdown(
+  document: SessionMarkdownDocument,
+): string {
+  const parts = [
+    renderFrontmatter(document),
+    sectionHeading("notes"),
+    document.notes.trimEnd(),
+    sectionHeading("summary"),
+    document.summary.trimEnd(),
+    sectionHeading("transcript"),
+    document.transcript.trimEnd(),
+  ];
+
+  return `${parts.join("\n\n").trimEnd()}\n`;
+}

--- a/docs/data-migration-plan.md
+++ b/docs/data-migration-plan.md
@@ -1,0 +1,116 @@
+# Session Files And SQLite Migration Plan
+
+## Target State
+
+Anarlog should use one Markdown file per session as the canonical session
+document. SQLite should own structured application data such as people,
+organizations, calendars, events, and relationship mappings. TinyBase should be
+treated as transitional UI/shadow state during migration and removed from
+durable main data over time.
+
+## Storage Boundaries
+
+- Session Markdown files are canonical for session content: raw notes,
+  generated summary, and readable transcript.
+- SQLite is canonical for structured data: people, organizations, calendars,
+  events, session participants, tags, and other queryable records.
+- TinyBase remains only as a compatibility bridge while consumers are moved
+  behind domain hooks.
+- TipTap JSON is runtime editor state, not the long-term source of truth.
+
+## Compatibility Rules
+
+- New readers must load the new single-file format first and fall back to the
+  legacy session directory format.
+- Update-time migration scripts may convert legacy session folders and TinyBase
+  data before the UI loads.
+- Runtime readers must still tolerate unmigrated legacy data for at least one
+  compatibility window.
+- Migration scripts must be idempotent and safe to resume after interruption.
+- Do not delete legacy source files in the same release that first creates the
+  new format.
+- Preserve existing session ids so tabs, recents, audio, search, and references
+  continue to resolve.
+- Writes for migrated sessions should go only to the new format to avoid stale
+  legacy files resurrecting content.
+
+## Session Markdown Contract
+
+Each migrated session should be represented by a single `session.md` file with
+versioned frontmatter and stable section headings:
+
+```md
+---
+schema_version: 1
+id: "session-id"
+created_at: "2026-05-19T00:00:00.000Z"
+updated_at: "2026-05-19T00:05:00.000Z"
+title: "Weekly sync"
+folder_id: "work"
+event_id: "calendar-event-id"
+event_json: {"tracking_id":"calendar-event-id"}
+participants_json: [{"person_id":"person-id","name":"Jane Doe"}]
+tags_json: ["work"]
+---
+
+# Notes
+
+Raw notes written in the editor.
+
+# Summary
+
+Generated summary content.
+
+# Transcript
+
+Readable transcript text.
+```
+
+Detailed transcript timing or speaker metadata should stay in this file only if
+it is user data. Use a fenced machine block later if timing metadata is needed
+for playback alignment.
+
+## Migration Flow
+
+1. Define and test the Markdown parse/render contract.
+2. Add a session file service with `loadSessionFile`, `saveSessionFile`, and
+   legacy-folder fallback.
+3. Add update-time migration scripts:
+   - convert legacy `sessions/<id>/{_meta.json,_memo.md,_summary.md,transcript.json}`
+     into `sessions/<id>/session.md`
+   - import TinyBase structured data into SQLite
+   - record per-domain and per-session migration markers
+4. Move editor writes to the session file service.
+5. Move structured domains to SQLite using the existing per-domain migration
+   pattern:
+   - put consumers behind stable hooks
+   - add Rust migrations and Drizzle schema
+   - import legacy data idempotently
+   - shadow-hydrate TinyBase where needed
+   - remove TinyBase tables and persisters after consumers move
+6. Rename contact-domain code from `humans` toward `people` at hook/API
+   boundaries first, then storage.
+7. After a compatibility window, remove old session content persisters and
+   legacy writers.
+
+## SQLite Domain Order
+
+1. `people` compatibility layer over existing `humans`
+2. organizations
+3. calendars
+4. events
+5. session participants
+6. tags and mappings
+
+Use text ids, safe defaults, minimal triggers, and idempotent legacy imports.
+
+## Verification
+
+- Markdown parse/render golden tests.
+- Legacy session-folder migration fixtures.
+- Delete and reopen tests proving deleted notes do not reappear.
+- Update-time migration idempotency tests.
+- SQLite import idempotency tests.
+- `pnpm -F @hypr/desktop typecheck`
+- `pnpm -F @hypr/desktop test`
+- `cargo check` when Rust migrations or migration scripts change.


### PR DESCRIPTION
Summary:
- Add the durable session Markdown and SQLite migration plan.
- Add the canonical session Markdown parse/render contract with tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new session Markdown parsing/rendering utility and documentation, but it is not yet wired into runtime session I/O, so impact is limited to new codepaths and test coverage.
> 
> **Overview**
> Introduces a canonical, versioned `session.md` file format for sessions, including frontmatter for stable identity/metadata and `# Notes`/`# Summary`/`# Transcript` sections, plus `parseSessionMarkdown`/`renderSessionMarkdown` helpers.
> 
> Adds Vitest coverage for round-tripping, loose/hand-authored compatibility (unsectioned bodies treated as notes), nested heading handling, and required metadata errors. Also adds `docs/data-migration-plan.md` describing the target storage boundaries and a phased migration approach from legacy session folders/TinyBase to Markdown + SQLite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c99b2a873cb403232555c08bee18bee94e2e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->