### PR TITLE
fix(ci): preserve STT e2e provider JSON

### DIFF
--- a/.github/workflows/stt_e2e.yaml
+++ b/.github/workflows/stt_e2e.yaml
@@ -87,7 +87,7 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo 'providers=["${{ inputs.provider }}"]' >> $GITHUB_OUTPUT
           else
-            echo "providers=${{ needs.detect-changes.outputs.providers }}" >> $GITHUB_OUTPUT
+            printf 'providers=%s\n' '${{ needs.detect-changes.outputs.providers }}' >> "$GITHUB_OUTPUT"
           fi
 
   direct-provider-batch-e2e:


### PR DESCRIPTION
Forward detected provider output with printf so workflow matrices receive valid JSON.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts how a job output is forwarded; main risk is misquoting the output and breaking the E2E matrix expansion.
> 
> **Overview**
> Fixes the STT E2E GitHub Actions workflow to **preserve the detected `providers` JSON** when forwarding it from `detect-changes` into the `setup` job output.
> 
> Replaces `echo` with `printf` (and safer quoting) so `fromJson(needs.setup.outputs.providers)` reliably receives valid JSON for the provider matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b19240af16ba28cffb6e4421d8dd59d3bc788a18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->