### PR TITLE
fix(stt): add batch language routing fallback

### DIFF
--- a/crates/owhisper-client/src/adapter/deepgram/batch.rs
+++ b/crates/owhisper-client/src/adapter/deepgram/batch.rs
@@ -259,6 +259,30 @@ mod tests {
         assert!(query.contains("multichannel=true"));
     }
 
+    #[test]
+    fn batch_url_restricts_detect_language_for_unsupported_multi_language() {
+        let params = ListenParams {
+            languages: vec![
+                hypr_language::ISO639::En.into(),
+                hypr_language::ISO639::Pl.into(),
+            ],
+            ..Default::default()
+        };
+
+        let url = build_batch_url(
+            "https://api.deepgram.com/v1",
+            &params,
+            &DeepgramLanguageStrategy,
+            &DeepgramKeywordStrategy,
+        );
+
+        let query = url.query().unwrap_or_default();
+        assert!(query.contains("detect_language=en"));
+        assert!(query.contains("detect_language=pl"));
+        assert!(!query.contains("detect_language=true"));
+        assert!(!query.contains("language=multi"));
+    }
+
     #[tokio::test]
     #[ignore]
     async fn test_deepgram_batch_transcription() {

--- a/crates/owhisper-client/src/adapter/deepgram/language.rs
+++ b/crates/owhisper-client/src/adapter/deepgram/language.rs
@@ -7,6 +7,11 @@ use crate::adapter::deepgram_compat::{
 
 const NOVA2_MULTI_LANGS: &[&str] = &["en", "es"];
 const NOVA3_MULTI_LANGS: &[&str] = &["en", "es", "fr", "de", "hi", "ru", "pt", "ja", "it", "nl"];
+const LANGUAGE_DETECTION_LANGS: &[&str] = &[
+    "bg", "ca", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr", "hi", "hu", "id", "it", "ja",
+    "ko", "lt", "lv", "ms", "nl", "no", "pl", "pt", "ro", "ru", "sk", "sv", "th", "tr", "uk", "vi",
+    "zh",
+];
 
 pub fn can_use_multi(model: &str, languages: &[hypr_language::Language]) -> bool {
     if languages.len() < 2 {
@@ -55,7 +60,7 @@ impl LanguageQueryStrategy for DeepgramLanguageStrategy {
                 if can_use_multi(model, &params.languages) {
                     query_pairs.append_pair("language", "multi");
                 } else if mode == TranscriptionMode::Batch {
-                    query_pairs.append_pair("detect_language", "true");
+                    append_detect_language_query(query_pairs, &params.languages);
                 } else if let Some(language) = params.languages.first() {
                     let code = single_language_query_code(params, language);
                     query_pairs.append_pair("language", &code);
@@ -80,6 +85,23 @@ fn single_language_query_code(params: &ListenParams, language: &hypr_language::L
     } else {
         language.iso639().code().to_string()
     }
+}
+
+fn append_detect_language_query<'a>(
+    query_pairs: &mut Serializer<'a, UrlQuery>,
+    languages: &[hypr_language::Language],
+) {
+    if languages.iter().all(supports_language_detection) {
+        for language in languages {
+            query_pairs.append_pair("detect_language", language.iso639().code());
+        }
+    } else {
+        query_pairs.append_pair("detect_language", "true");
+    }
+}
+
+pub(super) fn supports_language_detection(language: &hypr_language::Language) -> bool {
+    LANGUAGE_DETECTION_LANGS.contains(&language.iso639().code())
 }
 
 fn effective_model(params: &ListenParams) -> Option<DeepgramModel> {

--- a/crates/owhisper-client/src/adapter/deepgram/mod.rs
+++ b/crates/owhisper-client/src/adapter/deepgram/mod.rs
@@ -162,6 +162,10 @@ impl DeepgramAdapter {
         Self::language_support_batch(languages, model).is_supported()
     }
 
+    pub fn supports_batch_language_detection(languages: &[hypr_language::Language]) -> bool {
+        !languages.is_empty() && languages.iter().all(language::supports_language_detection)
+    }
+
     fn can_use_multi(languages: &[hypr_language::Language]) -> bool {
         language::can_use_multi(DeepgramModel::Nova3General.as_ref(), languages)
             || language::can_use_multi(DeepgramModel::Nova2General.as_ref(), languages)
@@ -396,6 +400,15 @@ mod tests {
                 iso_codes
             );
         }
+    }
+
+    #[test]
+    fn test_supports_batch_language_detection() {
+        let en_pl: Vec<Language> = vec![ISO639::En.into(), ISO639::Pl.into()];
+        assert!(DeepgramAdapter::supports_batch_language_detection(&en_pl));
+
+        let en_ar: Vec<Language> = vec![ISO639::En.into(), ISO639::Ar.into()];
+        assert!(!DeepgramAdapter::supports_batch_language_detection(&en_ar));
     }
 
     #[test]

--- a/crates/soniox/src/lib.rs
+++ b/crates/soniox/src/lib.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 pub const API_HOST: &str = "https://api.soniox.com";
+const TRANSCRIPTION_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const TRANSCRIPTION_MAX_POLLS: usize = 1800;
 
 #[derive(Debug)]
 pub struct Error {
@@ -319,8 +322,6 @@ pub async fn wait_for_completion(
     transcription_id: &str,
     api_key: &str,
 ) -> Result<(), Error> {
-    use std::time::Duration;
-
     #[derive(Deserialize)]
     struct StatusResponse {
         status: String,
@@ -330,7 +331,7 @@ pub async fn wait_for_completion(
 
     let url = format!("{API_HOST}/v1/transcriptions/{transcription_id}");
 
-    for _ in 0..300 {
+    for _ in 0..TRANSCRIPTION_MAX_POLLS {
         let response = client
             .get(&url)
             .header("Authorization", format!("Bearer {api_key}"))
@@ -369,7 +370,7 @@ pub async fn wait_for_completion(
                 });
             }
             "queued" | "processing" => {
-                tokio::time::sleep(Duration::from_secs(2)).await;
+                tokio::time::sleep(TRANSCRIPTION_POLL_INTERVAL).await;
             }
             unknown => {
                 return Err(Error {
@@ -381,7 +382,23 @@ pub async fn wait_for_completion(
     }
 
     Err(Error {
-        message: "transcription timed out".to_string(),
+        message: format!(
+            "transcription timed out after {} seconds",
+            TRANSCRIPTION_POLL_INTERVAL.as_secs() * TRANSCRIPTION_MAX_POLLS as u64
+        ),
         is_retryable: false,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn soniox_polling_allows_long_batch_jobs() {
+        assert_eq!(
+            TRANSCRIPTION_POLL_INTERVAL.as_secs() * TRANSCRIPTION_MAX_POLLS as u64,
+            3600
+        );
+    }
 }

--- a/crates/transcribe-proxy/src/routes/batch/sync.rs
+++ b/crates/transcribe-proxy/src/routes/batch/sync.rs
@@ -105,7 +105,9 @@ pub(super) async fn handle_hyprnote_batch(
     body: Bytes,
     content_type: &str,
 ) -> Response {
-    let provider_chain = state.resolve_hyprnote_provider_chain_for_mode(RoutingMode::Batch, params);
+    let mut provider_chain =
+        state.resolve_hyprnote_provider_chain_for_mode(RoutingMode::Batch, params);
+    append_deepgram_batch_detection_fallback(state, &mut provider_chain, &listen_params);
 
     if provider_chain.is_empty() {
         return (
@@ -211,6 +213,25 @@ pub(super) async fn handle_hyprnote_batch(
         })),
     )
         .into_response()
+}
+
+fn append_deepgram_batch_detection_fallback(
+    state: &AppState,
+    provider_chain: &mut Vec<SelectedProvider>,
+    listen_params: &ListenParams,
+) {
+    if listen_params.languages.len() <= 1
+        || provider_chain
+            .iter()
+            .any(|selected| selected.provider() == Provider::Deepgram)
+        || !DeepgramAdapter::supports_batch_language_detection(&listen_params.languages)
+    {
+        return;
+    }
+
+    if let Ok(selected) = state.selector.select(Some(Provider::Deepgram)) {
+        provider_chain.push(selected);
+    }
 }
 
 pub(super) async fn transcribe_with_retry(

--- a/crates/transcribe-proxy/tests/hyprnote_routing_mock.rs
+++ b/crates/transcribe-proxy/tests/hyprnote_routing_mock.rs
@@ -99,6 +99,33 @@ async fn batch_cloud_model_resolved_for_deepgram() {
 }
 
 #[tokio::test]
+async fn batch_en_pl_uses_deepgram_detection_fallback_when_soniox_unavailable() {
+    let batch = start_mock_batch_upstream().await;
+    let upstream_url = batch_upstream_url(batch.addr);
+    let proxy = start_proxy(Some(&upstream_url), None).await;
+
+    send_batch(proxy, "model=cloud&language=en&language=pl").await;
+    let query = wait_for_first_batch_query(&batch, TIMEOUT).await;
+
+    assert!(
+        query.contains("detect_language=en"),
+        "should restrict Deepgram detection to English: {query}"
+    );
+    assert!(
+        query.contains("detect_language=pl"),
+        "should restrict Deepgram detection to Polish: {query}"
+    );
+    assert!(
+        !query.contains("detect_language=true"),
+        "should not fall back to unrestricted language detection: {query}"
+    );
+    assert!(
+        !query.contains("language=multi"),
+        "Polish is not in Deepgram's multi-language model set: {query}"
+    );
+}
+
+#[tokio::test]
 async fn batch_explicit_model_preserved_for_deepgram() {
     let batch = start_mock_batch_upstream().await;
     let upstream_url = batch_upstream_url(batch.addr);


### PR DESCRIPTION
Route Char Pro multi-language batch requests through Deepgram language detection fallback when Soniox is unavailable, and allow longer Soniox async polling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch STT routing behavior by conditionally appending Deepgram as a fallback provider and alters Deepgram query generation for multi-language batches; misclassification could route traffic differently or affect transcription accuracy. Soniox polling timeout increase is low risk but may extend request lifetimes.
> 
> **Overview**
> Improves multi-language *batch* transcription resiliency by appending **Deepgram as a last-resort fallback** in the batch provider chain when the request has multiple languages, Deepgram isn’t already selected, and the language set supports Deepgram’s language-detection mode.
> 
> Updates Deepgram batch URL generation to **prefer constrained language detection** (multiple `detect_language=<code>` params) when the requested languages are all supported for detection, instead of always using `detect_language=true`, with new unit/integration tests covering the `en+pl` case.
> 
> Extends Soniox async batch polling to **up to 1 hour** via configurable constants and improves the timeout error message, with a small test asserting the new limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a083ae8948902ba02afa0de32b9aad17038ea00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->