### PR TITLE
fix(stt): limit Soniqo model options

### DIFF
--- a/crates/local-stt-core/src/lib.rs
+++ b/crates/local-stt-core/src/lib.rs
@@ -3,9 +3,6 @@ pub use hypr_local_model::{AmModel, CactusSttModel, LocalModel, SoniqoModel, Whi
 pub static SUPPORTED_MODELS: &[LocalModel] = &[
     LocalModel::Soniqo(SoniqoModel::ParakeetStreaming),
     LocalModel::Soniqo(SoniqoModel::ParakeetBatch),
-    LocalModel::Soniqo(SoniqoModel::Omnilingual),
-    LocalModel::Soniqo(SoniqoModel::Qwen3Small),
-    LocalModel::Soniqo(SoniqoModel::Qwen3Large),
     LocalModel::Am(AmModel::ParakeetV2),
     LocalModel::Am(AmModel::ParakeetV3),
     LocalModel::Am(AmModel::WhisperLargeV3),
@@ -87,7 +84,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        assert_eq!(supported_soniqo_models, SoniqoModel::all());
+        assert_eq!(supported_soniqo_models, SoniqoModel::selectable());
     }
 
     #[test]

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -64,14 +64,22 @@ pub enum SoniqoModel {
 }
 
 impl SoniqoModel {
+    const ALL: &'static [Self] = &[
+        Self::ParakeetStreaming,
+        Self::ParakeetBatch,
+        Self::Omnilingual,
+        Self::Qwen3Small,
+        Self::Qwen3Large,
+    ];
+
+    const SELECTABLE: &'static [Self] = &[Self::ParakeetStreaming, Self::ParakeetBatch];
+
     pub const fn all() -> &'static [Self] {
-        &[
-            Self::ParakeetStreaming,
-            Self::ParakeetBatch,
-            Self::Omnilingual,
-            Self::Qwen3Small,
-            Self::Qwen3Large,
-        ]
+        Self::ALL
+    }
+
+    pub const fn selectable() -> &'static [Self] {
+        Self::SELECTABLE
     }
 
     pub const fn as_str(self) -> &'static str {
@@ -162,7 +170,7 @@ impl FromStr for SoniqoModel {
     type Err = Error;
 
     fn from_str(value: &str) -> Result<Self> {
-        Self::all()
+        Self::ALL
             .iter()
             .copied()
             .find(|model| value == model.as_str() || value == model.repo())
@@ -768,6 +776,28 @@ mod tests {
         assert_eq!(
             "soniqo-parakeet-streaming".parse::<SoniqoModel>().unwrap(),
             SoniqoModel::ParakeetStreaming
+        );
+    }
+
+    #[test]
+    fn all_includes_every_model_variant() {
+        assert_eq!(
+            SoniqoModel::all(),
+            &[
+                SoniqoModel::ParakeetStreaming,
+                SoniqoModel::ParakeetBatch,
+                SoniqoModel::Omnilingual,
+                SoniqoModel::Qwen3Small,
+                SoniqoModel::Qwen3Large,
+            ]
+        );
+    }
+
+    #[test]
+    fn selectable_includes_advertised_models() {
+        assert_eq!(
+            SoniqoModel::selectable(),
+            &[SoniqoModel::ParakeetStreaming, SoniqoModel::ParakeetBatch]
         );
     }
 


### PR DESCRIPTION
- Only advertise Soniqo Parakeet Streaming and Parakeet Batch in the local STT model list.
- Keep legacy Soniqo Omnilingual and Qwen model IDs parseable for existing configs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only narrows the *advertised* Soniqo model list while keeping legacy model IDs parseable; main risk is UI/config expectations changing due to fewer selectable models.
> 
> **Overview**
> Limits the local STT `SUPPORTED_MODELS` list to only advertise Soniqo Parakeet Streaming/Batch, removing Omnilingual and Qwen variants from the selectable model set.
> 
> Introduces `SoniqoModel::selectable()` (distinct from `SoniqoModel::all()`) and updates parsing/tests to ensure **legacy** Soniqo model IDs/repos remain supported while only the curated subset is surfaced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f2cc05bf4560f627d6189816e713ead387590cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->