### PR TITLE
fix(chat): hydrate session picker from store

### DIFF
--- a/apps/desktop/src/chat/components/context-bar.test.tsx
+++ b/apps/desktop/src/chat/components/context-bar.test.tsx
@@ -1,0 +1,182 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { openNewMock, searchMock, storeState } = vi.hoisted(() => ({
+  openNewMock: vi.fn(),
+  searchMock: vi.fn(),
+  storeState: {
+    rows: {} as Record<string, Record<string, unknown>>,
+    sessionIds: [] as string[],
+  },
+}));
+
+vi.mock("@hypr/ui/components/ui/popover", () => ({
+  AppFloatingPanel: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@hypr/ui/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("~/contexts/shell", () => ({
+  useShell: () => ({
+    chat: {
+      mode: "RightPanelOpen",
+    },
+  }),
+}));
+
+vi.mock("~/search/contexts/engine", () => ({
+  useSearchEngine: () => ({
+    search: searchMock,
+  }),
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useRowIds: () => storeState.sessionIds,
+    useStore: () => ({
+      getRow: (_table: string, rowId: string) => storeState.rows[rowId] ?? {},
+      hasRow: (_table: string, rowId: string) => rowId in storeState.rows,
+    }),
+  },
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: <T,>(selector: (state: { openNew: typeof openNewMock }) => T) =>
+    selector({ openNew: openNewMock }),
+}));
+
+import { ContextBar } from "./context-bar";
+
+function renderContextBar() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ContextBar
+        entities={[
+          {
+            kind: "session",
+            key: "session:auto:current",
+            source: "auto-current",
+            sessionId: "current",
+            title: "Current Note",
+            date: "2026-04-01T00:00:00.000Z",
+            pending: false,
+          },
+        ]}
+        onAddEntity={vi.fn()}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ContextBar session picker", () => {
+  beforeEach(() => {
+    cleanup();
+    openNewMock.mockClear();
+    searchMock.mockReset();
+    storeState.rows = {};
+    storeState.sessionIds = [];
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof ResizeObserver;
+  });
+
+  it("shows recent sessions from TinyBase and skips malformed blank rows", () => {
+    storeState.sessionIds = ["blank", "old", "new"];
+    storeState.rows = {
+      blank: {
+        title: "",
+        created_at: "",
+      },
+      old: {
+        title: "Old Note",
+        created_at: "2024-01-01T00:00:00.000Z",
+      },
+      new: {
+        title: "New Note",
+        created_at: "2026-04-14T00:00:00.000Z",
+      },
+    };
+
+    renderContextBar();
+
+    const newNote = screen.getByText("New Note");
+    const oldNote = screen.getByText("Old Note");
+
+    expect(
+      newNote.compareDocumentPosition(oldNote) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(screen.queryByText("Untitled")).toBeNull();
+    expect(screen.queryByText(/1970/)).toBeNull();
+    expect(searchMock).not.toHaveBeenCalled();
+  });
+
+  it("hydrates search hits from TinyBase before rendering", async () => {
+    storeState.sessionIds = ["session-1"];
+    storeState.rows = {
+      "session-1": {
+        title: "Hydrated Note",
+        created_at: "2026-02-02T00:00:00.000Z",
+      },
+    };
+    searchMock.mockResolvedValue([
+      {
+        score: 1,
+        document: {
+          id: "session-1",
+          type: "session",
+          title: "",
+          content: "",
+          created_at: 0,
+        },
+      },
+    ]);
+
+    renderContextBar();
+
+    fireEvent.change(screen.getByPlaceholderText("Search sessions..."), {
+      target: { value: "hydrated" },
+    });
+
+    await waitFor(() => {
+      expect(searchMock).toHaveBeenCalledWith("hydrated", {
+        created_at: undefined,
+      });
+    });
+
+    expect(await screen.findByText("Hydrated Note")).toBeTruthy();
+    expect(screen.queryByText(/1970/)).toBeNull();
+  });
+});

--- a/apps/desktop/src/chat/components/context-bar.tsx
+++ b/apps/desktop/src/chat/components/context-bar.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { ChevronDownIcon, PlusIcon, XIcon } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
@@ -12,14 +13,75 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@hypr/ui/components/ui/tooltip";
-import { cn } from "@hypr/utils";
+import { cn, safeParseDate } from "@hypr/utils";
 
 import type { ContextRef } from "~/chat/context/entities";
 import { type ContextChipProps, renderChip } from "~/chat/context/registry";
 import type { DisplayEntity } from "~/chat/context/use-chat-context-pipeline";
 import { useShell } from "~/contexts/shell";
 import { useSearchEngine } from "~/search/contexts/engine";
+import { getSessionEvent } from "~/session/utils";
+import * as main from "~/store/tinybase/store/main";
 import { useTabs } from "~/store/zustand/tabs";
+
+const MAX_SESSION_PICKER_RESULTS = 8;
+
+type SessionPickerItem = {
+  id: string;
+  title: string;
+  dateLabel: string | null;
+  timestamp: number | null;
+};
+
+type MainStore = ReturnType<typeof main.UI.useStore>;
+
+function getSessionTimestamp(row: {
+  created_at?: unknown;
+  event_json?: unknown;
+}): number | null {
+  const event =
+    typeof row.event_json === "string"
+      ? getSessionEvent({ event_json: row.event_json })
+      : null;
+  const date = safeParseDate(event?.started_at ?? row.created_at);
+  return date ? date.getTime() : null;
+}
+
+function toSessionPickerItem(
+  store: MainStore,
+  sessionId: string,
+): SessionPickerItem | null {
+  if (!store?.hasRow("sessions", sessionId)) {
+    return null;
+  }
+
+  const row = store.getRow("sessions", sessionId);
+  const title = typeof row.title === "string" ? row.title.trim() : "";
+  const timestamp = getSessionTimestamp(row);
+
+  if (!title && timestamp === null) {
+    return null;
+  }
+
+  return {
+    id: sessionId,
+    title: title || "Untitled",
+    timestamp,
+    dateLabel: timestamp ? new Date(timestamp).toLocaleDateString() : null,
+  };
+}
+
+function sortByNewestSession(
+  a: SessionPickerItem,
+  b: SessionPickerItem,
+): number {
+  const aTime = a.timestamp ?? Number.NEGATIVE_INFINITY;
+  const bTime = b.timestamp ?? Number.NEGATIVE_INFINITY;
+  if (aTime === bTime) {
+    return a.title.localeCompare(b.title);
+  }
+  return bTime - aTime;
+}
 
 function useOverflow(
   ref: React.RefObject<HTMLDivElement | null>,
@@ -192,25 +254,34 @@ function SessionPicker({
   onClose: () => void;
 }) {
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<
-    Array<{ id: string; title: string; created_at: number }>
-  >([]);
+  const normalizedQuery = query.trim();
   const { search } = useSearchEngine();
+  const store = main.UI.useStore(main.STORE_ID);
+  const sessionIds = main.UI.useRowIds("sessions", main.STORE_ID);
 
-  useEffect(() => {
-    search(query, { created_at: undefined }).then((hits) => {
-      setResults(
-        hits
-          .filter((h) => h.document.type === "session")
-          .slice(0, 8)
-          .map((h) => ({
-            id: h.document.id,
-            title: h.document.title,
-            created_at: h.document.created_at,
-          })),
-      );
-    });
-  }, [query, search]);
+  const searchResults = useQuery({
+    queryKey: ["chat-session-picker", normalizedQuery],
+    enabled: normalizedQuery.length > 0,
+    queryFn: () => search(normalizedQuery, { created_at: undefined }),
+  });
+
+  const recentSessions = useMemo(() => {
+    return sessionIds
+      .map((sessionId) => toSessionPickerItem(store, sessionId))
+      .filter((item): item is SessionPickerItem => item !== null)
+      .sort(sortByNewestSession)
+      .slice(0, MAX_SESSION_PICKER_RESULTS);
+  }, [sessionIds, store]);
+
+  const matchingSessions = useMemo(() => {
+    return (searchResults.data ?? [])
+      .filter((hit) => hit.document.type === "session")
+      .map((hit) => toSessionPickerItem(store, hit.document.id))
+      .filter((item): item is SessionPickerItem => item !== null)
+      .slice(0, MAX_SESSION_PICKER_RESULTS);
+  }, [searchResults.data, store]);
+
+  const results = normalizedQuery ? matchingSessions : recentSessions;
 
   return (
     <div className="flex flex-col gap-2">
@@ -237,13 +308,13 @@ function SessionPicker({
               {result.title || "Untitled"}
             </span>
             <span className="text-[10px] text-neutral-400">
-              {new Date(result.created_at).toLocaleDateString()}
+              {result.dateLabel ?? "Unknown date"}
             </span>
           </button>
         ))}
         {results.length === 0 && (
           <span className="px-2 py-1.5 text-xs text-neutral-400">
-            No sessions found
+            {searchResults.isFetching ? "Searching..." : "No sessions found"}
           </span>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Use TinyBase session rows as the source of truth for chat context picker titles and dates
- Use Tantivy only to find matching session IDs when a query is typed
- Skip malformed blank session rows so the picker does not show empty 1970-dated notes
- Add regression coverage for malformed rows and stale search-index hits

## Verification
- `pnpm exec dprint fmt`
- `pnpm -F @hypr/desktop typecheck`
- `pnpm -F @hypr/desktop exec vitest run src/chat/components/context-bar.test.tsx`

Fixes #5061

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI change in the chat context bar with no auth or data-pipeline changes; regression tests cover the new picker behavior.
> 
> **Overview**
> The chat **session picker** no longer renders titles and dates straight from the search index. **TinyBase** session rows are the source of truth; Tantivy is used only to resolve matching session IDs when the user types a query.
> 
> With an empty search box, the picker shows up to eight **recent** sessions from the store, sorted newest-first, and **drops** rows that have no usable title and no parseable date (avoiding empty “Untitled” entries and bogus **1970** dates from `created_at: 0`). Search hits are **hydrated** from the store the same way, and dates prefer `event_json` `started_at` when present via `safeParseDate`. Search runs through **React Query** with a loading state instead of a one-off `useEffect`.
> 
> New **Vitest** coverage in `context-bar.test.tsx` exercises recent-list ordering/filtering and stale index payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79edc639a3e8930da92affca56feeee1ae288a9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->