### PR TITLE
fix(desktop): use flex gap skeleton layout

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -228,17 +228,16 @@ function BatchTranscriptSkeleton({ fillHeight }: { fillHeight: boolean }) {
       aria-hidden
       data-testid="transcript-skeleton"
       className={cn([
-        "flex overflow-hidden px-6 py-4",
-        fillHeight ? "min-h-0 flex-1 items-center" : "h-[178px] items-start",
+        "flex flex-col overflow-hidden px-6 py-4",
+        fillHeight
+          ? "min-h-0 flex-1 justify-center"
+          : "h-[178px] justify-start",
       ])}
     >
-      <div className="w-full max-w-[940px] space-y-8">
+      <div className="flex w-full max-w-[940px] flex-col gap-8">
         {rows.map((row, index) => (
-          <div
-            key={index}
-            className="grid grid-cols-[72px_minmax(0,1fr)] gap-4"
-          >
-            <div className="space-y-3 pt-0.5">
+          <div key={index} className="flex gap-4">
+            <div className="flex w-[72px] shrink-0 flex-col gap-3 pt-0.5">
               <div
                 className={cn([
                   "h-2.5 rounded-full bg-neutral-200/80",
@@ -254,7 +253,7 @@ function BatchTranscriptSkeleton({ fillHeight }: { fillHeight: boolean }) {
                 ])}
               />
             </div>
-            <div className="space-y-3 pt-0.5">
+            <div className="flex min-w-0 flex-1 flex-col gap-3 pt-0.5">
               {row.lines.map((lineWidth, lineIndex) => (
                 <div
                   key={lineIndex}


### PR DESCRIPTION
Use flex column stacks with gap spacing for the transcript batch skeleton.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts Tailwind layout classes for the batching transcript skeleton; no behavior, data, or state management changes.
> 
> **Overview**
> Updates the batching transcript loading skeleton in `post-session.tsx` to use flex column stacks with `gap` spacing instead of grid/`space-y`, and tweaks alignment/centering based on `fillHeight` (switching to `justify-*`). This is a visual/layout adjustment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee92aac408e5a0e88115bef82ecb1af610eb2cba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->