### PR TITLE
fix(accessory): compact bottom controls

### DIFF
--- a/apps/desktop/src/audio-player/provider.tsx
+++ b/apps/desktop/src/audio-player/provider.tsx
@@ -143,7 +143,7 @@ export function AudioPlayerProvider({
 
     const ws = WaveSurfer.create({
       container,
-      height: 30,
+      height: 24,
       waveColor: "#e5e5e5",
       progressColor: "#a8a8a8",
       cursorColor: "#737373",

--- a/apps/desktop/src/audio-player/timeline-shell.tsx
+++ b/apps/desktop/src/audio-player/timeline-shell.tsx
@@ -26,7 +26,12 @@ export function TimelineShell({
       className="w-full rounded-xl bg-neutral-50 select-none"
       onContextMenu={onContextMenu}
     >
-      <div className={cn(["flex items-center gap-2 p-2", "w-full max-w-full"])}>
+      <div
+        className={cn([
+          "flex items-center gap-2 px-2 py-1",
+          "w-full max-w-full",
+        ])}
+      >
         {leading}
         {meta}
         <div className="min-w-0 flex-1">{main}</div>

--- a/apps/desktop/src/audio-player/timeline.tsx
+++ b/apps/desktop/src/audio-player/timeline.tsx
@@ -99,16 +99,22 @@ export function Timeline() {
           onClick={handleClick}
           className={cn([
             "flex items-center justify-center",
-            "h-8 w-8 rounded-full",
+            "h-7 w-7 rounded-full",
             "border border-neutral-200 bg-white",
             "transition-all hover:scale-110 hover:bg-neutral-100",
             "shrink-0 shadow-xs select-none",
           ])}
         >
           {state === "playing" ? (
-            <Pause className="h-4 w-4 text-neutral-900" fill="currentColor" />
+            <Pause
+              className="h-3.5 w-3.5 text-neutral-900"
+              fill="currentColor"
+            />
           ) : (
-            <Play className="h-4 w-4 text-neutral-900" fill="currentColor" />
+            <Play
+              className="h-3.5 w-3.5 text-neutral-900"
+              fill="currentColor"
+            />
           )}
         </button>
       }
@@ -170,7 +176,7 @@ export function Timeline() {
         <div
           ref={registerContainer}
           className="min-w-0 flex-1"
-          style={{ minHeight: "30px", width: "100%" }}
+          style={{ minHeight: "24px", width: "100%" }}
         />
       }
     />

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -36,7 +36,7 @@ export function DuringSessionAccessory({
     return (
       <div className="relative w-full pt-1 select-none">
         <div className="rounded-xl bg-neutral-50">
-          <div className="flex min-h-12 items-center gap-2 p-2">
+          <div className="flex min-h-9 items-center gap-2 px-2 py-1">
             <div className="min-w-0 flex-1">
               <span className="text-xs text-neutral-400">Finalizing...</span>
             </div>
@@ -234,7 +234,7 @@ function CollapsedFooterMessage({ message }: { message: string }) {
   return (
     <div
       className={cn([
-        "flex min-h-9 items-center gap-2 px-2 py-1",
+        "flex min-h-7 items-center gap-2 px-2 py-0.5",
         "w-full max-w-full",
       ])}
     >

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -197,7 +197,7 @@ describe("PostSessionAccessory", () => {
 
     const collapsedSlotClassName =
       screen.getByTestId("timeline").parentElement?.className;
-    expect(collapsedSlotClassName).toContain("h-14");
+    expect(collapsedSlotClassName).toContain("h-10");
 
     unmount();
 
@@ -234,10 +234,10 @@ describe("PostSessionAccessory", () => {
     const transcriptCard = scrollArea?.parentElement;
     const transcriptSlot = transcriptCard?.parentElement;
     expect(transcriptCard?.className).toContain("h-full");
-    expect(transcriptCard?.className).toContain("min-h-0");
+    expect(transcriptCard?.className).toContain("min-h-[114px]");
     expect(transcriptCard?.className).not.toContain("min-h-[96px]");
     expect(transcriptSlot?.className).toContain("flex-1");
-    expect(transcriptSlot?.className).toContain("min-h-0");
+    expect(transcriptSlot?.className).toContain("min-h-[114px]");
   });
 
   it("shows transcript skeletons instead of duplicating batch progress in the body", () => {

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -60,7 +60,7 @@ export function PostSessionAccessory({
       {isTranscriptExpanded ? (
         <div
           className={cn([
-            fillHeight ? "min-h-0 flex-1 overflow-hidden" : "shrink-0",
+            fillHeight ? "min-h-[114px] flex-1 overflow-hidden" : "shrink-0",
           ])}
         >
           <TranscriptPanel
@@ -80,7 +80,7 @@ export function PostSessionAccessory({
 
 function TimelineSlot({ children }: { children: ReactNode }) {
   return (
-    <div className="flex h-14 w-full shrink-0 items-center">{children}</div>
+    <div className="flex h-10 w-full shrink-0 items-center">{children}</div>
   );
 }
 
@@ -301,12 +301,12 @@ function BatchProgressTimeline({
       leading={
         <div
           className={cn([
-            "flex h-8 w-8 items-center justify-center rounded-full",
+            "flex h-7 w-7 items-center justify-center rounded-full",
             "border border-neutral-200 bg-white shadow-xs",
             "shrink-0",
           ])}
         >
-          <Spinner size={14} />
+          <Spinner size={12} />
         </div>
       }
       meta={
@@ -318,8 +318,8 @@ function BatchProgressTimeline({
         </AudioPlayer.TimelineMeta>
       }
       main={
-        <div className="flex h-[30px] items-center">
-          <div className="relative h-2.5 w-full overflow-hidden rounded-full bg-neutral-200/80">
+        <div className="flex h-6 items-center">
+          <div className="relative h-2 w-full overflow-hidden rounded-full bg-neutral-200/80">
             <div
               className="absolute inset-y-0 left-0 rounded-full bg-neutral-400 transition-[width] duration-300 ease-out"
               style={{ width: `${Math.max(progress * 100, 8)}%` }}
@@ -536,7 +536,7 @@ function TranscriptCard({
     <div
       className={cn([
         "overflow-hidden rounded-b-xl border-x border-b border-neutral-200 bg-white",
-        fillHeight ? "flex h-full min-h-0 flex-col" : "min-h-[96px]",
+        fillHeight ? "flex h-full min-h-[114px] flex-col" : "min-h-[96px]",
       ])}
     >
       {children}

--- a/apps/desktop/src/shared/main/index.test.tsx
+++ b/apps/desktop/src/shared/main/index.test.tsx
@@ -117,6 +117,9 @@ describe("StandardTabWrapper", () => {
     expect(screen.getByTestId("resize-handle").dataset.className).toContain(
       "data-[panel-group-direction=vertical]:h-0",
     );
+
+    const panels = screen.getAllByTestId("panel");
+    expect(panels[1]?.dataset.className).toContain("min-h-[154px]");
   });
 
   it("sizes collapsed bottom content to its row instead of reserving split space", () => {

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -92,7 +92,10 @@ export function StandardTabWrapper({
               defaultSize={afterBorderSize}
               minSize={afterBorderExpanded ? 10 : 6}
               maxSize={60}
-              className="min-h-[96px] overflow-hidden"
+              className={cn([
+                "overflow-hidden",
+                mergeAfterBorder ? "min-h-[154px]" : "min-h-[96px]",
+              ])}
             >
               <AfterBorderContent
                 bottomBorderHandle={bottomBorderHandle}
@@ -182,7 +185,7 @@ function AfterBorderContent({
   return (
     <div
       className={cn([
-        !mergeAfterBorder && (bottomBorderHandle ? "pt-[10px]" : "mt-1"),
+        !mergeAfterBorder && (bottomBorderHandle ? "pt-1.5" : "mt-1"),
         fill && "flex h-full min-h-0 flex-col overflow-hidden",
       ])}
     >


### PR DESCRIPTION
Reduce vertical spacing in playback and live transcript footers, including the audio timeline shell and waveform height.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout and Tailwind sizing only; no logic, auth, or data changes.
> 
> **Overview**
> Tightens the session bottom accessory by shrinking playback and transcript chrome: **WaveSurfer** height **30→24px**, smaller play/pause controls and icons, and **TimelineShell** padding **p-2 → px-2 py-1**.
> 
> **During-session** and **post-session** footers use shorter rows (**min-h-12→9**, collapsed live line **min-h-9→7**), a fixed **h-10** timeline slot (was **h-14**), and a slimmer batch-progress bar/spinner to match. Expanded transcript areas keep usable height via **min-h-[114px]** on transcript slots/cards instead of **min-h-0** alone.
> 
> **StandardTabWrapper** when **mergeAfterBorder** is on raises the resizable bottom panel minimum to **min-h-[154px]** (vs **96px**) and slightly reduces top padding above merged bottom content (**pt-[10px] → pt-1.5**). Tests updated for the new heights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b778bb2b6a08825230e665fb97baff4f94e4bae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->