### PR TITLE
fix(editor): distinguish heading levels

### DIFF
--- a/packages/tiptap/src/styles/nodes/heading.css
+++ b/packages/tiptap/src/styles/nodes/heading.css
@@ -7,11 +7,36 @@
   h6 {
     color: #374151;
     font-weight: 600;
-    font-size: 1.25rem;
     margin-top: 0;
     margin-bottom: 0.25rem;
     min-height: 1.5rem;
     position: relative;
+  }
+
+  h1 {
+    font-size: 1.75rem;
+    line-height: 2.125rem;
+  }
+
+  h2 {
+    font-size: 1.5rem;
+    line-height: 1.875rem;
+  }
+
+  h3 {
+    font-size: 1.25rem;
+    line-height: 1.625rem;
+  }
+
+  h4 {
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+
+  h5,
+  h6 {
+    font-size: 1rem;
+    line-height: 1.375rem;
   }
 
   :not(:first-child) {


### PR DESCRIPTION
Add a default heading scale for note editor typography so H1, H2, and H3 render distinctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CSS-only changes that adjust heading font sizes/line-heights; main risk is minor visual regressions in editor layouts.
> 
> **Overview**
> Adds a default per-heading typography scale under `.tiptap`, replacing the single shared heading `font-size` with specific `font-size`/`line-height` values for `h1`–`h6` so heading levels render distinctly (while keeping existing spacing rules and blog-editor overrides intact).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 826caeee30dec07cc43633816c03cea3e280d831. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->