### PR TITLE
fix(desktop): show skip reasons in FAB slot

### DIFF
--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -92,11 +92,77 @@ describe("FloatingActionButton", () => {
 
     expect(hoverZone?.className).toContain("group");
     expect(hoverZone?.className).toContain("pointer-events-auto");
+    expect(hoverZone?.className).toContain("max-w-[calc(100%-2rem)]");
+    expect(hoverZone?.className).not.toContain("w-96");
     expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
     expect(wrapper?.className).toContain("pointer-events-none");
-    expect(wrapper?.className).toContain("translate-y-[calc(100%+0.5rem)]");
+    expect(wrapper?.className).toContain(
+      "translate-y-[var(--floating-fab-tuck-offset)]",
+    );
+    expect(wrapper?.style.getPropertyValue("--floating-fab-tuck-offset")).toBe(
+      "calc(100% - 0.5rem + 18px)",
+    );
     expect(wrapper?.className).toContain("group-hover:pointer-events-auto");
     expect(wrapper?.className).toContain("group-hover:translate-y-0");
-    expect(wrapper?.className).toContain("opacity-100");
+  });
+
+  it("tucks the listen FAB near the editor caret instead of scroll state", () => {
+    hoisted.hasTranscript = false;
+    hoisted.isCaretNearBottom = true;
+
+    render(<FloatingActionButton tab={tab} />);
+
+    const wrapper = screen.getByText("Start listening").parentElement;
+
+    expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
+    expect(wrapper?.style.getPropertyValue("--floating-fab-tuck-offset")).toBe(
+      "calc(100% - 0.5rem + 18px)",
+    );
+  });
+
+  it("keeps the listen FAB popped up when only scroll hidden is set", () => {
+    hoisted.hasTranscript = false;
+
+    render(<FloatingActionButton hidden tab={tab} />);
+
+    const wrapper = screen.getByText("Start listening").parentElement;
+
+    expect(wrapper?.getAttribute("aria-hidden")).toBe("false");
+    expect(wrapper?.style.getPropertyValue("--floating-fab-tuck-offset")).toBe(
+      "0px",
+    );
+  });
+
+  it("shows a skip reason in the FAB slot instead of the chat FAB", () => {
+    render(
+      <FloatingActionButton
+        tab={tab}
+        skipReason="Not enough words recorded (3/5 minimum)"
+      />,
+    );
+
+    const status = screen.getByRole("status");
+
+    expect(status.textContent).toBe("Not enough words recorded (3/5 minimum)");
+    expect(status.className).toContain("text-red-400");
+    expect(status.parentElement?.className).toContain("pb-4");
+    expect(
+      screen.queryByRole("button", { name: "Ask about this session" }),
+    ).toBeNull();
+  });
+
+  it("keeps a skip reason visible even when the FAB is tucked", () => {
+    render(
+      <FloatingActionButton
+        hidden
+        tab={tab}
+        skipReason="Not enough words recorded (3/5 minimum)"
+      />,
+    );
+
+    const status = screen.getByRole("status");
+
+    expect(status.className).toContain("translate-y-0");
+    expect(status.parentElement?.className).not.toContain("group");
   });
 });

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -1,5 +1,9 @@
+import { AnimatePresence, motion } from "motion/react";
+import type { CSSProperties } from "react";
+
 import { cn } from "@hypr/utils";
 
