### PR TITLE
fix: prevent floating bar font resource crash

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -37,6 +37,8 @@
       "icons/stable/icon.ico"
     ],
     "resources": {
+      "../../../plugins/windows/swift-lib/src/Resources/CabinSketch-Regular.ttf": "CabinSketch-Regular.ttf",
+      "../../../plugins/windows/swift-lib/src/Resources/OFL.txt": "CabinSketch-OFL.txt",
       "icons/stable/icon.icns": "icons/stable.icns"
     },
     "macOS": {

--- a/plugins/windows/swift-lib/src/FloatingBarFonts.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarFonts.swift
@@ -10,14 +10,29 @@ enum FloatingBarFonts {
     guard !didRegister else { return }
     didRegister = true
 
-    guard
-      let url = Bundle.module.url(
-        forResource: "CabinSketch-Regular",
-        withExtension: "ttf")
-    else {
+    guard let url = cabinSketchURL() else {
       return
     }
 
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  private static func cabinSketchURL() -> URL? {
+    let fileManager = FileManager.default
+    let resourceName = "CabinSketch-Regular"
+
+    let candidates = [
+      Bundle.main.url(forResource: resourceName, withExtension: "ttf"),
+      Bundle.main.resourceURL?.appendingPathComponent("\(resourceName).ttf"),
+      Bundle.main.resourceURL?.appendingPathComponent(
+        "windows-swift_swift-lib.bundle/\(resourceName).ttf"),
+      URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .appendingPathComponent("Resources/\(resourceName).ttf"),
+    ]
+
+    return candidates.compactMap { $0 }.first {
+      fileManager.fileExists(atPath: $0.path)
+    }
   }
 }


### PR DESCRIPTION
Load the native floating bar font from packaged app resources without touching Bundle.module, and include the Cabin Sketch font assets in desktop bundles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized packaging and font registration for the native floating bar UI, with no auth, data, or core business logic changes.
> 
> **Overview**
> Fixes a crash when the Windows floating bar registers **Cabin Sketch** by no longer loading the font through `Bundle.module`, which is unreliable in the packaged desktop app.
> 
> **Tauri** now bundles `CabinSketch-Regular.ttf` and its OFL license from the Swift plugin into app resources. **`FloatingBarFonts`** resolves the TTF by checking several locations (`Bundle.main`, flat resource path, `windows-swift_swift-lib.bundle`, and the plugin `Resources` folder for dev) and registers the first path that exists on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e81beb90db05076dfd93a1792e438e82fef2d12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->