### PR TITLE
Preserve manual session titles during AI generation

### DIFF
--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
@@ -1,8 +1,10 @@
 import type { LanguageModel } from "ai";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TaskConfig } from ".";
 import { enhanceSuccess } from "./enhance-success";
+
+import { useLiveTitle } from "~/store/zustand/live-title";
 
 type EnhanceSuccessParams = Parameters<
   NonNullable<TaskConfig<"enhance">["onSuccess"]>
@@ -35,6 +37,10 @@ function createParams(
 }
 
 describe("enhanceSuccess.onSuccess", () => {
+  beforeEach(() => {
+    useLiveTitle.setState({ titles: {} });
+  });
+
   it("persists enhanced note content as TipTap JSON string", async () => {
     const params = createParams();
 
@@ -77,6 +83,16 @@ describe("enhanceSuccess.onSuccess", () => {
     } as unknown as EnhanceSuccessParams["store"];
     const startTask = vi.fn().mockResolvedValue(undefined);
     const params = createParams({ store, startTask });
+
+    await enhanceSuccess.onSuccess?.(params);
+
+    expect(startTask).not.toHaveBeenCalled();
+  });
+
+  it("does not start title generation while the title is being edited", async () => {
+    useLiveTitle.getState().setTitle("session-1", "Custom title");
+    const startTask = vi.fn().mockResolvedValue(undefined);
+    const params = createParams({ startTask });
 
     await enhanceSuccess.onSuccess?.(params);
 

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
@@ -2,6 +2,8 @@ import { md2json } from "@hypr/editor/markdown";
 
 import { createTaskId, type TaskConfig } from ".";
 
+import { hasLiveSessionTitleDraft } from "~/store/zustand/live-title";
+
 const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = ({
   text,
   args,
@@ -27,7 +29,7 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = ({
   const currentTitle = store.getCell("sessions", args.sessionId, "title");
   const trimmedTitle =
     typeof currentTitle === "string" ? currentTitle.trim() : "";
-  if (trimmedTitle) {
+  if (trimmedTitle || hasLiveSessionTitleDraft(args.sessionId)) {
     return;
   }
 

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.test.ts
@@ -1,8 +1,10 @@
 import type { LanguageModel } from "ai";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TaskConfig } from ".";
 import { titleSuccess } from "./title-success";
+
+import { useLiveTitle } from "~/store/zustand/live-title";
 
 type TitleSuccessParams = Parameters<
   NonNullable<TaskConfig<"title">["onSuccess"]>
@@ -13,6 +15,7 @@ function createParams(
 ): TitleSuccessParams {
   const store = {
     setPartialRow: vi.fn(),
+    getCell: vi.fn().mockReturnValue(""),
   } as unknown as TitleSuccessParams["store"];
 
   return {
@@ -30,6 +33,10 @@ function createParams(
 }
 
 describe("titleSuccess.onSuccess", () => {
+  beforeEach(() => {
+    useLiveTitle.setState({ titles: {} });
+  });
+
   it("persists trimmed title text", () => {
     const params = createParams({ text: "  Weekly sync  " });
 
@@ -40,6 +47,36 @@ describe("titleSuccess.onSuccess", () => {
       "session-1",
       { title: "Weekly sync" },
     );
+  });
+
+  it("does not overwrite an existing session title", () => {
+    const store = {
+      setPartialRow: vi.fn(),
+      getCell: vi.fn().mockReturnValue("Custom title"),
+    } as unknown as TitleSuccessParams["store"];
+    const params = createParams({ store });
+
+    titleSuccess.onSuccess?.(params);
+
+    expect(store.setPartialRow).not.toHaveBeenCalled();
+  });
+
+  it("does not overwrite an active title edit", () => {
+    useLiveTitle.getState().setTitle("session-1", "Custom title");
+    const params = createParams();
+
+    titleSuccess.onSuccess?.(params);
+
+    expect(params.store.setPartialRow).not.toHaveBeenCalled();
+  });
+
+  it("does not write a generated title while an active edit is blank", () => {
+    useLiveTitle.getState().setTitle("session-1", "");
+    const params = createParams();
+
+    titleSuccess.onSuccess?.(params);
+
+    expect(params.store.setPartialRow).not.toHaveBeenCalled();
   });
 
   it("ignores empty or placeholder title outputs", () => {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.ts
@@ -1,5 +1,7 @@
 import type { TaskConfig } from ".";
 
+import { hasLiveSessionTitleDraft } from "~/store/zustand/live-title";
+
 const onSuccess: NonNullable<TaskConfig<"title">["onSuccess"]> = ({
   text,
   args,
@@ -11,6 +13,15 @@ const onSuccess: NonNullable<TaskConfig<"title">["onSuccess"]> = ({
 
   const trimmed = text.trim();
   if (!trimmed || trimmed === "<EMPTY>") {
+    return;
+  }
+
+  const currentTitle = store.getCell("sessions", args.sessionId, "title");
+  if (typeof currentTitle === "string" && currentTitle.trim()) {
+    return;
+  }
+
+  if (hasLiveSessionTitleDraft(args.sessionId)) {
     return;
   }
 

--- a/apps/desktop/src/store/zustand/live-title.ts
+++ b/apps/desktop/src/store/zustand/live-title.ts
@@ -17,6 +17,13 @@ export const useLiveTitle = create<LiveTitleState>((set) => ({
     }),
 }));
 
+export function hasLiveSessionTitleDraft(sessionId: string): boolean {
+  return Object.prototype.hasOwnProperty.call(
+    useLiveTitle.getState().titles,
+    sessionId,
+  );
+}
+
 export function useSessionTitle(
   sessionId: string,
   storeTitle: string | undefined,


### PR DESCRIPTION
## Summary
- Skip auto-title generation when a session title draft is active.
- Prevent generated title completion from overwriting an existing or actively edited title.
- Add tests for auto-enhance and title completion guards.

Fixes #4497

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop session-title and AI task success logic with added unit tests; no auth, security, or data-migration impact.
> 
> **Overview**
> Stops AI title flows from clobbering **manual or in-progress session titles**. After note enhance, auto title generation is skipped when a **live title draft** exists (not only when the persisted title is non-empty). When a title task completes, persistence is skipped if the session already has a stored title or any active live draft—including a **blank draft** while the user is editing.
> 
> Adds `hasLiveSessionTitleDraft` on the live-title store and expands **enhance** / **title** success handler tests for these guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2834376ea66c0e377e458165947f674fa2eeb89c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->