### PR TITLE
fix(desktop): peek session FAB while scrolling

### DIFF
--- a/apps/desktop/src/session/components/caret-position-context.tsx
+++ b/apps/desktop/src/session/components/caret-position-context.tsx
@@ -71,10 +71,10 @@ export function useCaretNearBottom({
 
       const { from } = view.state.selection;
       const coords = view.coordsAtPos(from);
+      const containerRect = container.getBoundingClientRect();
+      const distanceFromEditorBottom = containerRect.bottom - coords.bottom;
 
-      const distanceFromViewportBottom = window.innerHeight - coords.bottom;
-
-      setCaretNearBottom(distanceFromViewportBottom < BOTTOM_THRESHOLD);
+      setCaretNearBottom(distanceFromEditorBottom < BOTTOM_THRESHOLD);
     };
 
     const handleBlur = () => setCaretNearBottom(false);

--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FloatingActionButton } from "./index";
+
+import type { Tab } from "~/store/zustand/tabs";
+
+const hoisted = vi.hoisted(() => ({
+  currentTab: { type: "raw" } as
+    | { type: "raw" }
+    | {
+        type: "enhanced";
+        id: string;
+      },
+  hasTranscript: true,
+  isCaretNearBottom: false,
+  sessionMode: "inactive",
+}));
+
+vi.mock("./listen", () => ({
+  ListenButton: () => <button type="button">Start listening</button>,
+}));
+
+vi.mock("~/shared/chat-cta", () => ({
+  ChatCTA: () => <button type="button">Ask about this session</button>,
+}));
+
+vi.mock("~/session/components/shared", () => ({
+  useCurrentNoteTab: () => hoisted.currentTab,
+  useHasTranscript: () => hoisted.hasTranscript,
+}));
+
+vi.mock("../caret-position-context", () => ({
+  useCaretPosition: () => ({
+    isCaretNearBottom: hoisted.isCaretNearBottom,
+  }),
+}));
+
+vi.mock("~/stt/contexts", () => ({
+  useListener: (
+    selector: (state: { getSessionMode: () => string }) => unknown,
+  ) =>
+    selector({
+      getSessionMode: () => hoisted.sessionMode,
+    }),
+}));
+
+describe("FloatingActionButton", () => {
+  const tab = {
+    type: "sessions",
+    id: "session-1",
+    active: true,
+    pinned: false,
+    slotId: "slot-1",
+    state: { view: null, autoStart: null },
+  } as Extract<Tab, { type: "sessions" }>;
+
+  beforeEach(() => {
+    hoisted.currentTab = { type: "raw" };
+    hoisted.hasTranscript = true;
+    hoisted.isCaretNearBottom = false;
+    hoisted.sessionMode = "inactive";
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the chat FAB on raw memo view after transcript exists", () => {
+    render(<FloatingActionButton tab={tab} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Ask about this session" }),
+    ).not.toBeNull();
+  });
+
+  it("shows the chat FAB on enhanced summary views", () => {
+    hoisted.currentTab = { type: "enhanced", id: "note-1" };
+
+    render(<FloatingActionButton tab={tab} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Ask about this session" }),
+    ).not.toBeNull();
+  });
+
+  it("keeps the chat FAB mounted as a peek while hidden and reveals it from the hover zone", () => {
+    render(<FloatingActionButton hidden tab={tab} />);
+
+    const wrapper = screen.getByText("Ask about this session").parentElement;
+    const hoverZone = wrapper?.parentElement;
+
+    expect(hoverZone?.className).toContain("group");
+    expect(hoverZone?.className).toContain("pointer-events-auto");
+    expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
+    expect(wrapper?.className).toContain("pointer-events-none");
+    expect(wrapper?.className).toContain("translate-y-[calc(100%+0.5rem)]");
+    expect(wrapper?.className).toContain("group-hover:pointer-events-auto");
+    expect(wrapper?.className).toContain("group-hover:translate-y-0");
+    expect(wrapper?.className).toContain("opacity-100");
+  });
+});

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@hypr/utils";
+
 import { ListenButton } from "./listen";
 
 import {
@@ -9,8 +11,10 @@ import type { Tab } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
 
 export function FloatingActionButton({
+  hidden = false,
   tab,
 }: {
+  hidden?: boolean;
   tab: Extract<Tab, { type: "sessions" }>;
 }) {
   const shouldShowListen = useShouldShowListeningFab(tab);
@@ -21,8 +25,23 @@ export function FloatingActionButton({
   }
 
   return (
-    <div className="absolute bottom-4 left-1/2 z-20 -translate-x-1/2">
-      {shouldShowListen ? <ListenButton tab={tab} /> : <ChatCTA />}
+    <div
+      className={cn([
+        "absolute bottom-0 left-1/2 z-20 h-14 w-96 max-w-[calc(100%-2rem)] -translate-x-1/2",
+        hidden ? "group pointer-events-auto" : "pointer-events-none",
+      ])}
+    >
+      <div
+        aria-hidden={hidden}
+        className={cn([
+          "absolute bottom-4 left-1/2 -translate-x-1/2 transition-[opacity,visibility,transform] duration-150",
+          hidden
+            ? "pointer-events-none visible translate-y-[calc(100%+0.5rem)] opacity-100 group-hover:pointer-events-auto group-hover:translate-y-0"
+            : "pointer-events-auto visible translate-y-0 opacity-100",
+        ])}
+      >
+        {shouldShowListen ? <ListenButton tab={tab} /> : <ChatCTA />}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -1,6 +1,7 @@
 import type { EditorView } from "prosemirror-view";
 import {
   forwardRef,
+  type UIEventHandler,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -37,8 +38,9 @@ export const NoteInput = forwardRef<
   {
     tab: Extract<Tab, { type: "sessions" }>;
     onNavigateToTitle?: (pixelWidth?: number) => void;
+    onScroll?: UIEventHandler<HTMLDivElement>;
   }
->(({ tab, onNavigateToTitle }, ref) => {
+>(({ tab, onNavigateToTitle, onScroll }, ref) => {
   const editorTabs = useEditorTabs({ sessionId: tab.id });
   const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
   const internalEditorRef = useRef<NoteEditorRef>(null);
@@ -150,6 +152,7 @@ export const NoteInput = forwardRef<
             setContainer(node);
           }}
           onClick={handleContainerClick}
+          onScroll={onScroll}
           className={cn([
             "h-full px-3",
             "scroll-fade-y overflow-auto",

--- a/apps/desktop/src/session/floating-scroll-state.test.ts
+++ b/apps/desktop/src/session/floating-scroll-state.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { getNextFloatingButtonHidden } from "./floating-scroll-state";
+
+describe("getNextFloatingButtonHidden", () => {
+  it("hides when scrolling down", () => {
+    expect(
+      getNextFloatingButtonHidden({
+        currentHidden: false,
+        delta: 12,
+        scrollTop: 120,
+        scrollHeight: 1000,
+        clientHeight: 400,
+      }),
+    ).toBe(true);
+  });
+
+  it("shows when scrolling up away from the bottom", () => {
+    expect(
+      getNextFloatingButtonHidden({
+        currentHidden: true,
+        delta: -12,
+        scrollTop: 420,
+        scrollHeight: 1000,
+        clientHeight: 400,
+      }),
+    ).toBe(false);
+  });
+
+  it("stays hidden during bottom bounce", () => {
+    expect(
+      getNextFloatingButtonHidden({
+        currentHidden: true,
+        delta: -12,
+        scrollTop: 552,
+        scrollHeight: 1000,
+        clientHeight: 400,
+      }),
+    ).toBe(true);
+  });
+
+  it("shows near the top", () => {
+    expect(
+      getNextFloatingButtonHidden({
+        currentHidden: true,
+        delta: 0,
+        scrollTop: 4,
+        scrollHeight: 1000,
+        clientHeight: 400,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/session/floating-scroll-state.ts
+++ b/apps/desktop/src/session/floating-scroll-state.ts
@@ -1,0 +1,35 @@
+const FLOATING_BUTTON_SCROLL_TOP_THRESHOLD = 8;
+const FLOATING_BUTTON_SCROLL_BOTTOM_THRESHOLD = 64;
+const FLOATING_BUTTON_SCROLL_DIRECTION_THRESHOLD = 2;
+
+export function getNextFloatingButtonHidden({
+  currentHidden,
+  delta,
+  scrollTop,
+  scrollHeight,
+  clientHeight,
+}: {
+  currentHidden: boolean;
+  delta: number;
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}) {
+  const distanceToBottom = scrollHeight - scrollTop - clientHeight;
+  const isNearBottom =
+    distanceToBottom <= FLOATING_BUTTON_SCROLL_BOTTOM_THRESHOLD;
+
+  if (scrollTop <= FLOATING_BUTTON_SCROLL_TOP_THRESHOLD) {
+    return false;
+  }
+
+  if (delta > FLOATING_BUTTON_SCROLL_DIRECTION_THRESHOLD) {
+    return true;
+  }
+
+  if (delta < -FLOATING_BUTTON_SCROLL_DIRECTION_THRESHOLD && !isNearBottom) {
+    return false;
+  }
+
+  return currentHidden;
+}

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -15,6 +15,7 @@ import { SessionPreviewCard } from "./components/session-preview-card";
 import { SessionSurface } from "./components/session-surface";
 import { useCurrentNoteTab, useHasTranscript } from "./components/shared";
 import { TitleInput, type TitleInputHandle } from "./components/title-input";
+import { getNextFloatingButtonHidden } from "./floating-scroll-state";
 import { useAutoEnhance } from "./hooks/useAutoEnhance";
 import { useIsSessionEnhancing } from "./hooks/useEnhancedNotes";
 import { getSessionTabStatus } from "./tab-visual-state";
@@ -182,10 +183,26 @@ function TabContentNoteInner({
 }) {
   const titleInputRef = React.useRef<TitleInputHandle>(null);
   const noteInputRef = React.useRef<NoteInputHandle>(null);
+  const noteScrollRef = React.useRef({
+    viewKey: "",
+    scrollTop: 0,
+  });
 
   const currentView = useCurrentNoteTab(tab);
+  const currentViewKey =
+    currentView.type === "enhanced"
+      ? `enhanced-${currentView.id}`
+      : currentView.type;
   const { generateTitle } = useTitleGeneration(tab);
   const hasTranscript = useHasTranscript(tab.id);
+  const [floatingButtonScrollState, setFloatingButtonScrollState] =
+    React.useState({
+      viewKey: currentViewKey,
+      hidden: false,
+    });
+  const floatingButtonHidden =
+    floatingButtonScrollState.viewKey === currentViewKey &&
+    floatingButtonScrollState.hidden;
 
   const sessionId = tab.id;
   const { skipReason } = useAutoEnhance(tab);
@@ -223,6 +240,40 @@ function TabContentNoteInner({
       noteInputRef.current?.focusAtPixelWidth(pixelWidth);
     },
     [],
+  );
+
+  const handleNoteScroll = React.useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      const scrollTop = event.currentTarget.scrollTop;
+      const scrollHeight = event.currentTarget.scrollHeight;
+      const clientHeight = event.currentTarget.clientHeight;
+      const lastScroll =
+        noteScrollRef.current.viewKey === currentViewKey
+          ? noteScrollRef.current.scrollTop
+          : scrollTop;
+      const delta = scrollTop - lastScroll;
+
+      noteScrollRef.current = {
+        viewKey: currentViewKey,
+        scrollTop,
+      };
+
+      setFloatingButtonScrollState((state) => {
+        const hidden = getNextFloatingButtonHidden({
+          currentHidden:
+            state.viewKey === currentViewKey ? state.hidden : false,
+          delta,
+          scrollTop,
+          scrollHeight,
+          clientHeight,
+        });
+
+        return state.viewKey === currentViewKey && state.hidden === hidden
+          ? state
+          : { viewKey: currentViewKey, hidden };
+      });
+    },
+    [currentViewKey],
   );
 
   useSessionStatusBanner({
@@ -264,12 +315,15 @@ function TabContentNoteInner({
       afterBorderResizable={canResizeTranscriptSurface}
       bottomBorderHandle={bottomBorderHandle}
       mergeAfterBorder={mergeTranscriptSurface}
-      floatingButton={<FloatingActionButton tab={tab} />}
+      floatingButton={
+        <FloatingActionButton hidden={floatingButtonHidden} tab={tab} />
+      }
     >
       <NoteInput
         ref={noteInputRef}
         tab={tab}
         onNavigateToTitle={handleNavigateToTitle}
+        onScroll={handleNoteScroll}
       />
     </SessionSurface>
   );

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -1,5 +1,7 @@
 import { MessageCircle } from "lucide-react";
 
+import { cn } from "@hypr/utils";
+
 import { useShell } from "~/contexts/shell";
 
 export function ChatCTA({
@@ -27,10 +29,14 @@ export function ChatCTA({
     <button
       type="button"
       onClick={handleClick}
-      className="flex items-center gap-2 rounded-full border-2 border-stone-600 bg-stone-800 px-4 py-2 text-sm text-white shadow-[0_4px_14px_rgba(87,83,78,0.4)] transition-colors hover:bg-stone-700"
+      className={cn([
+        "inline-flex max-w-full items-center gap-2 rounded-full border-2 border-stone-600 bg-stone-800",
+        "px-4 py-2 text-sm text-white shadow-[0_4px_14px_rgba(87,83,78,0.4)]",
+        "transition-colors hover:bg-stone-700",
+      ])}
     >
       <MessageCircle className="size-4 shrink-0" aria-hidden="true" />
-      <span>{label}</span>
+      <span className="min-w-0 truncate">{label}</span>
     </button>
   );
 }


### PR DESCRIPTION
Show the chat FAB on inactive transcript-backed sessions, including summary views, and tuck it into a noninteractive peek state while scrolling down.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change that adjusts when and how the session floating action button is shown; main risk is regressions in scroll-based hide/show behavior across different note views.
> 
> **Overview**
> Adjusts session FAB behavior so the **chat CTA appears on transcript-backed sessions (including enhanced summary views)** and introduces a *scroll-driven “peek” mode* that tucks the FAB away while scrolling down but keeps it mounted and revealable via hover.
> 
> Adds `getNextFloatingButtonHidden` to compute hide/show from scroll deltas (with top/bottom thresholds), wires note scroll events through `NoteInput` into `session/index.tsx`, and updates `FloatingActionButton` to support a `hidden` prop with hover-zone styling. Also fixes caret-near-bottom detection to use the editor container bounds (not viewport) and makes `ChatCTA` labels truncate; includes new unit tests for the scroll state helper and FAB peek behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783f1fdc7642fe9c7d0d2615a6f444a50ad393dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->