### PR TITLE
chore(changelog): add desktop 1.0.30 notes

### DIFF
--- a/packages/changelog/content/1.0.30.md
+++ b/packages/changelog/content/1.0.30.md
@@ -1,0 +1,26 @@
+---
+date: "2026-05-25"
+summary: "Default templates, the native floating meeting bar, transcript panel layout, and new-install data paths were improved."
+---
+
+## Meetings
+
+- Live meetings now use a native floating meeting bar with live audio activity, drag support, a quick stop action, and a shortcut back to the main app
+- Notes stay synced between the main window and floating meeting window while a live session is open
+
+## Templates
+
+- New installs and upgraded databases now include built-in templates for standups, 1:1s, sprint planning, sales calls, customer discovery, lectures, board meetings, and other common workflows
+- Saved templates are filtered out of web template suggestions so the library does not show duplicates after you add one
+- Invalid legacy or draft template data no longer blanks the templates UI
+- The quick format picker now includes the full template library when there are more useful formats available
+
+## Transcript Panel
+
+- The transcript panel now keeps a steadier minimum height when expanded, collapsed, batching, or showing the audio timeline
+- The merged transcript and audio controls no longer leave a thin layout gap under the session border
+
+## App Data
+
+- New stable installs now use the Anarlog data folder by default
+- Existing Hyprnote data folders and database paths are still preserved so current installs continue to open the same data


### PR DESCRIPTION
Add the next desktop changelog entry for the native meeting bar, default templates, transcript panel layout, and app data path updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime or application code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.0.30.md`**, the desktop **1.0.30** release notes for the changelog package.
> 
> The entry documents shipped work in four areas: a **native floating meeting bar** with synced notes between main and floating windows; **default and upgraded templates** plus suggestion/picker fixes; **transcript panel** minimum-height and layout gap fixes; and **Anarlog** as the default data folder for new installs while keeping existing Hyprnote paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ebf2cc68db33ccadfa2bfda8867fed6d8b77627. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->