### PR TITLE
fix(ui): pad open calendar button

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -371,6 +371,7 @@ export function TimelineView() {
                 "rounded-full bg-white hover:bg-neutral-50",
                 "border border-neutral-200 text-neutral-700",
                 "flex items-center gap-1",
+                "px-3",
                 "shadow-xs",
               ])}
               variant="outline"


### PR DESCRIPTION
Add explicit horizontal padding to the floating open calendar action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI styling tweak that adds horizontal padding to the "Open calendar" floating action; no behavioral or data-flow changes.
> 
> **Overview**
> Adds explicit horizontal padding (`px-3`) to the floating **Open calendar** button in the timeline sidebar so its pill-style button has consistent spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56eff62bba0a1c00f12295b6f406dde28ccaed3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->