### PR TITLE
fix(sidebar): open notes from command palette

### DIFF
--- a/apps/desktop/src/main/empty.tsx
+++ b/apps/desktop/src/main/empty.tsx
@@ -1,12 +1,10 @@
 import { AppWindowIcon } from "lucide-react";
-import { useCallback, useState } from "react";
-import { useHotkeys } from "react-hotkeys-hook";
+import { useCallback } from "react";
 
 import { Kbd } from "@hypr/ui/components/ui/kbd";
 import { cn } from "@hypr/utils";
 
 import { StandardTabWrapper } from "~/shared/main";
-import { OpenNoteDialog } from "~/shared/open-note-dialog";
 import { type TabItem, TabItemBase } from "~/shared/tabs";
 import { useNewNote, useNewNoteAndListen } from "~/shared/useNewNote";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
@@ -55,7 +53,6 @@ function EmptyView() {
   const newNote = useNewNote({ behavior: "current" });
   const newNoteAndListen = useNewNoteAndListen({ behavior: "current" });
   const openCurrent = useTabs((state) => state.openCurrent);
-  const [openNoteDialogOpen, setOpenNoteDialogOpen] = useState(false);
 
   const openCalendar = useCallback(
     () => openCurrent({ type: "calendar" }),
@@ -69,12 +66,6 @@ function EmptyView() {
     () => openCurrent({ type: "settings" }),
     [openCurrent],
   );
-  useHotkeys(
-    "mod+o",
-    () => setOpenNoteDialogOpen(true),
-    { preventDefault: true, enableOnFormTags: true },
-    [setOpenNoteDialogOpen],
-  );
 
   return (
     <div className="mb-12 flex h-full flex-col items-center justify-center gap-6 text-neutral-600">
@@ -84,11 +75,6 @@ function EmptyView() {
           label="Start Recording"
           shortcut={["⌘", "⇧", "N"]}
           onClick={newNoteAndListen}
-        />
-        <ActionItem
-          label="Open Note"
-          shortcut={["⌘", "O"]}
-          onClick={() => setOpenNoteDialogOpen(true)}
         />
         <div className="my-1 h-px bg-neutral-200" />
         <ActionItem
@@ -108,10 +94,6 @@ function EmptyView() {
           onClick={openSettings}
         />
       </div>
-      <OpenNoteDialog
-        open={openNoteDialogOpen}
-        onOpenChange={setOpenNoteDialogOpen}
-      />
     </div>
   );
 }

--- a/apps/desktop/src/main/layout.tsx
+++ b/apps/desktop/src/main/layout.tsx
@@ -10,7 +10,7 @@ import { ShellProvider } from "~/contexts/shell";
 import { ToolRegistryProvider } from "~/contexts/tool";
 import { useStoreBackedTaskStorage } from "~/editor-bridge/task-storage";
 import { SearchEngineProvider } from "~/search/contexts/engine";
-import { SearchUIProvider } from "~/search/contexts/ui";
+import { OpenNoteDialogProvider } from "~/shared/open-note-dialog";
 
 export function ClassicMainLayout({
   children,
@@ -31,7 +31,7 @@ export function ClassicMainLayout({
   return (
     <SearchEngineProvider store={persistedStore}>
       <TaskStorageProvider storage={taskStorage}>
-        <SearchUIProvider>
+        <OpenNoteDialogProvider>
           <ShellProvider>
             <ToolRegistryProvider registry={toolRegistry}>
               <AITaskProvider store={aiTaskStore}>
@@ -42,7 +42,7 @@ export function ClassicMainLayout({
               </AITaskProvider>
             </ToolRegistryProvider>
           </ShellProvider>
-        </SearchUIProvider>
+        </OpenNoteDialogProvider>
       </TaskStorageProvider>
     </SearchEngineProvider>
   );

--- a/apps/desktop/src/main/shell-sidebar.tsx
+++ b/apps/desktop/src/main/shell-sidebar.tsx
@@ -1,7 +1,4 @@
-import { useEffect, useRef } from "react";
-
 import { useShell } from "~/contexts/shell";
-import { useSearch } from "~/search/contexts/ui";
 import { LeftSidebar } from "~/sidebar";
 import {
   hasCustomSidebarTab,
@@ -11,25 +8,12 @@ import { useTabs } from "~/store/zustand/tabs";
 
 export function ClassicMainSidebar() {
   const { leftsidebar } = useShell();
-  const { query } = useSearch();
   const currentTab = useTabs((state) => state.currentTab);
   const isOnboarding = currentTab?.type === "onboarding";
-  const previousQueryRef = useRef(query);
 
   const hasCustomSidebar = hasCustomSidebarTab(currentTab);
 
   useCustomSidebarEffect(hasCustomSidebar, leftsidebar);
-
-  useEffect(() => {
-    const isStartingSearch =
-      query.trim() !== "" && previousQueryRef.current.trim() === "";
-
-    if (isStartingSearch && !leftsidebar.expanded && !isOnboarding) {
-      leftsidebar.setExpanded(true);
-    }
-
-    previousQueryRef.current = query;
-  }, [query, leftsidebar, isOnboarding]);
 
   if (!leftsidebar.expanded || isOnboarding) {
     return null;

--- a/apps/desktop/src/shared/main/shell-sidebar.test.tsx
+++ b/apps/desktop/src/shared/main/shell-sidebar.test.tsx
@@ -8,7 +8,6 @@ const hoisted = vi.hoisted(() => ({
 
 const { setExpanded, setLocked } = hoisted;
 
-let mockQuery = "";
 let mockCurrentTab: {
   type: "settings" | "empty" | "onboarding" | "calendar";
 } | null = { type: "empty" };
@@ -21,12 +20,6 @@ const mockLeftSidebar = {
 vi.mock("~/contexts/shell", () => ({
   useShell: () => ({
     leftsidebar: mockLeftSidebar,
-  }),
-}));
-
-vi.mock("~/search/contexts/ui", () => ({
-  useSearch: () => ({
-    query: mockQuery,
   }),
 }));
 
@@ -44,7 +37,6 @@ import { ClassicMainSidebar } from "~/main/shell-sidebar";
 
 describe("ClassicMainSidebar", () => {
   beforeEach(() => {
-    mockQuery = "";
     mockCurrentTab = { type: "empty" };
     mockLeftSidebar.expanded = false;
     setExpanded.mockClear();
@@ -65,17 +57,5 @@ describe("ClassicMainSidebar", () => {
 
     expect(setLocked).toHaveBeenLastCalledWith(false);
     expect(setExpanded).toHaveBeenLastCalledWith(false);
-  });
-
-  it("expands the sidebar when search starts from an empty query", () => {
-    const { rerender } = render(<ClassicMainSidebar />);
-
-    setExpanded.mockClear();
-
-    mockQuery = "meeting";
-
-    rerender(<ClassicMainSidebar />);
-
-    expect(setExpanded).toHaveBeenCalledWith(true);
   });
 });

--- a/apps/desktop/src/shared/open-note-dialog.tsx
+++ b/apps/desktop/src/shared/open-note-dialog.tsx
@@ -1,7 +1,14 @@
 import { Command as CommandPrimitive } from "cmdk";
 import { FileTextIcon, SearchIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
+import { useHotkeys } from "react-hotkeys-hook";
 
 import { Kbd } from "@hypr/ui/components/ui/kbd";
 import { cn } from "@hypr/utils";
@@ -16,15 +23,59 @@ interface OpenNoteDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+type OpenNoteDialogContextValue = {
+  open: () => void;
+};
+
 type Session = {
   id: string;
   title: string;
   createdAt: string;
 };
 
+const OpenNoteDialogContext = createContext<OpenNoteDialogContextValue | null>(
+  null,
+);
+
+export function OpenNoteDialogProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const openDialog = useCallback(() => {
+    setOpen(true);
+  }, []);
+
+  useHotkeys("mod+k", openDialog, {
+    preventDefault: true,
+    enableOnFormTags: true,
+    enableOnContentEditable: true,
+  });
+
+  const value = useMemo(() => ({ open: openDialog }), [openDialog]);
+
+  return (
+    <OpenNoteDialogContext.Provider value={value}>
+      {children}
+      <OpenNoteDialog open={open} onOpenChange={setOpen} />
+    </OpenNoteDialogContext.Provider>
+  );
+}
+
+export function useOpenNoteDialog() {
+  const context = useContext(OpenNoteDialogContext);
+  if (!context) {
+    throw new Error(
+      "useOpenNoteDialog must be used within OpenNoteDialogProvider",
+    );
+  }
+  return context;
+}
+
 export function OpenNoteDialog({ open, onOpenChange }: OpenNoteDialogProps) {
   const [query, setQuery] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
   const openCurrent = useTabs((state) => state.openCurrent);
   const recentlyOpenedSessionIds = useTabs(
     (state) => state.recentlyOpenedSessionIds,
@@ -88,27 +139,26 @@ export function OpenNoteDialog({ open, onOpenChange }: OpenNoteDialogProps) {
   const hasAnyResults =
     filteredRecentSessions.length > 0 || filteredOtherSessions.length > 0;
 
-  useEffect(() => {
-    if (open) {
-      const timer = setTimeout(() => {
-        inputRef.current?.focus();
-      }, 10);
-      return () => clearTimeout(timer);
-    }
-  }, [open]);
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        setQuery("");
+      }
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange],
+  );
 
-  useEffect(() => {
-    if (!open) {
-      setQuery("");
-    }
-  }, [open]);
+  const focusInput = useCallback((node: HTMLInputElement | null) => {
+    node?.focus();
+  }, []);
 
   const handleSelect = useCallback(
     (sessionId: string) => {
-      onOpenChange(false);
+      handleOpenChange(false);
       openCurrent({ type: "sessions", id: sessionId });
     },
-    [onOpenChange, openCurrent],
+    [handleOpenChange, openCurrent],
   );
 
   if (!open) return null;
@@ -116,7 +166,7 @@ export function OpenNoteDialog({ open, onOpenChange }: OpenNoteDialogProps) {
   return createPortal(
     <div
       className="fixed inset-0 z-50 bg-black/20 backdrop-blur-xs"
-      onClick={() => onOpenChange(false)}
+      onClick={() => handleOpenChange(false)}
     >
       <div
         data-tauri-drag-region
@@ -137,14 +187,14 @@ export function OpenNoteDialog({ open, onOpenChange }: OpenNoteDialogProps) {
             className="flex flex-col"
             onKeyDown={(e) => {
               if (e.key === "Escape") {
-                onOpenChange(false);
+                handleOpenChange(false);
               }
             }}
           >
             <div className="flex items-center gap-3 border-b border-neutral-200/60 px-4 py-3">
               <SearchIcon className="h-4 w-4 shrink-0 text-neutral-400" />
               <CommandPrimitive.Input
-                ref={inputRef}
+                ref={focusInput}
                 value={query}
                 onValueChange={setQuery}
                 placeholder="Find a note..."
@@ -154,7 +204,7 @@ export function OpenNoteDialog({ open, onOpenChange }: OpenNoteDialogProps) {
                 ])}
               />
               <button
-                onClick={() => onOpenChange(false)}
+                onClick={() => handleOpenChange(false)}
                 className={cn([
                   "h-5 w-5 rounded-full",
                   "flex items-center justify-center",

--- a/apps/desktop/src/sidebar/index.tsx
+++ b/apps/desktop/src/sidebar/index.tsx
@@ -1,17 +1,13 @@
-import { lazy, Suspense, useState } from "react";
+import { lazy, Suspense } from "react";
 
 import { CalendarNav } from "./calendar";
 import { ContactsNav } from "./contacts";
-import { ProfileSection } from "./profile";
-import { SidebarSearchInput } from "./search";
 import { SettingsNav } from "./settings";
 import { TemplatesNav } from "./templates";
 import { TimelineView } from "./timeline";
 import { ToastArea } from "./toast";
 
 import { useShell } from "~/contexts/shell";
-import { SearchResults } from "~/search/components/sidebar";
-import { useSearch } from "~/search/contexts/ui";
 import { useTabs } from "~/store/zustand/tabs";
 
 const DevtoolView = lazy(() =>
@@ -20,9 +16,7 @@ const DevtoolView = lazy(() =>
 
 export function LeftSidebar() {
   const { leftsidebar } = useShell();
-  const { query } = useSearch();
   const currentTab = useTabs((state) => state.currentTab);
-  const [isProfileExpanded, setIsProfileExpanded] = useState(false);
 
   const isSettingsMode = currentTab?.type === "settings";
   const isCalendarMode = currentTab?.type === "calendar";
@@ -30,12 +24,9 @@ export function LeftSidebar() {
   const isTemplatesMode = currentTab?.type === "templates";
   const isSpecialMode =
     isSettingsMode || isCalendarMode || isContactsMode || isTemplatesMode;
-  const showSearchResults = !isSpecialMode && query.trim() !== "";
 
   return (
     <div className="flex h-full w-[200px] shrink-0 flex-col gap-1 overflow-hidden pt-1">
-      {!isSpecialMode && <SidebarSearchInput />}
-
       <div className="flex flex-1 flex-col gap-1 overflow-hidden">
         <div className="relative min-h-0 flex-1 overflow-hidden">
           {leftsidebar.showDevtool ? (
@@ -51,21 +42,9 @@ export function LeftSidebar() {
           ) : isTemplatesMode ? (
             <TemplatesNav />
           ) : (
-            <>
-              <div className={showSearchResults ? "h-full" : "hidden"}>
-                <SearchResults />
-              </div>
-              <div className={showSearchResults ? "hidden" : "h-full"}>
-                <TimelineView />
-              </div>
-            </>
+            <TimelineView />
           )}
-          {!leftsidebar.showDevtool && !isSpecialMode && (
-            <ToastArea isProfileExpanded={isProfileExpanded} />
-          )}
-        </div>
-        <div className="relative z-30">
-          <ProfileSection onExpandChange={setIsProfileExpanded} />
+          {!leftsidebar.showDevtool && !isSpecialMode && <ToastArea />}
         </div>
       </div>
     </div>

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -13,14 +13,10 @@ import { useConfigValues } from "~/shared/config";
 import { useTabs } from "~/store/zustand/tabs";
 import { useToastAction } from "~/store/zustand/toast-action";
 
-export function ToastArea({
-  isProfileExpanded,
-}: {
-  isProfileExpanded: boolean;
-}) {
+export function ToastArea() {
   const auth = useAuth();
   const { dismissToast, isDismissed } = useDismissedToasts();
-  const shouldShowToast = useShouldShowToast(isProfileExpanded);
+  const shouldShowToast = useShouldShowToast();
   const {
     hasActiveDownload,
     downloadProgress,
@@ -167,7 +163,7 @@ export function ToastArea({
   );
 }
 
-function useShouldShowToast(isProfileExpanded: boolean) {
+function useShouldShowToast() {
   const TOAST_CHECK_DELAY_MS = 500;
 
   const [showToast, setShowToast] = useState(false);
@@ -180,5 +176,5 @@ function useShouldShowToast(isProfileExpanded: boolean) {
     return () => clearTimeout(timer);
   }, []);
 
-  return !isProfileExpanded && showToast;
+  return showToast;
 }


### PR DESCRIPTION
Replace the sidebar search entry point with the shared open-note palette and keep the sidebar focused on timeline navigation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes sidebar full-text search UX and rebinds ⌘K from sidebar search focus to the note picker; navigation/discoverability changes beyond a small refactor.
> 
> **Overview**
> Moves **open note** to a global command palette wired at the main app layout, replacing the old per-view dialog and sidebar search entry points.
> 
> `OpenNoteDialogProvider` registers **⌘K** app-wide, exposes `useOpenNoteDialog`, and always mounts the palette modal. The empty tab drops **Open Note** / **⌘O**; the left sidebar no longer shows search, search results, or the profile footer—default mode is **timeline only**, with toasts no longer gated on profile expansion. `ClassicMainLayout` swaps `SearchUIProvider` for this provider; sidebar auto-expand on search and related tests are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8872050119ca2c1901a78995a28a9dda234ed9bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->