### PR TITLE
Fix legacy Hyprnote import stalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4598,6 +4598,7 @@ dependencies = [
  "owhisper-interface",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/crates/importer-core/src/ir.rs
+++ b/crates/importer-core/src/ir.rs
@@ -18,6 +18,31 @@ pub struct Collection {
     pub tag_mappings: Vec<TagMapping>,
 }
 
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct CollectionStats {
+    pub sessions_count: usize,
+    pub transcripts_count: usize,
+    pub humans_count: usize,
+    pub organizations_count: usize,
+    pub participants_count: usize,
+    pub templates_count: usize,
+    pub enhanced_notes_count: usize,
+}
+
+impl CollectionStats {
+    pub fn from_collection(data: &Collection) -> Self {
+        Self {
+            sessions_count: data.sessions.len(),
+            transcripts_count: data.transcripts.len(),
+            humans_count: data.humans.len(),
+            organizations_count: data.organizations.len(),
+            participants_count: data.participants.len(),
+            templates_count: data.templates.len(),
+            enhanced_notes_count: data.enhanced_notes.len(),
+        }
+    }
+}
+
 impl std::fmt::Display for Collection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "sessions: {}", self.sessions.len())?;

--- a/legacy/db-parser/Cargo.toml
+++ b/legacy/db-parser/Cargo.toml
@@ -11,6 +11,7 @@ owhisper-interface = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 
 htmd = { workspace = true }

