### PR TITLE
fix(stt): notify when batch transcription completes

### DIFF
--- a/apps/desktop/src/services/event-listeners.test.tsx
+++ b/apps/desktop/src/services/event-listeners.test.tsx
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { EventListeners } from "./event-listeners";
 
+import { createAutoStopEndedNotificationKey } from "~/stt/auto-stop-notification";
+
 const {
   notificationListenMock,
   updaterListenMock,
@@ -14,6 +16,8 @@ const {
   createSessionMock,
   getOrCreateSessionForEventIdMock,
   setTriggerAppIdsMock,
+  stopMock,
+  getListenerStateMock,
 } = vi.hoisted(() => ({
   notificationListenMock: vi.fn(),
   updaterListenMock: vi.fn(),
@@ -25,6 +29,8 @@ const {
   createSessionMock: vi.fn(() => "session-new"),
   getOrCreateSessionForEventIdMock: vi.fn(() => "session-event"),
   setTriggerAppIdsMock: vi.fn(),
+  stopMock: vi.fn(),
+  getListenerStateMock: vi.fn(),
 }));
 
 vi.mock("@hypr/plugin-notification", () => ({
@@ -76,7 +82,7 @@ vi.mock("~/store/zustand/tabs", () => ({
 
 vi.mock("~/store/zustand/listener/instance", () => ({
   listenerStore: {
-    getState: () => ({ setTriggerAppIds: setTriggerAppIdsMock }),
+    getState: getListenerStateMock,
   },
 }));
 
@@ -92,6 +98,8 @@ describe("EventListeners notification events", () => {
     createSessionMock.mockReset();
     getOrCreateSessionForEventIdMock.mockReset();
     setTriggerAppIdsMock.mockReset();
+    stopMock.mockReset();
+    getListenerStateMock.mockReset();
 
     getCurrentWebviewWindowLabelMock.mockReturnValue("main");
     notificationListenMock.mockResolvedValue(() => {});
@@ -100,6 +108,11 @@ describe("EventListeners notification events", () => {
     getOrCreateSessionForEventIdMock.mockReturnValue("session-event");
     useMainStoreMock.mockReturnValue(null);
     useSettingsStoreMock.mockReturnValue(null);
+    getListenerStateMock.mockReturnValue({
+      setTriggerAppIds: setTriggerAppIdsMock,
+      stop: stopMock,
+      live: { status: "active", sessionId: "session-1" },
+    });
   });
 
   afterEach(() => {
@@ -139,6 +152,56 @@ describe("EventListeners notification events", () => {
       "ignored_platforms",
       JSON.stringify(["com.existing.app", "us.zoom.xos"]),
     );
+    expect(openNewMock).not.toHaveBeenCalled();
+  });
+
+  test("notification_accept with auto-stop prompt stops the active session", async () => {
+    useMainStoreMock.mockReturnValue({} as never);
+
+    render(<EventListeners />);
+
+    await vi.waitFor(() =>
+      expect(notificationListenMock).toHaveBeenCalledTimes(1),
+    );
+
+    const handler = notificationListenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "notification_accept",
+        key: createAutoStopEndedNotificationKey("session-1"),
+        source: null,
+      },
+    });
+
+    expect(stopMock).toHaveBeenCalledTimes(1);
+    expect(createSessionMock).not.toHaveBeenCalled();
+    expect(openNewMock).not.toHaveBeenCalled();
+  });
+
+  test("notification_confirm with auto-stop prompt ignores collapsed body click", async () => {
+    useMainStoreMock.mockReturnValue({} as never);
+
+    render(<EventListeners />);
+
+    await vi.waitFor(() =>
+      expect(notificationListenMock).toHaveBeenCalledTimes(1),
+    );
+
+    const handler = notificationListenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "notification_confirm",
+        key: createAutoStopEndedNotificationKey("session-1"),
+        source: null,
+      },
+    });
+
+    expect(stopMock).not.toHaveBeenCalled();
+    expect(createSessionMock).not.toHaveBeenCalled();
     expect(openNewMock).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/services/event-listeners.test.tsx
+++ b/apps/desktop/src/services/event-listeners.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { EventListeners } from "./event-listeners";
 
 import { createAutoStopEndedNotificationKey } from "~/stt/auto-stop-notification";
+import { createBatchCompletedNotificationKey } from "~/stt/batch-completed-notification";
 
 const {
   notificationListenMock,
@@ -222,6 +223,34 @@ describe("EventListeners notification events", () => {
         type: "notification_confirm",
         key: "batch-completed-session-1",
         source: { type: "session", session_id: "session-1" },
+      },
+    });
+
+    expect(createSessionMock).not.toHaveBeenCalled();
+    expect(openNewMock).toHaveBeenCalledWith({
+      type: "sessions",
+      id: "session-1",
+      state: { view: null, autoStart: null },
+    });
+  });
+
+  test("notification_confirm with batch key opens that session without source", async () => {
+    useMainStoreMock.mockReturnValue({} as never);
+
+    render(<EventListeners />);
+
+    await vi.waitFor(() =>
+      expect(notificationListenMock).toHaveBeenCalledTimes(1),
+    );
+
+    const handler = notificationListenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "notification_confirm",
+        key: createBatchCompletedNotificationKey("session-1"),
+        source: null,
       },
     });
 

--- a/apps/desktop/src/services/event-listeners.test.tsx
+++ b/apps/desktop/src/services/event-listeners.test.tsx
@@ -142,6 +142,34 @@ describe("EventListeners notification events", () => {
     expect(openNewMock).not.toHaveBeenCalled();
   });
 
+  test("notification_confirm with session source opens that session", async () => {
+    useMainStoreMock.mockReturnValue(null);
+
+    render(<EventListeners />);
+
+    await vi.waitFor(() =>
+      expect(notificationListenMock).toHaveBeenCalledTimes(1),
+    );
+
+    const handler = notificationListenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "notification_confirm",
+        key: "batch-completed-session-1",
+        source: { type: "session", session_id: "session-1" },
+      },
+    });
+
+    expect(createSessionMock).not.toHaveBeenCalled();
+    expect(openNewMock).toHaveBeenCalledWith({
+      type: "sessions",
+      id: "session-1",
+      state: { view: null, autoStart: null },
+    });
+  });
+
   test("notification_confirm with mic_detected source sets triggerAppIds (regression: #5120 confirm path)", async () => {
     useMainStoreMock.mockReturnValue({} as never);
 

--- a/apps/desktop/src/services/event-listeners.tsx
+++ b/apps/desktop/src/services/event-listeners.tsx
@@ -17,6 +17,7 @@ import * as settings from "~/store/tinybase/store/settings";
 import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
 import { parseAutoStopEndedNotificationKey } from "~/stt/auto-stop-notification";
+import { parseBatchCompletedNotificationKey } from "~/stt/batch-completed-notification";
 
 type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
 
@@ -179,7 +180,7 @@ function useNotificationEvents() {
           const sourceSessionId =
             payload.source?.type === "session"
               ? payload.source.session_id
-              : null;
+              : parseBatchCompletedNotificationKey(payload.key);
           const triggerAppIds =
             payload.source?.type === "mic_detected"
               ? (payload.source.app_ids ?? null)

--- a/apps/desktop/src/services/event-listeners.tsx
+++ b/apps/desktop/src/services/event-listeners.tsx
@@ -16,6 +16,7 @@ import {
 import * as settings from "~/store/tinybase/store/settings";
 import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
+import { parseAutoStopEndedNotificationKey } from "~/stt/auto-stop-notification";
 
 type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
 
@@ -56,6 +57,30 @@ function shouldAutoStartNotificationSession(
 
   const startTime = new Date(String(startedAt)).getTime();
   return !Number.isNaN(startTime) && startTime <= Date.now();
+}
+
+function handleAutoStopEndedNotification(
+  type: "notification_confirm" | "notification_accept",
+  key: string,
+): boolean {
+  const sessionId = parseAutoStopEndedNotificationKey(key);
+  if (!sessionId) {
+    return false;
+  }
+
+  if (type !== "notification_accept") {
+    return true;
+  }
+
+  const listenerState = listenerStore.getState();
+  if (
+    listenerState.live.status === "active" &&
+    listenerState.live.sessionId === sessionId
+  ) {
+    listenerState.stop();
+  }
+
+  return true;
 }
 
 function useUpdaterEvents() {
@@ -143,6 +168,10 @@ function useNotificationEvents() {
           payload.type === "notification_confirm" ||
           payload.type === "notification_accept"
         ) {
+          if (handleAutoStopEndedNotification(payload.type, payload.key)) {
+            return;
+          }
+
           const eventId =
             payload.source?.type === "calendar_event"
               ? payload.source.event_id

--- a/apps/desktop/src/services/event-listeners.tsx
+++ b/apps/desktop/src/services/event-listeners.tsx
@@ -147,11 +147,24 @@ function useNotificationEvents() {
             payload.source?.type === "calendar_event"
               ? payload.source.event_id
               : null;
+          const sourceSessionId =
+            payload.source?.type === "session"
+              ? payload.source.session_id
+              : null;
           const triggerAppIds =
             payload.source?.type === "mic_detected"
               ? (payload.source.app_ids ?? null)
               : null;
           const currentStore = storeRef.current;
+          if (sourceSessionId) {
+            openNewRef.current({
+              type: "sessions",
+              id: sourceSessionId,
+              state: { view: null, autoStart: null },
+            });
+            return;
+          }
+
           if (!currentStore) {
             pendingAutoStart.current = { eventId, triggerAppIds };
             return;

--- a/apps/desktop/src/sidebar/devtool.tsx
+++ b/apps/desktop/src/sidebar/devtool.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 
+import { commands as notificationCommands } from "@hypr/plugin-notification";
 import {
   commands as windowsCommands,
   openUrlWithInstruction,
@@ -11,6 +12,7 @@ import { TrialEndedDialog } from "~/billing/trial-ended-dialog";
 import { TrialStartedDialog } from "~/billing/trial-started-dialog";
 import { getLatestVersion } from "~/changelog";
 import * as main from "~/store/tinybase/store/main";
+import { showBatchCompletedNotification } from "~/store/zustand/listener/general-batch";
 import { useTabs } from "~/store/zustand/tabs";
 import { commands } from "~/types/tauri.gen";
 
@@ -20,6 +22,7 @@ export function DevtoolView() {
       <div className="flex flex-1 flex-col gap-2 overflow-y-auto px-1 py-2">
         <NavigationCard />
         <ToastsCard />
+        <NotificationsCard />
         <BillingCard />
         <CountdownTestCard />
         <ErrorTestCard />
@@ -185,6 +188,173 @@ function ToastsCard() {
           ])}
         >
           Reset All Dismissed
+        </button>
+      </div>
+    </DevtoolCard>
+  );
+}
+
+function NotificationsCard() {
+  const store = main.UI.useStore(main.STORE_ID) as main.Store | undefined;
+  const { user_id } = main.UI.useValues(main.STORE_ID);
+
+  const showCalendarNotification = useCallback(async () => {
+    const eventId = `devtool-event-${crypto.randomUUID()}`;
+    const startedAt = new Date(Date.now() + 5 * 60 * 1000);
+    const endedAt = new Date(startedAt.getTime() + 30 * 60 * 1000);
+
+    store?.setRow("events", eventId, {
+      user_id: user_id ?? "",
+      created_at: new Date().toISOString(),
+      tracking_id_event: eventId,
+      calendar_id: "devtool-calendar",
+      title: "Devtool design sync",
+      started_at: startedAt.toISOString(),
+      ended_at: endedAt.toISOString(),
+      location: "Conference Room",
+      meeting_link: "https://zoom.us/j/1234567890",
+      description: "Notification test event",
+      note: "",
+      recurrence_series_id: "",
+      has_recurrence_rules: false,
+      is_all_day: false,
+      provider: "google",
+      participants_json: JSON.stringify([
+        {
+          name: "Ada Lovelace",
+          email: "ada@example.com",
+          status: "accepted",
+        },
+      ]),
+    });
+
+    await notificationCommands.showNotification({
+      key: `devtool-calendar-${eventId}`,
+      title: "Devtool design sync",
+      message: "Starting in 5 minutes",
+      timeout: null,
+      source: { type: "calendar_event", event_id: eventId },
+      start_time: Math.floor(startedAt.getTime() / 1000),
+      participants: [
+        {
+          name: "Ada Lovelace",
+          email: "ada@example.com",
+          status: "Accepted",
+        },
+      ],
+      event_details: {
+        what: "Devtool design sync",
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        location: "Conference Room",
+      },
+      action_label: "Open notes",
+      options: null,
+      footer: null,
+      icon: null,
+    });
+  }, [store, user_id]);
+
+  const showMicDetectedNotification = useCallback(async () => {
+    await notificationCommands.showNotification({
+      key: `devtool-mic-${crypto.randomUUID()}`,
+      title: "Are you in a meeting?",
+      message: "",
+      timeout: { secs: 15, nanos: 0 },
+      source: {
+        type: "mic_detected",
+        app_names: ["Zoom"],
+        app_ids: ["us.zoom.xos"],
+        event_ids: [],
+      },
+      start_time: null,
+      participants: null,
+      event_details: null,
+      action_label: null,
+      options: null,
+      footer: null,
+      icon: null,
+    });
+  }, []);
+
+  const showMicDetectedOptionsNotification = useCallback(async () => {
+    await notificationCommands.showNotification({
+      key: `devtool-mic-options-${crypto.randomUUID()}`,
+      title: "Are you in a meeting?",
+      message: "",
+      timeout: { secs: 15, nanos: 0 },
+      source: {
+        type: "mic_detected",
+        app_names: ["Zoom", "Google Chrome"],
+        app_ids: ["us.zoom.xos", "com.google.Chrome"],
+        event_ids: [],
+      },
+      start_time: null,
+      participants: null,
+      event_details: null,
+      action_label: null,
+      options: ["Design sync", "Customer call"],
+      footer: {
+        text: "Ignore Zoom and Chrome?",
+        actionLabel: "Yes",
+        icon: { type: "bundle_id", bundle_id: "us.zoom.xos" },
+      },
+      icon: null,
+    });
+  }, []);
+
+  const showBatchNotification = useCallback(async () => {
+    await showBatchCompletedNotification("devtool", { force: true });
+  }, []);
+
+  const clearNotifications = useCallback(async () => {
+    await notificationCommands.clearNotifications();
+  }, []);
+
+  const btnClass = cn([
+    "w-full rounded-md px-2.5 py-1.5",
+    "text-left text-xs font-medium",
+    "border border-neutral-200 text-neutral-700",
+    "cursor-pointer transition-colors",
+    "hover:border-neutral-300 hover:bg-neutral-50",
+  ]);
+
+  return (
+    <DevtoolCard title="Notifications">
+      <div className="flex flex-col gap-1.5">
+        <button
+          type="button"
+          onClick={() => void showCalendarNotification()}
+          className={btnClass}
+        >
+          Calendar event
+        </button>
+        <button
+          type="button"
+          onClick={() => void showMicDetectedNotification()}
+          className={btnClass}
+        >
+          Mic detected
+        </button>
+        <button
+          type="button"
+          onClick={() => void showMicDetectedOptionsNotification()}
+          className={btnClass}
+        >
+          Mic detected with options
+        </button>
+        <button
+          type="button"
+          onClick={() => void showBatchNotification()}
+          className={btnClass}
+        >
+          Batch transcription complete
+        </button>
+        <button
+          type="button"
+          onClick={() => void clearNotifications()}
+          className={btnClass}
+        >
+          Clear notifications
         </button>
       </div>
     </DevtoolCard>

--- a/apps/desktop/src/sidebar/devtool.tsx
+++ b/apps/desktop/src/sidebar/devtool.tsx
@@ -13,7 +13,9 @@ import { TrialStartedDialog } from "~/billing/trial-started-dialog";
 import { getLatestVersion } from "~/changelog";
 import * as main from "~/store/tinybase/store/main";
 import { showBatchCompletedNotification } from "~/store/zustand/listener/general-batch";
+import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
+import { createAutoStopEndedNotificationKey } from "~/stt/auto-stop-notification";
 import { commands } from "~/types/tauri.gen";
 
 export function DevtoolView() {
@@ -302,6 +304,28 @@ function NotificationsCard() {
     });
   }, []);
 
+  const showAutoStopConfirmationNotification = useCallback(async () => {
+    const sessionId =
+      listenerStore.getState().live.sessionId ??
+      `devtool-${crypto.randomUUID()}`;
+
+    await notificationCommands.showNotification({
+      key: createAutoStopEndedNotificationKey(sessionId),
+      title: "Did your meeting end?",
+      message:
+        "Google Chrome stopped using the microphone before the scheduled end time.",
+      timeout: { secs: 60, nanos: 0 },
+      source: null,
+      start_time: null,
+      participants: null,
+      event_details: null,
+      action_label: "Stop recording",
+      options: null,
+      footer: null,
+      icon: { type: "bundle_id", bundle_id: "com.google.Chrome" },
+    });
+  }, []);
+
   const showBatchNotification = useCallback(async () => {
     await showBatchCompletedNotification("devtool", { force: true });
   }, []);
@@ -341,6 +365,13 @@ function NotificationsCard() {
           className={btnClass}
         >
           Mic detected with options
+        </button>
+        <button
+          type="button"
+          onClick={() => void showAutoStopConfirmationNotification()}
+          className={btnClass}
+        >
+          Auto-stop confirmation
         </button>
         <button
           type="button"

--- a/apps/desktop/src/store/zustand/listener/general-batch.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.test.ts
@@ -3,9 +3,31 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { EMPTY_BATCH_TRANSCRIPT_ERROR } from "./batch";
 import { runBatchSession } from "./general-batch";
 
-const { listenMock, startTranscriptionMock } = vi.hoisted(() => ({
+const {
+  isFocusedMock,
+  isVisibleMock,
+  listenMock,
+  showNotificationMock,
+  startTranscriptionMock,
+} = vi.hoisted(() => ({
+  isFocusedMock: vi.fn(),
+  isVisibleMock: vi.fn(),
   listenMock: vi.fn(),
+  showNotificationMock: vi.fn(),
   startTranscriptionMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    isFocused: isFocusedMock,
+    isVisible: isVisibleMock,
+  }),
+}));
+
+vi.mock("@hypr/plugin-notification", () => ({
+  commands: {
+    showNotification: showNotificationMock,
+  },
 }));
 
 vi.mock("@hypr/plugin-transcription", () => ({
@@ -22,6 +44,9 @@ vi.mock("@hypr/plugin-transcription", () => ({
 describe("runBatchSession", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    isFocusedMock.mockResolvedValue(true);
+    isVisibleMock.mockResolvedValue(true);
+    showNotificationMock.mockResolvedValue({ status: "ok", data: null });
   });
 
   test("resolves from the completed event and persists the response", async () => {
@@ -110,6 +135,97 @@ describe("runBatchSession", () => {
     expect(clearBatchSession).toHaveBeenCalledWith("session-1");
     expect(handleBatchFailed).not.toHaveBeenCalled();
     expect(handleBatchResponseStreamed).not.toHaveBeenCalled();
+    expect(showNotificationMock).not.toHaveBeenCalled();
+  });
+
+  test("shows a completion notification when the window is not focused", async () => {
+    isFocusedMock.mockResolvedValue(false);
+
+    const handleBatchStarted = vi.fn();
+    const handleBatchResponse = vi.fn();
+    const handleBatchCompleted = vi.fn();
+    const clearBatchPersist = vi.fn();
+    const clearBatchSession = vi.fn();
+    const handleBatchResponseStreamed = vi.fn();
+    const handleBatchFailed = vi.fn();
+    const handleBatchStopped = vi.fn();
+    const updateBatchProgress = vi.fn();
+    const setBatchPersist = vi.fn();
+
+    let handler:
+      | ((event: {
+          payload: {
+            type: string;
+            session_id: string;
+            response?: unknown;
+            mode?: "direct" | "streamed";
+          };
+        }) => void)
+      | undefined;
+
+    listenMock.mockImplementation(async (cb) => {
+      handler = cb;
+      return vi.fn();
+    });
+
+    startTranscriptionMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          queueMicrotask(() => {
+            handler?.({
+              payload: {
+                type: "completed",
+                session_id: "session-1",
+                mode: "streamed",
+                response: {
+                  metadata: null,
+                  results: { channels: [] },
+                },
+              },
+            });
+            resolve({
+              status: "ok",
+              data: null,
+            });
+          });
+        }),
+    );
+
+    await runBatchSession(
+      () => ({
+        batch: {},
+        batchPreview: {},
+        batchPersist: {},
+        handleBatchStarted,
+        handleBatchResponse,
+        handleBatchCompleted,
+        clearBatchPersist,
+        clearBatchSession,
+        handleBatchResponseStreamed,
+        handleBatchFailed,
+        handleBatchStopped,
+        updateBatchProgress,
+        setBatchPersist,
+      }),
+      "session-1",
+      {
+        session_id: "session-1",
+        provider: "hyprnote",
+        file_path: "/tmp/session.wav",
+        base_url: "",
+        api_key: "",
+      },
+    );
+
+    expect(showNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "batch-completed-session-1",
+        title: "Transcription complete",
+        message: "Your transcript is ready.",
+        action_label: "Open Anarlog",
+        source: { type: "session", session_id: "session-1" },
+      }),
+    );
   });
 
   test("forwards streamed progress events before completion", async () => {

--- a/apps/desktop/src/store/zustand/listener/general-batch.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { EMPTY_BATCH_TRANSCRIPT_ERROR } from "./batch";
-import { runBatchSession } from "./general-batch";
+import {
+  runBatchSession,
+  showBatchCompletedNotification,
+} from "./general-batch";
+
+import { parseBatchCompletedNotificationKey } from "~/stt/batch-completed-notification";
 
 const {
   isFocusedMock,
@@ -217,15 +222,30 @@ describe("runBatchSession", () => {
       },
     );
 
-    expect(showNotificationMock).toHaveBeenCalledWith(
+    const notification = showNotificationMock.mock.calls[0]?.[0];
+    expect(notification).toEqual(
       expect.objectContaining({
-        key: "batch-completed-session-1",
         title: "Transcription complete",
         message: "Your transcript is ready.",
         action_label: "Open Anarlog",
         source: { type: "session", session_id: "session-1" },
       }),
     );
+    expect(parseBatchCompletedNotificationKey(notification.key)).toBe(
+      "session-1",
+    );
+  });
+
+  test("uses a fresh notification key for each batch completion", async () => {
+    await showBatchCompletedNotification("session-1", { force: true });
+    await showBatchCompletedNotification("session-1", { force: true });
+
+    const firstKey = showNotificationMock.mock.calls[0]?.[0].key;
+    const secondKey = showNotificationMock.mock.calls[1]?.[0].key;
+
+    expect(parseBatchCompletedNotificationKey(firstKey)).toBe("session-1");
+    expect(parseBatchCompletedNotificationKey(secondKey)).toBe("session-1");
+    expect(firstKey).not.toBe(secondKey);
   });
 
   test("forwards streamed progress events before completion", async () => {

--- a/apps/desktop/src/store/zustand/listener/general-batch.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.ts
@@ -1,5 +1,7 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { StoreApi } from "zustand";
 
+import { commands as notificationCommands } from "@hypr/plugin-notification";
 import {
   type BatchErrorCode,
   type TranscriptionParams,
@@ -14,6 +16,56 @@ import {
 } from "./batch";
 
 type BatchStore = BatchActions & BatchState;
+
+async function shouldNotifyBatchCompleted() {
+  try {
+    const window = getCurrentWindow();
+    const [focused, visible] = await Promise.all([
+      window.isFocused(),
+      window.isVisible(),
+    ]);
+
+    return !focused || !visible;
+  } catch (error) {
+    console.error("[runBatch] failed to inspect window state", error);
+    return true;
+  }
+}
+
+export async function showBatchCompletedNotification(
+  sessionId: string,
+  options?: { force?: boolean },
+) {
+  if (!options?.force && !(await shouldNotifyBatchCompleted())) {
+    return;
+  }
+
+  try {
+    const result = await notificationCommands.showNotification({
+      key: `batch-completed-${sessionId}`,
+      title: "Transcription complete",
+      message: "Your transcript is ready.",
+      timeout: null,
+      source: { type: "session", session_id: sessionId },
+      start_time: null,
+      participants: null,
+      event_details: null,
+      action_label: "Open Anarlog",
+      options: null,
+      footer: null,
+      icon: null,
+    });
+
+    if (result.status === "error") {
+      console.error(
+        "[runBatch] failed to show completion notification",
+        result.error,
+      );
+    }
+  } catch (error) {
+    console.error("[runBatch] failed to show completion notification", error);
+  }
+}
 
 export const runBatchSession = async <T extends BatchStore>(
   get: StoreApi<T>["getState"],
@@ -173,4 +225,6 @@ export const runBatchSession = async <T extends BatchStore>(
         rejectFailure(error, reject);
       });
   });
+
+  await showBatchCompletedNotification(sessionId);
 };

--- a/apps/desktop/src/store/zustand/listener/general-batch.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.ts
@@ -15,6 +15,8 @@ import {
   type BatchState,
 } from "./batch";
 
+import { createBatchCompletedNotificationKey } from "~/stt/batch-completed-notification";
+
 type BatchStore = BatchActions & BatchState;
 
 async function shouldNotifyBatchCompleted() {
@@ -42,7 +44,7 @@ export async function showBatchCompletedNotification(
 
   try {
     const result = await notificationCommands.showNotification({
-      key: `batch-completed-${sessionId}`,
+      key: createBatchCompletedNotificationKey(sessionId),
       title: "Transcription complete",
       message: "Your transcript is ready.",
       timeout: null,

--- a/apps/desktop/src/stt/auto-stop-notification.test.ts
+++ b/apps/desktop/src/stt/auto-stop-notification.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX,
+  createAutoStopEndedNotificationKey,
+  parseAutoStopEndedNotificationKey,
+} from "./auto-stop-notification";
+
+describe("auto-stop notification keys", () => {
+  test("creates unique keys that still parse to the session id", () => {
+    const firstKey = createAutoStopEndedNotificationKey("session-1");
+    const secondKey = createAutoStopEndedNotificationKey("session-1");
+
+    expect(firstKey).not.toBe(secondKey);
+    expect(parseAutoStopEndedNotificationKey(firstKey)).toBe("session-1");
+    expect(parseAutoStopEndedNotificationKey(secondKey)).toBe("session-1");
+  });
+
+  test("parses legacy stable keys", () => {
+    expect(
+      parseAutoStopEndedNotificationKey(
+        `${AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX}session-1`,
+      ),
+    ).toBe("session-1");
+  });
+});

--- a/apps/desktop/src/stt/auto-stop-notification.ts
+++ b/apps/desktop/src/stt/auto-stop-notification.ts
@@ -1,0 +1,29 @@
+export const AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX =
+  "auto-stop-ended:" as const;
+
+const AUTO_STOP_ENDED_NOTIFICATION_KEY_NONCE_SEPARATOR = ":prompt:";
+
+export function createAutoStopEndedNotificationKey(sessionId: string) {
+  return `${AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX}${sessionId}${AUTO_STOP_ENDED_NOTIFICATION_KEY_NONCE_SEPARATOR}${crypto.randomUUID()}`;
+}
+
+export function parseAutoStopEndedNotificationKey(
+  key: string | null | undefined,
+) {
+  if (!key) {
+    return null;
+  }
+
+  if (!key.startsWith(AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX)) {
+    return null;
+  }
+
+  const value = key.slice(AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX.length);
+  const separatorIndex = value.lastIndexOf(
+    AUTO_STOP_ENDED_NOTIFICATION_KEY_NONCE_SEPARATOR,
+  );
+
+  return (
+    value.slice(0, separatorIndex === -1 ? undefined : separatorIndex) || null
+  );
+}

--- a/apps/desktop/src/stt/batch-completed-notification.ts
+++ b/apps/desktop/src/stt/batch-completed-notification.ts
@@ -1,0 +1,32 @@
+const LEGACY_BATCH_COMPLETED_NOTIFICATION_KEY_PREFIX = "batch-completed-";
+
+export const BATCH_COMPLETED_NOTIFICATION_KEY_PREFIX =
+  "batch-completed:" as const;
+
+export function createBatchCompletedNotificationKey(sessionId: string) {
+  return `${BATCH_COMPLETED_NOTIFICATION_KEY_PREFIX}${sessionId}:${crypto.randomUUID()}`;
+}
+
+export function parseBatchCompletedNotificationKey(
+  key: string | null | undefined,
+) {
+  if (!key) {
+    return null;
+  }
+
+  if (key.startsWith(BATCH_COMPLETED_NOTIFICATION_KEY_PREFIX)) {
+    const value = key.slice(BATCH_COMPLETED_NOTIFICATION_KEY_PREFIX.length);
+    const separatorIndex = value.lastIndexOf(":");
+    return (
+      value.slice(0, separatorIndex === -1 ? undefined : separatorIndex) || null
+    );
+  }
+
+  if (key.startsWith(LEGACY_BATCH_COMPLETED_NOTIFICATION_KEY_PREFIX)) {
+    return (
+      key.slice(LEGACY_BATCH_COMPLETED_NOTIFICATION_KEY_PREFIX.length) || null
+    );
+  }
+
+  return null;
+}

--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -1,9 +1,9 @@
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import { parseAutoStopEndedNotificationKey } from "./auto-stop-notification";
 import {
-  AUTO_STOP_BROWSER_CONFIRM_DELAY_MS,
-  AUTO_STOP_BROWSER_CALENDAR_CONFIRM_DELAY_MS,
+  AUTO_STOP_CALENDAR_EARLY_END_THRESHOLD_MS,
   AUTO_STOP_CONFIRM_DELAY_MS,
   ListenerProvider,
 } from "./contexts";
@@ -395,7 +395,7 @@ describe("ListenerProvider detect events", () => {
     expect(stopSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("uses a longer auto-stop grace period for browser meeting triggers", async () => {
+  test("uses the standard auto-stop grace period for browser meeting triggers without calendar context", async () => {
     const store = createListenerStore();
     const stopSpy = vi.fn();
 
@@ -424,15 +424,10 @@ describe("ListenerProvider detect events", () => {
     });
 
     await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
-    expect(stopSpy).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(
-      AUTO_STOP_BROWSER_CONFIRM_DELAY_MS - AUTO_STOP_CONFIRM_DELAY_MS,
-    );
     expect(stopSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("uses calendar context to extend browser auto-stop during an active scheduled meeting", async () => {
+  test("asks before stopping when a browser meeting stops well before the scheduled end", async () => {
     const store = createListenerStore();
     const stopSpy = vi.fn();
     const now = new Date("2026-05-19T10:05:00.000Z");
@@ -469,16 +464,76 @@ describe("ListenerProvider detect events", () => {
       },
     });
 
-    await vi.advanceTimersByTimeAsync(AUTO_STOP_BROWSER_CONFIRM_DELAY_MS);
-    expect(stopSpy).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
 
-    await vi.advanceTimersByTimeAsync(
-      AUTO_STOP_BROWSER_CALENDAR_CONFIRM_DELAY_MS -
-        AUTO_STOP_BROWSER_CONFIRM_DELAY_MS,
+    expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
+    expect(stopSpy).not.toHaveBeenCalled();
+    const notification = showNotificationMock.mock.calls[0]?.[0];
+    expect(parseAutoStopEndedNotificationKey(notification.key)).toBe(
+      "session-1",
     );
+    expect(notification).toEqual({
+      key: expect.stringContaining("auto-stop-ended:session-1"),
+      title: "Did your meeting end?",
+      message:
+        "Google Chrome stopped using the microphone before the scheduled end time.",
+      timeout: { secs: 60, nanos: 0 },
+      source: null,
+      start_time: null,
+      participants: null,
+      event_details: null,
+      action_label: "Stop recording",
+      options: null,
+      footer: null,
+      icon: { type: "bundle_id", bundle_id: "com.google.Chrome" },
+    });
+  });
+
+  test("auto-stops browser meetings inside the scheduled end window", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+    const endedAtMs = new Date("2026-05-19T10:30:00.000Z").getTime();
+    const now = new Date(
+      endedAtMs - AUTO_STOP_CALENDAR_EARLY_END_THRESHOLD_MS + 1,
+    );
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["com.google.Chrome"]);
+    setStoreActive(store);
+    (useStoreMock as any).mockReturnValue(
+      mockSessionEventStore({
+        started_at: "2026-05-19T10:00:00.000Z",
+        ended_at: "2026-05-19T10:30:00.000Z",
+      }),
+    );
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    listMicUsingApplicationsMock.mockClear();
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "com.google.Chrome", name: "Google Chrome" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
 
     expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
     expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(showNotificationMock).not.toHaveBeenCalled();
   });
 
   test("cancels pending auto-stop when a browser trigger restarts", async () => {
@@ -510,7 +565,7 @@ describe("ListenerProvider detect events", () => {
       },
     });
 
-    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS - 1);
 
     handler({
       payload: {
@@ -521,9 +576,7 @@ describe("ListenerProvider detect events", () => {
       },
     });
 
-    await vi.advanceTimersByTimeAsync(
-      AUTO_STOP_BROWSER_CONFIRM_DELAY_MS - AUTO_STOP_CONFIRM_DELAY_MS,
-    );
+    await vi.advanceTimersByTimeAsync(1);
 
     expect(listMicUsingApplicationsMock).not.toHaveBeenCalled();
     expect(stopSpy).not.toHaveBeenCalled();

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -11,6 +11,8 @@ import {
   type NotificationIcon,
 } from "@hypr/plugin-notification";
 
+import { createAutoStopEndedNotificationKey } from "./auto-stop-notification";
+
 import { getSessionEventById } from "~/session/utils";
 import * as main from "~/store/tinybase/store/main";
 import * as settings from "~/store/tinybase/store/settings";
@@ -21,9 +23,7 @@ import {
 
 const ListenerContext = createContext<ListenerStore | null>(null);
 export const AUTO_STOP_CONFIRM_DELAY_MS = 5_000;
-export const AUTO_STOP_BROWSER_CONFIRM_DELAY_MS = 30_000;
-export const AUTO_STOP_BROWSER_CALENDAR_CONFIRM_DELAY_MS = 10 * 60_000;
-export const AUTO_STOP_CALENDAR_END_BUFFER_MS = 2 * 60_000;
+export const AUTO_STOP_CALENDAR_EARLY_END_THRESHOLD_MS = 3 * 60_000;
 export const AUTO_STOP_CALENDAR_EARLY_START_BUFFER_MS = 5 * 60_000;
 
 const BROWSER_MEETING_APP_IDS = new Set([
@@ -96,61 +96,88 @@ function parseEventTimeMs(value: string | undefined): number | null {
   return Number.isNaN(ms) ? null : ms;
 }
 
-function getCalendarAwareBrowserDelayMs({
+function shouldPromptBeforeAutoStopping({
+  appIds,
   tinybaseStore,
   sessionId,
   nowMs,
 }: {
+  appIds: string[];
   tinybaseStore: MainStore | null | undefined;
   sessionId: string | null;
   nowMs: number;
-}): number | null {
+}) {
+  if (!appIds.some((id) => BROWSER_MEETING_APP_IDS.has(id))) {
+    return false;
+  }
+
   if (!tinybaseStore || !sessionId) {
-    return null;
+    return false;
   }
 
   const event = getSessionEventById(tinybaseStore, sessionId);
   if (!event || event.is_all_day) {
-    return null;
+    return false;
   }
 
   const endMs = parseEventTimeMs(event.ended_at);
   if (!endMs) {
-    return null;
+    return false;
   }
 
   const startMs = parseEventTimeMs(event.started_at);
   if (startMs && nowMs < startMs - AUTO_STOP_CALENDAR_EARLY_START_BUFFER_MS) {
-    return null;
+    return false;
   }
 
-  const guardUntilMs = endMs + AUTO_STOP_CALENDAR_END_BUFFER_MS;
-  if (guardUntilMs <= nowMs) {
-    return null;
-  }
+  return nowMs < endMs - AUTO_STOP_CALENDAR_EARLY_END_THRESHOLD_MS;
+}
 
-  return Math.min(
-    Math.max(guardUntilMs - nowMs, AUTO_STOP_BROWSER_CONFIRM_DELAY_MS),
-    AUTO_STOP_BROWSER_CALENDAR_CONFIRM_DELAY_MS,
+function getPrimaryStoppedApp(
+  stoppedTriggerAppIds: string[],
+  stoppedApps: { id: string; name: string }[],
+) {
+  return (
+    stoppedApps.find(
+      (app) =>
+        stoppedTriggerAppIds.includes(app.id) &&
+        BROWSER_MEETING_APP_IDS.has(app.id),
+    ) ??
+    stoppedApps.find((app) => stoppedTriggerAppIds.includes(app.id)) ??
+    null
   );
 }
 
-function getAutoStopConfirmDelayMs(
-  appIds: string[],
-  options: {
-    tinybaseStore: MainStore | null | undefined;
-    sessionId: string | null;
-    nowMs: number;
-  },
-) {
-  if (!appIds.some((id) => BROWSER_MEETING_APP_IDS.has(id))) {
-    return AUTO_STOP_CONFIRM_DELAY_MS;
-  }
+function getStoppedAppLabel(app: { name: string } | null) {
+  const name = app?.name.trim();
+  return name || "The meeting app";
+}
 
-  return (
-    getCalendarAwareBrowserDelayMs(options) ??
-    AUTO_STOP_BROWSER_CONFIRM_DELAY_MS
-  );
+function showMeetingEndedPrompt({
+  sessionId,
+  stoppedTriggerAppIds,
+  stoppedApps,
+}: {
+  sessionId: string;
+  stoppedTriggerAppIds: string[];
+  stoppedApps: { id: string; name: string }[];
+}) {
+  const app = getPrimaryStoppedApp(stoppedTriggerAppIds, stoppedApps);
+
+  void notificationCommands.showNotification({
+    key: createAutoStopEndedNotificationKey(sessionId),
+    title: "Did your meeting end?",
+    message: `${getStoppedAppLabel(app)} stopped using the microphone before the scheduled end time.`,
+    timeout: { secs: 60, nanos: 0 },
+    source: null,
+    start_time: null,
+    participants: null,
+    event_details: null,
+    action_label: "Stop recording",
+    options: null,
+    footer: null,
+    icon: app ? getNotificationIconForAppId(app.id) : null,
+  });
 }
 
 export const ListenerProvider = ({
@@ -240,12 +267,16 @@ const useHandleDetectEvents = (store: ListenerStore) => {
       }
     };
 
-    const confirmAutoStop = async (stoppedTriggerAppIds: string[]) => {
-      if (store.getState().live.status !== "active") {
+    const confirmAutoStop = async (
+      stoppedTriggerAppIds: string[],
+      stoppedApps: { id: string; name: string }[],
+    ) => {
+      const live = store.getState().live;
+      if (live.status !== "active") {
         return;
       }
 
-      const currentTrigger = store.getState().live.triggerAppIds;
+      const currentTrigger = live.triggerAppIds;
       if (
         !currentTrigger ||
         !stoppedTriggerAppIds.some((id) => currentTrigger.includes(id))
@@ -259,6 +290,25 @@ const useHandleDetectEvents = (store: ListenerStore) => {
         if (stoppedTriggerAppIds.some((id) => activeAppIds.has(id))) {
           return;
         }
+      }
+
+      const sessionId = store.getState().live.sessionId;
+      if (
+        shouldPromptBeforeAutoStopping({
+          appIds: stoppedTriggerAppIds,
+          tinybaseStore: tinybaseStoreRef.current,
+          sessionId,
+          nowMs: Date.now(),
+        })
+      ) {
+        if (sessionId) {
+          showMeetingEndedPrompt({
+            sessionId,
+            stoppedTriggerAppIds,
+            stoppedApps,
+          });
+        }
+        return;
       }
 
       stop();
@@ -332,19 +382,11 @@ const useHandleDetectEvents = (store: ListenerStore) => {
             ) ?? [];
           if (stoppedTriggerAppIds.length > 0) {
             clearPendingAutoStop();
-            const confirmDelayMs = getAutoStopConfirmDelayMs(
-              stoppedTriggerAppIds,
-              {
-                tinybaseStore: tinybaseStoreRef.current,
-                sessionId: store.getState().live.sessionId,
-                nowMs: Date.now(),
-              },
-            );
 
             pendingAutoStopRef.current = setTimeout(() => {
               pendingAutoStopRef.current = null;
-              void confirmAutoStop(stoppedTriggerAppIds);
-            }, confirmDelayMs);
+              void confirmAutoStop(stoppedTriggerAppIds, payload.apps);
+            }, AUTO_STOP_CONFIRM_DELAY_MS);
           }
         } else if (payload.type === "sleepStateChanged") {
           if (payload.value) {

--- a/crates/notification-interface/src/lib.rs
+++ b/crates/notification-interface/src/lib.rs
@@ -102,6 +102,8 @@ pub struct NotificationFooter {
 pub enum NotificationSource {
     #[serde(rename = "calendar_event")]
     CalendarEvent { event_id: String },
+    #[serde(rename = "session")]
+    Session { session_id: String },
     #[serde(rename = "mic_detected")]
     MicDetected {
         app_names: Vec<String>,
@@ -180,6 +182,7 @@ impl NotificationSource {
                 base: NotificationIconAsset::AppIcon,
                 badge: NotificationIconAsset::Calendar,
             }),
+            Self::Session { .. } => None,
             Self::MicDetected { app_ids, .. } => app_ids
                 .iter()
                 .find_map(|app_id| NotificationIcon::from_app_id(app_id)),

--- a/crates/notification-macos/swift-lib/src/Models.swift
+++ b/crates/notification-macos/swift-lib/src/Models.swift
@@ -131,11 +131,13 @@ enum NotificationIcon: Codable {
 
 enum NotificationSource: Codable {
   case calendarEvent(eventId: String)
+  case session(sessionId: String)
   case micDetected(appNames: [String], appIds: [String], eventIds: [String])
 
   private enum CodingKeys: String, CodingKey {
     case type
     case eventId = "event_id"
+    case sessionId = "session_id"
     case appNames = "app_names"
     case appIds = "app_ids"
     case eventIds = "event_ids"
@@ -143,6 +145,7 @@ enum NotificationSource: Codable {
 
   private enum SourceType: String, Codable {
     case calendarEvent = "calendar_event"
+    case session = "session"
     case micDetected = "mic_detected"
   }
 
@@ -152,6 +155,8 @@ enum NotificationSource: Codable {
     switch try container.decode(SourceType.self, forKey: .type) {
     case .calendarEvent:
       self = .calendarEvent(eventId: try container.decode(String.self, forKey: .eventId))
+    case .session:
+      self = .session(sessionId: try container.decode(String.self, forKey: .sessionId))
     case .micDetected:
       self = .micDetected(
         appNames: try container.decode([String].self, forKey: .appNames),
@@ -168,6 +173,9 @@ enum NotificationSource: Codable {
     case .calendarEvent(let eventId):
       try container.encode(SourceType.calendarEvent, forKey: .type)
       try container.encode(eventId, forKey: .eventId)
+    case .session(let sessionId):
+      try container.encode(SourceType.session, forKey: .type)
+      try container.encode(sessionId, forKey: .sessionId)
     case .micDetected(let appNames, let appIds, let eventIds):
       try container.encode(SourceType.micDetected, forKey: .type)
       try container.encode(appNames, forKey: .appNames)

--- a/plugins/notification/js/bindings.gen.ts
+++ b/plugins/notification/js/bindings.gen.ts
@@ -46,7 +46,7 @@ export type NotificationEvent = { type: "notification_confirm"; key: string; sou
 export type NotificationFooter = { text: string; actionLabel: string; icon: NotificationIcon | null }
 export type NotificationIcon = { type: "hidden" } | { type: "bundle_id"; bundle_id: string } | { type: "path"; path: string } | { type: "overlay"; base: NotificationIconAsset; badge: NotificationIconAsset }
 export type NotificationIconAsset = { type: "app_icon" } | { type: "calendar" } | { type: "bundle_id"; bundle_id: string } | { type: "path"; path: string }
-export type NotificationSource = { type: "calendar_event"; event_id: string } | { type: "mic_detected"; app_names: string[]; app_ids?: string[]; event_ids?: string[] }
+export type NotificationSource = { type: "calendar_event"; event_id: string } | { type: "session"; session_id: string } | { type: "mic_detected"; app_names: string[]; app_ids?: string[]; event_ids?: string[] }
 export type Participant = { name: string | null; email: string; status: ParticipantStatus }
 export type ParticipantStatus = "Accepted" | "Maybe" | "Declined"
 


### PR DESCRIPTION
Show a desktop notification after successful batch transcription when the app window is hidden or unfocused.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new desktop notifications and new notification event handling paths (including stopping active sessions and opening sessions from notification keys), plus extends the notification source interface across TS/Rust/Swift; mistakes could lead to incorrect session navigation or unintended stops.
> 
> **Overview**
> Adds a desktop notification when batch transcription completes, gated on the app window being unfocused/hidden (with a `force` override) and using a fresh per-notification key that still encodes the `sessionId`.
> 
> Extends notification handling so clicking notifications can directly open a specific session (via new `NotificationSource.session` or by parsing batch-completion keys), and adds an auto-stop “meeting ended?” prompt flow where accepting the notification stops the matching active session.
> 
> Refactors browser meeting auto-stop timing to use a single confirmation delay and introduces a scheduled-meeting *early-end* threshold that triggers the new prompt instead of auto-stopping. Adds a devtools Notifications panel to manually trigger these notifications, and updates Rust/Swift/TS notification source types plus tests for the new behaviors and key parsing/back-compat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce0e3b7105930989d18ee4c0b4827fb637e0273b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->