### PR TITLE
fix(stt): improve Soniqo Qwen transcript coverage

### DIFF
--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -116,10 +116,7 @@ pub(super) async fn run_soniqo_batch(
             })?;
 
         let file_path = params.file_path.clone();
-        let language = listen_params
-            .languages
-            .first()
-            .map(hypr_language::Language::bcp47_code);
+        let language = soniqo_language_hint(&listen_params.languages);
 
         let transcribed = tokio::task::spawn_blocking(move || {
             transcribe_soniqo_file(model, &file_path, language.as_deref())
@@ -223,6 +220,12 @@ fn transcribe_soniqo_samples(
     hypr_transcribe_soniqo::transcribe_file(model, file.path(), language).map_err(|e| e.to_string())
 }
 
+fn soniqo_language_hint(languages: &[hypr_language::Language]) -> Option<String> {
+    languages
+        .first()
+        .map(|language| language.iso639().code().to_string())
+}
+
 fn collapse_identical_channels(channels: Vec<Vec<f32>>) -> Vec<Vec<f32>> {
     if channels.len() != 2 || !channels_are_effectively_identical(&channels[0], &channels[1]) {
         return channels;
@@ -268,5 +271,27 @@ mod tests {
         let channels = collapse_identical_channels(vec![vec![0.1, 0.2], vec![0.9, 0.8]]);
 
         assert_eq!(channels, vec![vec![0.1, 0.2], vec![0.9, 0.8]]);
+    }
+
+    #[test]
+    fn soniqo_batch_uses_iso_language_hint() {
+        let params = BatchParams {
+            session_id: "session".to_string(),
+            provider: super::super::BatchProvider::Soniqo,
+            file_path: "/tmp/audio.wav".to_string(),
+            model: Some("soniqo-qwen3-small".to_string()),
+            base_url: "soniqo://local".to_string(),
+            api_key: String::new(),
+            languages: vec!["en-US".parse().unwrap()],
+            keywords: vec![],
+            num_speakers: None,
+            min_speakers: None,
+            max_speakers: None,
+        };
+
+        assert_eq!(
+            soniqo_language_hint(&params.languages).as_deref(),
+            Some("en")
+        );
     }
 }

--- a/crates/transcribe-soniqo/swift-lib/src/lib.swift
+++ b/crates/transcribe-soniqo/swift-lib/src/lib.swift
@@ -255,23 +255,28 @@ private enum LoadedSpeechModel {
     language: String?
   ) -> String {
     let minimumSamples = max(sampleRate, 1)
-    guard audio.count >= minimumSamples else {
+    guard !audio.isEmpty else {
       return ""
     }
 
+    let preparedAudio =
+      audio.count < minimumSamples
+      ? audio + [Float](repeating: 0, count: minimumSamples - audio.count)
+      : audio
+
     let chunkSamples = max(sampleRate * 30, minimumSamples)
-    guard audio.count > chunkSamples else {
-      return model.transcribe(audio: audio, sampleRate: sampleRate, language: language)
+    guard preparedAudio.count > chunkSamples else {
+      return model.transcribe(audio: preparedAudio, sampleRate: sampleRate, language: language)
     }
 
     var chunks: [String] = []
     var offset = 0
 
-    while offset < audio.count {
-      var end = min(offset + chunkSamples, audio.count)
-      let trailingSamples = audio.count - end
+    while offset < preparedAudio.count {
+      var end = min(offset + chunkSamples, preparedAudio.count)
+      let trailingSamples = preparedAudio.count - end
       if trailingSamples > 0 && trailingSamples < minimumSamples {
-        end = audio.count
+        end = preparedAudio.count
       }
       defer {
         offset = end
@@ -279,7 +284,7 @@ private enum LoadedSpeechModel {
 
       let text = autoreleasepool {
         model.transcribe(
-          audio: Array(audio[offset..<end]),
+          audio: Array(preparedAudio[offset..<end]),
           sampleRate: sampleRate,
           language: language
         )


### PR DESCRIPTION
Normalize Soniqo language hints to ISO codes and pad short Qwen audio chunks so VAD-split speech is not dropped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes in Soniqo transcription (language hint mapping and Qwen3 chunk handling) may alter transcript output and edge-case coverage, but does not touch security-sensitive logic.
> 
> **Overview**
> Improves Soniqo batch transcription by **normalizing language hints** from BCP-47 (e.g. `en-US`) to an ISO-639 code (e.g. `en`) via `soniqo_language_hint`, with a regression test to lock the behavior.
> 
> Updates the Soniqo Swift bridge’s Qwen3 path to **pad sub-1-second audio** up to a minimum sample count and run chunking/transcription on the padded buffer, preventing very short segments from returning empty transcripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 805874719937e0704c175f72314d3f015b8a0a44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->