### PR TITLE
fix(session): align title padding

### DIFF
--- a/apps/desktop/src/session/components/session-surface.tsx
+++ b/apps/desktop/src/session/components/session-surface.tsx
@@ -29,7 +29,7 @@ export function SessionSurface({
       mergeAfterBorder={mergeAfterBorder}
     >
       <div className="flex h-full flex-col">
-        {header ? <div className="pr-1 pl-2">{header}</div> : null}
+        {header ? <div className="pr-1 pl-3">{header}</div> : null}
         <div className="mt-2 min-h-0 flex-1 px-2">{children}</div>
       </div>
     </StandardTabWrapper>


### PR DESCRIPTION
Increase the session header left inset so the title lines up with note content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on session tab layout with no logic, data, or security impact.
> 
> **Overview**
> Updates **`SessionSurface`** so the optional session header uses **`pl-3`** instead of **`pl-2`**, increasing the left inset so the session title lines up with the note area below (which still uses **`px-2`** on the content wrapper).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be59bd1ded429e7234fdc913e203ae5d7d38c525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->