### PR TITLE
fix(api): stabilize Fly deploy startup

### DIFF
--- a/.github/workflows/api_cd.yaml
+++ b/.github/workflows/api_cd.yaml
@@ -27,7 +27,47 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: ./.github/actions/infisical_install
+      - run: |
+          set -euo pipefail
+
+          secrets_json="$(mktemp)"
+          secrets_file="$(mktemp)"
+          trap 'rm -f "$secrets_json" "$secrets_file"' EXIT
+
+          infisical export \
+            --token="$INFISICAL_TOKEN" \
+            --env=dev \
+            --projectId="$INFISICAL_PROJECT_ID" \
+            --path="/ai" \
+            --format=json \
+            --output-file="$secrets_json"
+
+          python3 - "$secrets_json" "$secrets_file" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1]) as source:
+              secrets = json.load(source)
+
+          with open(sys.argv[2], "w") as target:
+              for secret in secrets:
+                  key = secret["key"]
+                  value = secret.get("value", "")
+                  value = value.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "\\n")
+                  target.write(f"{key}={value}\n")
+          PY
+
+          flyctl secrets import --app hyprnote-ai --stage < "$secrets_file"
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          INFISICAL_TOKEN: ${{ secrets.INFISICAL_TOKEN }}
+          INFISICAL_PROJECT_ID: ${{ secrets.INFISICAL_PROJECT_ID }}
       - run: flyctl deploy --config apps/api/fly.toml --dockerfile apps/api/Dockerfile --remote-only --build-arg APP_VERSION=${{ needs.compute-version.outputs.version }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - if: failure()
+        run: timeout 60s flyctl logs --app hyprnote-ai --no-tail || true
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -464,10 +464,11 @@ fn main() -> std::io::Result<()> {
         .build()?
         .block_on(async {
             let addr = SocketAddr::from(([0, 0, 0, 0], env.port));
+            let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+            let app = app().await;
             tracing::info!(addr = %addr, "server_listening");
 
-            let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-            axum::serve(listener, app().await)
+            axum::serve(listener, app)
                 .with_graceful_shutdown(shutdown_signal())
                 .await
                 .unwrap();

--- a/crates/api-support/src/routes/mod.rs
+++ b/crates/api-support/src/routes/mod.rs
@@ -32,7 +32,7 @@ pub async fn router(config: SupportConfig) -> Router {
         .with_model_resolver(std::sync::Arc::new(resolver));
     let llm_router = hypr_llm_proxy::router(llm_config);
 
-    let state = AppState::new(config).await;
+    let state = AppState::new(config);
     let mcp = mcp_service(state.clone());
 
     let chatwoot_routes = Router::new()

--- a/crates/api-support/src/state.rs
+++ b/crates/api-support/src/state.rs
@@ -2,7 +2,6 @@ use hypr_api_auth::{AuthContext, AuthState};
 use octocrab::Octocrab;
 use reqwest::Client as HttpClient;
 use serde::Deserialize;
-use sqlx::PgPool;
 use stripe::Client as StripeClient;
 
 use crate::config::SupportConfig;
@@ -11,7 +10,6 @@ use crate::config::SupportConfig;
 pub(crate) struct AppState {
     pub(crate) config: SupportConfig,
     pub(crate) octocrab: Octocrab,
-    pub(crate) _db_pool: PgPool,
     pub(crate) stripe: StripeClient,
     pub(crate) _auth: AuthState,
     pub(crate) http_client: HttpClient,
@@ -19,7 +17,7 @@ pub(crate) struct AppState {
 }
 
 impl AppState {
-    pub(crate) async fn new(config: SupportConfig) -> Self {
+    pub(crate) fn new(config: SupportConfig) -> Self {
         let key = {
             let pem = config.github.github_bot_private_key.replace("\\n", "\n");
             let pem = if pem.starts_with("-----") {
@@ -35,10 +33,6 @@ impl AppState {
             .app(config.github.github_bot_app_id.into(), key)
             .build()
             .expect("failed to build octocrab client");
-
-        let db_pool = PgPool::connect(&config.support_database.support_database_url)
-            .await
-            .expect("failed to connect to Supabase Postgres");
 
         let stripe = StripeClient::new(&config.stripe.stripe_secret_key);
 
@@ -66,7 +60,6 @@ impl AppState {
         Self {
             config,
             octocrab,
-            _db_pool: db_pool,
             stripe,
             _auth: auth,
             http_client: HttpClient::new(),

--- a/crates/transcribe-proxy/src/routes/mod.rs
+++ b/crates/transcribe-proxy/src/routes/mod.rs
@@ -24,6 +24,8 @@ use crate::supabase::SupabaseClient;
 
 pub(crate) use error::{RouteError, parse_async_provider};
 
+const MAX_BATCH_AUDIO_BODY_BYTES: usize = 512 * 1024 * 1024;
+
 #[derive(Clone)]
 pub(crate) struct AppState {
     pub config: SttProxyConfig,
@@ -158,7 +160,7 @@ fn make_state(config: SttProxyConfig) -> AppState {
 }
 
 fn with_common_layers(router: Router) -> Router {
-    router.layer(DefaultBodyLimit::max(100 * 1024 * 1024))
+    router.layer(DefaultBodyLimit::max(MAX_BATCH_AUDIO_BODY_BYTES))
 }
 
 pub fn router(config: SttProxyConfig) -> Router {


### PR DESCRIPTION
Summary:
- Stage Infisical /ai secrets into Fly before bluegreen API deploys.
- Stop eagerly opening the unused support Postgres pool during API startup.
- Raise the STT proxy request body limit so long batch audio uploads reach provider routing.

Verification:
- pnpm exec dprint fmt crates/transcribe-proxy/src/routes/mod.rs
- cargo check -p api
- API CD workflow passed: https://github.com/fastrepl/anarlog/actions/runs/26267517625
- https://api.char.com/health returns 0.0.48
- https://api.anarlog.so/health returns 0.0.48
- Soniox direct/proxy STT e2e checks passed on PR #5298