### PR TITLE
fix(ui): tune floating session buttons

### DIFF
--- a/apps/desktop/src/session/components/floating/listen.tsx
+++ b/apps/desktop/src/session/components/floating/listen.tsx
@@ -100,7 +100,7 @@ function RemoteMeetingButton({ remote }: { remote: RemoteMeeting }) {
   return (
     <FloatingButton
       onClick={handleJoin}
-      className="h-10 justify-center gap-2 border-neutral-200 bg-white px-3 text-neutral-800 shadow-[0_4px_14px_rgba(0,0,0,0.1)] hover:bg-neutral-100 lg:px-4"
+      className="h-10 justify-center gap-2 border-neutral-200 bg-white px-4 text-neutral-800 shadow-[0_4px_14px_rgba(0,0,0,0.1)] hover:bg-neutral-100"
     >
       <span>Join</span>
       {icon}

--- a/apps/desktop/src/session/components/listen-action.tsx
+++ b/apps/desktop/src/session/components/listen-action.tsx
@@ -48,7 +48,7 @@ export function ListenActionButton({ sessionId }: { sessionId: string }) {
         <FloatingButton
           onClick={startListening}
           disabled={isDisabled}
-          className="justify-center gap-2 border-stone-600 bg-stone-800 pr-8 pl-3 text-white shadow-[0_4px_14px_rgba(87,83,78,0.4)] hover:bg-stone-700 lg:pr-10 lg:pl-4"
+          className="w-[148px] justify-start gap-2 border-stone-600 bg-stone-800 pr-7 pl-3 text-white shadow-[0_4px_14px_rgba(87,83,78,0.4)] hover:bg-stone-700"
           tooltip={
             warningMessage
               ? {
@@ -66,7 +66,7 @@ export function ListenActionButton({ sessionId }: { sessionId: string }) {
               : undefined
           }
         >
-          <span className="flex items-center gap-2 pl-3">
+          <span className="flex items-center gap-1.5">
             <RecordingIcon /> Start listening
           </span>
         </FloatingButton>


### PR DESCRIPTION
Constrain the start listening action to 148px and add consistent horizontal padding to the remote meeting join action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational Tailwind class tweaks to the floating session buttons; low risk aside from potential minor layout regressions across breakpoints.
> 
> **Overview**
> Tightens layout of the floating session controls by **standardizing button sizing/padding**.
> 
> The *Start listening* action is now constrained to a fixed `148px` width with adjusted alignment/padding, and the remote meeting *Join* button gets consistent horizontal padding (removing breakpoint-specific padding overrides).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e9bd71a2ea9d5697f9938d5ea2ab1de30268dc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->