### PR TITLE
chore(changelog): update 1.0.28 release notes

### DIFF
--- a/packages/changelog/content/1.0.28.md
+++ b/packages/changelog/content/1.0.28.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-05-19"
+date: "2026-05-20"
 summary: "Editor recovery, task checkboxes, heading styles, transcription reliability, speech-to-text settings, session UI polish, and audio cleanup were improved."
 ---
 
@@ -9,18 +9,20 @@ summary: "Editor recovery, task checkboxes, heading styles, transcription reliab
 - Heading levels in notes now render at distinct sizes, making H1, H2, and H3 easier to tell apart
 - Simple task checkboxes are back, with direct todo/done toggling while preserving existing task status data
 - Floating editor menus now have clearer borders and more consistent shadows
-- Streamdown-rendered top-level headings are now sized like H3 so AI output and changelogs sit closer to body copy
+- Top-level headings in AI-rendered output now scale down so they sit closer to body copy
 
 ## Transcription
 
 - Interrupted batch transcriptions now save progress more reliably so recovered sessions keep completed transcript text
 - Local batch transcription is more resilient for very short Qwen recordings and long Parakeet, Omnilingual, and Qwen recordings
 - Speaker count hints are passed through live and batch transcription providers to improve diarization where supported
-- Transcript-only batch responses now persist with synthesized word timings, and empty batch output is surfaced as a no-speech error instead of vanishing
-- Soniqo batch recordings keep each channel separate so multi-mic captures stay distinguishable in the transcript
+- Transcript-only batch responses are now persisted with synthesized word timings, and empty batch output surfaces as a no-speech error instead of disappearing
+- OpenAI Whisper batches now request word timestamps, and synthesized timings no longer trigger audio seek when clicking transcript words
+- Soniqo batch recordings preserve each channel so multi-mic captures stay distinguishable in the transcript
 - Inactive sessions now open the transcript at the top instead of jumping to the latest line
 - The collapsed live transcript footer is shorter and tighter, giving notes more room during recording
-- The duplicate transcript progress indicator has been removed during batch transcription, replaced with skeleton rows while the header and timeline carry status
+- Batch transcription no longer doubles up progress between the header and the panel — skeleton rows fill the panel with cleaner spacing while batching
+- Regenerating a batch transcript now keeps the transcript panel visible while progress runs
 - Browser-based meetings are now detected during active listening so recording can stop automatically when the meeting ends
 
 ## Speech-to-Text Settings
@@ -28,6 +30,8 @@ summary: "Editor recovery, task checkboxes, heading styles, transcription reliab
 - Speech-to-text provider badges have been cleaned up so models are not shown as beta when they are no longer beta
 - Cactus models are now labeled as deprecated, the legacy Anarlog provider card has been removed, and local model folder/delete controls live directly in the model picker
 - The STT settings layout has been simplified — language warnings appear as a top banner, legacy Cactus choices stay hidden unless already selected, selected and downloaded model rows are more compact, and local model actions reveal on hover
+- The Soniqo model list now only advertises Parakeet Streaming and Parakeet Batch, while existing sessions on legacy Soniqo model IDs still resolve
+- Clearing every spoken language now sticks across restarts instead of being replaced by OS defaults
 
 ## Data & Cleanup
 
@@ -39,8 +43,8 @@ summary: "Editor recovery, task checkboxes, heading styles, transcription reliab
 
 - Sidebar and tab chrome now share a more stable layout, with the left sidebar locked to a consistent 200px width
 - Main language settings now use localized display text
-- The chat floating action button now appears on inactive transcript-backed sessions, tucking into a peek state while scrolling and revealing on hover near the bottom
-- Auto-enhance skip reasons now display in the floating action button slot with a smooth fade between the message and the button
+- The chat shortcut now appears on inactive transcript-backed sessions, tucking into a peek state while scrolling and revealing on hover near the bottom
+- Auto-enhance skip reasons now display in the chat shortcut slot, fading smoothly between the message and the button
 - Locked calendar provider rows now reveal their pro upgrade action only on hover or focus, keeping the sidebar quieter
 - The transparent transcript resize divider no longer renders a gray gap under the session border
 - Changelog pages are now available on the Anarlog website, with cleaner release summaries

--- a/packages/changelog/content/1.0.28.md
+++ b/packages/changelog/content/1.0.28.md
@@ -1,20 +1,27 @@
 ---
 date: "2026-05-19"
-summary: "Editor recovery, task checkboxes, transcription persistence, speaker detection, browser meeting auto-stop, note deletion, and audio cleanup were improved."
+summary: "Editor recovery, task checkboxes, heading styles, transcription reliability, speech-to-text settings, note deletion, and audio cleanup were improved."
 ---
 
 ## Editor
 
 - Editor crashes are handled more safely so a bad node view or failed transaction is less likely to bring down the app
+- Heading levels in notes now render at distinct sizes, making H1, H2, and H3 easier to tell apart
 - Simple task checkboxes are back, with direct todo/done toggling while preserving existing task status data
 - Floating editor menus now have clearer borders and more consistent shadows
 
 ## Transcription
 
 - Interrupted batch transcriptions now save progress more reliably so recovered sessions keep completed transcript text
