### PR TITLE
fix(desktop): remove duplicate transcript progress

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -201,4 +201,27 @@ describe("PostSessionAccessory", () => {
     expect(scrollArea?.className).not.toContain("h-[300px]");
     expect(scrollArea?.parentElement?.className).toContain("flex-1");
   });
+
+  it("shows transcript skeletons instead of duplicating batch progress in the body", () => {
+    useTranscriptScreenMock.mockReturnValue({
+      kind: "running_batch",
+      percentage: 0.25,
+      phase: "transcribing",
+    });
+
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio
+        hasTranscript
+        isTranscriptExpanded
+      />,
+    );
+
+    expect(screen.getByText("Transcript")).toBeTruthy();
+    expect(screen.getAllByText("Transcribing...")).toHaveLength(1);
+    expect(screen.getAllByTestId("spinner")).toHaveLength(1);
+    expect(screen.getByTestId("transcript-skeleton")).toBeTruthy();
+    expect(screen.queryByTestId("transcript")).toBeNull();
+  });
 });

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -103,7 +103,6 @@ function TranscriptPanel({
       <BatchingTranscriptPanel
         sessionId={sessionId}
         screen={screen}
-        hasTranscript={hasTranscript}
         isExpanded={isExpanded}
         fillHeight={fillHeight}
       />
@@ -156,7 +155,6 @@ function useRegenerateTranscript(sessionId: string) {
 function BatchingTranscriptPanel({
   sessionId,
   screen,
-  hasTranscript,
   isExpanded,
   fillHeight,
 }: {
@@ -166,11 +164,9 @@ function BatchingTranscriptPanel({
     percentage?: number;
     phase?: "importing" | "transcribing";
   };
-  hasTranscript: boolean;
   isExpanded: boolean;
   fillHeight: boolean;
 }) {
-  const scrollRef = useRef<HTMLDivElement>(null);
   const stopTranscription = useListener((state) => state.stopTranscription);
   const handleStop = useCallback(() => {
     void stopTranscription(sessionId);
@@ -203,27 +199,77 @@ function BatchingTranscriptPanel({
         </div>
       </div>
 
-      {hasTranscript ? (
-        <TranscriptScrollArea fillHeight={fillHeight}>
-          <Transcript sessionId={sessionId} scrollRef={scrollRef} />
-        </TranscriptScrollArea>
-      ) : (
-        <div
-          className={cn([
-            "flex flex-col items-center justify-center gap-2",
-            fillHeight ? "min-h-0 flex-1" : "h-[120px]",
-          ])}
-        >
-          <Spinner size={24} />
-          {typeof percentage === "number" && percentage > 0 && (
-            <p className="text-xl font-medium text-neutral-500 tabular-nums">
-              {Math.round(percentage * 100)}%
-            </p>
-          )}
-          <p className="text-sm text-neutral-400">{phaseLabel}</p>
-        </div>
-      )}
+      <BatchTranscriptSkeleton fillHeight={fillHeight} />
     </TranscriptCard>
+  );
+}
+
+function BatchTranscriptSkeleton({ fillHeight }: { fillHeight: boolean }) {
+  const rows = [
+    {
+      speaker: "w-16",
+      time: "w-8",
+      lines: ["w-[74%]", "w-[54%]"],
+    },
+    {
+      speaker: "w-12",
+      time: "w-10",
+      lines: ["w-[62%]", "w-[82%]", "w-[38%]"],
+    },
+    {
+      speaker: "w-20",
+      time: "w-8",
+      lines: ["w-[70%]", "w-[48%]"],
+    },
+  ] as const;
+
+  return (
+    <div
+      aria-hidden
+      data-testid="transcript-skeleton"
+      className={cn([
+        "flex overflow-hidden px-6 py-4",
+        fillHeight ? "min-h-0 flex-1 items-center" : "h-[178px] items-start",
+      ])}
+    >
+      <div className="w-full max-w-[940px] space-y-7">
+        {rows.map((row, index) => (
+          <div
+            key={index}
+            className="grid grid-cols-[72px_minmax(0,1fr)] gap-4"
+          >
+            <div className="space-y-2 pt-0.5">
+              <div
+                className={cn([
+                  "h-2.5 rounded-full bg-neutral-200/80",
+                  "animate-pulse",
+                  row.speaker,
+                ])}
+              />
+              <div
+                className={cn([
+                  "h-1.5 rounded-full bg-neutral-100",
+                  "animate-pulse",
+                  row.time,
+                ])}
+              />
+            </div>
+            <div className="space-y-2 pt-0.5">
+              {row.lines.map((lineWidth, lineIndex) => (
+                <div
+                  key={lineIndex}
+                  className={cn([
+                    "h-2.5 rounded-full bg-neutral-100",
+                    "animate-pulse",
+                    lineWidth,
+                  ])}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
Keep the empty batch transcript panel blank while relying on the header and timeline for progress status.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts rendering during `running_batch` and adds a targeted test to prevent regressions.
> 
> **Overview**
> During `running_batch`, the expanded transcript panel no longer renders the in-body progress/percentage (or the transcript itself); it now shows a lightweight `BatchTranscriptSkeleton` while progress remains in the header/timeline.
> 
> Adds a test asserting only a single "Transcribing..." indicator/spinner is shown and that the transcript content is replaced by the new skeleton (`data-testid="transcript-skeleton"`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d0dc5072f0b9463fb6e1346632d966f1627d3e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->