### PR TITLE
fix(desktop): compact streamdown h1 rendering

### DIFF
--- a/apps/desktop/src/session/components/streamdown.tsx
+++ b/apps/desktop/src/session/components/streamdown.tsx
@@ -6,17 +6,17 @@ const HEADING_WITH_MARGIN = "mt-4 first:mt-0";
 
 export const streamdownComponents = {
   h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
-    <h1 className={cn([HEADING_SHARED, HEADING_WITH_MARGIN, "text-xl"])}>
+    <h3 className={cn([HEADING_SHARED, HEADING_WITH_MARGIN, "text-base"])}>
       {props.children as React.ReactNode}
-    </h1>
+    </h3>
   ),
   h2: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
-    <h2 className={cn([HEADING_SHARED, HEADING_WITH_MARGIN, "text-lg"])}>
+    <h2 className={cn([HEADING_SHARED, HEADING_WITH_MARGIN, "text-sm"])}>
       {props.children as React.ReactNode}
     </h2>
   ),
   h3: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
-    <h3 className={cn([HEADING_SHARED, HEADING_WITH_MARGIN, "text-base"])}>
+    <h3 className={cn([HEADING_SHARED, HEADING_WITH_MARGIN, "text-sm"])}>
       {props.children as React.ReactNode}
     </h3>
   ),

--- a/packages/tiptap/src/shared/streamdown-components.tsx
+++ b/packages/tiptap/src/shared/streamdown-components.tsx
@@ -7,17 +7,17 @@ const HEADING_WITH_MARGIN = "mt-4 first:mt-0";
 
 export const streamdownComponents = {
   h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
-    <h1 className={cn([HEADING_SHARED, HEADING_WITH_MARGIN, "text-xl"])}>
+    <h3 className={cn([HEADING_SHARED, HEADING_WITH_MARGIN, "text-base"])}>
       {props.children as React.ReactNode}
-    </h1>
+    </h3>
   ),
   h2: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
-    <h2 className={cn([HEADING_SHARED, HEADING_WITH_MARGIN, "text-lg"])}>
+    <h2 className={cn([HEADING_SHARED, HEADING_WITH_MARGIN, "text-sm"])}>
       {props.children as React.ReactNode}
     </h2>
   ),
   h3: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
-    <h3 className={cn([HEADING_SHARED, HEADING_WITH_MARGIN, "text-base"])}>
+    <h3 className={cn([HEADING_SHARED, HEADING_WITH_MARGIN, "text-sm"])}>
       {props.children as React.ReactNode}
     </h3>
   ),


### PR DESCRIPTION
Render top-level Streamdown headings as h3-sized text while keeping them above body copy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change, though it alters the semantic HTML tag used for `h1` which could affect accessibility/anchor behavior if relied upon elsewhere.
> 
> **Overview**
> **Streamdown headings are now rendered more compactly.** Both desktop and shared `streamdownComponents` downscale `h1` to render as an `h3` with `text-base`, and reduce `h2`/`h3` typography to `text-sm`, keeping heading spacing consistent while making titles less visually dominant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2b47d666b379f8840404f0d2168796896500168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->