### PR TITLE
chore(changelog): add desktop 1.0.29 notes

### DIFF
--- a/packages/changelog/content/1.0.29.md
+++ b/packages/changelog/content/1.0.29.md
@@ -1,0 +1,30 @@
+---
+date: "2026-05-23"
+summary: "Floating meeting controls, batch transcription notifications, non-English transcription, note creation, summary styling, account copy, and typography were improved."
+---
+
+## Meetings
+
+- Live sessions now have an always-on-top floating meeting panel, with a compact collapsed state and expanded tabs for quick meeting controls
+- Browser meeting auto-stop now asks before ending a recording when a meeting appears to drop well before its scheduled end
+- Floating session actions now have steadier sizing and padding, including start listening, remote meeting join, and open calendar controls
+
+## Transcription
+
+- Batch transcription now sends a desktop notification when it finishes while the app is hidden or unfocused
+- Batch completion notifications are more reliable across repeated runs, with unique notification keys for each completed session
+- Soniqo transcription is more stable for German and other non-English recordings, keeping those sessions on batch mode when live transcription cannot force a language hint
+- Multi-language Pro batch transcription now falls back to automatic language detection when the preferred provider is unavailable
+- Longer batch recordings can now finish more reliably thanks to longer provider polling and larger audio upload handling
+
+## Notes & Summaries
+
+- New blank notes now include you as a participant, which keeps note metadata consistent with meeting-backed sessions
+- Empty self-only notes still clean up automatically when they are no longer needed
+- Completed enhanced summaries now use the same heading scale as streaming summaries, keeping generated notes visually consistent
+
+## UI & Account
+
+- The app and website now use system sans fonts throughout, giving screens a cleaner and more native feel
+- The expired Pro trial dialog now explains that free local transcription remains available, with lower accuracy than Pro cloud transcription
+- A few developer-only startup warnings were cleaned up so the app opens the floating meeting panel more predictably


### PR DESCRIPTION
Summarize user-facing desktop changes for the next release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds a changelog entry and does not modify runtime code paths.
> 
> **Overview**
> Adds a new `packages/changelog/content/1.0.29.md` release note entry describing desktop improvements: **floating meeting controls** and safer browser meeting auto-stop prompts, **batch transcription** notifications/reliability and better non-English/multi-language handling, plus **notes/summary** metadata and styling tweaks.
> 
> Also notes **UI/account** copy updates (system sans typography, clearer expired trial messaging) and cleanup of developer-only startup warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 127ba395d1884aa22744688f8fb0cd13dc4a6fd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->