### PR TITLE
fix(chat): avoid widening comfortable windows

### DIFF
--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -1,0 +1,101 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { clearContentMock, editorState } = vi.hoisted(() => ({
+  clearContentMock: vi.fn(),
+  editorState: {
+    json: undefined as unknown,
+    onUpdate: undefined as undefined | ((json: unknown) => void),
+  },
+}));
+
+vi.mock("@hypr/editor/chat", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    ChatEditor: React.forwardRef<
+      { clearContent: () => void; focus: () => void; getJSON: () => unknown },
+      {
+        onSubmit: () => void;
+        onUpdate: (json: unknown) => void;
+      }
+    >(function ChatEditor({ onUpdate }, ref) {
+      editorState.onUpdate = onUpdate;
+
+      React.useImperativeHandle(ref, () => ({
+        clearContent: clearContentMock,
+        focus: vi.fn(),
+        getJSON: () => editorState.json,
+      }));
+
+      return <div data-testid="chat-editor" />;
+    }),
+  };
+});
+
+vi.mock("@hypr/plugin-analytics", () => ({
+  commands: {
+    event: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+vi.mock("~/contexts/shell", () => ({
+  useShell: () => ({
+    chat: {
+      mode: "RightPanelOpen",
+    },
+  }),
+}));
+
+vi.mock("~/editor-bridge/mention-config", () => ({
+  useMentionConfig: () => undefined,
+}));
+
+import { ChatMessageInput } from "./index";
+
+describe("ChatMessageInput", () => {
+  beforeEach(() => {
+    clearContentMock.mockClear();
+    editorState.json = { type: "doc", content: [] };
+    editorState.onUpdate = undefined;
+  });
+
+  it("disables send until the draft has content", () => {
+    const onSendMessage = vi.fn();
+    render(
+      <ChatMessageInput
+        draftKey="chat-input-test"
+        onSendMessage={onSendMessage}
+      />,
+    );
+
+    const sendButton = screen.getByRole("button", {
+      name: /send/i,
+    }) as HTMLButtonElement;
+    expect(sendButton.disabled).toBe(true);
+
+    editorState.json = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello" }],
+        },
+      ],
+    };
+    act(() => {
+      editorState.onUpdate?.(editorState.json);
+    });
+
+    expect(sendButton.disabled).toBe(false);
+
+    fireEvent.click(sendButton);
+
+    expect(onSendMessage).toHaveBeenCalledWith(
+      "Hello",
+      [{ type: "text", text: "Hello" }],
+      [],
+    );
+    expect(clearContentMock).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -53,6 +53,7 @@ export function ChatMessageInput({
   });
   useAutoFocusEditor({ editorRef, disabled, shouldFocus });
   const mentionConfig = useMentionConfig();
+  const isSendDisabled = Boolean(disabled) || !hasContent;
 
   return (
     <Container
@@ -86,25 +87,24 @@ export function ChatMessageInput({
           ) : (
             <button
               onClick={handleSubmit}
-              disabled={disabled}
+              disabled={isSendDisabled}
               className={cn([
                 "inline-flex h-7 items-center gap-1.5 rounded-lg pr-1.5 pl-2.5 text-xs font-medium transition-all duration-100",
                 "border",
-                disabled
+                isSendDisabled
                   ? "cursor-default border-neutral-200 text-neutral-300"
                   : [
                       "border-stone-600 bg-stone-800 text-white",
                       "hover:bg-stone-700",
                       "active:scale-[0.97] active:bg-stone-600",
                     ],
-                !hasContent && !disabled && "opacity-50",
               ])}
             >
               Send
               <span
                 className={cn([
                   "font-mono text-xs",
-                  disabled ? "text-neutral-300" : "text-stone-400",
+                  isSendDisabled ? "text-neutral-300" : "text-stone-400",
                 ])}
               >
                 ⌘ ↩

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -122,7 +122,7 @@ function ChatGroups({
         <Button
           variant="ghost"
           className={cn([
-            "group flex h-8 max-w-64 min-w-0 justify-start gap-2 px-0 py-0",
+            "group -ml-2 flex h-8 max-w-64 min-w-0 justify-start gap-2 px-2 py-0",
             "text-neutral-700",
           ])}
         >

--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getSizeMock, resizeMock, windowExpandWidthMock } = vi.hoisted(() => ({
+  getSizeMock: vi.fn(() => 100),
+  resizeMock: vi.fn(),
+  windowExpandWidthMock: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@hypr/plugin-windows", () => ({
+  commands: {
+    windowExpandWidth: windowExpandWidthMock,
+    windowRestoreWidth: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+vi.mock("~/chat/components/persistent-chat", () => ({
+  PersistentChatPanel: () => null,
+}));
+
+vi.mock("@hypr/ui/components/ui/resizable", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    ResizablePanelGroup: ({
+      children,
+      direction,
+    }: {
+      children: React.ReactNode;
+      direction: string;
+    }) => (
+      <div data-direction={direction} data-testid="panel-group">
+        {children}
+      </div>
+    ),
+    ResizablePanel: React.forwardRef<
+      { getSize: () => number; resize: (size: number) => void },
+      {
+        children: React.ReactNode;
+        className?: string;
+        defaultSize?: number;
+        maxSize?: number;
+        minSize?: number;
+      }
+    >(function ResizablePanel(
+      { children, className, defaultSize, maxSize, minSize },
+      ref,
+    ) {
+      React.useImperativeHandle(ref, () => ({
+        getSize: getSizeMock,
+        resize: resizeMock,
+      }));
+
+      return (
+        <div
+          data-class-name={className}
+          data-default-size={defaultSize}
+          data-max-size={maxSize}
+          data-min-size={minSize}
+          data-testid="panel"
+        >
+          {children}
+        </div>
+      );
+    }),
+    ResizableHandle: ({ className }: { className?: string }) => (
+      <div data-class-name={className} data-testid="resize-handle" />
+    ),
+  };
+});
+
+import { MainChatPanels } from "./chat-panels";
+
+describe("MainChatPanels", () => {
+  beforeEach(() => {
+    cleanup();
+    getSizeMock.mockClear();
+    resizeMock.mockClear();
+    windowExpandWidthMock.mockClear();
+  });
+
+  it("only asks the native window to expand while below the chat replacement width", async () => {
+    const { rerender } = render(
+      <MainChatPanels autoSaveId="test-chat" isRightPanelOpen={false}>
+        <div data-testid="main-content" />
+      </MainChatPanels>,
+    );
+
+    rerender(
+      <MainChatPanels autoSaveId="test-chat" isRightPanelOpen>
+        <div data-testid="main-content" />
+      </MainChatPanels>,
+    );
+
+    await waitFor(() => {
+      expect(windowExpandWidthMock).toHaveBeenCalledWith(400, 720, true, false);
+    });
+    expect(resizeMock).toHaveBeenCalledWith(100);
+  });
+});

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -11,6 +11,8 @@ import {
 import { PersistentChatPanel } from "~/chat/components/persistent-chat";
 
 const CHAT_MIN_WIDTH_PX = 280;
+const CHAT_EXPANSION_WIDTH_PX = 400;
+const CHAT_REPLACE_MIN_WINDOW_WIDTH_PX = 720;
 
 export function MainChatPanels({
   autoSaveId,
@@ -32,7 +34,12 @@ export function MainChatPanels({
         bodyPanelRef.current.resize(currentSize);
       }
       windowsCommands
-        .windowExpandWidth(400, null, true, false)
+        .windowExpandWidth(
+          CHAT_EXPANSION_WIDTH_PX,
+          CHAT_REPLACE_MIN_WINDOW_WIDTH_PX,
+          true,
+          false,
+        )
         .catch(console.error);
     } else if (!isRightPanelOpen && previousOpenRef.current) {
       windowsCommands.windowRestoreWidth().catch(console.error);


### PR DESCRIPTION
Skip native window expansion for the chat panel once the main shell is already wide enough, and cover the threshold with a focused test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop UI and window-sizing behavior with focused tests; no auth, data, or security paths touched.
> 
> **Overview**
> Opening the right-hand chat panel no longer forces native window growth when the shell is already wide enough: **`windowExpandWidth`** now passes a **720px** minimum window width (with named constants) instead of **`null`**, so expansion only runs below that threshold.
> 
> **`ChatMessageInput`** ties Send disabled state and styling to **`isSendDisabled`** (empty draft or other disable), removing the half-opacity empty-draft case. The chat toolbar title trigger gets a small layout tweak (**`-ml-2`**, **`px-2`**).
> 
> New tests cover empty-draft Send behavior and the expand call arguments when the panel opens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f87a1e936f53b5361d17b549952955f021749824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->