### PR TITLE
fix(desktop): add transcript skeleton spacing

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -232,13 +232,13 @@ function BatchTranscriptSkeleton({ fillHeight }: { fillHeight: boolean }) {
         fillHeight ? "min-h-0 flex-1 items-center" : "h-[178px] items-start",
       ])}
     >
-      <div className="w-full max-w-[940px] space-y-7">
+      <div className="w-full max-w-[940px] space-y-8">
         {rows.map((row, index) => (
           <div
             key={index}
             className="grid grid-cols-[72px_minmax(0,1fr)] gap-4"
           >
-            <div className="space-y-2 pt-0.5">
+            <div className="space-y-3 pt-0.5">
               <div
                 className={cn([
                   "h-2.5 rounded-full bg-neutral-200/80",
@@ -254,7 +254,7 @@ function BatchTranscriptSkeleton({ fillHeight }: { fillHeight: boolean }) {
                 ])}
               />
             </div>
-            <div className="space-y-2 pt-0.5">
+            <div className="space-y-3 pt-0.5">
               {row.lines.map((lineWidth, lineIndex) => (
                 <div
                   key={lineIndex}


### PR DESCRIPTION
Increase vertical gaps between batch transcript skeleton rows and placeholder lines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only Tailwind class tweaks that only affect the loading skeleton layout.
> 
> **Overview**
> Increases vertical gaps in the batch transcript loading skeleton by bumping Tailwind `space-y-*` values, adding more separation between skeleton rows and between placeholder lines in `BatchTranscriptSkeleton`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1616a0758407553353055df4858e5cfa7d4e1e60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->