### PR TITLE
fix(desktop): avoid relay dev port collision

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,7 +14,7 @@
     "i18n:extract": "lingui extract",
     "i18n:compile": "lingui compile",
     "i18n:check": "lingui extract --clean --workers 1 && lingui compile --strict --workers 1 && git diff --exit-code -- src/i18n/locales",
-    "tauri:dev": "dotenvx run --ignore MISSING_ENV_FILE -f ../../.env.supabase -f .env -- tauri dev --no-watch --features dev",
+    "tauri:dev": "dotenvx run --ignore MISSING_ENV_FILE --env RELAY_PORT=1424 -f ../../.env.supabase -f .env -- tauri dev --no-watch --features dev",
     "tauri:build": "tauri build"
   },
   "dependencies": {

--- a/plugins/relay/js/shim.js
+++ b/plugins/relay/js/shim.js
@@ -137,7 +137,8 @@
   // ---------------------------------------------------------------------------
 
   var env = detectPlatform();
-  var relay = createRelayConnection(1423);
+  var relayPort = Number("__RELAY_PORT__") || 1423;
+  var relay = createRelayConnection(relayPort);
 
   // -- window.__TAURI_INTERNALS__ -------------------------------------------
 

--- a/plugins/relay/js/vite.js
+++ b/plugins/relay/js/vite.js
@@ -4,6 +4,12 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const shimPath = resolve(__dirname, "shim.js");
+const defaultRelayPort = 1423;
+
+function getRelayPort() {
+  const value = Number.parseInt(process.env.RELAY_PORT || "", 10);
+  return Number.isInteger(value) && value > 0 ? value : defaultRelayPort;
+}
 
 /** @returns {import('vite').Plugin} */
 export function relayShim() {
@@ -11,7 +17,10 @@ export function relayShim() {
     name: "relay-shim",
     configureServer(server) {
       server.middlewares.use("/relay-shim.js", (_req, res) => {
-        const content = readFileSync(shimPath, "utf-8");
+        const content = readFileSync(shimPath, "utf-8").replaceAll(
+          "__RELAY_PORT__",
+          String(getRelayPort()),
+        );
         res.setHeader("Content-Type", "application/javascript");
         res.end(content);
       });


### PR DESCRIPTION
Run Tauri dev relay on a separate port and inject the configured relay port into the browser shim.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes local dev configuration by moving the Tauri relay to a different port and plumbing that port into the browser relay shim; production/runtime behavior should remain unchanged.
> 
> **Overview**
> **Avoids relay port conflicts in desktop dev.** `tauri:dev` now sets `RELAY_PORT=1424` instead of relying on the default `1423`.
> 
> The browser relay shim is updated to use an injected `__RELAY_PORT__` value, and the Vite `relayShim` plugin now replaces that placeholder from `process.env.RELAY_PORT` (falling back to `1423`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a43f58cd882a9c629e449e46f2fd27ff6535ca1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->