### PR TITLE
fix(desktop): migrate app naming to Anarlog

### DIFF
--- a/crates/detect/src/list/mod.rs
+++ b/crates/detect/src/list/mod.rs
@@ -23,6 +23,9 @@ const SELF_BUNDLE_IDS: &[&str] = &[
 ];
 
 const SELF_APP_NAMES: &[&str] = &[
+    "anarlog",
+    "anarlog staging",
+    "anarlog nightly",
     "hyprnote",
     "hyprnote staging",
     "hyprnote nightly",
@@ -32,6 +35,9 @@ const SELF_APP_NAMES: &[&str] = &[
 ];
 
 const SELF_APP_PATH_SEGMENTS: &[&str] = &[
+    "/anarlog.app/",
+    "/anarlog staging.app/",
+    "/anarlog nightly.app/",
     "/hyprnote.app/",
     "/hyprnote staging.app/",
     "/hyprnote nightly.app/",
@@ -90,13 +96,13 @@ mod tests {
 
     #[test]
     fn test_is_self_app_matches_known_bundle_ids() {
-        assert!(is_self_app(&app("com.hyprnote.stable", "Char")));
+        assert!(is_self_app(&app("com.hyprnote.stable", "Anarlog")));
         assert!(is_self_app(&app("com.hyprnote.Hyprnote", "Hyprnote")));
     }
 
     #[test]
     fn test_is_self_app_matches_renamed_app_names() {
-        assert!(is_self_app(&app("pid:42", "Char")));
+        assert!(is_self_app(&app("pid:42", "Anarlog")));
         assert!(is_self_app(&app("pid:43", "Char Nightly")));
         assert!(is_self_app(&app("pid:44", "Hyprnote Staging")));
     }
@@ -104,7 +110,7 @@ mod tests {
     #[test]
     fn test_is_self_app_matches_path_fallbacks() {
         assert!(is_self_app(&app(
-            "/Applications/Char.app/Contents/MacOS/Char",
+            "/Applications/Anarlog.app/Contents/MacOS/anarlog",
             "Unknown",
         )));
         assert!(is_self_app(&app(

--- a/plugins/deeplink2/src/server/callback.html
+++ b/plugins/deeplink2/src/server/callback.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Char</title>
+  <title>Anarlog</title>
   <script src="https://cdn.twind.style" crossorigin></script>
 </head>
 <body class="min-h-screen bg-gradient-to-b from-white via-stone-50 to-white flex items-center justify-center p-6">
@@ -14,7 +14,7 @@
     </div>
     {% if is_success %}
     <a href="{{ deeplink_url }}" class="w-full h-12 flex items-center justify-center text-base font-medium transition-all bg-gradient-to-t from-stone-600 to-stone-500 text-white rounded-full shadow-md hover:shadow-lg cursor-pointer">
-      Open Char
+      Open Anarlog
     </a>
     {% endif %}
   </div>

--- a/plugins/tray/src/menu_items/tray_open.rs
+++ b/plugins/tray/src/menu_items/tray_open.rs
@@ -11,7 +11,13 @@ impl MenuItemHandler for TrayOpen {
     const ID: &'static str = "hypr_tray_open";
 
     fn build(app: &AppHandle<tauri::Wry>) -> Result<MenuItemKind<tauri::Wry>> {
-        let item = MenuItem::with_id(app, Self::ID, "Open Char", true, None::<&str>)?;
+        let item = MenuItem::with_id(
+            app,
+            Self::ID,
+            format!("Open {}", app.package_info().name.as_str()),
+            true,
+            None::<&str>,
+        )?;
         Ok(MenuItemKind::MenuItem(item))
     }
 

--- a/plugins/tray/src/menu_items/tray_version.rs
+++ b/plugins/tray/src/menu_items/tray_version.rs
@@ -10,8 +10,8 @@ pub struct TrayVersion;
 impl TrayVersion {
     fn get_channel(app_name: &str) -> &'static str {
         match app_name {
-            "Char" | "Hyprnote" => "stable",
-            "Char Staging" | "Hyprnote Staging" => "staging",
+            "Anarlog" | "Char" | "Hyprnote" => "stable",
+            "Anarlog Staging" | "Char Staging" | "Hyprnote Staging" => "staging",
             _ => "dev",
         }
     }

--- a/plugins/updater2/src/startup_migration.rs
+++ b/plugins/updater2/src/startup_migration.rs
@@ -74,9 +74,9 @@ fn should_skip_startup_migration(args: &[OsString]) -> bool {
 
 fn legacy_target_app_path(current_app_path: &Path) -> Option<PathBuf> {
     let target_name = match current_app_path.file_name().and_then(|name| name.to_str()) {
-        Some("Hyprnote.app") => "Char.app",
-        Some("Hyprnote Nightly.app") => "Char Nightly.app",
-        Some("Hyprnote Staging.app") => "Char Staging.app",
+        Some("Hyprnote.app") | Some("Char.app") => "Anarlog.app",
+        Some("Hyprnote Nightly.app") | Some("Char Nightly.app") => "Anarlog Nightly.app",
+        Some("Hyprnote Staging.app") | Some("Char Staging.app") => "Anarlog Staging.app",
         _ => return None,
     };
 
@@ -202,16 +202,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn maps_legacy_bundle_names_to_char_names() {
+    fn maps_legacy_bundle_names_to_anarlog_names() {
         let cases = [
-            ("/Applications/Hyprnote.app", "/Applications/Char.app"),
+            ("/Applications/Hyprnote.app", "/Applications/Anarlog.app"),
+            ("/Applications/Char.app", "/Applications/Anarlog.app"),
             (
                 "/Applications/Hyprnote Nightly.app",
+                "/Applications/Anarlog Nightly.app",
+            ),
+            (
                 "/Applications/Char Nightly.app",
+                "/Applications/Anarlog Nightly.app",
             ),
             (
                 "/Applications/Hyprnote Staging.app",
+                "/Applications/Anarlog Staging.app",
+            ),
+            (
                 "/Applications/Char Staging.app",
+                "/Applications/Anarlog Staging.app",
             ),
         ];
 
@@ -226,9 +235,9 @@ mod tests {
     #[test]
     fn ignores_non_legacy_bundle_names() {
         for path in [
-            "/Applications/Char.app",
-            "/Applications/Char Nightly.app",
-            "/Applications/Char Staging.app",
+            "/Applications/Anarlog.app",
+            "/Applications/Anarlog Nightly.app",
+            "/Applications/Anarlog Staging.app",
         ] {
             assert_eq!(legacy_target_app_path(Path::new(path)), None);
         }
@@ -271,7 +280,7 @@ mod tests {
         let command = build_bundle_rename_command(
             4242,
             Path::new("/Applications/Hyprnote Nightly.app"),
-            Path::new("/Applications/Char Nightly.app"),
+            Path::new("/Applications/Anarlog Nightly.app"),
             &relaunch_args,
         );
         let args = command
@@ -279,7 +288,7 @@ mod tests {
             .map(|arg| arg.to_string_lossy().to_string())
             .collect::<Vec<_>>();
 
-        assert!(args[1].contains("if [ -e '/Applications/Char Nightly.app' ]; then"));
+        assert!(args[1].contains("if [ -e '/Applications/Anarlog Nightly.app' ]; then"));
         assert!(args[1].contains("return 1"));
     }
 
@@ -292,7 +301,7 @@ mod tests {
         let command = build_bundle_rename_command(
             4242,
             Path::new("/Applications/Hyprnote Nightly.app"),
-            Path::new("/Applications/Char Nightly.app"),
+            Path::new("/Applications/Anarlog Nightly.app"),
             &relaunch_args,
         );
         let args = command
@@ -309,11 +318,11 @@ mod tests {
 
     #[test]
     fn current_bundle_path_from_executable_uses_bundle_root() {
-        let executable = Path::new("/Applications/Char.app/Contents/MacOS/char");
+        let executable = Path::new("/Applications/Anarlog.app/Contents/MacOS/anarlog");
 
         let bundle = current_app_bundle_path_from_executable(executable).unwrap();
 
-        assert_eq!(bundle, PathBuf::from("/Applications/Char.app"));
+        assert_eq!(bundle, PathBuf::from("/Applications/Anarlog.app"));
     }
 
     #[test]
@@ -325,7 +334,7 @@ mod tests {
         let command = build_bundle_rename_command(
             4242,
             Path::new("/Applications/Hyprnote Nightly.app"),
-            Path::new("/Applications/Char Nightly.app"),
+            Path::new("/Applications/Anarlog Nightly.app"),
             &relaunch_args,
         );
         let args = command
@@ -337,10 +346,10 @@ mod tests {
         assert_eq!(args[0], "-c");
         assert!(args[1].contains(r#"while kill -0 "$1" 2>/dev/null; do sleep 0.1; done;"#));
         assert!(args[1].contains(
-            "mv -f '/Applications/Hyprnote Nightly.app' '/Applications/Char Nightly.app'"
+            "mv -f '/Applications/Hyprnote Nightly.app' '/Applications/Anarlog Nightly.app'"
         ));
         assert!(args[1].contains(
-            "open -n '/Applications/Char Nightly.app' --args '--onboarding=123' '--updater2-skip-startup-migration=1'"
+            "open -n '/Applications/Anarlog Nightly.app' --args '--onboarding=123' '--updater2-skip-startup-migration=1'"
         ));
         assert_eq!(&args[2..], ["sh", "4242"]);
     }
@@ -352,8 +361,8 @@ mod tests {
         )]);
         let command = build_bundle_rename_command(
             4242,
-            Path::new("/Applications/Hyprnote.app"),
             Path::new("/Applications/Char.app"),
+            Path::new("/Applications/Anarlog.app"),
             &relaunch_args,
         );
         let args = command
@@ -361,9 +370,9 @@ mod tests {
             .map(|arg| arg.to_string_lossy().to_string())
             .collect::<Vec<_>>();
 
-        assert!(args[1].contains("mv -f '/Applications/Hyprnote.app' '/Applications/Char.app'"));
+        assert!(args[1].contains("mv -f '/Applications/Char.app' '/Applications/Anarlog.app'"));
         assert!(args[1].contains(
-            "open -n '/Applications/Char.app' --args '--updater2-skip-startup-migration=1'"
+            "open -n '/Applications/Anarlog.app' --args '--updater2-skip-startup-migration=1'"
         ));
     }
 }

--- a/plugins/windows/src/window/v1.rs
+++ b/plugins/windows/src/window/v1.rs
@@ -98,7 +98,7 @@ impl AppWindow {
 impl WindowImpl for AppWindow {
     fn title(&self) -> String {
         match self {
-            Self::Main => "Char".into(),
+            Self::Main => "Anarlog".into(),
             Self::Composer => "Composer".into(),
         }
     }


### PR DESCRIPTION
Rename legacy macOS bundle targets from Char to Anarlog and update remaining desktop chrome labels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches macOS startup migration logic that renames installed app bundles, so mistakes could prevent relaunch or rename correctly. Other changes are mostly UI label/string updates and should be low risk.
> 
> **Overview**
> Migrates desktop-facing naming from **Char** to **Anarlog** across UI chrome and detection.
> 
> Updates macOS legacy bundle rename/migration to target `Anarlog*.app` (from `Hyprnote*.app` and `Char*.app`) and refreshes associated tests. Also extends self-app filtering to recognize `anarlog` names/paths, updates the deeplink callback page copy, and makes the tray “Open …” menu label derive from the current `package_info().name` while expanding channel detection to include `Anarlog` variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 177240cffee1c8277fcc9ca2e455382e0be34793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->