### PR TITLE
fix(desktop): hide transcript resize divider

### DIFF
--- a/apps/desktop/src/shared/main/index.test.tsx
+++ b/apps/desktop/src/shared/main/index.test.tsx
@@ -47,8 +47,15 @@ vi.mock("@hypr/ui/components/ui/resizable", async () => {
         </div>
       );
     }),
-    ResizableHandle: ({ disabled }: { disabled?: boolean }) => (
+    ResizableHandle: ({
+      className,
+      disabled,
+    }: {
+      className?: string;
+      disabled?: boolean;
+    }) => (
       <div
+        data-class-name={className}
         data-disabled={disabled ? "true" : "false"}
         data-testid="resize-handle"
       />
@@ -80,6 +87,9 @@ describe("StandardTabWrapper", () => {
       "vertical",
     );
     expect(screen.getByTestId("resize-handle").dataset.disabled).toBe("false");
+    expect(screen.getByTestId("resize-handle").dataset.className).toContain(
+      "data-[panel-group-direction=vertical]:-mb-px",
+    );
 
     const panels = screen.getAllByTestId("panel");
     expect(panels[0]?.dataset.defaultSize).toBe("78");

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -80,7 +80,7 @@ export function StandardTabWrapper({
             <ResizableHandle
               disabled={!afterBorderExpanded}
               className={cn([
-                "z-10 !bg-transparent",
+                "z-10 !bg-transparent data-[panel-group-direction=vertical]:-mb-px",
                 !afterBorderExpanded && "pointer-events-none",
               ])}
             />


### PR DESCRIPTION
Collapse the transparent bottom accessory resize handle so it does not render a gray gap under the session border.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only styling tweak to the resizable handle plus a small test update to assert the new class; no data flow or business logic changes.
> 
> **Overview**
> Prevents a visible gap/line under the session border when the bottom accessory panel is resizable by applying a vertical-only negative margin class to the `ResizableHandle` in `StandardTabWrapper`.
> 
> Updates the `StandardTabWrapper` unit test mock and assertions to pass through `className` on `ResizableHandle` and verify the new Tailwind data-variant class is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44b78ae3e805674411485544db34e178f3bcc36f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->