### PR TITLE
fix(billing): clarify free transcription after trial

### DIFF
--- a/apps/desktop/src/billing/trial-ended-dialog.tsx
+++ b/apps/desktop/src/billing/trial-ended-dialog.tsx
@@ -30,9 +30,10 @@ export function TrialEndedDialog({
             Your Pro trial has ended
           </DialogTitle>
           <DialogDescription className="max-w-[260px] text-center text-[13px] leading-[1.36] text-neutral-800">
-            You're back on the free plan. Your notes and recordings are safe —
-            you can still capture and edit them locally. Upgrade to Pro to keep
-            cloud AI, longer recordings, and premium templates.
+            You're back on the free plan. Your notes and recordings are safe.
+            You can keep using free local transcription forever, but it will be
+            significantly less accurate than Pro cloud transcription. Upgrade to
+            Pro to keep cloud AI, longer recordings, and premium templates.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="grid grid-cols-2 gap-2 px-4 pt-4 pb-4 sm:grid-cols-2 sm:justify-normal">


### PR DESCRIPTION
Update expired Pro trial modal copy to explain that free local transcription remains available with lower accuracy than Pro cloud transcription.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only update to the trial-ended modal; no logic, data handling, or billing flow changes, so risk is low.
> 
> **Overview**
> Updates the `TrialEndedDialog` expired-trial modal copy to clarify that users keep **free local transcription** after returning to the free plan, but it is *less accurate* than Pro’s cloud transcription, while still prompting an upgrade for cloud AI, longer recordings, and premium templates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 422b564625649c9bf22f136814832747dccd47c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->