### PR TITLE
chore(changelog): add desktop 1.0.31 notes

### DIFF
--- a/packages/changelog/content/1.0.31.md
+++ b/packages/changelog/content/1.0.31.md
@@ -1,0 +1,40 @@
+---
+date: "2026-05-28"
+summary: "A top meeting carousel, profile menu in the top bar, command palette note search, and refreshed playback and floating bar controls."
+---
+
+## Timeline
+
+- The day timeline now sits at the top of the main window as a compact, date-ordered carousel of cards, with dense meetings grouped together and note and event actions available from each card's context menu
+
+## Profile
+
+- The profile menu has moved from the sidebar footer into a compact button in the top bar
+
+## Sidebar
+
+- Note search moved from the sidebar into the shared open-note command palette, leaving the sidebar focused on timeline navigation
+
+## Meetings
+
+- A new General setting lets you show or hide the floating meeting bar while listening
+- Manually started recordings now capture the meeting app earlier, so auto-stop can still end the recording when the app releases the microphone
+- The floating meeting bar now uses a lighter recording accent with a tinted hover fill on the stop button
+
+## Transcript Panel
+
+- Playback and live transcript footers are more compact, with a slimmer audio timeline shell and waveform
+- The expanded transcript panel now keeps the playback timeline pinned in its reserved row
+
+## Chat
+
+- The chat panel no longer expands the window when the main shell is already wide enough
+
+## Audio & Storage
+
+- Upgraded installs that previously disabled saved recordings now keep that preference instead of falling back to one-month audio retention
+- Changing the audio retention setting now keeps the older saved-recordings preference in sync for existing app data
+
+## Menu Bar
+
+- The menu bar icon has been refreshed with the new lowercase Anarlog mark across idle, recording, degraded, and update states


### PR DESCRIPTION
Create the next desktop changelog entry for floating meeting controls, auto-stop reliability, audio retention, and the menu bar icon.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition of a changelog file; no runtime or application code is modified.
> 
> **Overview**
> Adds the **desktop 1.0.31** changelog at `packages/changelog/content/1.0.31.md` with front matter (`date`, `summary`) and release notes grouped by area (Timeline, Profile, Sidebar, Meetings, Transcript Panel, Chat, Audio & Storage, Menu Bar).
> 
> The entry documents UX and behavior called out in the PR description—e.g. top timeline carousel, profile in the top bar, note search via command palette, floating meeting bar settings and styling, compact transcript footers, chat width behavior, audio retention migration fixes, and refreshed menu bar icons—without accompanying code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e068d792aa01f364cbe5d2db890fee3b4c940b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->