### PR TITLE
fix: honor legacy audio retention setting

### DIFF
--- a/apps/desktop/src/services/audio-retention.test.ts
+++ b/apps/desktop/src/services/audio-retention.test.ts
@@ -184,4 +184,67 @@ describe("audio retention", () => {
     expect(audioDeleteMock).toHaveBeenCalledWith("processed");
     expect(deleted).toEqual(["processed"]);
   });
+
+  test("uses legacy save_recordings when audio_retention is missing", async () => {
+    const now = Date.parse("2026-05-13T00:00:00.000Z");
+    const store = createMainStore();
+    const settingsStore = createSettingsStore();
+
+    settingsStore.setValue("save_recordings", false);
+    store.setRow("sessions", "processed", {
+      user_id: "user",
+      created_at: "2026-05-13T00:00:00.000Z",
+      title: "",
+      raw_md: "",
+    });
+    store.setRow("transcripts", "processed-transcript", {
+      user_id: "user",
+      created_at: "2026-05-13T00:00:00.000Z",
+      session_id: "processed",
+      started_at: now,
+      words: JSON.stringify([{ text: " saved" }]),
+      speaker_hints: "[]",
+      memo_md: "",
+    });
+
+    const deleted = await cleanupExpiredAudio(store, settingsStore, now);
+
+    expect(audioDeleteMock).toHaveBeenCalledTimes(1);
+    expect(audioDeleteMock).toHaveBeenCalledWith("processed");
+    expect(deleted).toEqual(["processed"]);
+  });
+
+  test("prefers explicit audio_retention over legacy save_recordings", async () => {
+    const now = Date.parse("2026-05-13T00:00:00.000Z");
+    const store = createMainStore();
+    const settingsStore = createSettingsStore();
+
+    settingsStore.setValue("save_recordings", false);
+    settingsStore.setValue("audio_retention", "oneMonth");
+    store.setRow("sessions", "fresh", {
+      user_id: "user",
+      created_at: "2026-05-01T00:00:00.000Z",
+      title: "",
+      raw_md: "",
+    });
+    store.setRow("transcripts", "fresh-transcript", {
+      user_id: "user",
+      created_at: "2026-05-13T00:00:00.000Z",
+      session_id: "fresh",
+      started_at: now,
+      words: JSON.stringify([{ text: " saved" }]),
+      speaker_hints: "[]",
+      memo_md: "",
+    });
+
+    const deleted = await cleanupExpiredAudio(store, settingsStore, now);
+
+    expect(audioDeleteMock).not.toHaveBeenCalled();
+    expect(audioDeleteOrphanedExpiredMock).toHaveBeenCalledWith(
+      ["fresh"],
+      30 * 24 * 60 * 60 * 1000,
+      now,
+    );
+    expect(deleted).toEqual([]);
+  });
 });

--- a/apps/desktop/src/services/audio-retention.ts
+++ b/apps/desktop/src/services/audio-retention.ts
@@ -39,6 +39,20 @@ export function sessionAudioExpired(
   return nowMs >= createdAtMs + AUDIO_RETENTION_DURATION_MS[policy];
 }
 
