### PR TITLE
fix(desktop): open transcript at top

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TranscriptViewer } from "./index";
+
+vi.mock("react-hotkeys-hook", () => ({
+  useHotkeys: vi.fn(),
+}));
+
+vi.mock("~/audio-player", () => ({
+  useAudioPlayer: () => ({
+    state: "stopped",
+    pause: vi.fn(),
+    resume: vi.fn(),
+    start: vi.fn(),
+    seek: vi.fn(),
+    audioExists: true,
+  }),
+}));
+
+vi.mock("~/audio-player/provider", () => ({
+  useAudioTime: () => ({ current: 0 }),
+}));
+
+vi.mock("./selection-menu", () => ({
+  SelectionMenu: () => null,
+}));
+
+vi.mock("./transcript", () => ({
+  RenderTranscript: ({ shouldScrollToEnd }: { shouldScrollToEnd: boolean }) => (
+    <div
+      data-testid="render-transcript"
+      data-should-scroll-to-end={String(shouldScrollToEnd)}
+    />
+  ),
+}));
+
+vi.mock("./viewport-hooks", () => ({
+  useAutoScroll: vi.fn(),
+  usePlaybackAutoScroll: vi.fn(),
+  useScrollDetection: () => ({
+    isAtBottom: true,
+    autoScrollEnabled: true,
+    scrollToBottom: vi.fn(),
+  }),
+}));
+
+describe("TranscriptViewer", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("does not pin inactive transcript sessions to the bottom on open", () => {
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive={false}
+        scrollRef={createRef()}
+      />,
+    );
+
+    expect(
+      screen
+        .getByTestId("render-transcript")
+        .getAttribute("data-should-scroll-to-end"),
+    ).toBe("false");
+  });
+
+  it("keeps active transcript sessions pinned to the bottom", () => {
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive
+        scrollRef={createRef()}
+      />,
+    );
+
+    expect(
+      screen
+        .getByTestId("render-transcript")
+        .getAttribute("data-should-scroll-to-end"),
+    ).toBe("true");
+  });
+});

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -78,6 +78,7 @@ export function TranscriptViewer({
 
   usePlaybackAutoScroll(containerRef, deferredCurrentMs, isPlaying);
   const shouldAutoScroll = currentActive && autoScrollEnabled;
+  const shouldScrollLastTranscriptToEnd = currentActive && isAtBottom;
   useAutoScroll(
     containerRef,
     [transcriptIds, liveSegments, shouldAutoScroll],
@@ -107,7 +108,7 @@ export function TranscriptViewer({
             <RenderTranscript
               scrollElement={scrollElement}
               isLastTranscript={index === transcriptIds.length - 1}
-              isAtBottom={isAtBottom}
+              shouldScrollToEnd={shouldScrollLastTranscriptToEnd}
               transcriptId={transcriptId}
               liveSegments={
                 index === transcriptIds.length - 1 && currentActive

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
@@ -27,7 +27,7 @@ import {
 export function RenderTranscript({
   scrollElement,
   isLastTranscript,
-  isAtBottom,
+  shouldScrollToEnd,
   transcriptId,
   liveSegments,
   currentMs,
@@ -37,7 +37,7 @@ export function RenderTranscript({
 }: {
   scrollElement: HTMLDivElement | null;
   isLastTranscript: boolean;
-  isAtBottom: boolean;
+  shouldScrollToEnd: boolean;
   transcriptId: string;
   liveSegments: Segment[];
   currentMs: number;
@@ -63,7 +63,7 @@ export function RenderTranscript({
       scrollElement={scrollElement}
       transcriptId={transcriptId}
       offsetMs={offsetMs}
-      shouldScrollToEnd={isLastTranscript && isAtBottom}
+      shouldScrollToEnd={isLastTranscript && shouldScrollToEnd}
       currentMs={currentMs}
       seek={seek}
       startPlayback={startPlayback}


### PR DESCRIPTION
Only pin transcript scrolling to the bottom for active sessions and cover inactive open behavior with renderer tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to transcript scrolling, with added unit tests to guard the new conditions.
> 
> **Overview**
> Adjusts transcript auto-scroll/pinning so the last transcript scrolls to the end **only when the session is active and the user is already at the bottom**, preventing inactive sessions from jumping to the bottom on open.
> 
> Renames/plumbs the prop from `isAtBottom` to `shouldScrollToEnd` through `TranscriptViewer` → `RenderTranscript`, and adds `index.test.tsx` coverage to assert inactive sessions don’t pin while active ones do.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00c8432fadb5a3d1cd54ef0d386ff9451e01799c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->