### PR TITLE
fix(storage): use Anarlog paths for fresh installs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,6 +4856,7 @@ dependencies = [
  "serde_json",
  "specta",
  "specta-typescript",
+ "storage",
  "strum 0.28.0",
  "supervisor",
  "tauri",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -89,6 +89,7 @@ hypr-audio-actual = { workspace = true }
 hypr-audio-mock = { workspace = true, optional = true }
 hypr-db-core = { workspace = true }
 hypr-host = { workspace = true }
+hypr-storage = { workspace = true }
 hypr-supervisor = { workspace = true }
 
 dirs = { workspace = true }

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -2,17 +2,13 @@ use std::sync::Arc;
 
 use hypr_db_core::Db;
 
-pub async fn open_desktop_db(identifier: &str) -> Arc<Db> {
-    let base = dirs::data_dir().expect("data_dir must be available");
+const DEV_BUNDLE_ID: &str = "com.hyprnote.dev";
+const DB_FILENAME: &str = "app.db";
 
-    let db_path = match identifier {
-        "com.hyprnote.dev" => None,
-        "com.hyprnote.stable" => Some(base.join("hyprnote")),
-        _ => Some(base.join(identifier)),
-    }
-    .map(|dir| {
+pub async fn open_desktop_db(identifier: &str) -> Arc<Db> {
+    let db_path = desktop_db_dir(identifier).map(|dir| {
         std::fs::create_dir_all(&dir).expect("failed to create app data dir");
-        dir.join("app.db")
+        dir.join(DB_FILENAME)
     });
 
     let db = tauri_plugin_db::open_app_db(db_path.as_deref())
@@ -20,4 +16,21 @@ pub async fn open_desktop_db(identifier: &str) -> Arc<Db> {
         .expect("failed to open app database");
 
     Arc::new(db)
+}
+
+fn desktop_db_dir(identifier: &str) -> Option<std::path::PathBuf> {
+    if identifier == DEV_BUNDLE_ID {
+        return None;
+    }
+
+    let data_dir = dirs::data_dir().expect("data_dir must be available");
+    let default_dir =
+        hypr_storage::global::compute_default_base(identifier).expect("data_dir must be available");
+    let identifier_dir = data_dir.join(identifier);
+
+    if identifier_dir.join(DB_FILENAME).is_file() && !default_dir.join(DB_FILENAME).is_file() {
+        Some(identifier_dir)
+    } else {
+        Some(default_dir)
+    }
 }

--- a/crates/storage/src/global.rs
+++ b/crates/storage/src/global.rs
@@ -1,6 +1,9 @@
 use std::path::{Path, PathBuf};
 
 pub const VAULT_CONFIG_FILENAME: &str = "global.json";
+const STAGING_BUNDLE_ID: &str = "com.hyprnote.staging";
+const RELEASE_APP_FOLDER: &str = "anarlog";
+const LEGACY_RELEASE_APP_FOLDER: &str = "hyprnote";
 
 pub fn compute_vault_config_path(base: &Path) -> PathBuf {
     base.join(VAULT_CONFIG_FILENAME)
@@ -8,27 +11,106 @@ pub fn compute_vault_config_path(base: &Path) -> PathBuf {
 
 pub fn compute_default_base(bundle_id: &str) -> Option<PathBuf> {
     let data_dir = dirs::data_dir()?;
-    let app_folder = resolve_app_folder(bundle_id);
+    let app_folder = resolve_app_folder(&data_dir, bundle_id, cfg!(debug_assertions));
     Some(data_dir.join(app_folder))
 }
 
-fn resolve_app_folder(bundle_id: &str) -> &str {
-    if cfg!(debug_assertions) || bundle_id == "com.hyprnote.staging" {
+fn resolve_app_folder<'a>(data_dir: &Path, bundle_id: &'a str, is_debug: bool) -> &'a str {
+    if is_debug || bundle_id == STAGING_BUNDLE_ID {
         bundle_id
+    } else if has_app_data(&data_dir.join(LEGACY_RELEASE_APP_FOLDER))
+        && !has_app_data(&data_dir.join(RELEASE_APP_FOLDER))
+    {
+        LEGACY_RELEASE_APP_FOLDER
     } else {
-        "hyprnote"
+        RELEASE_APP_FOLDER
     }
+}
+
+fn has_app_data(path: &Path) -> bool {
+    std::fs::read_dir(path)
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or_else(|_| path.exists())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn resolve_app_folder_uses_anarlog_for_new_stable_installs() {
+        let temp = tempdir().unwrap();
+
+        assert_eq!(
+            resolve_app_folder(temp.path(), "com.hyprnote.stable", false),
+            RELEASE_APP_FOLDER
+        );
+    }
+
+    #[test]
+    fn resolve_app_folder_keeps_legacy_stable_folder_when_it_has_data() {
+        let temp = tempdir().unwrap();
+        let legacy_base = temp.path().join(LEGACY_RELEASE_APP_FOLDER);
+        std::fs::create_dir_all(&legacy_base).unwrap();
+        std::fs::write(legacy_base.join("store.json"), "{}").unwrap();
+
+        assert_eq!(
+            resolve_app_folder(temp.path(), "com.hyprnote.stable", false),
+            LEGACY_RELEASE_APP_FOLDER
+        );
+    }
+
+    #[test]
+    fn resolve_app_folder_prefers_anarlog_when_new_folder_has_data() {
+        let temp = tempdir().unwrap();
+        let legacy_base = temp.path().join(LEGACY_RELEASE_APP_FOLDER);
+        let new_base = temp.path().join(RELEASE_APP_FOLDER);
+        std::fs::create_dir_all(&legacy_base).unwrap();
+        std::fs::create_dir_all(&new_base).unwrap();
+        std::fs::write(legacy_base.join("store.json"), "{}").unwrap();
+        std::fs::write(new_base.join("app.db"), "").unwrap();
+
+        assert_eq!(
+            resolve_app_folder(temp.path(), "com.hyprnote.stable", false),
+            RELEASE_APP_FOLDER
+        );
+    }
+
+    #[test]
+    fn resolve_app_folder_ignores_empty_legacy_stable_folder() {
+        let temp = tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join(LEGACY_RELEASE_APP_FOLDER)).unwrap();
+
+        assert_eq!(
+            resolve_app_folder(temp.path(), "com.hyprnote.stable", false),
+            RELEASE_APP_FOLDER
+        );
+    }
+
+    #[test]
+    fn resolve_app_folder_uses_anarlog_for_other_release_bundle_ids() {
+        let temp = tempdir().unwrap();
+
+        assert_eq!(
+            resolve_app_folder(temp.path(), "com.hyprnote.Hyprnote", false),
+            RELEASE_APP_FOLDER
+        );
+    }
 
     #[test]
     fn resolve_app_folder_returns_bundle_id_for_staging() {
         assert_eq!(
-            resolve_app_folder("com.hyprnote.staging"),
-            "com.hyprnote.staging"
+            resolve_app_folder(Path::new("/tmp"), STAGING_BUNDLE_ID, false),
+            STAGING_BUNDLE_ID
+        );
+    }
+
+    #[test]
+    fn resolve_app_folder_returns_bundle_id_in_debug_builds() {
+        assert_eq!(
+            resolve_app_folder(Path::new("/tmp"), "com.hyprnote.stable", true),
+            "com.hyprnote.stable"
         );
     }
 }


### PR DESCRIPTION
Default release storage to the Anarlog folder while keeping legacy Hyprnote folders and existing DB paths when data already exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the desktop app computes on-disk storage/database locations for release builds, which can affect data discovery and perceived “missing data” if edge cases aren’t covered. Added fallback checks and tests reduce but don’t eliminate migration/path-resolution risk.
> 
> **Overview**
> Updates desktop storage path resolution to default new release installs to the `anarlog` data directory while keeping existing users on legacy locations when data already exists.
> 
> `hypr_storage::global::compute_default_base` now chooses between `hyprnote` (legacy) and `anarlog` (new) based on whether either folder contains data, with new unit tests covering the selection logic; the desktop DB opener is updated to use this default and to fall back to an identifier-based DB path when an existing `app.db` is found there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a20bd2d6817017e7d5b15f3ea4ef04aeacc321f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->