### PR TITLE
Fix: Preserve markdown formatting when copying notes #4838

### DIFF
--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -129,7 +129,12 @@ async function copyTextToClipboard(
   },
 ) {
   try {
-    await navigator.clipboard.writeText(text);
+    await navigator.clipboard.write([
+      new ClipboardItem({
+        "text/plain": new Blob([text], { type: "text/plain" }),
+        "text/markdown": new Blob([text], { type: "text/markdown" }),
+      }),
+    ]);
 
     if (messages) {
       sonnerToast.success(messages.success);
@@ -146,7 +151,6 @@ async function copyTextToClipboard(
     return false;
   }
 }
-
 function HeaderTabRaw({
   isActive,
   onClick = () => {},

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -129,12 +129,21 @@ async function copyTextToClipboard(
   },
 ) {
   try {
-    await navigator.clipboard.write([
-      new ClipboardItem({
-        "text/plain": new Blob([text], { type: "text/plain" }),
-        "text/markdown": new Blob([text], { type: "text/markdown" }),
-      }),
-    ]);
+    try {
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          "text/plain": new Blob([text], {
+            type: "text/plain",
+          }),
+          "text/markdown": new Blob([text], {
+            type: "text/markdown",
+          }),
+        }),
+      ]);
+    } catch {
+      // Fallback for environments that do not support text/markdown
+      await navigator.clipboard.writeText(text);
+    }
 
     if (messages) {
       sonnerToast.success(messages.success);


### PR DESCRIPTION
Fixes #4838

## Summary

Preserves markdown formatting when copying note content by writing both `text/plain` and `text/markdown` MIME types to the clipboard.

## Changes

* Replaced `navigator.clipboard.writeText()` with `navigator.clipboard.write()`
* Added `text/markdown` clipboard MIME support alongside `text/plain`

## Why

This allows markdown-aware tools/editors to preserve markdown formatting when pasting copied note content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX change to local clipboard writes in the note header; no auth, data, or server impact.
> 
> **Overview**
> Note tab **Copy** (memos and enhanced summaries) now writes both `text/plain` and `text/markdown` via `navigator.clipboard.write()` so markdown-aware paste targets keep formatting.
> 
> If the clipboard API rejects the `text/markdown` item, copy **falls back** to `navigator.clipboard.writeText()` so copy still works in environments that only support plain text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccdb7918344155a4ed66f2f29b1d2777fb450753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->