### PR TITLE
fix(api): keep production billing on live Stripe

### DIFF
--- a/.github/workflows/api_cd.yaml
+++ b/.github/workflows/api_cd.yaml
@@ -1,6 +1,9 @@
 on:
   workflow_dispatch:
 
+env:
+  INFISICAL_ENV: prod
+
 jobs:
   compute-version:
     runs-on: ubuntu-latest
@@ -37,7 +40,7 @@ jobs:
 
           infisical export \
             --token="$INFISICAL_TOKEN" \
-            --env=dev \
+            --env="$INFISICAL_ENV" \
             --projectId="$INFISICAL_PROJECT_ID" \
             --path="/ai" \
             --format=json \

--- a/apps/api/src/env.rs
+++ b/apps/api/src/env.rs
@@ -60,8 +60,21 @@ pub fn env() -> &'static Env {
 
         let _ = dotenvy::from_path(repo_root.join(".env.supabase"));
         let _ = dotenvy::from_path(manifest_dir.join(".env"));
-        envy::from_env().unwrap_or_else(|error| panic!("{}", format_env_error(error)))
+        let env: Env =
+            envy::from_env().unwrap_or_else(|error| panic!("{}", format_env_error(error)));
+        validate_env(&env);
+        env
     })
+}
+
+fn validate_env(env: &Env) {
+    if !cfg!(debug_assertions) && is_stripe_test_key(&env.stripe.stripe_secret_key) {
+        panic!("Failed to load environment: STRIPE_SECRET_KEY must be a live key in production");
+    }
+}
+
+fn is_stripe_test_key(key: &str) -> bool {
+    key.starts_with("sk_test_") || key.starts_with("rk_test_")
 }
 
 fn format_env_error(error: EnvyError) -> String {


### PR DESCRIPTION
Use prod Infisical secrets for API deploys and reject Stripe test keys during release startup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes production deployment secret sourcing and introduces a startup hard-fail when a Stripe test key is detected, which could block releases if misconfigured.
> 
> **Overview**
> API deploys now export secrets from Infisical using a workflow-level `INFISICAL_ENV=prod` instead of hardcoding `dev`, ensuring Fly secrets come from the production environment.
> 
> At API startup, `apps/api/src/env.rs` now validates the loaded env and **panics in non-debug builds** if `STRIPE_SECRET_KEY` looks like a test key (`sk_test_`/`rk_test_`), preventing accidental production billing against Stripe test credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8a92f72161558ca8a8df7161d9ed2aed13fb975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->