### PR TITLE
fix(desktop): package MLX metallib as resource

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -59,7 +59,7 @@
         }
       },
       "files": {
-        "MacOS/mlx.metallib": "resources/mlx.metallib",
+        "Resources/mlx-swift_Cmlx.bundle/default.metallib": "resources/mlx.metallib",
         "Resources/AppIcon.incs": "resources/stable/AppIcon.icns",
         "Resources/Assets.car": "resources/stable/Assets.car"
       }

--- a/apps/desktop/src-tauri/tauri.conf.staging.json
+++ b/apps/desktop/src-tauri/tauri.conf.staging.json
@@ -21,7 +21,7 @@
     ],
     "macOS": {
       "files": {
-        "MacOS/mlx.metallib": "resources/mlx.metallib",
+        "Resources/mlx-swift_Cmlx.bundle/default.metallib": "resources/mlx.metallib",
         "Resources/AppIcon.incs": "resources/stable/AppIcon.icns",
         "Resources/Assets.car": "resources/stable/Assets.car"
       },


### PR DESCRIPTION
Move the bundled MLX Metal library under the SwiftPM Cmlx resource bundle path so macOS signing no longer treats it as nested executable code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts macOS bundling paths for a single resource in Tauri config; main risk is a packaging/regression if the new metallib path is wrong and the app can’t find the Metal library at runtime.
> 
> **Overview**
> Updates the macOS bundle `files` mapping in `tauri.conf.json` and `tauri.conf.staging.json` to ship the MLX Metal library from `Resources/mlx-swift_Cmlx.bundle/default.metallib` instead of `MacOS/mlx.metallib`.
> 
> This changes where `resources/mlx.metallib` is placed in the packaged app to avoid macOS treating it as nested executable code during signing/notarization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caa980baede49cc45a6a1a61fd9126e24eab4670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->