### PR TITLE
fix(stt): stabilize Soniqo German transcription

### DIFF
--- a/apps/desktop/src/store/zustand/listener/batch.ts
+++ b/apps/desktop/src/store/zustand/listener/batch.ts
@@ -64,6 +64,8 @@ export type BatchActions = {
 
 export const EMPTY_BATCH_TRANSCRIPT_ERROR =
   "No speech was detected in the audio.";
+const SYNTHETIC_TEXT_WORD_SECONDS = 0.4;
+const MIN_SYNTHETIC_TEXT_WORD_SECONDS = 0.05;
 
 export const createBatchSlice = <T extends BatchState>(
   set: StoreApi<T>["setState"],
@@ -149,11 +151,11 @@ export const createBatchSlice = <T extends BatchState>(
       wordsByChannel: {},
       hintsByChannel: {},
     };
-    const nextPreview = mergeBatchPreview(currentPreview, event);
     const persist = get().batchPersist[sessionId];
-    const [words, hints] = flattenBatchPreview(nextPreview);
+    const result = batchPreviewResult(currentPreview, event);
+    const { nextPreview, words, hints } = result;
 
-    if (event.type === "segment" && words.length > 0) {
+    if (result.shouldPersist && words.length > 0) {
       persist?.(words, hints, { mode: "replace" });
     }
 
@@ -285,6 +287,42 @@ export const createBatchSlice = <T extends BatchState>(
   },
 });
 
+function batchPreviewResult(
+  currentPreview: {
+    wordsByChannel: Record<number, WordLike[]>;
+    hintsByChannel: Record<number, RuntimeSpeakerHint[]>;
+  },
+  event: BatchStreamEvent,
+): {
+  nextPreview: {
+    wordsByChannel: Record<number, WordLike[]>;
+    hintsByChannel: Record<number, RuntimeSpeakerHint[]>;
+  };
+  words: WordLike[];
+  hints: RuntimeSpeakerHint[];
+  shouldPersist: boolean;
+} {
+  if (event.type === "result") {
+    const [words, hints] = transformBatch(event.response);
+    return {
+      nextPreview: batchPreviewFromWords(words, hints),
+      words,
+      hints,
+      shouldPersist: true,
+    };
+  }
+
+  const nextPreview = mergeBatchPreview(currentPreview, event);
+  const [words, hints] = flattenBatchPreview(nextPreview);
+
+  return {
+    nextPreview,
+    words,
+    hints,
+    shouldPersist: event.type === "segment",
+  };
+}
+
 function transformBatch(
   response: BatchResponse,
 ): [WordLike[], RuntimeSpeakerHint[]] {
@@ -359,6 +397,49 @@ function flattenBatchPreview(preview: {
     });
 
   return [allWords, allHints];
+}
+
+function batchPreviewFromWords(
+  words: WordLike[],
+  hints: RuntimeSpeakerHint[],
+): {
+  wordsByChannel: Record<number, WordLike[]>;
+  hintsByChannel: Record<number, RuntimeSpeakerHint[]>;
+} {
+  const wordsByChannel: Record<number, WordLike[]> = {};
+  const hintsByChannel: Record<number, RuntimeSpeakerHint[]> = {};
+  const channelIndexByWordIndex = new Map<
+    number,
+    { channel: number; wordIndex: number }
+  >();
+
+  words.forEach((word, wordIndex) => {
+    const channelWords = wordsByChannel[word.channel] ?? [];
+    if (!(word.channel in wordsByChannel)) {
+      wordsByChannel[word.channel] = channelWords;
+      hintsByChannel[word.channel] = [];
+    }
+
+    channelIndexByWordIndex.set(wordIndex, {
+      channel: word.channel,
+      wordIndex: channelWords.length,
+    });
+    channelWords.push(word);
+  });
+
+  hints.forEach((hint) => {
+    const target = channelIndexByWordIndex.get(hint.wordIndex);
+    if (!target) {
+      return;
+    }
+
+    hintsByChannel[target.channel]!.push({
+      ...hint,
+      wordIndex: target.wordIndex,
+    });
+  });
+
+  return { wordsByChannel, hintsByChannel };
 }
 
 function mergeBatchPreview(
@@ -515,12 +596,15 @@ function wordEntriesFromTranscript(
     return [];
   }
 
-  const duration = Math.max(
-    durationSeconds && Number.isFinite(durationSeconds)
-      ? durationSeconds
-      : tokens.length * 0.4,
-    tokens.length * 0.05,
-  );
+  const duration =
+    timingSource === "synthetic_text"
+      ? tokens.length * SYNTHETIC_TEXT_WORD_SECONDS
+      : Math.max(
+          durationSeconds && Number.isFinite(durationSeconds)
+            ? durationSeconds
+            : tokens.length * SYNTHETIC_TEXT_WORD_SECONDS,
+          tokens.length * MIN_SYNTHETIC_TEXT_WORD_SECONDS,
+        );
 
   return tokens.map((token, index) => ({
     word: token,

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -237,7 +237,7 @@ describe("General Listener Slice", () => {
 
       expect(
         handleBatchResponse(sessionId, {
-          metadata: { duration: 2, timing_source: "provider_word" },
+          metadata: { duration: 120, timing_source: "provider_word" },
           results: {
             channels: [
               {
@@ -259,7 +259,7 @@ describe("General Listener Slice", () => {
           {
             text: " hello",
             start_ms: 0,
-            end_ms: 1000,
+            end_ms: 400,
             channel: 0,
             metadata: {
               timing: {
@@ -269,8 +269,8 @@ describe("General Listener Slice", () => {
           },
           {
             text: " world",
-            start_ms: 1000,
-            end_ms: 2000,
+            start_ms: 400,
+            end_ms: 800,
             channel: 0,
             metadata: {
               timing: {
@@ -283,6 +283,111 @@ describe("General Listener Slice", () => {
         { mode: "replace" },
       );
       expect(store.getState().batch[sessionId]).toBeUndefined();
+    });
+
+    test("handleBatchResponseStreamed replaces preview with transcript-only result", () => {
+      const sessionId = "session-transcript-only-result";
+      const persist = vi.fn();
+      const { handleBatchResponseStreamed, setBatchPersist } = store.getState();
+
+      setBatchPersist(sessionId, persist);
+
+      handleBatchResponseStreamed(sessionId, {
+        type: "segment",
+        percentage: 0.5,
+        response: {
+          type: "Results",
+          start: 0,
+          duration: 120,
+          is_final: true,
+          speech_final: true,
+          from_finalize: false,
+          channel: {
+            alternatives: [
+              {
+                transcript: "partial",
+                languages: [],
+                words: [],
+                confidence: 0.9,
+              },
+            ],
+          },
+          metadata: {
+            request_id: "test-request",
+            model_info: {
+              name: "test-model",
+              version: "1.0",
+              arch: "test-arch",
+            },
+            model_uuid: "test-uuid",
+          },
+          channel_index: [0],
+        },
+      });
+
+      handleBatchResponseStreamed(sessionId, {
+        type: "result",
+        response: {
+          metadata: { duration: 120, timing_source: "synthetic_text" },
+          results: {
+            channels: [
+              {
+                alternatives: [
+                  {
+                    transcript: "final transcript survived",
+                    confidence: 0.9,
+                    words: [],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      });
+
+      const finalWords = [
+        {
+          text: " final",
+          start_ms: 0,
+          end_ms: 400,
+          channel: 0,
+          metadata: {
+            timing: {
+              source: "synthetic_text",
+            },
+          },
+        },
+        {
+          text: " transcript",
+          start_ms: 400,
+          end_ms: 800,
+          channel: 0,
+          metadata: {
+            timing: {
+              source: "synthetic_text",
+            },
+          },
+        },
+        {
+          text: " survived",
+          start_ms: 800,
+          end_ms: 1200,
+          channel: 0,
+          metadata: {
+            timing: {
+              source: "synthetic_text",
+            },
+          },
+        },
+      ];
+
+      expect(persist).toHaveBeenLastCalledWith(finalWords, [], {
+        mode: "replace",
+      });
+      expect(
+        store.getState().batchPreview[sessionId]?.wordsByChannel[0],
+      ).toEqual(finalWords);
+      expect(store.getState().batch[sessionId]?.isComplete).toBe(true);
     });
 
     test("handleBatchResponseStreamed persists transcript-only segment responses", () => {

--- a/apps/desktop/src/stt/capabilities.test.ts
+++ b/apps/desktop/src/stt/capabilities.test.ts
@@ -43,6 +43,12 @@ describe("getOnDeviceTranscriptionMode", () => {
       getOnDeviceTranscriptionMode("soniqo-parakeet-streaming", ["ko"]),
     ).toBe("batch");
   });
+
+  test("falls back to batch for non-English Soniqo streaming languages", () => {
+    expect(
+      getOnDeviceTranscriptionMode("soniqo-parakeet-streaming", ["de"]),
+    ).toBe("batch");
+  });
 });
 
 describe("getOnDeviceTranscriptionConfig", () => {
@@ -52,6 +58,15 @@ describe("getOnDeviceTranscriptionConfig", () => {
     ).toEqual({
       languages: ["en"],
       transcriptionMode: "live",
+    });
+  });
+
+  test("keeps German on batch even when English is an additional language", () => {
+    expect(
+      getOnDeviceTranscriptionConfig("soniqo-parakeet-streaming", ["de", "en"]),
+    ).toEqual({
+      languages: ["de", "en"],
+      transcriptionMode: "batch",
     });
   });
 });

--- a/apps/desktop/src/stt/capabilities.ts
+++ b/apps/desktop/src/stt/capabilities.ts
@@ -8,33 +8,7 @@ type LiveTranscriptionConfig = {
   transcriptionMode?: TranscriptionMode;
 };
 
-const SONIQO_PARAKEET_LANGUAGE_CODES = new Set([
-  "bg",
-  "cs",
-  "da",
-  "de",
-  "el",
-  "en",
-  "es",
-  "et",
-  "fi",
-  "fr",
-  "hr",
-  "hu",
-  "it",
-  "lt",
-  "lv",
-  "mt",
-  "nl",
-  "pl",
-  "pt",
-  "ro",
-  "ru",
-  "sk",
-  "sl",
-  "sv",
-  "uk",
-]);
+const SONIQO_STREAMING_LANGUAGE_CODES = new Set(["en"]);
 
 export function isRealtimeLocalModel(model?: string | null) {
   return model === "soniqo-parakeet-streaming";
@@ -97,8 +71,22 @@ export function getOnDeviceTranscriptionConfig(
     };
   }
 
+  const primaryLanguage = languages[0];
+  const primaryLanguageSupported =
+    !primaryLanguage ||
+    SONIQO_STREAMING_LANGUAGE_CODES.has(baseLanguageCode(primaryLanguage));
+
+  // The Soniqo streaming session API does not accept a language hint, so keep
+  // non-English primary languages on batch instead of relying on live auto-detect.
+  if (!primaryLanguageSupported) {
+    return {
+      languages: [...languages],
+      transcriptionMode: "batch",
+    };
+  }
+
   const supportedLiveLanguages = languages.filter((language) =>
-    SONIQO_PARAKEET_LANGUAGE_CODES.has(baseLanguageCode(language)),
+    SONIQO_STREAMING_LANGUAGE_CODES.has(baseLanguageCode(language)),
   );
 
   if (languages.length > 0 && supportedLiveLanguages.length === 0) {

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -4,6 +4,8 @@ use std::str::FromStr;
 use owhisper_interface::{batch, stream};
 
 pub const LOCAL_BASE_URL: &str = "soniqo://local";
+const SYNTHETIC_BATCH_WORD_SECONDS: f64 = 0.4;
+const MIN_SYNTHETIC_DURATION_SECONDS: f64 = 0.05;
 
 pub fn is_local_base_url(base_url: &str) -> bool {
     base_url.trim_end_matches('/') == LOCAL_BASE_URL
@@ -385,7 +387,8 @@ pub fn stream_response_from_text(
     is_final: bool,
     channel_index: &[i32],
 ) -> stream::StreamResponse {
-    let duration = duration.max(0.05);
+    let text = normalize_transcript_text(&text);
+    let duration = duration.max(MIN_SYNTHETIC_DURATION_SECONDS);
     let words = stream_words_from_text(&text, start, duration);
 
     stream::StreamResponse::TranscriptResponse {
@@ -446,15 +449,16 @@ pub fn batch_response_from_channels(
                 .into_iter()
                 .enumerate()
                 .map(|(channel_index, channel)| {
-                    let duration = channel.duration_seconds.max(0.05);
+                    let transcript = normalize_transcript_text(&channel.text);
+                    let synthetic_duration = synthetic_text_duration(&transcript);
                     batch::Channel {
                         alternatives: vec![batch::Alternatives {
                             words: batch_words_from_text(
-                                &channel.text,
-                                duration,
+                                &transcript,
+                                synthetic_duration,
                                 channel_index as i32,
                             ),
-                            transcript: channel.text,
+                            transcript,
                             confidence: 1.0,
                         }],
                     }
@@ -481,6 +485,10 @@ fn metadata_json(model: SoniqoModel, duration_seconds: f64, channels: u32) -> se
     if let Some(object) = value.as_object_mut() {
         object.insert("duration".to_string(), serde_json::json!(duration_seconds));
         object.insert("channels".to_string(), serde_json::json!(channels));
+        object.insert(
+            "timing_source".to_string(),
+            serde_json::json!("synthetic_text"),
+        );
     }
     value
 }
@@ -544,6 +552,19 @@ fn split_words(text: &str) -> Vec<&str> {
     text.split_whitespace()
         .filter(|word| !word.is_empty())
         .collect()
+}
+
+fn normalize_transcript_text(text: &str) -> String {
+    split_words(text).join(" ")
+}
+
+fn synthetic_text_duration(text: &str) -> f64 {
+    let word_count = split_words(text).len();
+    if word_count == 0 {
+        MIN_SYNTHETIC_DURATION_SECONDS
+    } else {
+        (word_count as f64 * SYNTHETIC_BATCH_WORD_SECONDS).max(MIN_SYNTHETIC_DURATION_SECONDS)
+    }
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -850,6 +871,7 @@ mod tests {
         assert_eq!(response.results.channels[0].alternatives[0].words.len(), 2);
         assert_eq!(response.metadata["model_info"]["arch"], "soniqo");
         assert_eq!(response.metadata["duration"], 2.0);
+        assert_eq!(response.metadata["timing_source"], "synthetic_text");
     }
 
     #[test]
@@ -886,6 +908,42 @@ mod tests {
         assert_eq!(
             response.results.channels[1].alternatives[0].words[0].channel,
             1
+        );
+    }
+
+    #[test]
+    fn batch_response_uses_compact_synthetic_word_timing() {
+        let response = batch_response_from_text(
+            SoniqoModel::ParakeetBatch,
+            "one two three four".to_string(),
+            120.0,
+        );
+        let words = &response.results.channels[0].alternatives[0].words;
+
+        assert_eq!(words[0].start, 0.0);
+        assert_eq!(words[0].end, SYNTHETIC_BATCH_WORD_SECONDS);
+        assert_eq!(words[3].end, 4.0 * SYNTHETIC_BATCH_WORD_SECONDS);
+        assert!(words[3].end < 3.0);
+        assert_eq!(response.metadata["duration"], 120.0);
+    }
+
+    #[test]
+    fn batch_response_normalizes_internal_whitespace() {
+        let response = batch_response_from_text(
+            SoniqoModel::ParakeetBatch,
+            "eins zwei\n drei\tvier".to_string(),
+            4.0,
+        );
+        let alternative = &response.results.channels[0].alternatives[0];
+
+        assert_eq!(alternative.transcript, "eins zwei drei vier");
+        assert_eq!(
+            alternative
+                .words
+                .iter()
+                .map(|word| word.word.as_str())
+                .collect::<Vec<_>>(),
+            vec!["eins", "zwei", "drei", "vier"]
         );
     }
 


### PR DESCRIPTION
Use compact synthetic timing for Soniqo batch responses and keep non-English Soniqo sessions on batch mode because live cannot force a language hint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transcription mode selection and synthetic word-timing generation for Soniqo, which can affect output timing/preview behavior and when sessions run live vs batch.
> 
> **Overview**
> Stabilizes Soniqo non-English (e.g. German) behavior by **forcing `soniqo-parakeet-streaming` to run live only when the primary language is English**, otherwise keeping the session in `batch` even if English is also selected.
> 
> Tightens handling of transcript-only results by generating **compact synthetic word timings** (fixed per-word duration) and ensuring final `result` events replace the streamed preview; the Soniqo Rust bridge now normalizes transcript whitespace, emits `timing_source: "synthetic_text"`, and derives batch word timestamps from text length rather than the full audio duration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a68dfeb89c6d3ed308f37fda87ad2f69a6904675. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->