+- Local batch transcription is more resilient for very short Qwen recordings and long Parakeet, Omnilingual, and Qwen recordings
 - Speaker count hints are passed through live and batch transcription providers to improve diarization where supported
 - Long cloud batch uploads can wait for the final provider response instead of timing out too early
 - Browser-based meetings are now detected during active listening so recording can stop automatically when the meeting ends
+
+## Speech-to-Text Settings
+
+- Speech-to-text provider badges have been cleaned up so models are not shown as beta when they are no longer beta
+- Cactus models are now labeled as deprecated, and local model folder/delete controls are available directly from the model picker
 
 ## Data & Cleanup
 
@@ -24,6 +31,6 @@ summary: "Editor recovery, task checkboxes, transcription persistence, speaker d
 
 ## UI & Changelog
 
-- Sidebar and tab chrome now share a more stable layout, including a consistent sidebar toggle position
+- Sidebar and tab chrome now share a more stable layout, including a consistent sidebar width and toggle position
 - Main language settings now use localized display text
 - Changelog pages are now available on the Anarlog website, with cleaner release summaries

--- a/packages/changelog/content/1.0.28.md
+++ b/packages/changelog/content/1.0.28.md
@@ -1,6 +1,6 @@
 ---
 date: "2026-05-19"
-summary: "Editor recovery, task checkboxes, heading styles, transcription reliability, speech-to-text settings, note deletion, and audio cleanup were improved."
+summary: "Editor recovery, task checkboxes, heading styles, transcription reliability, speech-to-text settings, session UI polish, and audio cleanup were improved."
 ---
 
 ## Editor
@@ -9,19 +9,25 @@ summary: "Editor recovery, task checkboxes, heading styles, transcription reliab
 - Heading levels in notes now render at distinct sizes, making H1, H2, and H3 easier to tell apart
 - Simple task checkboxes are back, with direct todo/done toggling while preserving existing task status data
 - Floating editor menus now have clearer borders and more consistent shadows
+- Streamdown-rendered top-level headings are now sized like H3 so AI output and changelogs sit closer to body copy
 
 ## Transcription
 
 - Interrupted batch transcriptions now save progress more reliably so recovered sessions keep completed transcript text
 - Local batch transcription is more resilient for very short Qwen recordings and long Parakeet, Omnilingual, and Qwen recordings
 - Speaker count hints are passed through live and batch transcription providers to improve diarization where supported
-- Long cloud batch uploads can wait for the final provider response instead of timing out too early
+- Transcript-only batch responses now persist with synthesized word timings, and empty batch output is surfaced as a no-speech error instead of vanishing
+- Soniqo batch recordings keep each channel separate so multi-mic captures stay distinguishable in the transcript
+- Inactive sessions now open the transcript at the top instead of jumping to the latest line
+- The collapsed live transcript footer is shorter and tighter, giving notes more room during recording
+- The duplicate transcript progress indicator has been removed during batch transcription, replaced with skeleton rows while the header and timeline carry status
 - Browser-based meetings are now detected during active listening so recording can stop automatically when the meeting ends
 
 ## Speech-to-Text Settings
 
 - Speech-to-text provider badges have been cleaned up so models are not shown as beta when they are no longer beta
-- Cactus models are now labeled as deprecated, and local model folder/delete controls are available directly from the model picker
+- Cactus models are now labeled as deprecated, the legacy Anarlog provider card has been removed, and local model folder/delete controls live directly in the model picker
+- The STT settings layout has been simplified — language warnings appear as a top banner, legacy Cactus choices stay hidden unless already selected, selected and downloaded model rows are more compact, and local model actions reveal on hover
 
 ## Data & Cleanup
 
@@ -31,6 +37,10 @@ summary: "Editor recovery, task checkboxes, heading styles, transcription reliab
 
 ## UI & Changelog
 
-- Sidebar and tab chrome now share a more stable layout, including a consistent sidebar width and toggle position
+- Sidebar and tab chrome now share a more stable layout, with the left sidebar locked to a consistent 200px width
 - Main language settings now use localized display text
+- The chat floating action button now appears on inactive transcript-backed sessions, tucking into a peek state while scrolling and revealing on hover near the bottom
+- Auto-enhance skip reasons now display in the floating action button slot with a smooth fade between the message and the button
+- Locked calendar provider rows now reveal their pro upgrade action only on hover or focus, keeping the sidebar quieter
+- The transparent transcript resize divider no longer renders a gray gap under the session border
 - Changelog pages are now available on the Anarlog website, with cleaner release summaries


### PR DESCRIPTION
Add the latest user-facing editor, transcription, STT settings, and UI changes to the 1.0.28 changelog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating release notes with no runtime or behavioral impact.
> 
> **Overview**
> Updates the `1.0.28` changelog entry (date/summary) and expands release notes to include additional items around **heading rendering**, **batch transcription reliability/UX**, a new **Speech-to-Text Settings** section (provider/model labeling, layout tweaks, local model controls, language persistence), and a handful of **session/sidebar UI polish** details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f11c54408137070496cf941b146a7c0ff597bd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->