### PR TITLE
fix(ui): stabilize transcript panel layout

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -185,6 +185,37 @@ describe("PostSessionAccessory", () => {
     expect(screen.queryByTestId("transcript")).toBeNull();
   });
 
+  it("keeps the audio timeline slot height stable between collapsed and expanded states", () => {
+    const { unmount } = render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio
+        hasTranscript
+        isTranscriptExpanded={false}
+      />,
+    );
+
+    const collapsedSlotClassName =
+      screen.getByTestId("timeline").parentElement?.className;
+    expect(collapsedSlotClassName).toContain("h-14");
+
+    unmount();
+
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio
+        hasTranscript
+        isTranscriptExpanded
+        fillHeight
+      />,
+    );
+
+    expect(screen.getByTestId("timeline").parentElement?.className).toBe(
+      collapsedSlotClassName,
+    );
+  });
+
   it("lets expanded transcript content fill the resizable bottom panel", () => {
     render(
       <PostSessionAccessory
@@ -200,6 +231,7 @@ describe("PostSessionAccessory", () => {
     expect(scrollArea?.className).toContain("flex-1");
     expect(scrollArea?.className).not.toContain("h-[300px]");
     expect(scrollArea?.parentElement?.className).toContain("flex-1");
+    expect(scrollArea?.parentElement?.className).toContain("min-h-[96px]");
   });
 
   it("shows transcript skeletons instead of duplicating batch progress in the body", () => {

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -50,24 +50,8 @@ export function PostSessionAccessory({
     return null;
   }
 
-  const shouldBalanceCollapsedTimeline =
-    !isTranscriptExpanded && Boolean(timeline);
-
   return (
-    <div
-      className={cn([
-        "flex min-h-0 flex-col",
-        fillHeight && "h-full",
-        isTranscriptExpanded && "gap-1",
-        shouldBalanceCollapsedTimeline && "relative -mt-[6px] pb-1",
-      ])}
-    >
-      {shouldBalanceCollapsedTimeline ? (
-        <div
-          aria-hidden
-          className="pointer-events-none absolute top-[-4px] right-0 left-0 h-px bg-neutral-50"
-        />
-      ) : null}
+    <div className={cn(["flex min-h-0 flex-col", fillHeight && "h-full"])}>
       {isTranscriptExpanded ? (
         <TranscriptPanel
           sessionId={sessionId}
@@ -78,8 +62,14 @@ export function PostSessionAccessory({
           fillHeight={fillHeight}
         />
       ) : null}
-      {timeline}
+      {timeline ? <TimelineSlot>{timeline}</TimelineSlot> : null}
     </div>
+  );
+}
+
+function TimelineSlot({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-14 w-full shrink-0 items-center">{children}</div>
   );
 }
 
@@ -534,8 +524,8 @@ function TranscriptCard({
   return (
     <div
       className={cn([
-        "overflow-hidden rounded-b-xl border-x border-b border-neutral-200 bg-white",
-        fillHeight && "flex min-h-0 flex-1 flex-col",
+        "min-h-[96px] overflow-hidden rounded-b-xl border-x border-b border-neutral-200 bg-white",
+        fillHeight && "flex flex-1 flex-col",
       ])}
     >
       {children}

--- a/apps/desktop/src/shared/main/index.test.tsx
+++ b/apps/desktop/src/shared/main/index.test.tsx
@@ -24,12 +24,13 @@ vi.mock("@hypr/ui/components/ui/resizable", async () => {
       { resize: (size: number) => void },
       {
         children: React.ReactNode;
+        className?: string;
         defaultSize?: number;
         maxSize?: number;
         minSize?: number;
       }
     >(function ResizablePanel(
-      { children, defaultSize, maxSize, minSize },
+      { children, className, defaultSize, maxSize, minSize },
       ref,
     ) {
       React.useImperativeHandle(ref, () => ({
@@ -39,6 +40,7 @@ vi.mock("@hypr/ui/components/ui/resizable", async () => {
       return (
         <div
           data-default-size={defaultSize}
+          data-class-name={className}
           data-max-size={maxSize}
           data-min-size={minSize}
           data-testid="panel"
@@ -94,8 +96,27 @@ describe("StandardTabWrapper", () => {
     const panels = screen.getAllByTestId("panel");
     expect(panels[0]?.dataset.defaultSize).toBe("78");
     expect(panels[1]?.dataset.defaultSize).toBe("22");
+    expect(panels[1]?.dataset.className).toContain("min-h-[96px]");
     expect(panels[1]?.dataset.maxSize).toBe("60");
     expect(resizeMock).toHaveBeenCalledWith(22);
+  });
+
+  it("removes the resize spacer when bottom content is merged with the main surface", () => {
+    render(
+      <StandardTabWrapper
+        afterBorder={<div data-testid="bottom-area" />}
+        afterBorderExpanded
+        afterBorderResizable
+        bottomBorderHandle={<button>Transcript</button>}
+        mergeAfterBorder
+      >
+        <div data-testid="main-area" />
+      </StandardTabWrapper>,
+    );
+
+    expect(screen.getByTestId("resize-handle").dataset.className).toContain(
+      "data-[panel-group-direction=vertical]:h-0",
+    );
   });
 
   it("sizes collapsed bottom content to its row instead of reserving split space", () => {

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -80,7 +80,10 @@ export function StandardTabWrapper({
             <ResizableHandle
               disabled={!afterBorderExpanded}
               className={cn([
-                "z-10 !bg-transparent data-[panel-group-direction=vertical]:-mb-px",
+                "z-10 !bg-transparent",
+                mergeAfterBorder
+                  ? "data-[panel-group-direction=vertical]:h-0"
+                  : "data-[panel-group-direction=vertical]:-mb-px",
                 !afterBorderExpanded && "pointer-events-none",
               ])}
             />
@@ -89,7 +92,7 @@ export function StandardTabWrapper({
               defaultSize={afterBorderSize}
               minSize={afterBorderExpanded ? 10 : 6}
               maxSize={60}
-              className="min-h-0 overflow-hidden"
+              className="min-h-[96px] overflow-hidden"
             >
               <AfterBorderContent
                 bottomBorderHandle={bottomBorderHandle}


### PR DESCRIPTION
Set transcript panel to a 96px minimum height, remove the merged resize spacer, and keep the audio timeline slot height stable across collapsed and expanded states.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout-only changes that adjust sizing and spacing for the transcript/timeline panels; main risk is minor visual regressions in resizable split behavior.
> 
> **Overview**
> Stabilizes the post-session transcript/audio accessory layout by wrapping the timeline in a fixed-height `TimelineSlot` so its vertical size stays consistent when the transcript is collapsed vs expanded.
> 
> Sets a **96px minimum height** on transcript-related containers (including the resizable bottom panel) so expanded content can flex without collapsing, and hides the resizable handle spacer (`h-0`) when `mergeAfterBorder` is enabled.
> 
> Updates/extends unit tests to assert the fixed timeline slot height, the new `min-h-[96px]` constraints, and the spacer removal behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf69030e3b9aedbde03cb4cd8964126d212cd24f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->