### PR TITLE
fix(desktop): compact live transcript footer

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -131,7 +131,7 @@ function RecordOnlyFooter({
   isFallbackFromLive: boolean;
 }) {
   return (
-    <div className="flex min-h-8 items-center justify-center px-4">
+    <div className="flex items-center justify-center px-4 py-1">
       <p className="text-[11px] leading-none text-neutral-400">
         {isFallbackFromLive
           ? "Live transcription stopped. Transcript will be created after you stop."
@@ -238,7 +238,7 @@ function CollapsedFooterMessage({ message }: { message: string }) {
   return (
     <div
       className={cn([
-        "flex min-h-12 items-center gap-2 p-2",
+        "flex min-h-9 items-center gap-2 px-2 py-1",
         "w-full max-w-full",
       ])}
     >


### PR DESCRIPTION
Reduce the collapsed live transcript footer height and padding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely Tailwind class tweaks to footer spacing with no logic, data, or state changes.
> 
> **Overview**
> Makes the during-session bottom accessory footer more compact by reducing padding and minimum heights in `RecordOnlyFooter` and the collapsed `CollapsedFooterMessage` layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ad31c853dca29a81c2359ae77edaff759a0b8d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->