### PR TITLE
chore(ui): use system sans fonts

### DIFF
--- a/apps/desktop/src/contacts/shared.tsx
+++ b/apps/desktop/src/contacts/shared.tsx
@@ -113,7 +113,7 @@ export function ColumnHeader({
   return (
     <div className="@container">
       <div className="flex h-12 min-w-0 items-center justify-between py-2 pr-1 pl-3">
-        <h3 className="font-serif text-sm font-medium select-none">{title}</h3>
+        <h3 className="font-sans text-sm font-medium select-none">{title}</h3>
         <div className="flex shrink-0 items-center">
           {sortOption && setSortOption && (
             <div className="hidden @[220px]:block">

--- a/apps/desktop/src/instruction/index.tsx
+++ b/apps/desktop/src/instruction/index.tsx
@@ -74,7 +74,7 @@ function InstructionShell({
             <div className="text-[10px] font-medium tracking-[0.22em] text-stone-400 uppercase">
               Browser step required
             </div>
-            <h2 className="font-serif text-[22px] leading-[1.15] font-semibold text-stone-900 sm:text-[28px]">
+            <h2 className="font-sans text-[22px] leading-[1.15] font-semibold text-stone-900 sm:text-[28px]">
               {title}
             </h2>
             <p className="text-sm leading-6 text-stone-500">{description}</p>

--- a/apps/desktop/src/onboarding/index.tsx
+++ b/apps/desktop/src/onboarding/index.tsx
@@ -214,7 +214,7 @@ function OnboardingScreenContent({
             headerClassName,
           ])}
         >
-          <h1 className="font-serif text-3xl font-semibold text-neutral-900">
+          <h1 className="font-sans text-3xl font-semibold text-neutral-900">
             Welcome to Anarlog
           </h1>
           <button

--- a/apps/desktop/src/onboarding/shared.tsx
+++ b/apps/desktop/src/onboarding/shared.tsx
@@ -75,7 +75,7 @@ export function OnboardingSection({
                 "transition-all duration-300",
                 isCompleted
                   ? "text-sm font-normal text-neutral-300"
-                  : "mb-2 font-serif text-2xl font-semibold text-neutral-900",
+                  : "mb-2 font-sans text-2xl font-semibold text-neutral-900",
               ])}
             >
               {isCompleted ? (completedTitle ?? title) : title}

--- a/apps/desktop/src/settings/ai/llm/configure.tsx
+++ b/apps/desktop/src/settings/ai/llm/configure.tsx
@@ -28,7 +28,7 @@ export function ConfigureProviders() {
 
   return (
     <div className="flex flex-col gap-3">
-      <h3 className="text-md font-serif font-semibold">Configure Providers</h3>
+      <h3 className="text-md font-sans font-semibold">Configure Providers</h3>
       <Accordion
         type="single"
         collapsible

--- a/apps/desktop/src/settings/ai/llm/select.tsx
+++ b/apps/desktop/src/settings/ai/llm/select.tsx
@@ -169,7 +169,7 @@ export function SelectProviderAndModel() {
 
   return (
     <div className="flex flex-col gap-3">
-      <h3 className="text-md font-serif font-semibold">Model being used</h3>
+      <h3 className="text-md font-sans font-semibold">Model being used</h3>
       <div
         className={cn([
           "flex flex-col gap-4",

--- a/apps/desktop/src/settings/ai/stt/configure.tsx
+++ b/apps/desktop/src/settings/ai/stt/configure.tsx
@@ -10,7 +10,7 @@ export function ConfigureProviders() {
 
   return (
     <div className="flex flex-col gap-3">
-      <h3 className="text-md font-serif font-semibold">Configure Providers</h3>
+      <h3 className="text-md font-sans font-semibold">Configure Providers</h3>
       <Accordion
         type="single"
         collapsible

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -139,7 +139,7 @@ export function SelectProviderAndModel() {
         </div>
       )}
 
-      <h3 className="text-md font-serif font-semibold">Model being used</h3>
+      <h3 className="text-md font-sans font-semibold">Model being used</h3>
       <div className="flex flex-row items-center gap-4">
         <div className="min-w-0 flex-2" data-stt-provider-selector>
           <Select

--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -93,7 +93,7 @@ export function SettingsAccount() {
       return (
         <div className="flex flex-col gap-8">
           <div>
-            <h2 className="mb-4 font-serif text-lg font-semibold">Account</h2>
+            <h2 className="mb-4 font-sans text-lg font-semibold">Account</h2>
             <Container
               title="Finish sign-in"
               description="Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
@@ -118,7 +118,7 @@ export function SettingsAccount() {
         <section className="pb-4">
           <div className="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex min-w-0 flex-1 flex-col gap-4">
-              <h2 className="font-serif text-lg font-semibold">Account</h2>
+              <h2 className="font-sans text-lg font-semibold">Account</h2>
               <div className="flex flex-col gap-2">
                 <h3 className="text-sm font-medium">Sign in to Anarlog</h3>
                 <div className="text-sm text-neutral-600">
@@ -150,7 +150,7 @@ export function SettingsAccount() {
   return (
     <div className="flex flex-col gap-8">
       <div>
-        <h2 className="mb-4 font-serif text-lg font-semibold">Account</h2>
+        <h2 className="mb-4 font-sans text-lg font-semibold">Account</h2>
         <Container
           title="Your Account"
           description={auth.session?.user.email ?? "Signed in"}
@@ -380,7 +380,7 @@ function PlanBillingSection({
   return (
     <div>
       <div className="mb-2 flex items-center justify-between">
-        <h2 className="font-serif text-lg font-semibold">Plan & Billing</h2>
+        <h2 className="font-sans text-lg font-semibold">Plan & Billing</h2>
         {isPaid && (
           <button
             type="button"
@@ -456,7 +456,7 @@ function GuestPlanSection({ onSignIn }: { onSignIn: () => Promise<void> }) {
   return (
     <section className="border-t border-neutral-100 pt-6">
       <div className="mb-4 flex flex-col gap-1">
-        <h2 className="font-serif text-lg font-semibold">Plans</h2>
+        <h2 className="font-sans text-lg font-semibold">Plans</h2>
         <p className="text-sm text-neutral-600">
           Compare Free, Lite, and Pro before you sign in.
         </p>
@@ -518,7 +518,7 @@ function PlanTierList({
                 ])}
               >
                 <div className="mb-2 flex items-center gap-2">
-                  <span className="font-serif text-base font-medium text-stone-800">
+                  <span className="font-sans text-base font-medium text-stone-800">
                     {tier.name}
                   </span>
                   {isCurrent && (
@@ -529,7 +529,7 @@ function PlanTierList({
                 </div>
 
                 <div className="mb-2">
-                  <span className="font-serif text-xl text-stone-700">
+                  <span className="font-sans text-xl text-stone-700">
                     {tier.price}
                   </span>
                   {tier.period && (

--- a/apps/desktop/src/settings/general/app-settings.tsx
+++ b/apps/desktop/src/settings/general/app-settings.tsx
@@ -24,7 +24,7 @@ export function AppSettingsView({
 }: AppSettingsViewProps) {
   return (
     <div>
-      <h2 className="mb-4 font-serif text-lg font-semibold">
+      <h2 className="mb-4 font-sans text-lg font-semibold">
         <Trans>App</Trans>
       </h2>
       <div className="flex flex-col gap-4">

--- a/apps/desktop/src/settings/general/audio.tsx
+++ b/apps/desktop/src/settings/general/audio.tsx
@@ -12,7 +12,7 @@ import { cn } from "@hypr/utils";
 export function Audio() {
   return (
     <div className="flex flex-col gap-6">
-      <h2 className="font-serif text-lg font-semibold">Audio</h2>
+      <h2 className="font-sans text-lg font-semibold">Audio</h2>
       <div className="flex flex-col gap-6">
         <DeviceList direction="input" />
         <DeviceList direction="output" />

--- a/apps/desktop/src/settings/general/index.tsx
+++ b/apps/desktop/src/settings/general/index.tsx
@@ -186,7 +186,7 @@ export function SettingsApp() {
       </form.Field>
 
       <div>
-        <h2 className="mb-4 font-serif text-lg font-semibold">
+        <h2 className="mb-4 font-sans text-lg font-semibold">
           <Trans>Language &amp; Region</Trans>
         </h2>
         <div className="flex flex-col gap-6">

--- a/apps/desktop/src/settings/general/permissions.tsx
+++ b/apps/desktop/src/settings/general/permissions.tsx
@@ -155,7 +155,7 @@ export function Permissions() {
 
   return (
     <div>
-      <h2 className="mb-6 font-serif text-lg font-semibold">Permissions</h2>
+      <h2 className="mb-6 font-sans text-lg font-semibold">Permissions</h2>
       <div className="flex flex-col gap-8">
         <PermissionGroup title="Audio">
           <PermissionRow

--- a/apps/desktop/src/settings/general/storage/index.tsx
+++ b/apps/desktop/src/settings/general/storage/index.tsx
@@ -93,7 +93,7 @@ export function StorageSettingsView() {
 
   return (
     <div>
-      <h2 className="mb-4 font-serif text-lg font-semibold">Storage</h2>
+      <h2 className="mb-4 font-sans text-lg font-semibold">Storage</h2>
       <div className="flex flex-col gap-3">
         <AudioRetentionRow />
         <StoragePathRow

--- a/apps/desktop/src/settings/integrations.tsx
+++ b/apps/desktop/src/settings/integrations.tsx
@@ -135,7 +135,7 @@ export function SettingsIntegrations() {
       <div>
         <div className="mb-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <h2 className="cursor-default font-serif font-semibold">
+            <h2 className="cursor-default font-sans font-semibold">
               Integrations
             </h2>
             <Badge variant="secondary" className="text-xs">

--- a/apps/desktop/src/settings/page-title.tsx
+++ b/apps/desktop/src/settings/page-title.tsx
@@ -1,3 +1,3 @@
 export function SettingsPageTitle({ title }: { title: string }) {
-  return <h2 className="font-serif text-lg font-semibold">{title}</h2>;
+  return <h2 className="font-sans text-lg font-semibold">{title}</h2>;
 }

--- a/apps/desktop/src/sidebar/calendar.tsx
+++ b/apps/desktop/src/sidebar/calendar.tsx
@@ -4,7 +4,7 @@ export function CalendarNav() {
   return (
     <div className="flex h-full flex-col overflow-hidden pb-2">
       <div className="flex h-12 shrink-0 items-center py-2 pr-1 pl-3">
-        <h3 className="font-serif text-sm font-medium">Calendar</h3>
+        <h3 className="font-sans text-sm font-medium">Calendar</h3>
       </div>
       <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto px-3">
         <CalendarSidebarContent />

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -101,7 +101,7 @@ export function SettingsNav() {
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">
       <div className="flex h-12 items-center py-2 pr-1 pl-3">
-        <h3 className="font-serif text-sm font-medium">Settings</h3>
+        <h3 className="font-sans text-sm font-medium">Settings</h3>
       </div>
       <div className="scrollbar-hide flex-1 overflow-y-auto">
         <div className="flex flex-col gap-4 pb-2">

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Lora:wght@400;500;600;700&display=swap")
-  layer(base);
 @import "./scrollbar.css" layer(base);
 @import "./scrollbar.utilities.css";
 
@@ -10,8 +8,8 @@
 @source "../../../../packages/tiptap/src";
 
 @theme {
-  --font-serif: Lora, Georgia, serif;
-  --font-sans: SF Pro, system-ui, -apple-system, sans-serif;
+  --font-sans:
+    system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 
   --animate-shimmer: shimmer 2s infinite;
   --animate-reveal-left: reveal-left 0.5s ease-out forwards;
@@ -102,36 +100,6 @@
   }
 }
 
-@layer base {
-  @font-face {
-    font-family: "SF Pro";
-    src: url("/fonts/SF-Pro-Text-Regular.otf") format("opentype");
-    font-weight: 400;
-    font-style: normal;
-  }
-
-  @font-face {
-    font-family: "SF Pro";
-    src: url("/fonts/SF-Pro-Text-Medium.otf") format("opentype");
-    font-weight: 500;
-    font-style: normal;
-  }
-
-  @font-face {
-    font-family: "SF Pro";
-    src: url("/fonts/SF-Pro-Text-Semibold.otf") format("opentype");
-    font-weight: 600;
-    font-style: normal;
-  }
-
-  @font-face {
-    font-family: "SF Pro";
-    src: url("/fonts/SF-Pro-Text-Bold.otf") format("opentype");
-    font-weight: 700;
-    font-style: normal;
-  }
-}
-
 @layer utilities {
   /* https://www.joshwcomeau.com/css/custom-css-reset/ */
 
@@ -202,6 +170,7 @@
     height: 100vh;
     width: 100vw;
     overflow-y: hidden;
+    font-family: var(--font-sans);
 
     user-select: none;
     overscroll-behavior: none;

--- a/apps/desktop/src/templates/template-sidebar.tsx
+++ b/apps/desktop/src/templates/template-sidebar.tsx
@@ -293,7 +293,7 @@ export function TemplatesSidebarContent({
     <div className="flex h-full w-full flex-col overflow-hidden">
       <div>
         <div className="flex h-12 items-center justify-between py-2 pr-1 pl-3">
-          <h3 className="font-serif text-sm font-medium">Templates</h3>
+          <h3 className="font-sans text-sm font-medium">Templates</h3>
           <div className="flex items-center">
             {userTemplates.length > 1 && (
               <DropdownMenu>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -23,11 +23,6 @@ interface RouterContext {
   queryClient: QueryClient;
 }
 
-const FONT_STYLESHEETS = [
-  "https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&family=Instrument+Serif:ital@1&family=Lora:wght@400;500;600;700&family=Patrick+Hand&display=swap",
-  "https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&display=swap",
-] as const;
-
 export const Route = createRootRouteWithContext<RouterContext>()({
   head: () => ({
     meta: [
@@ -109,15 +104,6 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
-        {FONT_STYLESHEETS.map((href) => (
-          <link key={href} rel="stylesheet" href={href} />
-        ))}
         <link rel="stylesheet" href={appCss} />
         <HeadContent />
       </head>

--- a/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
@@ -120,7 +120,7 @@ export function ConnectFlow() {
   return (
     <IntegrationPageLayout>
       <div className="flex flex-col gap-3">
-        <h1 className="font-serif text-3xl tracking-tight text-stone-700">
+        <h1 className="font-sans text-3xl tracking-tight text-stone-700">
           Connect {display.name}
         </h1>
         <p className="text-neutral-600">

--- a/apps/web/src/routes/_view/app/-integrations-disconnect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-disconnect-flow.tsx
@@ -80,7 +80,7 @@ export function DisconnectFlow() {
   return (
     <IntegrationPageLayout>
       <div className="flex flex-col gap-3">
-        <h1 className="font-serif text-3xl tracking-tight text-stone-700">
+        <h1 className="font-sans text-3xl tracking-tight text-stone-700">
           Disconnect {display.name}
         </h1>
         <p className="text-neutral-600">

--- a/apps/web/src/routes/_view/app/-integrations-upgrade-prompt.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-upgrade-prompt.tsx
@@ -21,7 +21,7 @@ export function UpgradePrompt({
     <IntegrationPageLayout>
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-center gap-2">
-          <h1 className="font-serif text-3xl tracking-tight text-stone-700">
+          <h1 className="font-sans text-3xl tracking-tight text-stone-700">
             {display.name}
           </h1>
           <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700">

--- a/apps/web/src/routes/_view/callback/billing.tsx
+++ b/apps/web/src/routes/_view/callback/billing.tsx
@@ -51,7 +51,7 @@ function Component() {
     <div className="flex min-h-screen items-center justify-center bg-linear-to-b from-white via-stone-50/20 to-white p-6">
       <div className="flex w-full max-w-md flex-col gap-8 text-center">
         <div className="flex flex-col gap-3">
-          <h1 className="font-serif text-3xl tracking-tight text-stone-700">
+          <h1 className="font-sans text-3xl tracking-tight text-stone-700">
             Returning to Anarlog
           </h1>
           <p className="text-neutral-600">

--- a/apps/web/src/routes/_view/callback/integration.tsx
+++ b/apps/web/src/routes/_view/callback/integration.tsx
@@ -109,7 +109,7 @@ function Component() {
       <div className="flex min-h-screen items-center justify-center p-6">
         <div className="flex w-full max-w-md flex-col gap-8 text-center">
           <div className="flex flex-col gap-3">
-            <h1 className="font-serif text-3xl tracking-tight text-stone-700">
+            <h1 className="font-sans text-3xl tracking-tight text-stone-700">
               {isSuccess ? "Connection successful" : "Connection failed"}
             </h1>
             <p className="text-neutral-600">

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -60,7 +60,7 @@ function Component() {
         </Link>
 
         <header className="pt-10 pb-12">
-          <h1 className="font-hand text-5xl leading-[1.02] font-semibold tracking-normal text-balance text-black md:text-7xl">
+          <h1 className="font-sans text-5xl leading-[1.02] font-semibold tracking-normal text-balance text-black md:text-7xl">
             {article.title}
           </h1>
           <div className="mt-6 flex items-center gap-2 text-sm text-[#756b5d]">
@@ -81,16 +81,16 @@ function Component() {
             aria-label="TLDR"
             className="mb-12 border-y border-[#eee8df] py-5"
           >
-            <p className="font-hand text-xl font-semibold tracking-normal text-[#756b5d]">
+            <p className="font-sans text-xl font-semibold tracking-normal text-[#756b5d]">
               TL;DR
             </p>
-            <p className="font-hand mt-3 text-2xl leading-8 font-semibold text-[#363029]">
+            <p className="mt-3 font-sans text-2xl leading-8 font-semibold text-[#363029]">
               {tldr}
             </p>
           </aside>
         )}
 
-        <article className="blog-prose prose prose-stone prose-headings:font-hand prose-headings:font-semibold prose-headings:text-[#756b5d] prose-p:text-[#363029] prose-a:text-[#181613] prose-a:underline hover:prose-a:text-[#4f4940] prose-strong:text-[#181613] prose-li:text-[#363029] prose-img:rounded-md prose-img:border prose-img:border-[#eee8df] max-w-none">
+        <article className="blog-prose prose prose-stone prose-headings:font-sans prose-headings:font-semibold prose-headings:text-[#756b5d] prose-p:text-[#363029] prose-a:text-[#181613] prose-a:underline hover:prose-a:text-[#4f4940] prose-strong:text-[#181613] prose-li:text-[#363029] prose-img:rounded-md prose-img:border prose-img:border-[#eee8df] max-w-none">
           <MDXContent code={article.mdx} components={mdxComponents} />
         </article>
       </div>

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -36,7 +36,7 @@ function Component() {
         </header>
 
         <section className="pt-24 pb-16 md:pt-32">
-          <h1 className="font-hand text-6xl leading-[0.98] font-semibold tracking-normal text-balance text-black md:text-8xl">
+          <h1 className="font-sans text-6xl leading-[0.98] font-semibold tracking-normal text-balance text-black md:text-8xl">
             Blog
           </h1>
           <p className="mt-6 max-w-2xl text-xl leading-9 text-[#363029]">
@@ -54,7 +54,7 @@ function Component() {
                 className="group block"
               >
                 <article className="grid gap-3 border-t border-[#eee8df] pt-6">
-                  <h2 className="font-hand text-3xl leading-[1.05] font-semibold tracking-normal text-balance text-[#756b5d] group-hover:text-[#4f4940]">
+                  <h2 className="font-sans text-3xl leading-[1.05] font-semibold tracking-normal text-balance text-[#756b5d] group-hover:text-[#4f4940]">
                     {article.title}
                   </h2>
                   {article.meta_description && (

--- a/apps/web/src/routes/changelog/$version.tsx
+++ b/apps/web/src/routes/changelog/$version.tsx
@@ -65,7 +65,7 @@ function Component() {
         </Link>
 
         <header className="pt-10 pb-12">
-          <h1 className="font-hand text-5xl leading-[1.02] font-semibold tracking-normal text-balance text-black md:text-7xl">
+          <h1 className="font-sans text-5xl leading-[1.02] font-semibold tracking-normal text-balance text-black md:text-7xl">
             v{entry.version}
           </h1>
           {entry.date && (

--- a/apps/web/src/routes/changelog/index.tsx
+++ b/apps/web/src/routes/changelog/index.tsx
@@ -33,7 +33,7 @@ function Component() {
         </header>
 
         <section className="pt-24 pb-16 md:pt-32">
-          <h1 className="font-hand text-6xl leading-[0.98] font-semibold tracking-normal text-balance text-black md:text-8xl">
+          <h1 className="font-sans text-6xl leading-[0.98] font-semibold tracking-normal text-balance text-black md:text-8xl">
             Changelog
           </h1>
           <p className="mt-6 max-w-2xl text-xl leading-9 text-[#363029]">
@@ -56,7 +56,7 @@ function Component() {
                       params={{ version: entry.version }}
                       className="group"
                     >
-                      <h2 className="font-hand text-4xl leading-none font-semibold tracking-normal text-[#756b5d] group-hover:text-[#4f4940]">
+                      <h2 className="font-sans text-4xl leading-none font-semibold tracking-normal text-[#756b5d] group-hover:text-[#4f4940]">
                         v{entry.version}
                       </h2>
                     </Link>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -147,7 +147,7 @@ function Component() {
           </header>
 
           <section className="pt-24 pb-16 md:pt-32">
-            <h1 className="font-hand max-w-3xl text-6xl leading-[0.98] font-semibold tracking-normal text-balance md:text-8xl">
+            <h1 className="max-w-3xl font-sans text-6xl leading-[0.98] font-semibold tracking-normal text-balance md:text-8xl">
               AI notepad for private meetings.
             </h1>
             <p className="mt-6 max-w-2xl text-xl leading-9 text-[#363029]">
@@ -175,7 +175,7 @@ function Component() {
           </section>
 
           <section className="py-10">
-            <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+            <h2 className="font-sans text-3xl leading-none font-semibold text-[#756b5d]">
               Why Anarlog exists
             </h2>
             <ul className="mt-6 grid gap-8">
@@ -194,7 +194,7 @@ function Component() {
           </section>
 
           <section id="manifesto" className="py-10">
-            <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+            <h2 className="font-sans text-3xl leading-none font-semibold text-[#756b5d]">
               Manifesto
             </h2>
             <div className="mt-7 max-w-3xl">
@@ -204,10 +204,10 @@ function Component() {
                 ))}
               </div>
               <div className="mt-10">
-                <p className="font-signature text-3xl leading-none font-normal">
+                <p className="font-sans text-3xl leading-none font-normal">
                   {manifestoLetter.at(-1)}
                 </p>
-                <p className="font-crisp-serif mt-5 text-base leading-none font-normal text-[#4f4940]">
+                <p className="mt-5 font-sans text-base leading-none font-normal text-[#4f4940]">
                   Fastrepl, Inc.
                 </p>
               </div>

--- a/apps/web/src/routes/reset-password.tsx
+++ b/apps/web/src/routes/reset-password.tsx
@@ -67,7 +67,7 @@ function Component() {
               ])}
             />
           </div>
-          <h1 className="mb-2 font-serif text-3xl text-stone-800">
+          <h1 className="mb-2 font-sans text-3xl text-stone-800">
             Reset your password
           </h1>
           <p className="text-sm text-neutral-500">

--- a/apps/web/src/routes/update-password.tsx
+++ b/apps/web/src/routes/update-password.tsx
@@ -90,7 +90,7 @@ function Component() {
               ])}
             />
           </div>
-          <h1 className="mb-2 font-serif text-3xl text-stone-800">
+          <h1 className="mb-2 font-sans text-3xl text-stone-800">
             Set new password
           </h1>
           <p className="text-sm text-neutral-500">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,59 +1,3 @@
-@font-face {
-  font-family: "Redaction";
-  src: url("/fonts/Redaction-Regular.otf") format("opentype");
-  font-weight: normal;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: "Redaction";
-  src: url("/fonts/Redaction35-Regular.otf") format("opentype");
-  font-weight: 350;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: "Redaction";
-  src: url("/fonts/Redaction70-Regular.otf") format("opentype");
-  font-weight: 700;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: "SF Pro";
-  src: url("/fonts/SF-Pro-Text-Regular.otf") format("opentype");
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: "SF Pro";
-  src: url("/fonts/SF-Pro-Text-Medium.otf") format("opentype");
-  font-weight: 500;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: "SF Pro";
-  src: url("/fonts/SF-Pro-Text-Semibold.otf") format("opentype");
-  font-weight: 600;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: "SF Pro";
-  src: url("/fonts/SF-Pro-Text-Bold.otf") format("opentype");
-  font-weight: 700;
-  font-style: normal;
-  font-display: swap;
-}
-
 @import "tailwindcss";
 @import "tailwind-scrollbar-hide/v4";
 @plugin "@tailwindcss/typography";
@@ -64,13 +8,11 @@
 
 @theme {
   /* ── Typography ──────────────────────────────── */
-  --font-sans: "Geist", system-ui, -apple-system, sans-serif;
-  --font-mono: "Geist Mono", ui-monospace, monospace;
-  --font-serif: "Fraunces", Georgia, serif;
-  --font-serif2: "Instrument Serif", serif;
-  --font-hand: "Caveat", cursive;
-  --font-signature: "Patrick Hand", cursive;
-  --font-crisp-serif: "Lora", Georgia, serif;
+  --font-sans:
+    system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono:
+    ui-monospace, "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono",
+    Menlo, monospace;
 
   /* ── Layout ──────────────────────────────────── */
   --breakpoint-laptop: 72rem;
@@ -188,7 +130,7 @@
 
   h1,
   h2 {
-    font-family: var(--font-mono);
+    font-family: var(--font-sans);
     font-weight: 500;
     letter-spacing: -0.02em;
     line-height: 1.3 !important;
@@ -215,7 +157,7 @@
   [type="button"],
   [type="submit"],
   [type="reset"] {
-    font-family: var(--font-mono);
+    font-family: var(--font-sans);
     cursor: pointer;
   }
 
@@ -501,7 +443,7 @@
   :where(h2):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   margin-top: 4rem;
   margin-bottom: 1.25rem;
-  font-family: var(--font-hand);
+  font-family: var(--font-sans);
   font-size: 2.25rem;
   font-weight: 600;
   line-height: 1.05 !important;
@@ -513,7 +455,7 @@
   :where(h3):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   margin-top: 3.5rem;
   margin-bottom: 1rem;
-  font-family: var(--font-hand);
+  font-family: var(--font-sans);
   font-size: 1.875rem;
   font-weight: 600;
   line-height: 1.05;
@@ -525,7 +467,7 @@
   :where(h4):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   margin-top: 2.5rem;
   margin-bottom: 0.75rem;
-  font-family: var(--font-hand);
+  font-family: var(--font-sans);
   font-size: 1.5rem;
   font-weight: 600;
   line-height: 1.1;

--- a/plugins/deeplink2/src/server/callback.html
+++ b/plugins/deeplink2/src/server/callback.html
@@ -9,7 +9,7 @@
 <body class="min-h-screen bg-gradient-to-b from-white via-stone-50 to-white flex items-center justify-center p-6">
   <div class="max-w-md w-full text-center flex flex-col gap-8">
     <div class="flex flex-col gap-3">
-      <h1 class="text-3xl font-serif tracking-tight text-stone-700">{{ title }}</h1>
+      <h1 class="text-3xl font-sans tracking-tight text-stone-700">{{ title }}</h1>
       <p class="text-neutral-600">{{ description }}</p>
     </div>
     {% if is_success %}


### PR DESCRIPTION
Remove serif and decorative web font loading, map app text to system sans, and update typography guidance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change that removes custom/remote font loading and re-points typography classes to system sans stacks; primary risk is minor visual/layout regressions from font metric differences.
> 
> **Overview**
> Standardizes typography across desktop and web UIs by switching headings and section titles from `font-serif`/decorative classes to `font-sans`.
> 
> Removes remote Google Fonts and local `@font-face` declarations (e.g., SF Pro/Redaction/Lora) and updates theme font variables/CSS defaults so the apps use system sans (and a system mono stack on web) for base rendering, including deeplink callback pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ba3acc681c4bf017fb27587d6de5573c7f8c6c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->