### PR TITLE
fix(transcript): keep audio bar visible

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -230,8 +230,14 @@ describe("PostSessionAccessory", () => {
     const scrollArea = screen.getByTestId("transcript").parentElement;
     expect(scrollArea?.className).toContain("flex-1");
     expect(scrollArea?.className).not.toContain("h-[300px]");
-    expect(scrollArea?.parentElement?.className).toContain("flex-1");
-    expect(scrollArea?.parentElement?.className).toContain("min-h-[96px]");
+
+    const transcriptCard = scrollArea?.parentElement;
+    const transcriptSlot = transcriptCard?.parentElement;
+    expect(transcriptCard?.className).toContain("h-full");
+    expect(transcriptCard?.className).toContain("min-h-0");
+    expect(transcriptCard?.className).not.toContain("min-h-[96px]");
+    expect(transcriptSlot?.className).toContain("flex-1");
+    expect(transcriptSlot?.className).toContain("min-h-0");
   });
 
   it("shows transcript skeletons instead of duplicating batch progress in the body", () => {

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -51,16 +51,27 @@ export function PostSessionAccessory({
   }
 
   return (
-    <div className={cn(["flex min-h-0 flex-col", fillHeight && "h-full"])}>
+    <div
+      className={cn([
+        "flex min-h-0 flex-col",
+        fillHeight && "h-full overflow-hidden",
+      ])}
+    >
       {isTranscriptExpanded ? (
-        <TranscriptPanel
-          sessionId={sessionId}
-          screen={screen}
-          hasAudio={hasAudio}
-          hasTranscript={hasTranscript}
-          isExpanded={isTranscriptExpanded}
-          fillHeight={fillHeight}
-        />
+        <div
+          className={cn([
+            fillHeight ? "min-h-0 flex-1 overflow-hidden" : "shrink-0",
+          ])}
+        >
+          <TranscriptPanel
+            sessionId={sessionId}
+            screen={screen}
+            hasAudio={hasAudio}
+            hasTranscript={hasTranscript}
+            isExpanded={isTranscriptExpanded}
+            fillHeight={fillHeight}
+          />
+        </div>
       ) : null}
       {timeline ? <TimelineSlot>{timeline}</TimelineSlot> : null}
     </div>
@@ -524,8 +535,8 @@ function TranscriptCard({
   return (
     <div
       className={cn([
-        "min-h-[96px] overflow-hidden rounded-b-xl border-x border-b border-neutral-200 bg-white",
-        fillHeight && "flex flex-1 flex-col",
+        "overflow-hidden rounded-b-xl border-x border-b border-neutral-200 bg-white",
+        fillHeight ? "flex h-full min-h-0 flex-col" : "min-h-[96px]",
       ])}
     >
       {children}


### PR DESCRIPTION
Constrain the expanded transcript panel to a flex slot so the playback timeline keeps its reserved row.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only flex/overflow class changes and test updates; no auth, data, or API behavior.
> 
> **Overview**
> When the post-session transcript is **expanded** in a resizable bottom panel (`fillHeight`), layout is tightened so the **audio timeline** keeps its fixed `h-14` row instead of being pushed off-screen.
> 
> The accessory root now uses **`overflow-hidden`** when filling height, and the expanded transcript sits in a **`flex-1 min-h-0 overflow-hidden`** wrapper so only that region grows. **`TranscriptCard`** switches from always applying `min-h-[96px]` + `flex-1` to **`h-full min-h-0`** when `fillHeight` is on, reserving the minimum height only in the non-fill case.
> 
> Tests were updated to assert the new DOM chain (transcript slot vs card) instead of expecting `min-h-[96px]` on the scroll area’s parent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebefde7e2cd3e2ac62f81b7d1cb2d16dd0a1ca0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->