### PR TITLE
fix(stt): prompt before early browser auto-stop

### DIFF
--- a/apps/desktop/src/services/event-listeners.test.tsx
+++ b/apps/desktop/src/services/event-listeners.test.tsx
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { EventListeners } from "./event-listeners";
 
+import { createAutoStopEndedNotificationKey } from "~/stt/auto-stop-notification";
+
 const {
   notificationListenMock,
   updaterListenMock,
@@ -14,6 +16,8 @@ const {
   createSessionMock,
   getOrCreateSessionForEventIdMock,
   setTriggerAppIdsMock,
+  stopMock,
+  getListenerStateMock,
 } = vi.hoisted(() => ({
   notificationListenMock: vi.fn(),
   updaterListenMock: vi.fn(),
@@ -25,6 +29,8 @@ const {
   createSessionMock: vi.fn(() => "session-new"),
   getOrCreateSessionForEventIdMock: vi.fn(() => "session-event"),
   setTriggerAppIdsMock: vi.fn(),
+  stopMock: vi.fn(),
+  getListenerStateMock: vi.fn(),
 }));
 
 vi.mock("@hypr/plugin-notification", () => ({
@@ -76,7 +82,7 @@ vi.mock("~/store/zustand/tabs", () => ({
 
 vi.mock("~/store/zustand/listener/instance", () => ({
   listenerStore: {
-    getState: () => ({ setTriggerAppIds: setTriggerAppIdsMock }),
+    getState: getListenerStateMock,
   },
 }));
 
@@ -92,6 +98,8 @@ describe("EventListeners notification events", () => {
     createSessionMock.mockReset();
     getOrCreateSessionForEventIdMock.mockReset();
     setTriggerAppIdsMock.mockReset();
+    stopMock.mockReset();
+    getListenerStateMock.mockReset();
 
     getCurrentWebviewWindowLabelMock.mockReturnValue("main");
     notificationListenMock.mockResolvedValue(() => {});
@@ -100,6 +108,11 @@ describe("EventListeners notification events", () => {
     getOrCreateSessionForEventIdMock.mockReturnValue("session-event");
     useMainStoreMock.mockReturnValue(null);
     useSettingsStoreMock.mockReturnValue(null);
+    getListenerStateMock.mockReturnValue({
+      setTriggerAppIds: setTriggerAppIdsMock,
+      stop: stopMock,
+      live: { status: "active", sessionId: "session-1" },
+    });
   });
 
   afterEach(() => {
@@ -139,6 +152,56 @@ describe("EventListeners notification events", () => {
       "ignored_platforms",
       JSON.stringify(["com.existing.app", "us.zoom.xos"]),
     );
+    expect(openNewMock).not.toHaveBeenCalled();
+  });
+
+  test("notification_accept with auto-stop prompt stops the active session", async () => {
+    useMainStoreMock.mockReturnValue({} as never);
+
+    render(<EventListeners />);
+
+    await vi.waitFor(() =>
+      expect(notificationListenMock).toHaveBeenCalledTimes(1),
+    );
+
+    const handler = notificationListenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "notification_accept",
+        key: createAutoStopEndedNotificationKey("session-1"),
+        source: null,
+      },
+    });
+
+    expect(stopMock).toHaveBeenCalledTimes(1);
+    expect(createSessionMock).not.toHaveBeenCalled();
+    expect(openNewMock).not.toHaveBeenCalled();
+  });
+
+  test("notification_confirm with auto-stop prompt ignores collapsed body click", async () => {
+    useMainStoreMock.mockReturnValue({} as never);
+
+    render(<EventListeners />);
+
+    await vi.waitFor(() =>
+      expect(notificationListenMock).toHaveBeenCalledTimes(1),
+    );
+
+    const handler = notificationListenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "notification_confirm",
+        key: createAutoStopEndedNotificationKey("session-1"),
+        source: null,
+      },
+    });
+
+    expect(stopMock).not.toHaveBeenCalled();
+    expect(createSessionMock).not.toHaveBeenCalled();
     expect(openNewMock).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/services/event-listeners.tsx
+++ b/apps/desktop/src/services/event-listeners.tsx
@@ -16,6 +16,7 @@ import {
 import * as settings from "~/store/tinybase/store/settings";
 import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
+import { parseAutoStopEndedNotificationKey } from "~/stt/auto-stop-notification";
 
 type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
 
@@ -56,6 +57,30 @@ function shouldAutoStartNotificationSession(
 
   const startTime = new Date(String(startedAt)).getTime();
   return !Number.isNaN(startTime) && startTime <= Date.now();
+}
+
+function handleAutoStopEndedNotification(
+  type: "notification_confirm" | "notification_accept",
+  key: string,
+): boolean {
+  const sessionId = parseAutoStopEndedNotificationKey(key);
+  if (!sessionId) {
+    return false;
+  }
+
+  if (type !== "notification_accept") {
+    return true;
+  }
+
+  const listenerState = listenerStore.getState();
+  if (
+    listenerState.live.status === "active" &&
+    listenerState.live.sessionId === sessionId
+  ) {
+    listenerState.stop();
+  }
+
+  return true;
 }
 
 function useUpdaterEvents() {
@@ -143,6 +168,10 @@ function useNotificationEvents() {
           payload.type === "notification_confirm" ||
           payload.type === "notification_accept"
         ) {
+          if (handleAutoStopEndedNotification(payload.type, payload.key)) {
+            return;
+          }
+
           const eventId =
             payload.source?.type === "calendar_event"
               ? payload.source.event_id

--- a/apps/desktop/src/sidebar/devtool.tsx
+++ b/apps/desktop/src/sidebar/devtool.tsx
@@ -13,7 +13,9 @@ import { TrialStartedDialog } from "~/billing/trial-started-dialog";
 import { getLatestVersion } from "~/changelog";
 import * as main from "~/store/tinybase/store/main";
 import { showBatchCompletedNotification } from "~/store/zustand/listener/general-batch";
+import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
+import { createAutoStopEndedNotificationKey } from "~/stt/auto-stop-notification";
 import { commands } from "~/types/tauri.gen";
 
 export function DevtoolView() {
@@ -302,6 +304,28 @@ function NotificationsCard() {
     });
   }, []);
 
+  const showAutoStopConfirmationNotification = useCallback(async () => {
+    const sessionId =
+      listenerStore.getState().live.sessionId ??
+      `devtool-${crypto.randomUUID()}`;
+
+    await notificationCommands.showNotification({
+      key: createAutoStopEndedNotificationKey(sessionId),
+      title: "Did your meeting end?",
+      message:
+        "Google Chrome stopped using the microphone before the scheduled end time.",
+      timeout: { secs: 60, nanos: 0 },
+      source: null,
+      start_time: null,
+      participants: null,
+      event_details: null,
+      action_label: "Stop recording",
+      options: null,
+      footer: null,
+      icon: { type: "bundle_id", bundle_id: "com.google.Chrome" },
+    });
+  }, []);
+
   const showBatchNotification = useCallback(async () => {
     await showBatchCompletedNotification("devtool", { force: true });
   }, []);
@@ -341,6 +365,13 @@ function NotificationsCard() {
           className={btnClass}
         >
           Mic detected with options
+        </button>
+        <button
+          type="button"
+          onClick={() => void showAutoStopConfirmationNotification()}
+          className={btnClass}
+        >
+          Auto-stop confirmation
         </button>
         <button
           type="button"

--- a/apps/desktop/src/stt/auto-stop-notification.ts
+++ b/apps/desktop/src/stt/auto-stop-notification.ts
@@ -1,0 +1,20 @@
+export const AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX =
+  "auto-stop-ended:" as const;
+
+export function createAutoStopEndedNotificationKey(sessionId: string) {
+  return `${AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX}${sessionId}`;
+}
+
+export function parseAutoStopEndedNotificationKey(
+  key: string | null | undefined,
+) {
+  if (!key) {
+    return null;
+  }
+
+  if (!key.startsWith(AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX)) {
+    return null;
+  }
+
+  return key.slice(AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX.length) || null;
+}

--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -1,9 +1,9 @@
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import { createAutoStopEndedNotificationKey } from "./auto-stop-notification";
 import {
-  AUTO_STOP_BROWSER_CONFIRM_DELAY_MS,
-  AUTO_STOP_BROWSER_CALENDAR_CONFIRM_DELAY_MS,
+  AUTO_STOP_CALENDAR_EARLY_END_THRESHOLD_MS,
   AUTO_STOP_CONFIRM_DELAY_MS,
   ListenerProvider,
 } from "./contexts";
@@ -395,7 +395,7 @@ describe("ListenerProvider detect events", () => {
     expect(stopSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("uses a longer auto-stop grace period for browser meeting triggers", async () => {
+  test("uses the standard auto-stop grace period for browser meeting triggers without calendar context", async () => {
     const store = createListenerStore();
     const stopSpy = vi.fn();
 
@@ -424,15 +424,10 @@ describe("ListenerProvider detect events", () => {
     });
 
     await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
-    expect(stopSpy).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(
-      AUTO_STOP_BROWSER_CONFIRM_DELAY_MS - AUTO_STOP_CONFIRM_DELAY_MS,
-    );
     expect(stopSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("uses calendar context to extend browser auto-stop during an active scheduled meeting", async () => {
+  test("asks before stopping when a browser meeting stops well before the scheduled end", async () => {
     const store = createListenerStore();
     const stopSpy = vi.fn();
     const now = new Date("2026-05-19T10:05:00.000Z");
@@ -469,16 +464,72 @@ describe("ListenerProvider detect events", () => {
       },
     });
 
-    await vi.advanceTimersByTimeAsync(AUTO_STOP_BROWSER_CONFIRM_DELAY_MS);
-    expect(stopSpy).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
 
-    await vi.advanceTimersByTimeAsync(
-      AUTO_STOP_BROWSER_CALENDAR_CONFIRM_DELAY_MS -
-        AUTO_STOP_BROWSER_CONFIRM_DELAY_MS,
+    expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(showNotificationMock).toHaveBeenCalledWith({
+      key: createAutoStopEndedNotificationKey("session-1"),
+      title: "Did your meeting end?",
+      message:
+        "Google Chrome stopped using the microphone before the scheduled end time.",
+      timeout: { secs: 60, nanos: 0 },
+      source: null,
+      start_time: null,
+      participants: null,
+      event_details: null,
+      action_label: "Stop recording",
+      options: null,
+      footer: null,
+      icon: { type: "bundle_id", bundle_id: "com.google.Chrome" },
+    });
+  });
+
+  test("auto-stops browser meetings inside the scheduled end window", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+    const endedAtMs = new Date("2026-05-19T10:30:00.000Z").getTime();
+    const now = new Date(
+      endedAtMs - AUTO_STOP_CALENDAR_EARLY_END_THRESHOLD_MS + 1,
     );
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["com.google.Chrome"]);
+    setStoreActive(store);
+    (useStoreMock as any).mockReturnValue(
+      mockSessionEventStore({
+        started_at: "2026-05-19T10:00:00.000Z",
+        ended_at: "2026-05-19T10:30:00.000Z",
+      }),
+    );
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    listMicUsingApplicationsMock.mockClear();
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "com.google.Chrome", name: "Google Chrome" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
 
     expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
     expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(showNotificationMock).not.toHaveBeenCalled();
   });
 
   test("cancels pending auto-stop when a browser trigger restarts", async () => {
@@ -510,7 +561,7 @@ describe("ListenerProvider detect events", () => {
       },
     });
 
-    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS - 1);
 
     handler({
       payload: {
@@ -521,9 +572,7 @@ describe("ListenerProvider detect events", () => {
       },
     });
 
-    await vi.advanceTimersByTimeAsync(
-      AUTO_STOP_BROWSER_CONFIRM_DELAY_MS - AUTO_STOP_CONFIRM_DELAY_MS,
-    );
+    await vi.advanceTimersByTimeAsync(1);
 
     expect(listMicUsingApplicationsMock).not.toHaveBeenCalled();
     expect(stopSpy).not.toHaveBeenCalled();

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -11,6 +11,8 @@ import {
   type NotificationIcon,
 } from "@hypr/plugin-notification";
 
+import { createAutoStopEndedNotificationKey } from "./auto-stop-notification";
+
 import { getSessionEventById } from "~/session/utils";
 import * as main from "~/store/tinybase/store/main";
 import * as settings from "~/store/tinybase/store/settings";
@@ -21,9 +23,7 @@ import {
 
 const ListenerContext = createContext<ListenerStore | null>(null);
 export const AUTO_STOP_CONFIRM_DELAY_MS = 5_000;
-export const AUTO_STOP_BROWSER_CONFIRM_DELAY_MS = 30_000;
-export const AUTO_STOP_BROWSER_CALENDAR_CONFIRM_DELAY_MS = 10 * 60_000;
-export const AUTO_STOP_CALENDAR_END_BUFFER_MS = 2 * 60_000;
+export const AUTO_STOP_CALENDAR_EARLY_END_THRESHOLD_MS = 3 * 60_000;
 export const AUTO_STOP_CALENDAR_EARLY_START_BUFFER_MS = 5 * 60_000;
 
 const BROWSER_MEETING_APP_IDS = new Set([
@@ -96,61 +96,88 @@ function parseEventTimeMs(value: string | undefined): number | null {
   return Number.isNaN(ms) ? null : ms;
 }
 
-function getCalendarAwareBrowserDelayMs({
+function shouldPromptBeforeAutoStopping({
+  appIds,
   tinybaseStore,
   sessionId,
   nowMs,
 }: {
+  appIds: string[];
   tinybaseStore: MainStore | null | undefined;
   sessionId: string | null;
   nowMs: number;
-}): number | null {
+}) {
+  if (!appIds.some((id) => BROWSER_MEETING_APP_IDS.has(id))) {
+    return false;
+  }
+
   if (!tinybaseStore || !sessionId) {
-    return null;
+    return false;
   }
 
   const event = getSessionEventById(tinybaseStore, sessionId);
   if (!event || event.is_all_day) {
-    return null;
+    return false;
   }
 
   const endMs = parseEventTimeMs(event.ended_at);
   if (!endMs) {
-    return null;
+    return false;
   }
 
   const startMs = parseEventTimeMs(event.started_at);
   if (startMs && nowMs < startMs - AUTO_STOP_CALENDAR_EARLY_START_BUFFER_MS) {
-    return null;
+    return false;
   }
 
-  const guardUntilMs = endMs + AUTO_STOP_CALENDAR_END_BUFFER_MS;
-  if (guardUntilMs <= nowMs) {
-    return null;
-  }
+  return nowMs < endMs - AUTO_STOP_CALENDAR_EARLY_END_THRESHOLD_MS;
+}
 
-  return Math.min(
-    Math.max(guardUntilMs - nowMs, AUTO_STOP_BROWSER_CONFIRM_DELAY_MS),
-    AUTO_STOP_BROWSER_CALENDAR_CONFIRM_DELAY_MS,
+function getPrimaryStoppedApp(
+  stoppedTriggerAppIds: string[],
+  stoppedApps: { id: string; name: string }[],
+) {
+  return (
+    stoppedApps.find(
+      (app) =>
+        stoppedTriggerAppIds.includes(app.id) &&
+        BROWSER_MEETING_APP_IDS.has(app.id),
+    ) ??
+    stoppedApps.find((app) => stoppedTriggerAppIds.includes(app.id)) ??
+    null
   );
 }
 
-function getAutoStopConfirmDelayMs(
-  appIds: string[],
-  options: {
-    tinybaseStore: MainStore | null | undefined;
-    sessionId: string | null;
-    nowMs: number;
-  },
-) {
-  if (!appIds.some((id) => BROWSER_MEETING_APP_IDS.has(id))) {
-    return AUTO_STOP_CONFIRM_DELAY_MS;
-  }
+function getStoppedAppLabel(app: { name: string } | null) {
+  const name = app?.name.trim();
+  return name || "The meeting app";
+}
 
-  return (
-    getCalendarAwareBrowserDelayMs(options) ??
-    AUTO_STOP_BROWSER_CONFIRM_DELAY_MS
-  );
+function showMeetingEndedPrompt({
+  sessionId,
+  stoppedTriggerAppIds,
+  stoppedApps,
+}: {
+  sessionId: string;
+  stoppedTriggerAppIds: string[];
+  stoppedApps: { id: string; name: string }[];
+}) {
+  const app = getPrimaryStoppedApp(stoppedTriggerAppIds, stoppedApps);
+
+  void notificationCommands.showNotification({
+    key: createAutoStopEndedNotificationKey(sessionId),
+    title: "Did your meeting end?",
+    message: `${getStoppedAppLabel(app)} stopped using the microphone before the scheduled end time.`,
+    timeout: { secs: 60, nanos: 0 },
+    source: null,
+    start_time: null,
+    participants: null,
+    event_details: null,
+    action_label: "Stop recording",
+    options: null,
+    footer: null,
+    icon: app ? getNotificationIconForAppId(app.id) : null,
+  });
 }
 
 export const ListenerProvider = ({
@@ -240,12 +267,16 @@ const useHandleDetectEvents = (store: ListenerStore) => {
       }
     };
 
-    const confirmAutoStop = async (stoppedTriggerAppIds: string[]) => {
-      if (store.getState().live.status !== "active") {
+    const confirmAutoStop = async (
+      stoppedTriggerAppIds: string[],
+      stoppedApps: { id: string; name: string }[],
+    ) => {
+      const live = store.getState().live;
+      if (live.status !== "active") {
         return;
       }
 
-      const currentTrigger = store.getState().live.triggerAppIds;
+      const currentTrigger = live.triggerAppIds;
       if (
         !currentTrigger ||
         !stoppedTriggerAppIds.some((id) => currentTrigger.includes(id))
@@ -259,6 +290,25 @@ const useHandleDetectEvents = (store: ListenerStore) => {
         if (stoppedTriggerAppIds.some((id) => activeAppIds.has(id))) {
           return;
         }
+      }
+
+      const sessionId = store.getState().live.sessionId;
+      if (
+        shouldPromptBeforeAutoStopping({
+          appIds: stoppedTriggerAppIds,
+          tinybaseStore: tinybaseStoreRef.current,
+          sessionId,
+          nowMs: Date.now(),
+        })
+      ) {
+        if (sessionId) {
+          showMeetingEndedPrompt({
+            sessionId,
+            stoppedTriggerAppIds,
+            stoppedApps,
+          });
+        }
+        return;
       }
 
       stop();
@@ -332,19 +382,11 @@ const useHandleDetectEvents = (store: ListenerStore) => {
             ) ?? [];
           if (stoppedTriggerAppIds.length > 0) {
             clearPendingAutoStop();
-            const confirmDelayMs = getAutoStopConfirmDelayMs(
-              stoppedTriggerAppIds,
-              {
-                tinybaseStore: tinybaseStoreRef.current,
-                sessionId: store.getState().live.sessionId,
-                nowMs: Date.now(),
-              },
-            );
 
             pendingAutoStopRef.current = setTimeout(() => {
               pendingAutoStopRef.current = null;
-              void confirmAutoStop(stoppedTriggerAppIds);
-            }, confirmDelayMs);
+              void confirmAutoStop(stoppedTriggerAppIds, payload.apps);
+            }, AUTO_STOP_CONFIRM_DELAY_MS);
           }
         } else if (payload.type === "sleepStateChanged") {
           if (payload.value) {


### PR DESCRIPTION
Keep auto-stop confirmation at five seconds and ask users before stopping browser meetings that drop well before the scheduled end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-stop behavior for browser-triggered sessions and adds a notification-driven stop path, which could alter when recordings stop or continue if the new prompt logic misfires or notifications aren’t handled as expected.
> 
> **Overview**
> Updates STT auto-stop for browser-based meetings to keep the *5s confirmation delay* but **prompt the user instead of auto-stopping** when mic usage ends well before the scheduled calendar end (using a new `AUTO_STOP_CALENDAR_EARLY_END_THRESHOLD_MS` window).
> 
> Introduces a dedicated auto-stop notification key format (`auto-stop-ended:`), adds devtool support to trigger the prompt, and extends `EventListeners` to intercept these notifications so **Accept stops the active session** while **Confirm/body clicks are ignored**, with tests covering the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2af4cf912549a1ccf777d6e5c32546d7dc8bce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->