### PR TITLE
fix(readme): clarify anarlog links and history

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Granola, rearranged.
 
 Download the latest release for your platform:
 
-→ [github.com/fastrepl/char/releases/latest](https://github.com/fastrepl/char/releases/latest)
+→ [github.com/fastrepl/anarlog/releases/latest](https://github.com/fastrepl/anarlog/releases/latest)
 
 Open it. Join a meeting. anarlog records, transcribes locally, and saves your notes as markdown on disk. Bring your own LLM (OpenAI, Anthropic, Gemini, OpenRouter, Ollama, LM Studio, anything OpenAI-compatible).
 
@@ -32,13 +32,13 @@ Self-host? Clone the repo, build, run.
 - **Open source, MIT.** Fork it. Sell it. Self-host it. We mean it.
 - **No accounts. No tracking. No "free tier."** Just the app.
 
-## A short essay
+## Name history
 
-We started this as **Hyprnote**. It became **char**. Now it's **anarlog**.
+**anarlog** started as **Hyprnote**, then briefly carried the **char** name.
 
-Each name change came from a different reason — a legal one, a strategic one, a brand one. The product underneath kept getting clearer: a notetaker that respects your time, your data, and your right to walk away with both.
+We later split the work into two projects. **char** is the team's current productivity product, where most active development happens. **anarlog** is this open-source, local-first meeting notetaker.
 
-We're now building [**char**](https://v2.char.com) — a new product, productivity-focused, where most of our active development happens. **anarlog** isn't a sunset. It's the open-source companion we promised to keep alive, and we will. This repository keeps its full history, its stars, and its trajectory. Same team. Same standards. Just a clearer split between what's open and what's experimental.
+That means this repository is not the current char codebase, and anarlog is not being retired. It keeps the original open-source path: MIT-licensed, forkable, self-hostable, and built for people who want local notes they control.
 
 If you came here from Granola, welcome. If you came here from Hyprnote, welcome back.
 


### PR DESCRIPTION
Point the release link at anarlog and clarify how anarlog relates to char.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime, security, or data-handling impact.
> 
> **Overview**
> The **README** now sends the download link to **anarlog**’s GitHub releases instead of **char**’s.
> 
> The long “essay” section is retitled **Name history** and rewritten to spell out the Hyprnote → char → **anarlog** naming path, that **char** is the separate active product while this repo is the open-source notetaker, and that **anarlog** is maintained—not retired—and is not the current **char** codebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9a6fb2a04a4c630151216e69a6554b9e385af95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->