### PR TITLE
fix(desktop): persist transcript-only batch output

### DIFF
--- a/apps/desktop/src/store/zustand/listener/batch.ts
+++ b/apps/desktop/src/store/zustand/listener/batch.ts
@@ -7,7 +7,7 @@ import type {
 } from "@hypr/plugin-transcription";
 
 import type { BatchPersistCallback } from "./transcript";
-import { transformWordEntries } from "./utils";
+import { transformWordEntries, type WordEntry } from "./utils";
 
 import { type RuntimeSpeakerHint, type WordLike } from "~/stt/segment";
 
@@ -39,7 +39,7 @@ export type BatchState = {
 export type BatchActions = {
   handleBatchStarted: (sessionId: string, phase?: BatchPhase) => void;
   handleBatchCompleted: (sessionId: string) => void;
-  handleBatchResponse: (sessionId: string, response: BatchResponse) => void;
+  handleBatchResponse: (sessionId: string, response: BatchResponse) => boolean;
   handleBatchResponseStreamed: (
     sessionId: string,
     event: BatchStreamEvent,
@@ -56,6 +56,9 @@ export type BatchActions = {
   setBatchPersist: (sessionId: string, callback: BatchPersistCallback) => void;
   clearBatchPersist: (sessionId: string) => void;
 };
+
+export const EMPTY_BATCH_TRANSCRIPT_ERROR =
+  "No speech was detected in the audio.";
 
 export const createBatchSlice = <T extends BatchState>(
   set: StoreApi<T>["setState"],
@@ -112,7 +115,7 @@ export const createBatchSlice = <T extends BatchState>(
 
     const [words, hints] = transformBatch(response);
     if (!words.length) {
-      return;
+      return false;
     }
 
     persist?.(words, hints, { mode: "replace" });
@@ -130,6 +133,8 @@ export const createBatchSlice = <T extends BatchState>(
         batchPreview: restPreview,
       };
     });
+
+    return true;
   },
 
   handleBatchResponseStreamed: (sessionId, event) => {
@@ -284,12 +289,21 @@ function transformBatch(
 
   response.results.channels.forEach((channel, channelIndex) => {
     const alternative = channel.alternatives[0];
-    if (!alternative || !alternative.words || !alternative.words.length) {
+    if (!alternative) {
       return;
     }
 
-    const [words, hints] = transformWordEntries(
+    const wordEntries = wordEntriesFromTranscript(
       alternative.words,
+      alternative.transcript,
+      {
+        channel: channelIndex,
+        durationSeconds: getBatchDurationSeconds(response),
+      },
+    );
+
+    const [words, hints] = transformWordEntries(
+      wordEntries,
       alternative.transcript,
       channelIndex,
     );
@@ -357,8 +371,18 @@ function mergeBatchPreview(
     return preview;
   }
 
-  const [incomingWords, incomingHints] = transformWordEntries(
+  const wordEntries = wordEntriesFromTranscript(
     alternative.words,
+    alternative.transcript,
+    {
+      channel: channelIndex,
+      startSeconds: response.start,
+      durationSeconds: response.duration,
+    },
+  );
+
+  const [incomingWords, incomingHints] = transformWordEntries(
+    wordEntries,
     alternative.transcript,
     channelIndex,
   );
@@ -439,4 +463,57 @@ function getBatchStreamPercentage(event: BatchStreamEvent): number {
     case "error":
       return 0;
   }
+}
+
+function wordEntriesFromTranscript(
+  entries: WordEntry[] | null | undefined,
+  transcript: string,
+  {
+    channel,
+    startSeconds = 0,
+    durationSeconds,
+  }: {
+    channel: number;
+    startSeconds?: number;
+    durationSeconds?: number;
+  },
+): WordEntry[] {
+  if (entries?.length || !transcript.trim()) {
+    return entries ?? [];
+  }
+
+  const tokens = transcript.trim().split(/\s+/).filter(Boolean);
+  if (!tokens.length) {
+    return [];
+  }
+
+  const duration = Math.max(
+    durationSeconds && Number.isFinite(durationSeconds)
+      ? durationSeconds
+      : tokens.length * 0.4,
+    tokens.length * 0.05,
+  );
+
+  return tokens.map((token, index) => ({
+    word: token,
+    punctuated_word: token,
+    start: startSeconds + (index / tokens.length) * duration,
+    end: startSeconds + ((index + 1) / tokens.length) * duration,
+    channel,
+    speaker: null,
+  }));
+}
+
+function getBatchDurationSeconds(response: BatchResponse): number | undefined {
+  const metadata = response.metadata;
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return undefined;
+  }
+
+  const duration = (metadata as Record<string, unknown>).duration;
+  return typeof duration === "number" &&
+    Number.isFinite(duration) &&
+    duration > 0
+    ? duration
+    : undefined;
 }

--- a/apps/desktop/src/store/zustand/listener/general-batch.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+import { EMPTY_BATCH_TRANSCRIPT_ERROR } from "./batch";
 import { runBatchSession } from "./general-batch";
 
 const { listenMock, startTranscriptionMock } = vi.hoisted(() => ({
@@ -211,6 +212,91 @@ describe("runBatchSession", () => {
       results: { channels: [] },
     });
     expect(handleBatchFailed).not.toHaveBeenCalled();
+  });
+
+  test("rejects completed responses that have no transcribed words", async () => {
+    const handleBatchStarted = vi.fn();
+    const handleBatchResponse = vi.fn(() => false);
+    const handleBatchCompleted = vi.fn();
+    const clearBatchPersist = vi.fn();
+    const clearBatchSession = vi.fn();
+    const handleBatchResponseStreamed = vi.fn();
+    const handleBatchFailed = vi.fn();
+    const handleBatchStopped = vi.fn();
+    const updateBatchProgress = vi.fn();
+    const setBatchPersist = vi.fn();
+
+    let handler:
+      | ((event: {
+          payload: {
+            type: string;
+            session_id: string;
+            response?: unknown;
+            mode?: "direct" | "streamed";
+          };
+        }) => void)
+      | undefined;
+
+    listenMock.mockImplementation(async (cb) => {
+      handler = cb;
+      return vi.fn();
+    });
+
+    startTranscriptionMock.mockImplementation(async () => {
+      queueMicrotask(() => {
+        handler?.({
+          payload: {
+            type: "completed",
+            session_id: "session-1",
+            mode: "direct",
+            response: {
+              metadata: null,
+              results: { channels: [] },
+            },
+          },
+        });
+      });
+
+      return {
+        status: "ok",
+        data: null,
+      };
+    });
+
+    await expect(
+      runBatchSession(
+        () => ({
+          batch: {},
+          batchPreview: {},
+          batchPersist: {},
+          handleBatchStarted,
+          handleBatchResponse,
+          handleBatchCompleted,
+          clearBatchPersist,
+          clearBatchSession,
+          handleBatchResponseStreamed,
+          handleBatchFailed,
+          handleBatchStopped,
+          updateBatchProgress,
+          setBatchPersist,
+        }),
+        "session-1",
+        {
+          session_id: "session-1",
+          provider: "hyprnote",
+          file_path: "/tmp/session.wav",
+          base_url: "",
+          api_key: "",
+        },
+      ),
+    ).rejects.toThrow(EMPTY_BATCH_TRANSCRIPT_ERROR);
+
+    expect(handleBatchFailed).toHaveBeenCalledWith(
+      "session-1",
+      EMPTY_BATCH_TRANSCRIPT_ERROR,
+    );
+    expect(clearBatchPersist).toHaveBeenCalledWith("session-1");
+    expect(clearBatchSession).not.toHaveBeenCalled();
   });
 
   test("rejects when the transcription is stopped", async () => {

--- a/apps/desktop/src/store/zustand/listener/general-batch.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.ts
@@ -7,7 +7,11 @@ import {
   events as transcriptionEvents,
 } from "@hypr/plugin-transcription";
 
-import type { BatchActions, BatchState } from "./batch";
+import {
+  EMPTY_BATCH_TRANSCRIPT_ERROR,
+  type BatchActions,
+  type BatchState,
+} from "./batch";
 
 type BatchStore = BatchActions & BatchState;
 
@@ -39,6 +43,7 @@ export const runBatchSession = async <T extends BatchStore>(
       response: Parameters<BatchStore["handleBatchResponse"]>[1];
     },
     resolve: () => void,
+    reject: (reason?: unknown) => void,
   ) => {
     if (settled) {
       return;
@@ -47,7 +52,10 @@ export const runBatchSession = async <T extends BatchStore>(
     settled = true;
 
     try {
-      get().handleBatchResponse(sessionId, output.response);
+      const handled = get().handleBatchResponse(sessionId, output.response);
+      if (handled === false) {
+        throw new Error(EMPTY_BATCH_TRANSCRIPT_ERROR);
+      }
       cleanup();
     } catch (error) {
       console.error("[runBatch] error handling batch response", error);
@@ -55,7 +63,8 @@ export const runBatchSession = async <T extends BatchStore>(
         error instanceof Error ? error.message : String(error);
       get().handleBatchFailed(sessionId, errorMessage);
       cleanup(false);
-      throw error;
+      reject(error);
+      return;
     }
 
     resolve();
@@ -121,6 +130,7 @@ export const runBatchSession = async <T extends BatchStore>(
               response: payload.response,
             },
             resolve,
+            reject,
           );
           return;
         }

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -216,6 +216,115 @@ describe("General Listener Slice", () => {
       );
     });
 
+    test("handleBatchResponse persists transcript-only batch responses", () => {
+      const sessionId = "session-transcript-only-batch";
+      const persist = vi.fn();
+      const { handleBatchStarted, handleBatchResponse, setBatchPersist } =
+        store.getState();
+
+      handleBatchStarted(sessionId);
+      setBatchPersist(sessionId, persist);
+
+      expect(
+        handleBatchResponse(sessionId, {
+          metadata: { duration: 2 },
+          results: {
+            channels: [
+              {
+                alternatives: [
+                  {
+                    transcript: "hello world",
+                    confidence: 0.9,
+                    words: [],
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      ).toBe(true);
+
+      expect(persist).toHaveBeenCalledWith(
+        [
+          {
+            text: " hello",
+            start_ms: 0,
+            end_ms: 1000,
+            channel: 0,
+          },
+          {
+            text: " world",
+            start_ms: 1000,
+            end_ms: 2000,
+            channel: 0,
+          },
+        ],
+        [],
+        { mode: "replace" },
+      );
+      expect(store.getState().batch[sessionId]).toBeUndefined();
+    });
+
+    test("handleBatchResponseStreamed persists transcript-only segment responses", () => {
+      const sessionId = "session-transcript-only-stream";
+      const persist = vi.fn();
+      const { handleBatchResponseStreamed, setBatchPersist } = store.getState();
+
+      setBatchPersist(sessionId, persist);
+
+      handleBatchResponseStreamed(sessionId, {
+        type: "segment",
+        percentage: 0.5,
+        response: {
+          type: "Results",
+          start: 4,
+          duration: 2,
+          is_final: true,
+          speech_final: true,
+          from_finalize: false,
+          channel: {
+            alternatives: [
+              {
+                transcript: "hello world",
+                languages: [],
+                words: [],
+                confidence: 0.9,
+              },
+            ],
+          },
+          metadata: {
+            request_id: "test-request",
+            model_info: {
+              name: "test-model",
+              version: "1.0",
+              arch: "test-arch",
+            },
+            model_uuid: "test-uuid",
+          },
+          channel_index: [1],
+        },
+      });
+
+      expect(persist).toHaveBeenCalledWith(
+        [
+          {
+            text: " hello",
+            start_ms: 4000,
+            end_ms: 5000,
+            channel: 1,
+          },
+          {
+            text: " world",
+            start_ms: 5000,
+            end_ms: 6000,
+            channel: 1,
+          },
+        ],
+        [],
+        { mode: "replace" },
+      );
+    });
+
     test("handleBatchFailed preserves batch error for UI surfaces", () => {
       const sessionId = "session-batch-error";
       const { handleBatchFailed, getSessionMode } = store.getState();


### PR DESCRIPTION
Synthesize word timings for transcript-only batch responses and surface empty batch output as a no-speech error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes core batch-transcription result handling and introduces synthesized timing data plus a new failure path when no words are produced.
> 
> **Overview**
> **Batch transcription now handles transcript-only outputs.** When batch/streamed responses contain a `transcript` but no `words`, the listener synthesizes `WordEntry` timings (using segment start/duration or overall metadata duration) so results can still be persisted.
> 
> **Empty batch output is now treated as an error.** `handleBatchResponse` returns a boolean and `runBatchSession` rejects/marks the session failed with `EMPTY_BATCH_TRANSCRIPT_ERROR` when no words are produced; tests were added/updated to cover transcript-only persistence and the new no-speech failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bab1216accf46562ccc74c94628feb673dd61122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->