--- a/legacy/db-parser/src/error.rs
+++ b/legacy/db-parser/src/error.rs
@@ -11,6 +11,9 @@ pub enum Error {
     #[error("JSON parse error: {0}")]
     Json(#[from] serde_json::Error),
 
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
     #[error("Invalid data: {0}")]
     InvalidData(String),
 }

--- a/legacy/db-parser/src/v0/mod.rs
+++ b/legacy/db-parser/src/v0/mod.rs
@@ -1,14 +1,69 @@
 mod convert;
 
+use hypr_importer_core::ir::CollectionStats;
 use legacy_db_core::libsql;
 use legacy_db_user::UserDatabase;
-use std::path::Path;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
 
 use crate::types::*;
 use crate::{Error, Result};
 use convert::{html_to_markdown, session_to_transcript};
 
 const EXPECTED_TABLES: &[&str] = &["sessions", "humans", "organizations", "templates", "tags"];
+
+struct SqliteSnapshot {
+    _dir: tempfile::TempDir,
+    path: PathBuf,
+}
+
+impl SqliteSnapshot {
+    fn create(path: &Path) -> Result<Self> {
+        let dir = tempfile::tempdir()?;
+        let file_name = path.file_name().ok_or_else(|| {
+            Error::InvalidData(format!(
+                "v0 database path has no file name: {}",
+                path.display()
+            ))
+        })?;
+        let snapshot_path = dir.path().join(file_name);
+
+        std::fs::copy(path, &snapshot_path)?;
+        copy_sidecar_if_exists(path, dir.path(), file_name, "-wal")?;
+        copy_sidecar_if_exists(path, dir.path(), file_name, "-shm")?;
+
+        Ok(Self {
+            _dir: dir,
+            path: snapshot_path,
+        })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn copy_sidecar_if_exists(
+    source_db_path: &Path,
+    snapshot_dir: &Path,
+    file_name: &OsStr,
+    suffix: &str,
+) -> Result<()> {
+    let source_path = source_db_path.with_file_name(sidecar_file_name(file_name, suffix));
+    if !source_path.exists() {
+        return Ok(());
+    }
+
+    let target_path = snapshot_dir.join(sidecar_file_name(file_name, suffix));
+    std::fs::copy(source_path, target_path)?;
+    Ok(())
+}
+
+fn sidecar_file_name(file_name: &OsStr, suffix: &str) -> std::ffi::OsString {
+    let mut name = file_name.to_os_string();
+    name.push(suffix);
+    name
+}
 
 pub async fn validate(path: &Path) -> Result<()> {
     let db = libsql::Builder::new_local(path).build().await?;
@@ -46,6 +101,85 @@ pub async fn validate(path: &Path) -> Result<()> {
 }
 
 pub async fn parse_from_sqlite(path: &Path) -> Result<Collection> {
+    let snapshot = SqliteSnapshot::create(path)?;
+    parse_from_snapshot(snapshot.path()).await
+}
+
+pub async fn parse_stats_from_sqlite(path: &Path) -> Result<CollectionStats> {
+    let snapshot = SqliteSnapshot::create(path)?;
+    validate(snapshot.path()).await?;
+
+    let db = libsql::Builder::new_local(snapshot.path()).build().await?;
+    let conn = db.connect()?;
+    normalize_empty_words(&conn).await?;
+    let (sessions_count, transcripts_count) = count_session_rows(&conn).await?;
+
+    Ok(CollectionStats {
+        sessions_count,
+        transcripts_count,
+        humans_count: count_rows(&conn, "SELECT COUNT(*) FROM humans").await?,
+        organizations_count: count_rows(&conn, "SELECT COUNT(*) FROM organizations").await?,
+        participants_count: count_rows(
+            &conn,
+            "SELECT COUNT(*)
+             FROM session_participants sp
+             JOIN sessions s ON s.id = sp.session_id
+             JOIN humans h ON h.id = sp.human_id
+             WHERE sp.deleted = FALSE OR sp.deleted IS NULL",
+        )
+        .await?,
+        templates_count: count_rows(&conn, "SELECT COUNT(*) FROM templates").await?,
+        enhanced_notes_count: count_rows(
+            &conn,
+            "SELECT COUNT(*) FROM sessions WHERE COALESCE(enhanced_memo_html, '') <> ''",
+        )
+        .await?,
+    })
+}
+
+async fn count_session_rows(conn: &libsql::Connection) -> Result<(usize, usize)> {
+    let mut rows = conn
+        .query(
+            "SELECT raw_memo_html, enhanced_memo_html, words FROM sessions",
+            (),
+        )
+        .await?;
+    let mut sessions_count = 0;
+    let mut transcripts_count = 0;
+
+    while let Some(row) = rows.next().await? {
+        let raw_memo_html: String = row.get(0)?;
+        let enhanced_memo_html: Option<String> = row.get(1)?;
+        let words_json: String = row.get(2)?;
+        let words: Vec<owhisper_interface::Word2> = serde_json::from_str(&words_json)?;
+
+        if !words.is_empty() {
+            transcripts_count += 1;
+        }
+
+        if !legacy_db_user::is_session_content_empty(
+            &raw_memo_html,
+            enhanced_memo_html.as_deref(),
+            words.is_empty(),
+        ) {
+            sessions_count += 1;
+        }
+    }
+
+    Ok((sessions_count, transcripts_count))
+}
+
+async fn count_rows(conn: &libsql::Connection, sql: &str) -> Result<usize> {
+    let mut rows = conn.query(sql, ()).await?;
+    let row = rows
+        .next()
+        .await?
+        .ok_or_else(|| Error::InvalidData("count query returned no rows".to_string()))?;
+    let count: i64 = row.get(0)?;
+    Ok(count.max(0) as usize)
+}
+
+async fn parse_from_snapshot(path: &Path) -> Result<Collection> {
     validate(path).await?;
 
     let db = legacy_db_core::DatabaseBuilder::default()
@@ -54,15 +188,8 @@ pub async fn parse_from_sqlite(path: &Path) -> Result<Collection> {
         .await?;
     let db = UserDatabase::from(db);
 
-    // Older Char DBs can have `sessions.words` as NULL/empty, but db-user's
-    // `Session::from_row` expects a non-null JSON string.
     let conn = db.conn()?;
-    conn.execute(
-        "UPDATE sessions SET words = '[]' WHERE words IS NULL OR words = ''",
-        (),
-    )
-    .await
-    .map_err(legacy_db_user::Error::from)?;
+    normalize_empty_words(&conn).await?;
 
     let sessions_raw = db.list_sessions(None).await?;
 
@@ -209,4 +336,274 @@ pub async fn parse_from_sqlite(path: &Path) -> Result<Collection> {
         tags,
         tag_mappings,
     })
+}
+
+async fn normalize_empty_words(conn: &libsql::Connection) -> Result<()> {
+    // Older Char DBs can have `sessions.words` as NULL/empty, but db-user's
+    // `Session::from_row` expects a non-null JSON string.
+    conn.execute(
+        "UPDATE sessions SET words = '[]' WHERE words IS NULL OR words = ''",
+        (),
+    )
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use legacy_db_core::DatabaseBuilder;
+    use legacy_db_user::{UserDatabase, migrate};
+
+    async fn setup_db(path: &Path) -> UserDatabase {
+        let db = DatabaseBuilder::default()
+            .local(path)
+            .build()
+            .await
+            .unwrap();
+        let db = UserDatabase::from(db);
+        migrate(&db).await.unwrap();
+        db
+    }
+
+    async fn seed_rows(db: &UserDatabase) {
+        let conn = db.conn().unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO organizations (id, name, description)
+            VALUES ('org-1', 'Acme', 'Customer')
+            "#,
+            (),
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO humans (
+                id,
+                organization_id,
+                is_user,
+                full_name,
+                email,
+                job_title,
+                linkedin_username
+            ) VALUES (
+                'human-1',
+                'org-1',
+                FALSE,
+                'Ada Lovelace',
+                'ada@example.com',
+                'Engineer',
+                'ada'
+            )
+            "#,
+            (),
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO sessions (
+                id,
+                created_at,
+                visited_at,
+                user_id,
+                title,
+                raw_memo_html,
+                enhanced_memo_html,
+                conversations,
+                words
+            ) VALUES (
+                'session-1',
+                '2026-01-01T00:00:00Z',
+                '2026-01-01T00:00:00Z',
+                'human-1',
+                'Legacy meeting',
+                '<p>Notes</p>',
+                '<p>Summary</p>',
+                '[]',
+                '[{"text":"Hello","speaker":null,"confidence":1,"start_ms":1000,"end_ms":1500}]'
+            )
+            "#,
+            (),
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO session_participants (session_id, human_id, deleted)
+            VALUES ('session-1', 'human-1', FALSE)
+            "#,
+            (),
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO templates (
+                id,
+                user_id,
+                title,
+                description,
+                sections,
+                tags,
+                context_option
+            ) VALUES (
+                'template-1',
+                'human-1',
+                'Template',
+                'Description',
+                '[]',
+                '[]',
+                NULL
+            )
+            "#,
+            (),
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            "INSERT INTO tags (id, name) VALUES ('tag-1', 'Important')",
+            (),
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            "INSERT INTO tags_sessions (tag_id, session_id) VALUES ('tag-1', 'session-1')",
+            (),
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn insert_session_candidate(
+        db: &UserDatabase,
+        id: &str,
+        title: &str,
+        raw_memo_html: &str,
+        enhanced_memo_html: Option<&str>,
+        words: &str,
+    ) {
+        let conn = db.conn().unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO sessions (
+                id,
+                created_at,
+                visited_at,
+                user_id,
+                title,
+                raw_memo_html,
+                enhanced_memo_html,
+                conversations,
+                words
+            ) VALUES (
+                :id,
+                '2026-01-01T00:00:00Z',
+                '2026-01-01T00:00:00Z',
+                'human-1',
+                :title,
+                :raw_memo_html,
+                :enhanced_memo_html,
+                '[]',
+                :words
+            )
+            "#,
+            legacy_db_core::libsql::named_params! {
+                ":id": id,
+                ":title": title,
+                ":raw_memo_html": raw_memo_html,
+                ":enhanced_memo_html": enhanced_memo_html,
+                ":words": words,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn parse_stats_from_sqlite_counts_rows_without_full_import() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db.sqlite");
+        let db = setup_db(&path).await;
+        seed_rows(&db).await;
+
+        let stats = parse_stats_from_sqlite(&path).await.unwrap();
+
+        assert_eq!(stats.sessions_count, 1);
+        assert_eq!(stats.transcripts_count, 1);
+        assert_eq!(stats.humans_count, 1);
+        assert_eq!(stats.organizations_count, 1);
+        assert_eq!(stats.participants_count, 1);
+        assert_eq!(stats.templates_count, 1);
+        assert_eq!(stats.enhanced_notes_count, 1);
+    }
+
+    #[tokio::test]
+    async fn parse_stats_from_sqlite_uses_import_empty_session_filter() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db.sqlite");
+        let db = setup_db(&path).await;
+        seed_rows(&db).await;
+        insert_session_candidate(&db, "title-only", "Title only", "", None, "[]").await;
+        insert_session_candidate(&db, "raw-empty-html", "", "<p></p>", None, "[]").await;
+        insert_session_candidate(&db, "enhanced-empty-html", "", "", Some("<p></p>"), "[]").await;
+
+        let stats = parse_stats_from_sqlite(&path).await.unwrap();
+        let collection = parse_from_sqlite(&path).await.unwrap();
+
+        assert_eq!(stats.sessions_count, collection.sessions.len());
+        assert_eq!(stats.sessions_count, 1);
+        assert_eq!(stats.transcripts_count, collection.transcripts.len());
+        assert_eq!(stats.transcripts_count, 1);
+    }
+
+    #[tokio::test]
+    async fn parse_stats_from_sqlite_counts_only_joined_participants() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db.sqlite");
+        let db = setup_db(&path).await;
+        seed_rows(&db).await;
+
+        let conn = db.conn().unwrap();
+        conn.execute("PRAGMA foreign_keys = OFF", ()).await.unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO session_participants (session_id, human_id, deleted)
+            VALUES ('session-1', 'missing-human', FALSE)
+            "#,
+            (),
+        )
+        .await
+        .unwrap();
+
+        let stats = parse_stats_from_sqlite(&path).await.unwrap();
+        let collection = parse_from_sqlite(&path).await.unwrap();
+
+        assert_eq!(stats.participants_count, collection.participants.len());
+        assert_eq!(stats.participants_count, 1);
+    }
+
+    #[tokio::test]
+    async fn parse_from_sqlite_does_not_mutate_source_empty_words() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db.sqlite");
+        let db = setup_db(&path).await;
+        seed_rows(&db).await;
+
+        let conn = db.conn().unwrap();
+        conn.execute("UPDATE sessions SET words = '' WHERE id = 'session-1'", ())
+            .await
+            .unwrap();
+
+        parse_from_sqlite(&path).await.unwrap();
+
+        let mut rows = conn
+            .query("SELECT words FROM sessions WHERE id = 'session-1'", ())
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        let words: String = row.get(0).unwrap();
+        assert_eq!(words, "");
+    }
 }

--- a/legacy/db-user/src/sessions_types.rs
+++ b/legacy/db-user/src/sessions_types.rs
@@ -63,12 +63,20 @@ impl Session {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.enhanced_memo_html
-            .as_ref()
-            .is_none_or(|s| is_html_empty(s))
-            && is_html_empty(&self.raw_memo_html)
-            && self.words.is_empty()
+        is_session_content_empty(
+            &self.raw_memo_html,
+            self.enhanced_memo_html.as_deref(),
+            self.words.is_empty(),
+        )
     }
+}
+
+pub fn is_session_content_empty(
+    raw_memo_html: &str,
+    enhanced_memo_html: Option<&str>,
+    words_is_empty: bool,
+) -> bool {
+    enhanced_memo_html.is_none_or(is_html_empty) && is_html_empty(raw_memo_html) && words_is_empty
 }
 
 fn is_html_empty(html: &str) -> bool {

--- a/plugins/importer/Cargo.toml
+++ b/plugins/importer/Cargo.toml
@@ -30,5 +30,5 @@ tauri-specta = { workspace = true, features = ["derive", "typescript"] }
 chrono = { workspace = true }
 dirs = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 uuid = { workspace = true, features = ["v4", "v5"] }

--- a/plugins/importer/src/error.rs
+++ b/plugins/importer/src/error.rs
@@ -21,6 +21,12 @@ pub enum Error {
     #[error("import source not available: {0}")]
     SourceNotAvailable(String),
 
+    #[error("{operation} timed out after {seconds} seconds")]
+    Timeout {
+        operation: &'static str,
+        seconds: u64,
+    },
+
     #[error("tauri error: {0}")]
     Tauri(#[from] tauri::Error),
 

--- a/plugins/importer/src/ext.rs
+++ b/plugins/importer/src/ext.rs
@@ -56,8 +56,7 @@ impl<R: tauri::Runtime> Importer<R> {
             return Err(crate::Error::SourceNotAvailable(source.name.clone()));
         }
 
-        let data = crate::sources::import_all(source).await?;
-        Ok(ImportStats::from_data(&data))
+        crate::sources::import_stats(source).await
     }
 }
 

--- a/plugins/importer/src/sources/hyprnote/v0.rs
+++ b/plugins/importer/src/sources/hyprnote/v0.rs
@@ -1,7 +1,33 @@
-use crate::types::Collection;
+use crate::types::{Collection, ImportStats};
 use std::path::Path;
+use std::time::Duration;
+
+const SCAN_TIMEOUT: Duration = Duration::from_secs(30);
+const IMPORT_TIMEOUT: Duration = Duration::from_secs(300);
 
 pub async fn import_all_from_path(path: &Path) -> Result<Collection, crate::Error> {
-    let data = legacy_db_parser::v0::parse_from_sqlite(path).await?;
+    let data = tokio::time::timeout(
+        IMPORT_TIMEOUT,
+        legacy_db_parser::v0::parse_from_sqlite(path),
+    )
+    .await
+    .map_err(|_| crate::Error::Timeout {
+        operation: "Hyprnote legacy import",
+        seconds: IMPORT_TIMEOUT.as_secs(),
+    })??;
     Ok(data)
+}
+
+pub async fn import_stats_from_path(path: &Path) -> Result<ImportStats, crate::Error> {
+    let stats = tokio::time::timeout(
+        SCAN_TIMEOUT,
+        legacy_db_parser::v0::parse_stats_from_sqlite(path),
+    )
+    .await
+    .map_err(|_| crate::Error::Timeout {
+        operation: "Hyprnote legacy import scan",
+        seconds: SCAN_TIMEOUT.as_secs(),
+    })??;
+
+    Ok(stats.into())
 }

--- a/plugins/importer/src/sources/mod.rs
+++ b/plugins/importer/src/sources/mod.rs
@@ -4,13 +4,23 @@ mod hyprnote;
 
 pub use as_is::AsIsData;
 
-use crate::types::{Collection, ImportSource, ImportSourceInfo, TransformKind};
+use crate::types::{Collection, ImportSource, ImportSourceInfo, ImportStats, TransformKind};
 
 pub async fn import_all(source: &ImportSource) -> Result<Collection, crate::Error> {
     match source.transform {
         TransformKind::HyprnoteV0 => hyprnote::v0::import_all_from_path(&source.path).await,
         TransformKind::Granola => granola::import_all_from_path(&source.path).await,
         TransformKind::AsIs => as_is::load_data(&source.path),
+    }
+}
+
+pub async fn import_stats(source: &ImportSource) -> Result<ImportStats, crate::Error> {
+    match source.transform {
+        TransformKind::HyprnoteV0 => hyprnote::v0::import_stats_from_path(&source.path).await,
+        TransformKind::Granola | TransformKind::AsIs => {
+            let data = import_all(source).await?;
+            Ok(ImportStats::from_data(&data))
+        }
     }
 }
 

--- a/plugins/importer/src/types.rs
+++ b/plugins/importer/src/types.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 pub use hypr_importer_core::ir::{
-    Collection, EnhancedNote, Human, Organization, Session, SessionParticipant, Tag, TagMapping,
-    Template, TemplateSection, Transcript, Word,
+    Collection, CollectionStats, EnhancedNote, Human, Organization, Session, SessionParticipant,
+    Tag, TagMapping, Template, TemplateSection, Transcript, Word,
 };
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, specta::Type, PartialEq, Eq, Hash)]
@@ -147,14 +147,20 @@ pub struct ImportStats {
 
 impl ImportStats {
     pub fn from_data(data: &Collection) -> Self {
+        CollectionStats::from_collection(data).into()
+    }
+}
+
+impl From<CollectionStats> for ImportStats {
+    fn from(stats: CollectionStats) -> Self {
         Self {
-            sessions_count: data.sessions.len(),
-            transcripts_count: data.transcripts.len(),
-            humans_count: data.humans.len(),
-            organizations_count: data.organizations.len(),
-            participants_count: data.participants.len(),
-            templates_count: data.templates.len(),
-            enhanced_notes_count: data.enhanced_notes.len(),
+            sessions_count: stats.sessions_count,
+            transcripts_count: stats.transcripts_count,
+            humans_count: stats.humans_count,
+            organizations_count: stats.organizations_count,
+            participants_count: stats.participants_count,
+            templates_count: stats.templates_count,
+            enhanced_notes_count: stats.enhanced_notes_count,
         }
     }
 }


### PR DESCRIPTION
Summary:
- Snapshot legacy Hyprnote SQLite files before parsing so import normalization does not mutate the source DB.
- Use fast count queries for import preview scans instead of full parsing.
- Surface timeout errors for stalled legacy scans/imports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local user SQLite import paths and changes dry-run behavior; mitigated by snapshot isolation, tests for non-mutation and stat parity, and timeouts.
> 
> **Overview**
> Fixes legacy Hyprnote import **stalls** and **side effects** by copying the SQLite DB (and `-wal`/`-shm` sidecars) into a temp snapshot before parse/normalize, so preview and full import no longer mutate the user’s on-disk database.
> 
> **Dry-run / preview** now uses a dedicated **`parse_stats_from_sqlite`** path with SQL counts and the same empty-session and participant rules as full import, instead of building the whole `Collection`. The importer plugin routes **`run_import_dry`** through **`import_stats`** (fast path for v0; other sources still full import). Shared **`CollectionStats`** / **`is_session_content_empty`** keep counts aligned with import logic.
> 
> **Timeouts** (30s scan, 300s import) surface **`Error::Timeout`** instead of hanging indefinitely on large or stuck legacy DBs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 737d2d00e58d2ac23aad93fe4a2a6461867a41ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->