### PR TITLE
fix(desktop): set left sidebar width

### DIFF
--- a/apps/desktop/src/sidebar/index.tsx
+++ b/apps/desktop/src/sidebar/index.tsx
@@ -33,7 +33,7 @@ export function LeftSidebar() {
   const showSearchResults = !isSpecialMode && query.trim() !== "";
 
   return (
-    <div className="flex h-full w-70 shrink-0 flex-col gap-1 overflow-hidden pt-1">
+    <div className="flex h-full w-[200px] shrink-0 flex-col gap-1 overflow-hidden pt-1">
       {!isSpecialMode && <SidebarSearchInput />}
 
       <div className="flex flex-1 flex-col gap-1 overflow-hidden">


### PR DESCRIPTION
Set the desktop left sidebar to an explicit 200px width.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual/layout change limited to the desktop left sidebar width; no logic or data flow changes.
> 
> **Overview**
> Sets the desktop `LeftSidebar` container to a fixed `200px` width by replacing the Tailwind `w-70` class with an explicit `w-[200px]` value, ensuring consistent sidebar sizing across layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d61356726dc10eec3fac957cd5c869f0521bad4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->