### PR TITLE
fix(devtools): add auto-stop confirmation notification

### DIFF
--- a/apps/desktop/src/sidebar/devtool.tsx
+++ b/apps/desktop/src/sidebar/devtool.tsx
@@ -13,7 +13,9 @@ import { TrialStartedDialog } from "~/billing/trial-started-dialog";
 import { getLatestVersion } from "~/changelog";
 import * as main from "~/store/tinybase/store/main";
 import { showBatchCompletedNotification } from "~/store/zustand/listener/general-batch";
+import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
+import { createAutoStopEndedNotificationKey } from "~/stt/auto-stop-notification";
 import { commands } from "~/types/tauri.gen";
 
 export function DevtoolView() {
@@ -302,6 +304,28 @@ function NotificationsCard() {
     });
   }, []);
 
+  const showAutoStopConfirmationNotification = useCallback(async () => {
+    const sessionId =
+      listenerStore.getState().live.sessionId ??
+      `devtool-${crypto.randomUUID()}`;
+
+    await notificationCommands.showNotification({
+      key: createAutoStopEndedNotificationKey(sessionId),
+      title: "Did your meeting end?",
+      message:
+        "Google Chrome stopped using the microphone before the scheduled end time.",
+      timeout: { secs: 60, nanos: 0 },
+      source: null,
+      start_time: null,
+      participants: null,
+      event_details: null,
+      action_label: "Stop recording",
+      options: null,
+      footer: null,
+      icon: { type: "bundle_id", bundle_id: "com.google.Chrome" },
+    });
+  }, []);
+
   const showBatchNotification = useCallback(async () => {
     await showBatchCompletedNotification("devtool", { force: true });
   }, []);
@@ -341,6 +365,13 @@ function NotificationsCard() {
           className={btnClass}
         >
           Mic detected with options
+        </button>
+        <button
+          type="button"
+          onClick={() => void showAutoStopConfirmationNotification()}
+          className={btnClass}
+        >
+          Auto-stop confirmation
         </button>
         <button
           type="button"


### PR DESCRIPTION
Add a devtools button that previews the meeting-ended auto-stop prompt and uses the active live session when available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-stop behavior for browser-triggered sessions and wires notification actions to stop active recordings, which could affect when sessions stop or when notes open. Also adds new OS-notification paths (auto-stop + batch complete) gated by window focus/visibility.
> 
> **Overview**
> **Auto-stop confirmation prompt:** When a browser meeting’s mic stops *well before* the scheduled calendar end, the listener now shows a “Did your meeting end?” notification instead of immediately stopping, using a new `auto-stop-ended:` notification key helper.
> 
> **Notification action handling:** `EventListeners` now detects `notification_confirm`/`notification_accept` for the auto-stop prompt and stops the matching active session (and avoids opening notes for stale prompts).
> 
> **Devtools & batch notifications:** Devtools gains a Notifications panel to trigger calendar/mic/auto-stop/batch-complete notifications and clear them. Batch transcription now optionally shows a completion notification when the window is not focused/visible (with tests updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab67f2224a25b72543745b95118cd0d5b9f1c319. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->