### PR TITLE
fix(soniqo): preserve batch recording channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10643,6 +10643,7 @@ name = "listener2-core"
 version = "0.1.0"
 dependencies = [
  "aspasia",
+ "audio-chunking",
  "audio-utils",
  "bytes",
  "denoise",
@@ -10658,10 +10659,12 @@ dependencies = [
  "specta",
  "strum 0.28.0",
  "tauri-specta",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
+ "transcribe-core",
  "transcribe-soniqo",
 ]
 

--- a/crates/listener2-core/Cargo.toml
+++ b/crates/listener2-core/Cargo.toml
@@ -9,10 +9,12 @@ specta = ["dep:specta"]
 tauri-event = ["specta", "dep:tauri-specta"]
 
 [dependencies]
+hypr-audio-chunking = { workspace = true }
 hypr-audio-utils = { workspace = true }
 hypr-denoise = { workspace = true, features = ["onnx"] }
 hypr-host = { workspace = true }
 hypr-language = { workspace = true }
+hypr-transcribe-core = { workspace = true }
 hypr-transcribe-soniqo = { workspace = true }
 
 bytes = { workspace = true }
@@ -26,6 +28,7 @@ serde_json = { workspace = true }
 specta = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 tauri-specta = { workspace = true, optional = true, features = ["derive"] }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 
 ractor = { workspace = true, features = ["async-trait"] }

--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -5,6 +5,11 @@ use owhisper_client::{
 };
 use tracing::Instrument;
 
+use hypr_audio_utils::Source;
+use hypr_transcribe_core::{
+    TARGET_SAMPLE_RATE, channel_duration_sec, chunk_channel_audio, split_resampled_channels,
+};
+
 use super::{BatchParams, BatchRunMode, BatchRunOutput, format_user_friendly_error, session_span};
 
 macro_rules! dispatch_batch {
@@ -117,26 +122,19 @@ pub(super) async fn run_soniqo_batch(
             .map(hypr_language::Language::bcp47_code);
 
         let transcribed = tokio::task::spawn_blocking(move || {
-            hypr_transcribe_soniqo::transcribe_file(model, file_path, language.as_deref())
+            transcribe_soniqo_file(model, &file_path, language.as_deref())
         })
         .await
         .map_err(|e| crate::BatchFailure::DirectRequestFailed {
             provider: "soniqo".to_string(),
             message: format!("Soniqo transcription task failed: {e}"),
         })?
-        .map_err(|e| {
-            let raw_error = e.to_string();
-            crate::BatchFailure::DirectRequestFailed {
-                provider: "soniqo".to_string(),
-                message: format_user_friendly_error(&raw_error),
-            }
+        .map_err(|e| crate::BatchFailure::DirectRequestFailed {
+            provider: "soniqo".to_string(),
+            message: format_user_friendly_error(&e),
         })?;
 
-        let response = hypr_transcribe_soniqo::batch_response_from_text(
-            model,
-            transcribed.text,
-            transcribed.duration_seconds,
-        );
+        let response = hypr_transcribe_soniqo::batch_response_from_channels(model, transcribed);
 
         Ok(BatchRunOutput {
             session_id: params.session_id,
@@ -146,4 +144,129 @@ pub(super) async fn run_soniqo_batch(
     }
     .instrument(span)
     .await
+}
+
+fn transcribe_soniqo_file(
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    file_path: &str,
+    language: Option<&str>,
+) -> std::result::Result<Vec<hypr_transcribe_soniqo::FileTranscript>, String> {
+    let source = hypr_audio_utils::source_from_path(file_path).map_err(|e| e.to_string())?;
+    let channel_count = u16::from(source.channels()).max(1) as usize;
+
+    if channel_count <= 1 {
+        return hypr_transcribe_soniqo::transcribe_file(model, file_path, language)
+            .map(|transcript| vec![transcript])
+            .map_err(|e| e.to_string());
+    }
+
+    let samples =
+        hypr_audio_utils::resample_audio(source, TARGET_SAMPLE_RATE).map_err(|e| e.to_string())?;
+    let channel_samples =
+        collapse_identical_channels(split_resampled_channels(&samples, channel_count));
+
+    channel_samples
+        .into_iter()
+        .map(|samples| transcribe_soniqo_channel(model, &samples, language))
+        .collect()
+}
+
+fn transcribe_soniqo_channel(
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    samples: &[f32],
+    language: Option<&str>,
+) -> std::result::Result<hypr_transcribe_soniqo::FileTranscript, String> {
+    let duration_seconds = channel_duration_sec(samples);
+    let chunks =
+        chunk_channel_audio::<hypr_audio_chunking::Error>(samples).map_err(|e| e.to_string())?;
+    let mut texts = Vec::new();
+
+    for chunk in chunks {
+        let text = transcribe_soniqo_samples(model, &chunk.samples, language)?.text;
+        let text = text.trim();
+        if !text.is_empty() {
+            texts.push(text.to_string());
+        }
+    }
+
+    Ok(hypr_transcribe_soniqo::FileTranscript {
+        text: texts.join(" "),
+        duration_seconds,
+    })
+}
+
+fn transcribe_soniqo_samples(
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    samples: &[f32],
+    language: Option<&str>,
+) -> std::result::Result<hypr_transcribe_soniqo::FileTranscript, String> {
+    let file = tempfile::Builder::new()
+        .prefix("soniqo_channel_")
+        .suffix(".wav")
+        .tempfile()
+        .map_err(|e| e.to_string())?;
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: TARGET_SAMPLE_RATE,
+        bits_per_sample: 32,
+        sample_format: hound::SampleFormat::Float,
+    };
+
+    {
+        let mut writer = hound::WavWriter::create(file.path(), spec).map_err(|e| e.to_string())?;
+        for sample in samples {
+            writer.write_sample(*sample).map_err(|e| e.to_string())?;
+        }
+        writer.finalize().map_err(|e| e.to_string())?;
+    }
+
+    hypr_transcribe_soniqo::transcribe_file(model, file.path(), language).map_err(|e| e.to_string())
+}
+
+fn collapse_identical_channels(channels: Vec<Vec<f32>>) -> Vec<Vec<f32>> {
+    if channels.len() != 2 || !channels_are_effectively_identical(&channels[0], &channels[1]) {
+        return channels;
+    }
+
+    channels.into_iter().take(1).collect()
+}
+
+fn channels_are_effectively_identical(left: &[f32], right: &[f32]) -> bool {
+    if left.len().abs_diff(right.len()) > 1 {
+        return false;
+    }
+
+    let compared = left.len().min(right.len());
+    if compared == 0 {
+        return true;
+    }
+
+    let mean_abs_diff = left
+        .iter()
+        .zip(right.iter())
+        .map(|(a, b)| (a - b).abs())
+        .sum::<f32>()
+        / compared as f32;
+
+    mean_abs_diff < 0.0005
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collapses_effectively_identical_stereo_channels() {
+        let channels =
+            collapse_identical_channels(vec![vec![0.1, 0.2, 0.3], vec![0.1001, 0.2001, 0.3001]]);
+
+        assert_eq!(channels, vec![vec![0.1, 0.2, 0.3]]);
+    }
+
+    #[test]
+    fn keeps_distinct_stereo_channels() {
+        let channels = collapse_identical_channels(vec![vec![0.1, 0.2], vec![0.9, 0.8]]);
+
+        assert_eq!(channels, vec![vec![0.1, 0.2], vec![0.9, 0.8]]);
+    }
 }

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -404,20 +404,54 @@ pub fn batch_response_from_text(
     text: String,
     duration_seconds: f64,
 ) -> batch::Response {
-    let duration_seconds = duration_seconds.max(0.05);
-    let metadata = metadata_json(model, duration_seconds, 1);
-    let words = batch_words_from_text(&text, duration_seconds, 0);
+    batch_response_from_channels(
+        model,
+        vec![FileTranscript {
+            text,
+            duration_seconds,
+        }],
+    )
+}
+
+pub fn batch_response_from_channels(
+    model: SoniqoModel,
+    channels: Vec<FileTranscript>,
+) -> batch::Response {
+    let channels = if channels.is_empty() {
+        vec![FileTranscript {
+            text: String::new(),
+            duration_seconds: 0.05,
+        }]
+    } else {
+        channels
+    };
+    let duration_seconds = channels
+        .iter()
+        .map(|channel| channel.duration_seconds)
+        .fold(0.05, f64::max);
+    let metadata = metadata_json(model, duration_seconds, channels.len() as u32);
 
     batch::Response {
         metadata,
         results: batch::Results {
-            channels: vec![batch::Channel {
-                alternatives: vec![batch::Alternatives {
-                    transcript: text,
-                    confidence: 1.0,
-                    words,
-                }],
-            }],
+            channels: channels
+                .into_iter()
+                .enumerate()
+                .map(|(channel_index, channel)| {
+                    let duration = channel.duration_seconds.max(0.05);
+                    batch::Channel {
+                        alternatives: vec![batch::Alternatives {
+                            words: batch_words_from_text(
+                                &channel.text,
+                                duration,
+                                channel_index as i32,
+                            ),
+                            transcript: channel.text,
+                            confidence: 1.0,
+                        }],
+                    }
+                })
+                .collect(),
         },
     }
 }
@@ -786,6 +820,43 @@ mod tests {
         assert_eq!(response.results.channels[0].alternatives[0].words.len(), 2);
         assert_eq!(response.metadata["model_info"]["arch"], "soniqo");
         assert_eq!(response.metadata["duration"], 2.0);
+    }
+
+    #[test]
+    fn batch_response_preserves_channel_indexes() {
+        let response = batch_response_from_channels(
+            SoniqoModel::Omnilingual,
+            vec![
+                FileTranscript {
+                    text: "mic words".to_string(),
+                    duration_seconds: 2.0,
+                },
+                FileTranscript {
+                    text: "speaker words".to_string(),
+                    duration_seconds: 3.0,
+                },
+            ],
+        );
+
+        assert_eq!(response.metadata["channels"], 2);
+        assert_eq!(response.metadata["duration"], 3.0);
+        assert_eq!(response.results.channels.len(), 2);
+        assert_eq!(
+            response.results.channels[0].alternatives[0].transcript,
+            "mic words"
+        );
+        assert_eq!(
+            response.results.channels[1].alternatives[0].transcript,
+            "speaker words"
+        );
+        assert_eq!(
+            response.results.channels[0].alternatives[0].words[0].channel,
+            0
+        );
+        assert_eq!(
+            response.results.channels[1].alternatives[0].words[0].channel,
+            1
+        );
     }
 
     #[test]


### PR DESCRIPTION
Transcribe Soniqo batch recordings per channel with speech chunking and return multi-channel responses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Soniqo batch transcription to resample/split audio and transcribe per-channel with chunking, which may affect transcription output, performance, and temp-file I/O for multi-channel recordings.
> 
> **Overview**
> Soniqo batch transcription now **preserves recording channels** by resampling, splitting multi-channel audio, chunking each channel, and transcribing chunks via temporary mono WAVs before assembling results.
> 
> `transcribe-soniqo` adds `batch_response_from_channels` and updates batch response construction to emit one `results.channels[]` entry per transcript (with per-word `channel` indexes and duration/metadata derived from the longest channel), with new tests covering channel preservation and identical-stereo collapsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e174b2eccb3b855502067e246e0daf5da27d004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->