### PR TITLE
fix(timeline): move meetings to top timeline

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -3,10 +3,15 @@ import { useShallow } from "zustand/shallow";
 import { ClassicMainSidebar } from "./shell-sidebar";
 import { ClassicMainTabChrome } from "./tab-chrome";
 import { ClassicMainTabContent } from "./tab-content";
+import { TopMeetingTimeline } from "./top-meeting-timeline";
 
+import { useShell } from "~/contexts/shell";
+import { ToastArea } from "~/sidebar/toast";
+import { hasCustomSidebarTab } from "~/sidebar/use-custom-sidebar";
 import { type Tab, uniqueIdfromTab, useTabs } from "~/store/zustand/tabs";
 
 export function ClassicMainBody() {
+  const { leftsidebar } = useShell();
   const { tabs, currentTab } = useTabs(
     useShallow((state) => ({
       tabs: state.tabs,
@@ -18,9 +23,20 @@ export function ClassicMainBody() {
     return null;
   }
 
+  const isOnboarding = currentTab.type === "onboarding";
+  const hasCustomSidebar = hasCustomSidebarTab(currentTab);
+  const showTopTimeline =
+    leftsidebar.expanded &&
+    !leftsidebar.showDevtool &&
+    !hasCustomSidebar &&
+    !isOnboarding;
+  const showFloatingToast =
+    !leftsidebar.showDevtool && !hasCustomSidebar && !isOnboarding;
+
   return (
     <div className="relative flex h-full min-w-0 flex-1 flex-col">
       <ClassicMainTabChrome tabs={tabs} />
+      {showTopTimeline ? <TopMeetingTimeline currentTab={currentTab} /> : null}
       <div className="flex min-h-0 min-w-0 flex-1 gap-1">
         <ClassicMainSidebar />
         <div className="min-h-0 min-w-0 flex-1 overflow-auto">
@@ -30,6 +46,11 @@ export function ClassicMainBody() {
           />
         </div>
       </div>
+      {showFloatingToast ? (
+        <div className="absolute bottom-1 left-1 z-30 w-[200px]">
+          <ToastArea />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/main/meeting-timeline-layout.test.ts
+++ b/apps/desktop/src/main/meeting-timeline-layout.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+
+import { normalizeEndMs, TIMELINE_BLOCK_MS } from "./meeting-timeline-layout";
+
+describe("meeting timeline layout", () => {
+  test("uses one 30-minute block when an item has no end time", () => {
+    const start = new Date("2026-05-27T09:00:00.000Z");
+
+    expect(normalizeEndMs(start, null)).toBe(
+      start.getTime() + TIMELINE_BLOCK_MS,
+    );
+  });
+
+  test("uses one 30-minute block when an item end is before its start", () => {
+    const start = new Date("2026-05-27T09:00:00.000Z");
+    const end = new Date("2026-05-27T08:45:00.000Z");
+
+    expect(normalizeEndMs(start, end)).toBe(
+      start.getTime() + TIMELINE_BLOCK_MS,
+    );
+  });
+
+  test("keeps valid end times", () => {
+    const start = new Date("2026-05-27T09:00:00.000Z");
+    const end = new Date("2026-05-27T09:45:00.000Z");
+
+    expect(normalizeEndMs(start, end)).toBe(end.getTime());
+  });
+});

--- a/apps/desktop/src/main/meeting-timeline-layout.ts
+++ b/apps/desktop/src/main/meeting-timeline-layout.ts
@@ -1,0 +1,25 @@
+export const TIMELINE_BLOCK_MS = 30 * 60 * 1000;
+
+export type MeetingTimelineEntry = {
+  id: string;
+  type: "session" | "event";
+  title: string;
+  calendarId: string | null;
+  trackingId?: string | null;
+  recurrenceSeriesId?: string | null;
+  start: Date;
+  end: Date | null;
+  selected: boolean;
+  muted: boolean;
+};
+
+export function normalizeEndMs(start: Date, end: Date | null): number {
+  const startMs = start.getTime();
+  const endMs = end?.getTime();
+
+  if (!endMs || endMs <= startMs) {
+    return startMs + TIMELINE_BLOCK_MS;
+  }
+
+  return endMs;
+}

--- a/apps/desktop/src/main/meeting-timeline-recordings.test.ts
+++ b/apps/desktop/src/main/meeting-timeline-recordings.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+
+import { buildSessionRecordingRanges } from "./meeting-timeline-recordings";
+
+describe("meeting timeline recording ranges", () => {
+  test("derives recording end from transcript word timing", () => {
+    const startedAt = new Date("2026-05-27T10:51:00.000Z").getTime();
+    const ranges = buildSessionRecordingRanges({
+      transcript: {
+        session_id: "session",
+        started_at: startedAt,
+        words: JSON.stringify([{ end_ms: 98_000 }]),
+      },
+    });
+
+    expect(ranges.get("session")).toEqual({
+      start: new Date(startedAt),
+      end: new Date(startedAt + 98_000),
+    });
+  });
+
+  test("merges multiple transcript rows for a session", () => {
+    const firstStart = new Date("2026-05-27T10:00:00.000Z").getTime();
+    const secondStart = new Date("2026-05-27T10:04:00.000Z").getTime();
+    const ranges = buildSessionRecordingRanges({
+      first: {
+        session_id: "session",
+        started_at: firstStart,
+        ended_at: firstStart + 60_000,
+      },
+      second: {
+        session_id: "session",
+        started_at: secondStart,
+        words: JSON.stringify([{ end_ms: 30_000 }]),
+      },
+    });
+
+    expect(ranges.get("session")).toEqual({
+      start: new Date(firstStart),
+      end: new Date(secondStart + 30_000),
+    });
+  });
+});

--- a/apps/desktop/src/main/meeting-timeline-recordings.ts
+++ b/apps/desktop/src/main/meeting-timeline-recordings.ts
@@ -1,0 +1,95 @@
+export type TimelineTranscriptRow = {
+  session_id?: string | null;
+  started_at?: number | null;
+  ended_at?: number | null;
+  words?: string | null;
+};
+
+export type TimelineTranscriptsTable =
+  | Record<string, TimelineTranscriptRow>
+  | null
+  | undefined;
+
+export type SessionRecordingRange = {
+  start: Date;
+  end: Date;
+};
+
+export function buildSessionRecordingRanges(
+  transcriptsTable: TimelineTranscriptsTable,
+): Map<string, SessionRecordingRange> {
+  const rangesBySession = new Map<string, { startMs: number; endMs: number }>();
+
+  if (!transcriptsTable) {
+    return new Map();
+  }
+
+  Object.values(transcriptsTable).forEach((row) => {
+    if (!row.session_id || typeof row.started_at !== "number") {
+      return;
+    }
+
+    const startMs = row.started_at;
+    const endMs = getTranscriptEndMs(row, startMs);
+
+    if (!Number.isFinite(startMs) || !endMs || endMs <= startMs) {
+      return;
+    }
+
+    const existing = rangesBySession.get(row.session_id);
+    if (!existing) {
+      rangesBySession.set(row.session_id, { startMs, endMs });
+      return;
+    }
+
+    existing.startMs = Math.min(existing.startMs, startMs);
+    existing.endMs = Math.max(existing.endMs, endMs);
+  });
+
+  return new Map(
+    [...rangesBySession.entries()].map(([sessionId, range]) => [
+      sessionId,
+      {
+        start: new Date(range.startMs),
+        end: new Date(range.endMs),
+      },
+    ]),
+  );
+}
+
+function getTranscriptEndMs(
+  row: TimelineTranscriptRow,
+  startedAtMs: number,
+): number | null {
+  if (typeof row.ended_at === "number" && row.ended_at > startedAtMs) {
+    return row.ended_at;
+  }
+
+  const wordsEndMs = getWordsEndMs(row.words);
+  if (!wordsEndMs) {
+    return null;
+  }
+
+  return startedAtMs + wordsEndMs;
+}
+
+function getWordsEndMs(wordsJson?: string | null): number | null {
+  if (!wordsJson) {
+    return null;
+  }
+
+  try {
+    const words = JSON.parse(wordsJson) as Array<{ end_ms?: unknown }>;
+    const maxEndMs = words.reduce((max, word) => {
+      if (typeof word.end_ms !== "number" || !Number.isFinite(word.end_ms)) {
+        return max;
+      }
+
+      return Math.max(max, word.end_ms);
+    }, 0);
+
+    return maxEndMs > 0 ? maxEndMs : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/desktop/src/main/shell-sidebar.tsx
+++ b/apps/desktop/src/main/shell-sidebar.tsx
@@ -19,5 +19,9 @@ export function ClassicMainSidebar() {
     return null;
   }
 
-  return <LeftSidebar />;
+  if (leftsidebar.showDevtool || hasCustomSidebar) {
+    return <LeftSidebar />;
+  }
+
+  return null;
 }

--- a/apps/desktop/src/main/tab-chrome.tsx
+++ b/apps/desktop/src/main/tab-chrome.tsx
@@ -7,6 +7,8 @@ import {
   MessageCircleIcon,
   PanelLeftCloseIcon,
   PanelLeftOpenIcon,
+  PanelTopCloseIcon,
+  PanelTopOpenIcon,
   PlusIcon,
 } from "lucide-react";
 import { Reorder } from "motion/react";
@@ -34,6 +36,7 @@ import { TrafficLights } from "~/shared/ui/traffic-lights";
 import { useNewNote, useNewNoteAndListen } from "~/shared/useNewNote";
 import { ProfileMenu } from "~/sidebar/profile";
 import { Update } from "~/sidebar/update";
+import { hasCustomSidebarTab } from "~/sidebar/use-custom-sidebar";
 import { type Tab, uniqueIdfromTab, useTabs } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
 import { commands as tauriCommands } from "~/types/tauri.gen";
@@ -47,6 +50,10 @@ export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
   const currentTab = useTabs((state) => state.currentTab);
   const isOnboarding = currentTab?.type === "onboarding";
   const showSidebarToggle = !isOnboarding && !leftsidebar.locked;
+  const togglesTopTimeline =
+    currentTab !== null &&
+    !hasCustomSidebarTab(currentTab) &&
+    !leftsidebar.showDevtool;
   const {
     select,
     close,
@@ -150,15 +157,21 @@ export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
                 className="shrink-0"
                 onClick={leftsidebar.toggleExpanded}
               >
-                {leftsidebar.expanded ? (
+                {leftsidebar.expanded && togglesTopTimeline ? (
+                  <PanelTopCloseIcon size={16} className="text-neutral-600" />
+                ) : leftsidebar.expanded ? (
                   <PanelLeftCloseIcon size={16} className="text-neutral-600" />
+                ) : togglesTopTimeline ? (
+                  <PanelTopOpenIcon size={16} className="text-neutral-600" />
                 ) : (
                   <PanelLeftOpenIcon size={16} className="text-neutral-600" />
                 )}
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom" className="flex items-center gap-2">
-              <span>Toggle sidebar</span>
+              <span>
+                {togglesTopTimeline ? "Toggle timeline" : "Toggle sidebar"}
+              </span>
               <Kbd className="animate-kbd-press">⌘ \</Kbd>
             </TooltipContent>
           </Tooltip>

--- a/apps/desktop/src/main/top-meeting-timeline.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.tsx
@@ -1,0 +1,1230 @@
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  CalendarIcon,
+  PlusIcon,
+} from "lucide-react";
+import {
+  memo,
+  type CSSProperties,
+  type MouseEvent,
+  type MouseEventHandler,
+  type ReactNode,
+  type UIEvent,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
+import { commands as openerCommands } from "@hypr/plugin-opener2";
+import { Spinner } from "@hypr/ui/components/ui/spinner";
+import {
+  addDays,
+  cn,
+  differenceInCalendarDays,
+  format,
+  safeParseDate,
+  startOfDay,
+  TZDate,
+} from "@hypr/utils";
+
+import {
+  normalizeEndMs,
+  TIMELINE_BLOCK_MS,
+  type MeetingTimelineEntry,
+} from "./meeting-timeline-layout";
+import {
+  buildSessionRecordingRanges,
+  type SessionRecordingRange,
+  type TimelineTranscriptsTable,
+} from "./meeting-timeline-recordings";
+
+import { SessionPreviewCard } from "~/session/components/session-preview-card";
+import { useIsSessionEnhancing } from "~/session/hooks/useEnhancedNotes";
+import { getSessionEvent } from "~/session/utils";
+import { useConfigValue } from "~/shared/config";
+import {
+  type MenuItemDef,
+  useNativeContextMenu,
+} from "~/shared/hooks/useNativeContextMenu";
+import { useNewNoteAndListen } from "~/shared/useNewNote";
+import type {
+  TimelineEventRow,
+  TimelineEventsTable,
+  TimelineSessionRow,
+  TimelineSessionsTable,
+} from "~/sidebar/timeline/utils";
+import { useIgnoredEvents } from "~/store/tinybase/hooks";
+import {
+  captureSessionData,
+  deleteSessionCascade,
+  finalizeSessionDeletion,
+} from "~/store/tinybase/store/deleteSession";
+import * as main from "~/store/tinybase/store/main";
+import { getOrCreateSessionForEventId } from "~/store/tinybase/store/sessions";
+import { useSessionTitle } from "~/store/zustand/live-title";
+import { type Tab, useTabs } from "~/store/zustand/tabs";
+import { useUndoDelete } from "~/store/zustand/undo-delete";
+import { useListener } from "~/stt/contexts";
+
+const TIMELINE_HEIGHT = 44;
+const TIMELINE_CAROUSEL_CARD_WIDTH = 188;
+const TIMELINE_CAROUSEL_PADDING = 0;
+const TIMELINE_CAROUSEL_GAP = 4;
+type TodayChipDirection = "left" | "right";
+
+export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
+  const timezone = useConfigValue("timezone") || undefined;
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const detachWheelListenerRef = useRef<(() => void) | null>(null);
+  const appliedScrollAnchorRef = useRef<string | null>(null);
+
+  const selectedSessionId =
+    currentTab?.type === "sessions" ? currentTab.id : null;
+
+  const timelineEventsTable = main.UI.useResultTable(
+    main.QUERIES.timelineEvents,
+    main.STORE_ID,
+  ) as TimelineEventsTable;
+  const timelineSessionsTable = main.UI.useResultTable(
+    main.QUERIES.timelineSessions,
+    main.STORE_ID,
+  ) as TimelineSessionsTable;
+  const transcriptsTable = main.UI.useTable(
+    "transcripts",
+    main.STORE_ID,
+  ) as TimelineTranscriptsTable;
+
+  const { isIgnored } = useIgnoredEvents();
+
+  const sessionRecordingRanges = useMemo(
+    () => buildSessionRecordingRanges(transcriptsTable),
+    [transcriptsTable],
+  );
+
+  const entries = useMemo(
+    () =>
+      buildMeetingTimelineEntries({
+        timelineEventsTable,
+        timelineSessionsTable,
+        sessionRecordingRanges,
+        selectedSessionId,
+        isIgnored,
+      }),
+    [
+      timelineEventsTable,
+      timelineSessionsTable,
+      sessionRecordingRanges,
+      selectedSessionId,
+      isIgnored,
+    ],
+  );
+
+  const selectedEntry = useMemo(
+    () =>
+      selectedSessionId
+        ? entries.find(
+            (entry) =>
+              entry.type === "session" && entry.id === selectedSessionId,
+          )
+        : null,
+    [entries, selectedSessionId],
+  );
+
+  const todayMs = getTimelineDayStart(new Date(), timezone).getTime();
+  const [todayChipDirection, setTodayChipDirection] =
+    useState<TodayChipDirection | null>(null);
+  const createNewMeeting = useNewNoteAndListen({ behavior: "current" });
+  const openNew = useTabs((state) => state.openNew);
+
+  const renderItems = useMemo(
+    () => buildTimelineRenderItems(entries),
+    [entries],
+  );
+  const carouselItems = useMemo(
+    () =>
+      buildTimelineCarouselItems({
+        renderItems,
+        currentDate: new Date(todayMs),
+        timezone,
+      }),
+    [renderItems, todayMs, timezone],
+  );
+  const carouselWidth = getTimelineCarouselWidth(carouselItems);
+  const openCalendar = useCallback(
+    () => openNew({ type: "calendar" }),
+    [openNew],
+  );
+
+  const scrollAnchorKey = getTimelineCarouselAnchorKey(
+    carouselItems,
+    selectedSessionId,
+  );
+  const scrollAnchorMs = selectedEntry?.start.getTime() ?? todayMs;
+
+  const updateTodayChipFromScroll = useCallback(
+    (node: HTMLDivElement) => {
+      const nextDirection = getTimelineCarouselDateDirection({
+        items: carouselItems,
+        date: new Date(todayMs),
+        timezone,
+        scrollLeft: node.scrollLeft,
+        viewportWidth: node.clientWidth,
+      });
+
+      setTodayChipDirection((previousDirection) =>
+        previousDirection === nextDirection ? previousDirection : nextDirection,
+      );
+    },
+    [carouselItems, todayMs, timezone],
+  );
+
+  const handleWheel = useCallback(
+    (event: WheelEvent) => {
+      const node = scrollContainerRef.current;
+      if (!node) {
+        return;
+      }
+
+      if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
+        event.preventDefault();
+        node.scrollLeft += event.deltaY;
+        updateTodayChipFromScroll(node);
+      }
+    },
+    [updateTodayChipFromScroll],
+  );
+
+  const setScrollContainer = useCallback(
+    (node: HTMLDivElement | null) => {
+      detachWheelListenerRef.current?.();
+      detachWheelListenerRef.current = null;
+      scrollContainerRef.current = node;
+
+      if (!node) {
+        return;
+      }
+
+      node.addEventListener("wheel", handleWheel, { passive: false });
+      detachWheelListenerRef.current = () => {
+        node.removeEventListener("wheel", handleWheel);
+      };
+
+      if (appliedScrollAnchorRef.current === scrollAnchorKey) {
+        return;
+      }
+
+      const anchorLeft = selectedEntry
+        ? getTimelineCarouselX(carouselItems, scrollAnchorMs)
+        : getTimelineCarouselDateX(carouselItems, new Date(todayMs), timezone);
+      node.scrollLeft = Math.max(0, anchorLeft - node.clientWidth * 0.35);
+      updateTodayChipFromScroll(node);
+      appliedScrollAnchorRef.current = scrollAnchorKey;
+    },
+    [
+      scrollAnchorKey,
+      scrollAnchorMs,
+      selectedEntry,
+      todayMs,
+      timezone,
+      carouselItems,
+      updateTodayChipFromScroll,
+      handleWheel,
+    ],
+  );
+
+  const handleScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      updateTodayChipFromScroll(event.currentTarget);
+    },
+    [updateTodayChipFromScroll],
+  );
+
+  const handleGoToToday = useCallback(() => {
+    const node = scrollContainerRef.current;
+    if (!node) {
+      return;
+    }
+
+    const todayLeft = getTimelineCarouselDateX(
+      carouselItems,
+      new Date(todayMs),
+      timezone,
+    );
+    node.scrollLeft = Math.max(0, todayLeft - node.clientWidth * 0.5);
+    updateTodayChipFromScroll(node);
+  }, [carouselItems, todayMs, timezone, updateTodayChipFromScroll]);
+
+  const handleTimelineContextMenu = useCallback<
+    MouseEventHandler<HTMLDivElement>
+  >((event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
+  return (
+    <div className="min-w-0 shrink-0">
+      <div className="relative">
+        <div
+          ref={setScrollContainer}
+          onScroll={handleScroll}
+          className={cn([
+            "scroll-fade-x min-w-0",
+            "scrollbar-hide overflow-x-auto overflow-y-hidden",
+            "overscroll-contain",
+          ])}
+          style={{ height: TIMELINE_HEIGHT }}
+        >
+          <div
+            className="flex h-full min-w-full items-start gap-1"
+            onContextMenu={handleTimelineContextMenu}
+            style={{
+              width: carouselWidth,
+            }}
+          >
+            {carouselItems.map((renderItem) =>
+              renderItem.kind === "create-meeting" ? (
+                <TimelineCreateMeetingCard
+                  key={renderItem.id}
+                  item={renderItem}
+                  timezone={timezone}
+                  onClick={createNewMeeting}
+                />
+              ) : renderItem.kind === "open-calendar" ? (
+                <TimelineOpenCalendarCard
+                  key={renderItem.id}
+                  item={renderItem}
+                  onClick={openCalendar}
+                />
+              ) : renderItem.item.type === "session" ? (
+                <SessionTimelineBar
+                  key={`${renderItem.item.type}-${renderItem.item.id}`}
+                  item={renderItem.item}
+                  timezone={timezone}
+                />
+              ) : (
+                <EventTimelineBar
+                  key={`${renderItem.item.type}-${renderItem.item.id}`}
+                  item={renderItem.item}
+                  timezone={timezone}
+                />
+              ),
+            )}
+          </div>
+        </div>
+        {todayChipDirection ? (
+          <button
+            type="button"
+            className={cn([
+              "absolute top-1/2 z-40 flex h-6 -translate-y-1/2 items-center gap-1 rounded-full border border-neutral-200 bg-white/95 px-2.5 text-xs font-medium text-neutral-700 shadow-xs backdrop-blur",
+              "transition-colors hover:border-neutral-300 hover:bg-white hover:text-neutral-900",
+              "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+              todayChipDirection === "left" ? "left-3" : "right-3",
+            ])}
+            onClick={handleGoToToday}
+          >
+            {todayChipDirection === "left" ? <ArrowLeftIcon size={12} /> : null}
+            <span>Today</span>
+            {todayChipDirection === "right" ? (
+              <ArrowRightIcon size={12} />
+            ) : null}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+const SessionTimelineBar = memo(
+  ({ item, timezone }: { item: MeetingTimelineEntry; timezone?: string }) => {
+    const store = main.UI.useStore(main.STORE_ID);
+    const indexes = main.UI.useIndexes(main.STORE_ID);
+    const openCurrent = useTabs((state) => state.openCurrent);
+    const openNew = useTabs((state) => state.openNew);
+    const invalidateResource = useTabs((state) => state.invalidateResource);
+    const addDeletion = useUndoDelete((state) => state.addDeletion);
+    const { ignoreEvent } = useIgnoredEvents();
+    const sessionRow = main.UI.useRow("sessions", item.id, main.STORE_ID) as
+      | TimelineSessionRow
+      | undefined;
+    const storeTitle = main.UI.useCell(
+      "sessions",
+      item.id,
+      "title",
+      main.STORE_ID,
+    ) as string | undefined;
+    const title = useSessionTitle(item.id, storeTitle);
+    const sessionMode = useListener((state) => state.getSessionMode(item.id));
+    const isEnhancing = useIsSessionEnhancing(item.id);
+    const showSpinner =
+      sessionMode === "finalizing" ||
+      sessionMode === "running_batch" ||
+      isEnhancing;
+    const sessionEvent = useMemo(
+      () => (sessionRow ? getSessionEvent(sessionRow) : null),
+      [sessionRow?.event_json],
+    );
+
+    const handleClick = useCallback(
+      (event: MouseEvent<HTMLButtonElement>) => {
+        if (event.metaKey || event.ctrlKey) {
+          openNew({ id: item.id, type: "sessions" });
+          return;
+        }
+
+        openCurrent({ id: item.id, type: "sessions" });
+      },
+      [item.id, openCurrent, openNew],
+    );
+
+    const handleOpenNewTab = useCallback(() => {
+      openNew({ id: item.id, type: "sessions" });
+    }, [item.id, openNew]);
+
+    const handleDelete = useCallback(() => {
+      if (!store) {
+        return;
+      }
+
+      if (sessionEvent?.tracking_id) {
+        ignoreEvent(sessionEvent.tracking_id);
+      }
+
+      const capturedData = captureSessionData(store, indexes, item.id);
+
+      invalidateResource("sessions", item.id);
+      void deleteSessionCascade(store, indexes, item.id, {
+        deferFilesystemDelete: true,
+      });
+
+      if (capturedData) {
+        addDeletion(capturedData, () => {
+          void finalizeSessionDeletion(item.id);
+        });
+      }
+    }, [
+      store,
+      indexes,
+      item.id,
+      sessionEvent,
+      ignoreEvent,
+      invalidateResource,
+      addDeletion,
+    ]);
+
+    const handleShowInFinder = useCallback(async () => {
+      const result = await fsSyncCommands.sessionDir(item.id);
+      if (result.status === "ok") {
+        await openerCommands.openPath(result.data, null);
+      }
+    }, [item.id]);
+
+    const contextMenu = useMemo<MenuItemDef[]>(
+      () => [
+        {
+          id: "open-new-tab",
+          text: "Open in New Tab",
+          action: handleOpenNewTab,
+        },
+        {
+          id: "show",
+          text: "Show in Finder",
+          action: handleShowInFinder,
+        },
+        { separator: true },
+        {
+          id: "delete",
+          text: "Delete Note",
+          action: handleDelete,
+        },
+      ],
+      [handleOpenNewTab, handleShowInFinder, handleDelete],
+    );
+
+    return (
+      <TimelineCarouselCard item={item}>
+        <SessionPreviewCard sessionId={item.id} side="bottom" enabled>
+          <TimelineCardButton
+            item={item}
+            title={title || item.title || "Untitled"}
+            timezone={timezone}
+            showSpinner={showSpinner}
+            onClick={handleClick}
+            contextMenu={contextMenu}
+          />
+        </SessionPreviewCard>
+      </TimelineCarouselCard>
+    );
+  },
+);
+
+const EventTimelineBar = memo(
+  ({ item, timezone }: { item: MeetingTimelineEntry; timezone?: string }) => {
+    const store = main.UI.useStore(main.STORE_ID);
+    const openCurrent = useTabs((state) => state.openCurrent);
+    const openNew = useTabs((state) => state.openNew);
+    const { ignoreEvent, ignoreSeries } = useIgnoredEvents();
+
+    const openEvent = useCallback(
+      (openInNewTab: boolean) => {
+        if (!store) {
+          return;
+        }
+
+        const sessionId = getOrCreateSessionForEventId(
+          store,
+          item.id,
+          item.title,
+        );
+        const tab = { id: sessionId, type: "sessions" } as const;
+
+        openInNewTab ? openNew(tab) : openCurrent(tab);
+      },
+      [item.id, item.title, openCurrent, openNew, store],
+    );
+
+    const handleClick = useCallback(
+      (event: MouseEvent<HTMLButtonElement>) => {
+        openEvent(event.metaKey || event.ctrlKey);
+      },
+      [openEvent],
+    );
+
+    const handleOpenNewTab = useCallback(() => {
+      openEvent(true);
+    }, [openEvent]);
+
+    const handleIgnore = useCallback(() => {
+      if (!item.trackingId) {
+        return;
+      }
+
+      ignoreEvent(item.trackingId);
+    }, [item.trackingId, ignoreEvent]);
+
+    const handleIgnoreSeries = useCallback(() => {
+      if (!item.recurrenceSeriesId) {
+        return;
+      }
+
+      ignoreSeries(item.recurrenceSeriesId);
+    }, [item.recurrenceSeriesId, ignoreSeries]);
+
+    const contextMenu = useMemo<MenuItemDef[]>(() => {
+      const menu: MenuItemDef[] = [
+        {
+          id: "open-new-tab",
+          text: "Open in New Tab",
+          action: handleOpenNewTab,
+        },
+        { separator: true },
+        {
+          id: "ignore",
+          text: item.recurrenceSeriesId ? "Delete This Event" : "Delete Event",
+          action: handleIgnore,
+        },
+      ];
+
+      if (item.recurrenceSeriesId) {
+        menu.push({
+          id: "ignore-series",
+          text: "Delete All Recurring Events",
+          action: handleIgnoreSeries,
+        });
+      }
+
+      return menu;
+    }, [
+      handleOpenNewTab,
+      handleIgnore,
+      handleIgnoreSeries,
+      item.recurrenceSeriesId,
+    ]);
+
+    return (
+      <TimelineCarouselCard item={item}>
+        <TimelineCardButton
+          item={item}
+          title={item.title || "Untitled"}
+          timezone={timezone}
+          onClick={handleClick}
+          contextMenu={contextMenu}
+        />
+      </TimelineCarouselCard>
+    );
+  },
+);
+
+type TimelineRenderItem = {
+  kind: "item";
+  id: string;
+  item: MeetingTimelineEntry;
+  start: Date;
+};
+
+type TimelineCreateMeetingItem = {
+  kind: "create-meeting";
+  id: string;
+  start: Date;
+};
+
+type TimelineOpenCalendarItem = {
+  kind: "open-calendar";
+  id: string;
+  start: Date;
+};
+
+type TimelineCarouselItem =
+  | TimelineRenderItem
+  | TimelineCreateMeetingItem
+  | TimelineOpenCalendarItem;
+
+function TimelineCarouselCard({
+  item,
+  children,
+}: {
+  item: MeetingTimelineEntry;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      data-timeline-start-ms={item.start.getTime()}
+      className={cn([
+        "group/timeline-card relative shrink-0 snap-start",
+        "transition-transform focus-within:z-30 focus-within:scale-[1.02] hover:z-30 hover:scale-[1.02]",
+        item.selected && "z-20",
+      ])}
+      style={{ width: TIMELINE_CAROUSEL_CARD_WIDTH }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function TimelineCreateMeetingCard({
+  item,
+  timezone,
+  onClick,
+}: {
+  item: TimelineCreateMeetingItem;
+  timezone?: string;
+  onClick: () => void;
+}) {
+  return (
+    <div
+      data-timeline-start-ms={item.start.getTime()}
+      className="relative shrink-0 snap-start"
+      style={{ width: TIMELINE_CAROUSEL_CARD_WIDTH }}
+    >
+      <button
+        type="button"
+        className={cn([
+          "flex h-10 w-full flex-col justify-center rounded-md border border-dashed border-neutral-300 bg-white/80 px-2 text-left shadow-xs",
+          "transition-colors hover:border-neutral-600 hover:bg-white focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+        ])}
+        onClick={onClick}
+      >
+        <span className="font-mono text-[10px] text-neutral-500">
+          {formatRelativeTimelineDay(item.start, timezone)}
+        </span>
+        <span className="flex min-w-0 items-center gap-1.5 truncate text-xs font-semibold text-neutral-700">
+          <PlusIcon size={12} className="shrink-0" />
+          <span className="truncate">Create new meeting</span>
+        </span>
+      </button>
+    </div>
+  );
+}
+
+function TimelineOpenCalendarCard({
+  item,
+  onClick,
+}: {
+  item: TimelineOpenCalendarItem;
+  onClick: () => void;
+}) {
+  return (
+    <div
+      data-timeline-start-ms={item.start.getTime()}
+      className="relative shrink-0 snap-start"
+      style={{ width: TIMELINE_CAROUSEL_CARD_WIDTH }}
+    >
+      <button
+        type="button"
+        className={cn([
+          "flex h-10 w-full items-center gap-1.5 rounded-md border border-dashed border-neutral-300 bg-white/80 px-2 text-left text-xs font-semibold text-neutral-700 shadow-xs",
+          "transition-colors hover:border-neutral-600 hover:bg-white focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+        ])}
+        onClick={onClick}
+      >
+        <CalendarIcon size={12} className="shrink-0" />
+        <span className="truncate">See more</span>
+      </button>
+    </div>
+  );
+}
+
+function FadedTimelineLabel({
+  children,
+  className,
+  style,
+}: {
+  children: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}) {
+  const fadeMask =
+    "linear-gradient(to right, black calc(100% - 20px), transparent)";
+
+  return (
+    <span
+      className={cn(["overflow-hidden whitespace-nowrap", className])}
+      style={{
+        ...style,
+        WebkitMaskImage: fadeMask,
+        maskImage: fadeMask,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function TimelineCardButton({
+  item,
+  title,
+  timezone,
+  showSpinner,
+  onClick,
+  contextMenu,
+}: {
+  item: MeetingTimelineEntry;
+  title: string;
+  timezone?: string;
+  showSpinner?: boolean;
+  onClick: (event: MouseEvent<HTMLButtonElement>) => void;
+  contextMenu?: MenuItemDef[];
+}) {
+  const showContextMenu = useNativeContextMenu(contextMenu ?? []);
+  const handleContextMenu = useCallback<MouseEventHandler<HTMLButtonElement>>(
+    (event) => {
+      if (!contextMenu) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      void showContextMenu(event);
+    },
+    [contextMenu, showContextMenu],
+  );
+  const rangeLabel = formatDateTimeRange(
+    item.start,
+    new Date(normalizeEndMs(item.start, item.end)),
+    timezone,
+  );
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onContextMenu={handleContextMenu}
+      className={cn([
+        "flex h-10 w-full flex-col justify-center rounded-md border px-2 text-left shadow-xs",
+        "transition-colors hover:border-neutral-700 focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+        item.type === "session" &&
+          (item.selected
+            ? "border-neutral-900 bg-neutral-900 text-white hover:bg-neutral-800"
+            : "border-neutral-300 bg-white text-neutral-800 hover:bg-neutral-50"),
+        item.type === "event" &&
+          "border-dashed border-neutral-300 bg-white/80 text-neutral-600 hover:bg-white",
+        item.muted && !item.selected && "opacity-60",
+      ])}
+    >
+      <FadedTimelineLabel
+        className={cn([
+          "font-mono text-[10px]",
+          item.selected ? "text-white/65" : "text-neutral-500",
+        ])}
+      >
+        {rangeLabel}
+      </FadedTimelineLabel>
+      <span className="flex min-w-0 items-center gap-1.5">
+        {showSpinner ? (
+          <span className="shrink-0">
+            <Spinner size={12} />
+          </span>
+        ) : null}
+        {item.calendarId ? <CalendarDot calendarId={item.calendarId} /> : null}
+        <FadedTimelineLabel className="min-w-0 flex-1 text-xs font-semibold">
+          {title}
+        </FadedTimelineLabel>
+      </span>
+    </button>
+  );
+}
+
+function buildTimelineRenderItems(
+  items: MeetingTimelineEntry[],
+): TimelineRenderItem[] {
+  return [...items]
+    .sort((a, b) => {
+      const startDiff = a.start.getTime() - b.start.getTime();
+      if (startDiff !== 0) {
+        return startDiff;
+      }
+
+      return normalizeEndMs(a.start, a.end) - normalizeEndMs(b.start, b.end);
+    })
+    .map((item) => ({
+      kind: "item" as const,
+      id: `${item.type}-${item.id}`,
+      item,
+      start: item.start,
+    }));
+}
+
+function buildTimelineCarouselItems({
+  renderItems,
+  currentDate,
+  timezone,
+}: {
+  renderItems: TimelineRenderItem[];
+  currentDate: Date;
+  timezone?: string;
+}): TimelineCarouselItem[] {
+  const startInclusive = getTimelineDayStart(currentDate, timezone);
+  const endExclusive = addDays(startInclusive, 2);
+  const items: TimelineCarouselItem[] = renderItems.filter((item) => {
+    const startMs = getTimelineCarouselItemStart(item).getTime();
+    const beforeEnd = startMs < endExclusive.getTime();
+
+    if (item.item.type === "session") {
+      return beforeEnd || item.item.selected;
+    }
+
+    return startMs >= startInclusive.getTime() && beforeEnd;
+  });
+  const hasToday = items.some((item) =>
+    isSameTimelineDay(
+      getTimelineCarouselItemStart(item),
+      currentDate,
+      timezone,
+    ),
+  );
+
+  if (!hasToday) {
+    items.push({
+      kind: "create-meeting",
+      id: `create-meeting-${currentDate.getTime()}`,
+      start: currentDate,
+    });
+  }
+
+  const sortedItems = items.sort(
+    (a, b) =>
+      getTimelineCarouselItemStart(a).getTime() -
+      getTimelineCarouselItemStart(b).getTime(),
+  );
+  const hasHiddenFutureItems = renderItems.some((item) => {
+    if (item.item.selected) {
+      return false;
+    }
+
+    return (
+      getTimelineCarouselItemStart(item).getTime() >= endExclusive.getTime()
+    );
+  });
+
+  if (!hasHiddenFutureItems) {
+    return sortedItems;
+  }
+
+  return [
+    ...sortedItems,
+    {
+      kind: "open-calendar",
+      id: `open-calendar-${endExclusive.getTime()}`,
+      start: endExclusive,
+    },
+  ];
+}
+
+function getTimelineCarouselWidth(items: TimelineCarouselItem[]): number {
+  if (items.length === 0) {
+    return 1;
+  }
+
+  const contentWidth = items.reduce(
+    (sum, item) => sum + getTimelineCarouselItemWidth(item),
+    0,
+  );
+
+  return (
+    TIMELINE_CAROUSEL_PADDING * 2 +
+    contentWidth +
+    TIMELINE_CAROUSEL_GAP * Math.max(0, items.length - 1)
+  );
+}
+
+function getTimelineCarouselX(
+  items: TimelineCarouselItem[],
+  timestampMs: number,
+): number {
+  if (items.length === 0) {
+    return 0;
+  }
+
+  let left = TIMELINE_CAROUSEL_PADDING;
+  let closestLeft = left;
+  let closestDistance = Number.POSITIVE_INFINITY;
+
+  for (const item of items) {
+    const distance = Math.abs(
+      getTimelineCarouselItemStart(item).getTime() - timestampMs,
+    );
+
+    if (distance < closestDistance) {
+      closestDistance = distance;
+      closestLeft = left;
+    }
+
+    left += getTimelineCarouselItemWidth(item) + TIMELINE_CAROUSEL_GAP;
+  }
+
+  return closestLeft;
+}
+
+function getTimelineCarouselDateX(
+  items: TimelineCarouselItem[],
+  date: Date,
+  timezone?: string,
+): number {
+  const range = getTimelineCarouselDateRange(items, date, timezone);
+
+  if (range) {
+    return range.left;
+  }
+
+  return getTimelineCarouselX(items, date.getTime());
+}
+
+function getTimelineCarouselDateDirection({
+  items,
+  date,
+  timezone,
+  scrollLeft,
+  viewportWidth,
+}: {
+  items: TimelineCarouselItem[];
+  date: Date;
+  timezone?: string;
+  scrollLeft: number;
+  viewportWidth: number;
+}): TodayChipDirection | null {
+  const range = getTimelineCarouselDateRange(items, date, timezone);
+
+  if (!range) {
+    return null;
+  }
+
+  const viewportLeft = scrollLeft;
+  const viewportRight = scrollLeft + viewportWidth;
+
+  if (range.right <= viewportLeft) {
+    return "left";
+  }
+
+  if (range.left >= viewportRight) {
+    return "right";
+  }
+
+  return null;
+}
+
+function getTimelineCarouselDateRange(
+  items: TimelineCarouselItem[],
+  date: Date,
+  timezone?: string,
+): { left: number; right: number } | null {
+  let left = TIMELINE_CAROUSEL_PADDING;
+  let range: { left: number; right: number } | null = null;
+
+  for (const item of items) {
+    const width = getTimelineCarouselItemWidth(item);
+    const right = left + width;
+
+    if (isSameTimelineDay(getTimelineCarouselItemStart(item), date, timezone)) {
+      range = range
+        ? {
+            left: Math.min(range.left, left),
+            right: Math.max(range.right, right),
+          }
+        : { left, right };
+    }
+
+    left = right + TIMELINE_CAROUSEL_GAP;
+  }
+
+  return range;
+}
+
+function getTimelineCarouselAnchorKey(
+  items: TimelineCarouselItem[],
+  selectedSessionId: string | null,
+): string {
+  const first = items[0];
+  const last = items[items.length - 1];
+
+  return [
+    selectedSessionId ?? "today",
+    items.length,
+    first ? getTimelineCarouselItemStart(first).getTime() : 0,
+    last ? getTimelineCarouselItemStart(last).getTime() : 0,
+  ].join(":");
+}
+
+function getTimelineCarouselItemStart(item: TimelineCarouselItem): Date {
+  return item.start;
+}
+
+function getTimelineCarouselItemWidth(_item: TimelineCarouselItem): number {
+  return TIMELINE_CAROUSEL_CARD_WIDTH;
+}
+
+function getTimelineDayStart(date: Date, timezone?: string): Date {
+  return startOfDay(timezone ? new TZDate(date, timezone) : date);
+}
+
+function isSameTimelineDay(
+  first: Date,
+  second: Date,
+  timezone?: string,
+): boolean {
+  const firstDate = timezone ? new TZDate(first, timezone) : first;
+  const secondDate = timezone ? new TZDate(second, timezone) : second;
+
+  return format(firstDate, "yyyy-MM-dd") === format(secondDate, "yyyy-MM-dd");
+}
+
+function CalendarDot({ calendarId }: { calendarId: string }) {
+  const calendar = main.UI.useRow("calendars", calendarId, main.STORE_ID);
+  const color = calendar?.color ? String(calendar.color) : "#888";
+
+  return (
+    <span
+      aria-hidden
+      className="size-2 shrink-0 rounded-full opacity-70"
+      style={{ backgroundColor: color }}
+    />
+  );
+}
+
+function buildMeetingTimelineEntries({
+  timelineEventsTable,
+  timelineSessionsTable,
+  sessionRecordingRanges,
+  selectedSessionId,
+  isIgnored,
+}: {
+  timelineEventsTable: TimelineEventsTable;
+  timelineSessionsTable: TimelineSessionsTable;
+  sessionRecordingRanges: ReadonlyMap<string, SessionRecordingRange>;
+  selectedSessionId: string | null;
+  isIgnored: (
+    trackingId?: string | null,
+    recurrenceSeriesId?: string | null,
+  ) => boolean;
+}): MeetingTimelineEntry[] {
+  const entries: MeetingTimelineEntry[] = [];
+  const sessionTrackingIds = new Set<string>();
+  const now = Date.now();
+
+  if (timelineSessionsTable) {
+    Object.entries(timelineSessionsTable).forEach(([sessionId, row]) => {
+      const entry = getSessionTimelineEntry({
+        sessionId,
+        row,
+        recordingRange: sessionRecordingRanges.get(sessionId),
+        selected: selectedSessionId === sessionId,
+        now,
+      });
+
+      if (!entry) {
+        return;
+      }
+
+      entries.push(entry);
+
+      const event = getSessionEvent(row);
+      if (event?.tracking_id) {
+        sessionTrackingIds.add(event.tracking_id);
+      }
+    });
+  }
+
+  if (timelineEventsTable) {
+    Object.entries(timelineEventsTable).forEach(([eventId, row]) => {
+      if (row.is_all_day) {
+        return;
+      }
+
+      if (
+        row.tracking_id_event &&
+        sessionTrackingIds.has(row.tracking_id_event)
+      ) {
+        return;
+      }
+
+      if (isIgnored(row.tracking_id_event, row.recurrence_series_id)) {
+        return;
+      }
+
+      const entry = getEventTimelineEntry({ eventId, row, now });
+      if (entry) {
+        entries.push(entry);
+      }
+    });
+  }
+
+  return entries;
+}
+
+function getSessionTimelineEntry({
+  sessionId,
+  row,
+  recordingRange,
+  selected,
+  now,
+}: {
+  sessionId: string;
+  row: TimelineSessionRow;
+  recordingRange?: SessionRecordingRange;
+  selected: boolean;
+  now: number;
+}): MeetingTimelineEntry | null {
+  const event = getSessionEvent(row);
+  const start =
+    recordingRange?.start ?? safeParseDate(event?.started_at ?? row.created_at);
+
+  if (!start) {
+    return null;
+  }
+
+  const end = recordingRange?.end ?? safeParseDate(event?.ended_at);
+
+  return {
+    id: sessionId,
+    type: "session",
+    title: row.title || event?.title || "Untitled",
+    calendarId: event?.calendar_id ?? null,
+    start,
+    end,
+    selected,
+    muted: start.getTime() > now,
+  };
+}
+
+function getEventTimelineEntry({
+  eventId,
+  row,
+  now,
+}: {
+  eventId: string;
+  row: TimelineEventRow;
+  now: number;
+}): MeetingTimelineEntry | null {
+  const parsedStart = safeParseDate(row.started_at);
+  const parsedEnd = safeParseDate(row.ended_at);
+  const start =
+    parsedStart ??
+    (parsedEnd ? new Date(parsedEnd.getTime() - TIMELINE_BLOCK_MS) : null);
+
+  if (!start) {
+    return null;
+  }
+
+  const endMs = normalizeEndMs(start, parsedEnd);
+  if (endMs < now) {
+    return null;
+  }
+
+  return {
+    id: eventId,
+    type: "event",
+    title: row.title || "Untitled",
+    calendarId: row.calendar_id ?? null,
+    trackingId: row.tracking_id_event ?? null,
+    recurrenceSeriesId: row.recurrence_series_id ?? null,
+    start,
+    end: parsedEnd,
+    selected: false,
+    muted: start.getTime() > now,
+  };
+}
+
+function formatTimeRange(start: Date, end: Date, timezone?: string): string {
+  const displayStart = timezone ? new TZDate(start, timezone) : start;
+  const displayEnd = timezone ? new TZDate(end, timezone) : end;
+  const startMeridiem = format(displayStart, "a");
+  const endMeridiem = format(displayEnd, "a");
+
+  if (startMeridiem === endMeridiem) {
+    return `${format(displayStart, "h:mm")}-${format(displayEnd, "h:mm a")}`;
+  }
+
+  return `${format(displayStart, "h:mm a")}-${format(displayEnd, "h:mm a")}`;
+}
+
+function formatCompactDateTime(date: Date, timezone?: string): string {
+  const displayDate = timezone ? new TZDate(date, timezone) : date;
+  return `${formatRelativeTimelineDay(date, timezone)} ${format(displayDate, "h:mm a")}`;
+}
+
+function formatDateTimeRange(
+  start: Date,
+  end: Date,
+  timezone?: string,
+): string {
+  const displayStart = timezone ? new TZDate(start, timezone) : start;
+  const displayEnd = timezone ? new TZDate(end, timezone) : end;
+  const sameDay =
+    format(displayStart, "yyyy-MM-dd") === format(displayEnd, "yyyy-MM-dd");
+
+  if (sameDay) {
+    return `${formatRelativeTimelineDay(start, timezone)} ${formatTimeRange(start, end, timezone)}`;
+  }
+
+  return `${formatCompactDateTime(start, timezone)}-${formatCompactDateTime(end, timezone)}`;
+}
+
+function formatRelativeTimelineDay(date: Date, timezone?: string): string {
+  const displayDate = timezone ? new TZDate(date, timezone) : date;
+  const displayNow = timezone ? new TZDate(new Date(), timezone) : new Date();
+  const daysDiff = differenceInCalendarDays(displayDate, displayNow);
+  const absDays = Math.abs(daysDiff);
+
+  if (daysDiff === 0) {
+    return "Today";
+  }
+
+  if (daysDiff === -1) {
+    return "Yesterday";
+  }
+
+  if (daysDiff === 1) {
+    return "Tomorrow";
+  }
+
+  if (daysDiff < 0 && absDays <= 6) {
+    return `${absDays} days ago`;
+  }
+
+  if (daysDiff > 0 && absDays <= 6) {
+    return `In ${absDays} days`;
+  }
+
+  return format(displayDate, "M/d");
+}

--- a/apps/desktop/src/session/components/session-preview-card.tsx
+++ b/apps/desktop/src/session/components/session-preview-card.tsx
@@ -257,7 +257,9 @@ function useParticipantNames(mappingIds: string[]) {
     for (const id of mappingIds) {
       const row = allResults[id];
       if (!row) continue;
-      const name = (row.human_name as string) || "Unknown";
+      const name = ((row.human_name as string | undefined) || "").trim();
+      if (!name) continue;
+
       names.push(name);
     }
     return names;

--- a/apps/desktop/src/shared/hooks/useNativeContextMenu.ts
+++ b/apps/desktop/src/shared/hooks/useNativeContextMenu.ts
@@ -11,28 +11,35 @@ export type MenuItemDef =
     }
   | { separator: true };
 
+export async function showNativeContextMenu(
+  items: MenuItemDef[],
+  e: MouseEvent,
+) {
+  e.preventDefault();
+  e.stopPropagation();
+
+  const menuItems = await Promise.all(
+    items.map((item) =>
+      "separator" in item
+        ? PredefinedMenuItem.new({ item: "Separator" })
+        : MenuItem.new({
+            id: item.id,
+            text: item.text,
+            enabled: !item.disabled,
+            accelerator: item.accelerator,
+            action: item.action,
+          }),
+    ),
+  );
+
+  const menu = await Menu.new({ items: menuItems });
+  await menu.popup();
+}
+
 export function useNativeContextMenu(items: MenuItemDef[]) {
   const showMenu = useCallback(
     async (e: MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-
-      const menuItems = await Promise.all(
-        items.map((item) =>
-          "separator" in item
-            ? PredefinedMenuItem.new({ item: "Separator" })
-            : MenuItem.new({
-                id: item.id,
-                text: item.text,
-                enabled: !item.disabled,
-                accelerator: item.accelerator,
-                action: item.action,
-              }),
-        ),
-      );
-
-      const menu = await Menu.new({ items: menuItems });
-      await menu.popup();
+      await showNativeContextMenu(items, e);
     },
     [items],
   );

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -15,6 +15,23 @@ vi.mock("~/main/shell-sidebar", () => ({
   ClassicMainSidebar: () => <div data-testid="main-sidebar" />,
 }));
 
+vi.mock("~/main/top-meeting-timeline", () => ({
+  TopMeetingTimeline: () => <div data-testid="top-meeting-timeline" />,
+}));
+
+vi.mock("~/contexts/shell", () => ({
+  useShell: () => ({
+    leftsidebar: {
+      expanded: true,
+      showDevtool: false,
+    },
+  }),
+}));
+
+vi.mock("~/sidebar/toast", () => ({
+  ToastArea: () => <div data-testid="toast-area" />,
+}));
+
 vi.mock("~/store/zustand/tabs", () => ({
   uniqueIdfromTab: vi.fn(() => "empty-slot"),
   useTabs: vi.fn((selector: (state: unknown) => unknown) =>
@@ -37,6 +54,7 @@ describe("ClassicMainBody", () => {
     render(<ClassicMainBody />);
 
     expect(screen.getByTestId("main-tab-chrome")).toBeTruthy();
+    expect(screen.getByTestId("top-meeting-timeline")).toBeTruthy();
     expect(screen.getByTestId("main-sidebar")).toBeTruthy();
     expect(screen.getByTestId("main-tab-content").textContent).toContain(
       "empty",

--- a/apps/desktop/src/shared/main/shell-sidebar.test.tsx
+++ b/apps/desktop/src/shared/main/shell-sidebar.test.tsx
@@ -58,4 +58,18 @@ describe("ClassicMainSidebar", () => {
     expect(setLocked).toHaveBeenLastCalledWith(false);
     expect(setExpanded).toHaveBeenLastCalledWith(false);
   });
+
+  it("unlocks the custom sidebar when unmounted while active", () => {
+    mockCurrentTab = { type: "calendar" };
+
+    const { unmount } = render(<ClassicMainSidebar />);
+
+    expect(setExpanded).toHaveBeenCalledWith(true);
+    expect(setLocked).toHaveBeenCalledWith(true);
+
+    unmount();
+
+    expect(setLocked).toHaveBeenLastCalledWith(false);
+    expect(setExpanded).toHaveBeenLastCalledWith(false);
+  });
 });

--- a/apps/desktop/src/sidebar/timeline/utils/index.ts
+++ b/apps/desktop/src/sidebar/timeline/utils/index.ts
@@ -23,6 +23,7 @@ export type TimelineEventRow = {
   tracking_id_event?: string | null;
   has_recurrence_rules: boolean;
   recurrence_series_id?: string | null;
+  is_all_day?: boolean | null;
 };
 
 // comes from QUERIES.timelineSessions

--- a/apps/desktop/src/sidebar/use-custom-sidebar.ts
+++ b/apps/desktop/src/sidebar/use-custom-sidebar.ts
@@ -24,23 +24,44 @@ export function useCustomSidebarEffect(
 ) {
   const savedExpandedRef = useRef<boolean | null>(null);
   const wasActiveRef = useRef(false);
+  const leftsidebarRef = useRef(leftsidebar);
+  const restoreExpandedOnExitRef = useRef(restoreExpandedOnExit);
+
+  leftsidebarRef.current = leftsidebar;
+  restoreExpandedOnExitRef.current = restoreExpandedOnExit;
+
+  const releaseCustomSidebar = () => {
+    if (!wasActiveRef.current) {
+      return;
+    }
+
+    const currentLeftSidebar = leftsidebarRef.current;
+
+    currentLeftSidebar.setLocked(false);
+    if (restoreExpandedOnExitRef.current && savedExpandedRef.current !== null) {
+      currentLeftSidebar.setExpanded(savedExpandedRef.current);
+    } else if (!restoreExpandedOnExitRef.current) {
+      currentLeftSidebar.setExpanded(false);
+    }
+
+    savedExpandedRef.current = null;
+    wasActiveRef.current = false;
+  };
 
   useEffect(() => {
     if (active && !wasActiveRef.current) {
-      savedExpandedRef.current = leftsidebar.expanded;
-      if (!leftsidebar.expanded) {
-        leftsidebar.setExpanded(true);
+      const currentLeftSidebar = leftsidebarRef.current;
+
+      savedExpandedRef.current = currentLeftSidebar.expanded;
+      if (!currentLeftSidebar.expanded) {
+        currentLeftSidebar.setExpanded(true);
       }
-      leftsidebar.setLocked(true);
+      currentLeftSidebar.setLocked(true);
+      wasActiveRef.current = true;
     } else if (!active && wasActiveRef.current) {
-      leftsidebar.setLocked(false);
-      if (restoreExpandedOnExit && savedExpandedRef.current !== null) {
-        leftsidebar.setExpanded(savedExpandedRef.current);
-      } else if (!restoreExpandedOnExit) {
-        leftsidebar.setExpanded(false);
-      }
-      savedExpandedRef.current = null;
+      releaseCustomSidebar();
     }
-    wasActiveRef.current = active;
-  }, [active, leftsidebar, restoreExpandedOnExit]);
+
+    return releaseCustomSidebar;
+  }, [active]);
 }


### PR DESCRIPTION
Replace the default sidebar timeline with a top meeting timeline, add 30-minute duration bars with pan and zoom support, and keep custom sidebars intact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI shell change plus session delete/open and calendar-ignore paths on the new timeline; sidebar lock/unmount behavior was adjusted for custom tabs.
> 
> **Overview**
> Moves the default meetings experience from the left sidebar into a **horizontal top carousel** (`TopMeetingTimeline`) under tab chrome when the sidebar is expanded and the tab is not onboarding, devtool, or a custom-sidebar type (calendar, settings, etc.).
> 
> **Layout & chrome:** `ClassicMainBody` conditionally renders the top timeline and relocates `ToastArea` to a floating corner; `ClassicMainSidebar` no longer shows `LeftSidebar` for the default case—only devtool or custom-sidebar tabs. The sidebar toggle uses top-panel icons and **“Toggle timeline”** when that mode applies.
> 
> **Timeline behavior:** New helpers default missing/invalid ends to **30 minutes** (`normalizeEndMs`) and derive session spans from **transcript** rows (`buildSessionRecordingRanges`). Cards support open/delete/ignore flows, previews, a Today jump chip, and horizontal scroll (including vertical wheel → horizontal). Calendar events skip all-day rows; future events only; session/event deduping by tracking id.
> 
> **Supporting fixes:** `showNativeContextMenu` extracted for reuse; `useCustomSidebarEffect` cleans up on unmount; session preview omits blank participant names; tests updated for the new layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6e9d9004b827f2551646d54d7d15612a8c66c8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->