### PR TITLE
fix(desktop): remove STT beta tags

### DIFF
--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -149,7 +149,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "assemblyai",
     displayName: "AssemblyAI",
-    badge: "Beta",
+    badge: null,
     icon: <AssemblyAI size={12} />,
     baseUrl: "https://api.assemblyai.com",
     models: ["universal-3-pro"],
@@ -169,7 +169,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "gladia",
     displayName: "Gladia",
-    badge: "Beta",
+    badge: null,
     icon: (
       <img
         src="/assets/gladia.jpeg"
@@ -201,7 +201,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "elevenlabs",
     displayName: "ElevenLabs",
-    badge: "Beta",
+    badge: null,
     icon: <ElevenLabs size={16} />,
     baseUrl: "https://api.elevenlabs.io",
     models: ["scribe_v2"],
@@ -211,7 +211,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "mistral",
     displayName: "Mistral",
-    badge: "Beta",
+    badge: null,
     icon: <Mistral size={16} />,
     baseUrl: "https://api.mistral.ai/v1",
     models: ["voxtral-mini-2602"],


### PR DESCRIPTION
Stop showing Beta badges for STT providers that are no longer marked beta.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only metadata change that only affects provider labeling in settings, not API calls or model selection.
> 
> **Overview**
> Updates the STT provider list in `apps/desktop/src/settings/ai/stt/shared.tsx` to stop showing *Beta* badges for `AssemblyAI`, `Gladia`, `ElevenLabs`, and `Mistral` (sets their `badge` to `null`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a35340f7a498bda421a59770fd582a02e9dd44a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->