### PR TITLE
fix(profile): add menu button bottom padding

### DIFF
--- a/apps/desktop/src/sidebar/profile/auth.tsx
+++ b/apps/desktop/src/sidebar/profile/auth.tsx
@@ -22,7 +22,7 @@ export function AuthSection({
   }
 
   return (
-    <div className="px-3 pt-2 pb-1">
+    <div className="px-3 pt-2 pb-3">
       <button
         onClick={handleOpenSettings}
         className="flex h-10 w-full items-center justify-center gap-2 rounded-full border-2 border-stone-600 bg-stone-800 text-sm font-medium text-white shadow-[0_4px_14px_rgba(87,83,78,0.4)] transition-all duration-200 hover:bg-stone-700"


### PR DESCRIPTION
Increase the unauthenticated profile menu footer padding beneath the sign-in button.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind spacing tweak in the profile sidebar UI with no logic or data changes.
> 
> **Overview**
> Adds a bit more space below the **Sign in** control in the unauthenticated profile menu by increasing the footer wrapper’s bottom padding from `pb-1` to `pb-3` in `AuthSection`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 070db4e19c238e4d176529fec803429ac149e392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->