### PR TITLE
fix(desktop): preserve cleared spoken languages

### DIFF
--- a/apps/desktop/src/store/tinybase/persister/settings/persister.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/settings/persister.test.ts
@@ -463,6 +463,30 @@ describe("settingsPersister roundtrip", () => {
     expect(result.language).toEqual({});
   });
 
+  test("storeValuesToSettings preserves explicitly cleared spoken languages", () => {
+    const [tables, values] = settingsToContent({
+      language: {
+        ai_language: "ko",
+        spoken_languages: [],
+      },
+    });
+    const store = createMergeableStore()
+      .setTablesSchema(SCHEMA.table)
+      .setValuesSchema(SCHEMA.value);
+    store.setTables(tables);
+    store.setValues(values);
+
+    const storeValues = store.getValues();
+    const result = storeValuesToSettings(
+      storeValues as Record<string, unknown>,
+      { ai_language: "ko", spoken_languages: ["ko", "en"] },
+    );
+
+    expect(result.language).toEqual({
+      spoken_languages: [],
+    });
+  });
+
   test("storeValuesToSettings keeps language values differing from OS locale defaults", () => {
     const [tables, values] = settingsToContent({
       language: {

--- a/apps/desktop/src/store/tinybase/persister/settings/transform.ts
+++ b/apps/desktop/src/store/tinybase/persister/settings/transform.ts
@@ -170,7 +170,13 @@ export function storeValuesToSettings(
       continue;
     }
     if ("default" in config && value === config.default) {
-      continue;
+      const isClearedSpokenLanguages =
+        key === "spoken_languages" &&
+        (languageDefaults?.spoken_languages?.length ?? 0) > 0;
+
+      if (!isClearedSpokenLanguages) {
+        continue;
+      }
     }
     if (languageDefaults) {
       if (


### PR DESCRIPTION
Persist an explicit empty spoken language list so OS language defaults are not restored after reopening settings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes settings serialization logic for `spoken_languages`, which can affect what gets persisted vs omitted when values match defaults; risk is limited to desktop settings behavior.
> 
> **Overview**
> Ensures `storeValuesToSettings` *does not omit* `spoken_languages` when it is explicitly cleared (empty array) even if it matches the schema default, preventing OS locale defaults from being restored on reopen.
> 
> Adds a focused unit test asserting that an explicit empty `spoken_languages` value roundtrips through the TinyBase settings persister while other language values that match OS defaults can still be elided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 409e0abed2c8fc6c3791538c47385d338998f4ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->