### PR TITLE
fix: capture auto-stop triggers while listening starts

### DIFF
--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -352,6 +352,45 @@ describe("ListenerProvider detect events", () => {
     expect(store.getState().live.triggerAppIds).toEqual(["com.google.Chrome"]);
   });
 
+  test("records trigger app ids from micDetected while listening is starting", async () => {
+    const store = createListenerStore();
+
+    store.setState((state) => ({
+      live: {
+        ...state.live,
+        loading: true,
+        sessionId: "session-1",
+        status: "inactive",
+      },
+    }));
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "micDetected",
+        key: "mic-1",
+        apps: [
+          { id: "pid:42", name: "Chrome Helper" },
+          { id: "com.google.Chrome", name: "Google Chrome" },
+        ],
+        duration_secs: 15,
+      },
+    });
+
+    expect(showNotificationMock).not.toHaveBeenCalled();
+    expect(store.getState().live.triggerAppIds).toEqual(["com.google.Chrome"]);
+  });
+
   test("auto-stops after a trigger app learned during active listening stops", async () => {
     const store = createListenerStore();
     const stopSpy = vi.fn();

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -320,7 +320,12 @@ const useHandleDetectEvents = (store: ListenerStore) => {
           const ignorableApps = getIgnorableApps(payload.apps);
           const appIds = ignorableApps.map((app) => app.id);
 
-          if (store.getState().live.status === "active") {
+          const live = store.getState().live;
+          const shouldCaptureTriggerApps =
+            live.status === "active" ||
+            (live.status === "inactive" && live.loading && !!live.sessionId);
+
+          if (shouldCaptureTriggerApps) {
             if (appIds.length > 0) {
               const currentTrigger = store.getState().live.triggerAppIds ?? [];
               if (appIds.some((id) => currentTrigger.includes(id))) {


### PR DESCRIPTION
Record mic-detected app ids during the live-session loading window so manually started meeting recordings can auto-stop when the meeting app exits. Add regression coverage for the startup timing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow listener-state guard change plus a unit test; no auth, data, or API surface changes.
> 
> **Overview**
> **Mic-detected trigger apps** are now recorded not only while listening is **active**, but also during the **startup window** when `live` is still **inactive** but **`loading`** is true and a **`sessionId`** is set.
> 
> That closes a race where **`micDetected`** fired before capture flipped to active, so **`triggerAppIds`** stayed empty and **auto-stop on meeting app exit** never ran for manually started recordings. Ignorable app IDs are still merged the same way, without showing the “Are you in a meeting?” notification in that window.
> 
> A regression test covers **`micDetected`** while listening is starting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ace0fa7199a763455cc6728cd7128056c34fb9cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->