+import { useCaretPosition } from "../caret-position-context";
 import { ListenButton } from "./listen";
 
 import {
@@ -12,36 +16,72 @@ import { useListener } from "~/stt/contexts";
 
 export function FloatingActionButton({
   hidden = false,
+  skipReason = null,
   tab,
 }: {
   hidden?: boolean;
+  skipReason?: string | null;
   tab: Extract<Tab, { type: "sessions" }>;
 }) {
   const shouldShowListen = useShouldShowListeningFab(tab);
   const shouldShowChat = useShouldShowChatFab(tab);
+  const isCaretNearBottom = useCaretPosition()?.isCaretNearBottom ?? false;
+  const showSkipReason = !!skipReason;
+  const showAction = shouldShowListen || shouldShowChat;
+  const tuckAction =
+    !showSkipReason &&
+    ((shouldShowListen && isCaretNearBottom) || (shouldShowChat && hidden));
 
-  if (!shouldShowListen && !shouldShowChat) {
+  if (!showSkipReason && !showAction) {
     return null;
   }
 
   return (
     <div
       className={cn([
-        "absolute bottom-0 left-1/2 z-20 h-14 w-96 max-w-[calc(100%-2rem)] -translate-x-1/2",
-        hidden ? "group pointer-events-auto" : "pointer-events-none",
+        "absolute bottom-0 left-1/2 z-20 flex h-14 max-w-[calc(100%-2rem)] -translate-x-1/2 items-end justify-center pb-4",
+        tuckAction ? "group pointer-events-auto" : "pointer-events-none",
       ])}
     >
-      <div
-        aria-hidden={hidden}
-        className={cn([
-          "absolute bottom-4 left-1/2 -translate-x-1/2 transition-[opacity,visibility,transform] duration-150",
-          hidden
-            ? "pointer-events-none visible translate-y-[calc(100%+0.5rem)] opacity-100 group-hover:pointer-events-auto group-hover:translate-y-0"
-            : "pointer-events-auto visible translate-y-0 opacity-100",
-        ])}
-      >
-        {shouldShowListen ? <ListenButton tab={tab} /> : <ChatCTA />}
-      </div>
+      <AnimatePresence mode="wait" initial={false}>
+        {showSkipReason ? (
+          <motion.div
+            key={skipReason}
+            role="status"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3, ease: "easeOut" }}
+            className="max-w-full translate-y-0 text-center text-sm whitespace-nowrap text-red-400"
+          >
+            {skipReason}
+          </motion.div>
+        ) : (
+          <motion.div
+            key={shouldShowListen ? "listen" : "chat"}
+            aria-hidden={tuckAction}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            style={
+              {
+                "--floating-fab-tuck-offset": tuckAction
+                  ? "calc(100% - 0.5rem + 18px)"
+                  : "0px",
+              } as CSSProperties
+            }
+            className={cn([
+              "max-w-full translate-y-[var(--floating-fab-tuck-offset)] transition-transform duration-200 ease-out",
+              tuckAction
+                ? "pointer-events-none visible group-hover:pointer-events-auto group-hover:translate-y-0"
+                : "pointer-events-auto visible",
+            ])}
+          >
+            {shouldShowListen ? <ListenButton tab={tab} /> : <ChatCTA />}
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -22,7 +22,6 @@ import { getSessionTabStatus } from "./tab-visual-state";
 
 import { useTitleGeneration } from "~/ai/hooks";
 import * as AudioPlayer from "~/audio-player";
-import { useSessionStatusBanner } from "~/shared/main";
 import { type TabItem, TabItemBase } from "~/shared/tabs";
 import * as main from "~/store/tinybase/store/main";
 import { useSessionTitle } from "~/store/zustand/live-title";
@@ -276,11 +275,6 @@ function TabContentNoteInner({
     [currentViewKey],
   );
 
-  useSessionStatusBanner({
-    skipReason,
-    bottomAccessoryState,
-  });
-
   const mergeTranscriptSurface =
     bottomAccessoryState?.expanded === true &&
     (bottomAccessoryState.mode === "playback" ||
@@ -316,7 +310,11 @@ function TabContentNoteInner({
       bottomBorderHandle={bottomBorderHandle}
       mergeAfterBorder={mergeTranscriptSurface}
       floatingButton={
-        <FloatingActionButton hidden={floatingButtonHidden} tab={tab} />
+        <FloatingActionButton
+          hidden={floatingButtonHidden}
+          skipReason={skipReason}
+          tab={tab}
+        />
       }
     >
       <NoteInput


### PR DESCRIPTION
Render auto-enhance skip reasons in the floating action button position, fade between the message and FAB, and cover the replacement behavior with tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI behavior for the session floating action button is refactored to animate/tuck based on caret and to replace the action with skip-reason messaging; moderate risk of regressions in FAB visibility/interaction and layout across session states.
> 
> **Overview**
> Auto-enhance *skip reasons* are now rendered in the `FloatingActionButton` area (as a `role="status"` message) and **fade between** the message and the normal listen/chat action via `AnimatePresence`.
> 
> The FAB “tuck/peek” behavior is reworked: chat tucks when `hidden` (scroll state) while listen tucks based on editor caret proximity (`useCaretPosition`), using a CSS var offset for the translate. Session-level status banner publishing (`useSessionStatusBanner`) is removed in favor of passing `skipReason` directly into the FAB, and tests are expanded to cover the new tuck rules and skip-reason replacement behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e052af71c5183dcb9417485f70f03193bdb1189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->