### PR TITLE
fix(tray): derive version channel from bundle id

### DIFF
--- a/plugins/tray/src/menu_items/tray_version.rs
+++ b/plugins/tray/src/menu_items/tray_version.rs
@@ -8,11 +8,16 @@ use super::MenuItemHandler;
 pub struct TrayVersion;
 
 impl TrayVersion {
-    fn get_channel(app_name: &str) -> &'static str {
-        match app_name {
-            "Anarlog" | "Char" | "Hyprnote" => "stable",
-            "Anarlog Staging" | "Char Staging" | "Hyprnote Staging" => "staging",
-            _ => "dev",
+    fn get_channel(identifier: &str, app_name: &str) -> &'static str {
+        match identifier {
+            "com.hyprnote.stable" | "com.hyprnote.Hyprnote" => "stable",
+            "com.hyprnote.staging" => "staging",
+            "com.hyprnote.dev" => "dev",
+            _ => match app_name {
+                "Anarlog" | "Char" | "Hyprnote" => "stable",
+                "Anarlog Staging" | "Char Staging" | "Hyprnote Staging" => "staging",
+                _ => "dev",
+            },
         }
     }
 }
@@ -21,9 +26,10 @@ impl MenuItemHandler for TrayVersion {
     const ID: &'static str = "hypr_tray_version";
 
     fn build(app: &AppHandle<tauri::Wry>) -> Result<MenuItemKind<tauri::Wry>> {
+        let identifier = &app.config().identifier;
         let app_name = &app.package_info().name;
         let app_version = app.package_info().version.to_string();
-        let channel = Self::get_channel(app_name);
+        let channel = Self::get_channel(identifier, app_name);
 
         let text = format!("v{} ({})", app_version, channel);
         let item = MenuItem::with_id(app, Self::ID, text, false, None::<&str>)?;
@@ -31,4 +37,35 @@ impl MenuItemHandler for TrayVersion {
     }
 
     fn handle(_app: &AppHandle<tauri::Wry>) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TrayVersion;
+
+    #[test]
+    fn gets_channel_from_identifier() {
+        assert_eq!(
+            TrayVersion::get_channel("com.hyprnote.stable", "Anarlog"),
+            "stable"
+        );
+        assert_eq!(
+            TrayVersion::get_channel("com.hyprnote.staging", "Anarlog Staging"),
+            "staging"
+        );
+        assert_eq!(
+            TrayVersion::get_channel("com.hyprnote.dev", "Anarlog Dev"),
+            "dev"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_product_name_for_unknown_identifier() {
+        assert_eq!(TrayVersion::get_channel("unknown", "Anarlog"), "stable");
+        assert_eq!(
+            TrayVersion::get_channel("unknown", "Anarlog Staging"),
+            "staging"
+        );
+        assert_eq!(TrayVersion::get_channel("unknown", "Anarlog Dev"), "dev");
+    }
 }


### PR DESCRIPTION
Use the app identifier for tray channel detection and keep product-name fallback coverage for legacy configs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only how the tray version label derives its release channel and adds unit tests; impact is limited to displayed text in the tray menu.
> 
> **Overview**
> The tray version menu item now derives the release channel primarily from the app bundle identifier (`app.config().identifier`) instead of only the product name, with a fallback to the previous name-based mapping for unknown identifiers.
> 
> Adds unit tests covering identifier-based channel detection and the legacy product-name fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd9b0b269ed954036bdbd909660428ec45b83a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->