+function getAudioRetentionPolicy(settingsStore: settings.Store) {
+  const hasAudioRetention = settingsStore.hasValue("audio_retention");
+  const policy = normalizeAudioRetentionPolicy(
+    settingsStore.getValue("audio_retention"),
+  );
+  const saveRecordings = settingsStore.getValue("save_recordings");
+
+  if (!hasAudioRetention && saveRecordings === false) {
+    return "none";
+  }
+
+  return policy;
+}
+
 function sessionHasTranscriptWords(store: main.Store, sessionId: string) {
   let hasWords = false;
 
@@ -74,9 +88,7 @@ export async function cleanupExpiredAudio(
   settingsStore: settings.Store,
   nowMs = Date.now(),
 ) {
-  const policy = normalizeAudioRetentionPolicy(
-    settingsStore.getValue("audio_retention"),
-  );
+  const policy = getAudioRetentionPolicy(settingsStore);
   const deletes: Promise<void>[] = [];
   const knownSessionIds: string[] = [];
   const deletedSessionIds: string[] = [];

--- a/apps/desktop/src/settings/general/storage/index.tsx
+++ b/apps/desktop/src/settings/general/storage/index.tsx
@@ -138,9 +138,11 @@ export function StorageSettingsView() {
 
 function AudioRetentionRow() {
   const audioRetention = useConfigValue("audio_retention") || "oneMonth";
-  const setAudioRetention = settings.UI.useSetValueCallback(
-    "audio_retention",
-    (value: string) => value,
+  const setAudioRetention = settings.UI.useSetPartialValuesCallback(
+    (value: string) => ({
+      audio_retention: value,
+      save_recordings: value !== "none",
+    }),
     [],
     settings.STORE_ID,
   );

--- a/apps/desktop/src/shared/config/index.test.tsx
+++ b/apps/desktop/src/shared/config/index.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { createMergeableStore } from "tinybase/with-schemas";
+import { describe, expect, test } from "vitest";
+
+import { useConfigValue } from ".";
+
+import * as settings from "~/store/tinybase/store/settings";
+import type { SettingsValueKey } from "~/store/tinybase/store/settings";
+
+function createWrapper(
+  values: Partial<Record<SettingsValueKey, unknown>>,
+): ({ children }: { children: ReactNode }) => ReactNode {
+  return function ConfigTestWrapper({ children }) {
+    const store = settings.UI.useCreateMergeableStore(() => {
+      const store = createMergeableStore()
+        .setTablesSchema(settings.SCHEMA.table)
+        .setValuesSchema(settings.SCHEMA.value) as settings.Store;
+
+      store.setValues(values as Parameters<settings.Store["setValues"]>[0]);
+
+      return store;
+    });
+
+    return (
+      <settings.UI.Provider storesById={{ [settings.STORE_ID]: store }}>
+        {children}
+      </settings.UI.Provider>
+    );
+  };
+}
+
+describe("useConfigValue", () => {
+  test("uses legacy don't-save when audio retention is missing", () => {
+    const { result } = renderHook(() => useConfigValue("audio_retention"), {
+      wrapper: createWrapper({ save_recordings: false }),
+    });
+
+    expect(result.current).toBe("none");
+  });
+
+  test("keeps explicit default audio retention over legacy save_recordings", () => {
+    const { result } = renderHook(() => useConfigValue("audio_retention"), {
+      wrapper: createWrapper({
+        save_recordings: false,
+        audio_retention: "oneMonth",
+      }),
+    });
+
+    expect(result.current).toBe("oneMonth");
+  });
+});

--- a/apps/desktop/src/shared/config/index.ts
+++ b/apps/desktop/src/shared/config/index.ts
@@ -27,10 +27,23 @@ export function useConfigValue<K extends SettingsValueKey>(
   key: K,
 ): ConfigValueType<K> {
   const storedValue = settings.UI.useValue(key, settings.STORE_ID);
+  const hasStoredValue = settings.UI.useHasValue(key, settings.STORE_ID);
+  const legacySaveRecordings = settings.UI.useValue(
+    "save_recordings",
+    settings.STORE_ID,
+  );
   const mapping = settings.SETTINGS_MAPPING.values[key];
   const defaultValue = "default" in mapping ? mapping.default : undefined;
 
-  if (storedValue !== undefined) {
+  if (
+    key === "audio_retention" &&
+    legacySaveRecordings === false &&
+    !hasStoredValue
+  ) {
+    return "none" as ConfigValueType<K>;
+  }
+
+  if (hasStoredValue) {
     if (
       key === "ignored_platforms" ||
       key === "included_platforms" ||

--- a/apps/desktop/src/store/tinybase/store/settings.ts
+++ b/apps/desktop/src/store/tinybase/store/settings.ts
@@ -50,6 +50,7 @@ export const SETTINGS_MAPPING = {
       type: "string",
       path: ["general", "audio_retention"],
       default: "oneMonth" as string,
+      schemaDefault: false,
     },
     notification_event: {
       type: "boolean",
@@ -162,11 +163,14 @@ type ValueMapping = {
   type: ValueType;
   path: readonly [string, string];
   default?: boolean | string | number;
+  schemaDefault?: boolean;
 };
 
 type DeriveValuesSchema<T extends Record<string, ValueMapping>> = {
   [K in keyof T]: T[K] extends { default: infer D }
-    ? { type: T[K]["type"]; default: D }
+    ? T[K] extends { schemaDefault: false }
+      ? { type: T[K]["type"] }
+      : { type: T[K]["type"]; default: D }
     : { type: T[K]["type"] };
 };
 
@@ -174,7 +178,8 @@ export const SCHEMA = {
   value: Object.fromEntries(
     Object.entries(SETTINGS_MAPPING.values).map(([key, config]) => [
       key,
-      "default" in config
+      "default" in config &&
+      !("schemaDefault" in config && config.schemaDefault === false)
         ? { type: config.type, default: config.default }
         : { type: config.type },
     ]),


### PR DESCRIPTION
Treat legacy save_recordings=false as don't-save retention and keep the storage UI writing the legacy boolean alongside the new retention policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how expired meeting audio is deleted and how retention is read; a mistake could delete recordings early or keep them longer than users expect, though behavior is covered by new tests.
> 
> **Overview**
> **Legacy `save_recordings=false` is treated as “don’t save”** when `audio_retention` was never written to the settings store, so cleanup and the storage UI match older installs that only had the boolean.
> 
> Cleanup resolves policy via a new helper: missing `audio_retention` + `save_recordings === false` → **`none`**; an explicit `audio_retention` value still wins. **`audio_retention` no longer gets a TinyBase schema default**, so “unset” can be distinguished from an explicit choice (e.g. one month).
> 
> **`useConfigValue('audio_retention')`** mirrors that for the UI. Changing retention in **Storage** now writes **`audio_retention` and `save_recordings`** together (`save_recordings` is false when retention is `none`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 053bdd9d718bbe587a18a0d314913b526e1c3793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->