### PR TITLE
fix(ci): skip MLX metallib on Intel macOS builds

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -109,11 +109,14 @@ jobs:
           apple-certificate-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
       - run: |
-          FEATURES_FLAG=""
-          if [[ "${{ inputs.channel }}" == "staging" ]]; then
-            FEATURES_FLAG="--features devtools"
+          BUILD_ARGS=(--target "${{ matrix.target }}" --config "${{ env.TAURI_CONF_PATH }}" --verbose)
+          if [[ "${{ matrix.target }}" == "x86_64-apple-darwin" ]]; then
+            BUILD_ARGS+=(--config ./src-tauri/tauri.conf.macos-intel.json)
           fi
-          pnpm -F desktop tauri build --target ${{ matrix.target }} --config ${{ env.TAURI_CONF_PATH }} --verbose $FEATURES_FLAG
+          if [[ "${{ inputs.channel }}" == "staging" ]]; then
+            BUILD_ARGS+=(--features devtools)
+          fi
+          pnpm -F desktop tauri build "${BUILD_ARGS[@]}"
         env:
           # https://v2.tauri.app/reference/environment-variables/
           CI: false

--- a/apps/desktop/src-tauri/tauri.conf.macos-intel.json
+++ b/apps/desktop/src-tauri/tauri.conf.macos-intel.json
@@ -1,0 +1,9 @@
+{
+  "bundle": {
+    "macOS": {
+      "files": {
+        "Resources/mlx-swift_Cmlx.bundle/default.metallib": null
+      }
+    }
+  }
+}


### PR DESCRIPTION
Use an Intel-specific Tauri config override so stable x86_64 release jobs do not bundle the Apple-Silicon-only MLX resource.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI/config change limited to macOS packaging; main risk is accidentally omitting/overriding bundle resources for Intel builds.
> 
> **Overview**
> Adjusts the macOS desktop CD workflow to build via a `BUILD_ARGS` array and, on `x86_64-apple-darwin`, override the Tauri config with a new `tauri.conf.macos-intel.json`.
> 
> Adds that Intel-specific config to exclude `Resources/mlx-swift_Cmlx.bundle/default.metallib` from the app bundle, avoiding bundling an Apple-Silicon-only MLX resource on Intel release jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5042dd0534d6fa8626ff80f0bb0425b8c2ab8109. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->