### PR TITLE
fix(summary): align enhanced heading styles

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -51,6 +51,7 @@ export const EnhancedEditor = forwardRef<
     <div className="h-full">
       <NoteEditor
         ref={ref}
+        className="enhanced-summary-editor"
         key={`enhanced-note-${enhancedNoteId}`}
         initialContent={initialContent}
         handleChange={handleChange}

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -31,6 +31,7 @@ import {
 import { useDebounceCallback } from "usehooks-ts";
 
 import "@hypr/tiptap/styles.css";
+import { cn } from "@hypr/utils";
 
 import { EditorErrorBoundary } from "../editor-error-boundary";
 import {
@@ -124,6 +125,7 @@ type NodeViewComponents = NonNullable<
 >;
 
 export interface NoteEditorProps {
+  className?: string;
   handleChange?: (content: JSONContent) => void;
   initialContent?: JSONContent;
   mentionConfig?: MentionConfig;
@@ -340,6 +342,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
   function NoteEditor(props, ref) {
     const {
       handleChange,
+      className,
       initialContent,
       mentionConfig,
       placeholderComponent,
@@ -524,7 +527,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
                 autocorrect: "off",
                 autocapitalize: "off",
                 role: "textbox",
-                class: "tiptap",
+                class: cn(["tiptap", className]),
               }}
             >
               <ProseMirrorDoc />

--- a/packages/tiptap/src/styles/nodes/heading.css
+++ b/packages/tiptap/src/styles/nodes/heading.css
@@ -46,6 +46,28 @@
   }
 }
 
+.tiptap.enhanced-summary-editor {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+  }
+
+  h1 {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
+
+  h6 {
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+}
+
 .blog-editor .tiptap {
   h1 {
     font-size: 1.875rem;


### PR DESCRIPTION
Scope completed enhanced summaries to the same heading scale used by streaming summaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a scoped styling change that adds an optional `className` passthrough to `NoteEditor` and applies CSS overrides for enhanced summaries, with no data/auth logic changes.
> 
> **Overview**
> **Enhanced summaries now render headings at a smaller, consistent scale.** The desktop enhanced note editor passes a new `className` (`enhanced-summary-editor`) into `NoteEditor`.
> 
> `NoteEditor` now accepts an optional `className` prop and merges it onto the ProseMirror root (`tiptap`) class, enabling targeted CSS. New CSS rules under `.tiptap.enhanced-summary-editor` override `h1`–`h6` font sizes/line-heights to match the intended summary heading scale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e212b54bd82be5c2b669b128f01a1a1973f914b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->