### PR TITLE
fix(profile): resize topbar menu trigger

### DIFF
--- a/apps/desktop/src/sidebar/profile/index.tsx
+++ b/apps/desktop/src/sidebar/profile/index.tsx
@@ -98,7 +98,7 @@ export function ProfileMenu() {
             className="absolute top-full left-0 mt-1 w-56"
             data-tauri-drag-region="false"
           >
-            <div className="overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-[0_10px_30px_rgba(0,0,0,0.14)]">
+            <div className="overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-[0_10px_30px_rgba(0,0,0,0.14)]">
               <div className="py-1">
                 {menuItems.map((item) => (
                   <MenuItem key={item.label} {...item} />
@@ -148,17 +148,17 @@ function ProfileButton({
       aria-label="Open profile menu"
       aria-expanded={isExpanded}
       className={cn([
-        "flex size-8 cursor-pointer items-center justify-center rounded-lg",
-        "bg-neutral-200/70 p-1 shadow-xs ring-1 ring-neutral-200",
+        "flex size-7 cursor-pointer items-center justify-center rounded-lg",
+        "border border-transparent bg-transparent p-1",
         "transition-colors duration-150",
-        "hover:bg-neutral-300/70",
-        isExpanded && "bg-neutral-300/70",
+        "hover:border-neutral-200 hover:bg-neutral-200/70",
+        isExpanded && "border-neutral-200 bg-neutral-200/70",
       ])}
       onClick={onClick}
     >
       <div
         className={cn([
-          "flex size-6 shrink-0 items-center justify-center",
+          "flex size-[18px] shrink-0 items-center justify-center",
           "overflow-hidden rounded-md",
           "shadow-xs",
           "transition-transform duration-300",
@@ -175,7 +175,7 @@ function ProfileButton({
         ) : (
           <ProfileFacehash
             name={facehashName}
-            size={24}
+            size={18}
             className="rounded-md"
           />
         )}


### PR DESCRIPTION
Set the profile menu button to 28px and scale the avatar slot to fit.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5334 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5331 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only changes to profile button and dropdown styling in the desktop sidebar; no logic, auth, or data handling.
> 
> **Overview**
> Tightens the **profile menu** control in the desktop topbar: the trigger shrinks from **32px to 28px** (`size-7`), and the avatar / facehash slot scales down to **18px** so it fits the smaller hit target.
> 
> The trigger styling shifts from a always-on neutral fill and ring to a **transparent default** with **border + light background on hover and when open**. The dropdown panel corner radius increases from **`rounded-lg` to `rounded-2xl`** to match the updated chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb41c7579dee937fb51a43c320ac8642978da56d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->