### PR TITLE
fix(audio): preserve recordings by default

### DIFF
--- a/apps/desktop/src/services/audio-retention-policy.ts
+++ b/apps/desktop/src/services/audio-retention-policy.ts
@@ -6,14 +6,17 @@ export const AUDIO_RETENTION_DURATION_MS = {
   oneMonth: 30 * 24 * 60 * 60 * 1000,
 } as const;
 
-export type AudioRetentionPolicy = keyof typeof AUDIO_RETENTION_DURATION_MS;
+export type ExpiringAudioRetentionPolicy =
+  keyof typeof AUDIO_RETENTION_DURATION_MS;
+export type AudioRetentionPolicy = ExpiringAudioRetentionPolicy | "forever";
 
-const AUDIO_RETENTION_VALUES = new Set(
-  Object.keys(AUDIO_RETENTION_DURATION_MS),
-);
+const AUDIO_RETENTION_VALUES = new Set([
+  ...Object.keys(AUDIO_RETENTION_DURATION_MS),
+  "forever",
+]);
 
 export function normalizeAudioRetention<
-  T extends AudioRetentionPolicy | undefined = "oneMonth",
+  T extends AudioRetentionPolicy | undefined = "forever",
 >(value: unknown, fallback?: T): AudioRetentionPolicy | T {
   if (typeof value === "string" && AUDIO_RETENTION_VALUES.has(value)) {
     return value as AudioRetentionPolicy;
@@ -24,8 +27,8 @@ export function normalizeAudioRetention<
   }
 
   if (value === true) {
-    return "oneMonth";
+    return "forever";
   }
 
-  return arguments.length >= 2 ? (fallback as T) : ("oneMonth" as T);
+  return arguments.length >= 2 ? (fallback as T) : ("forever" as T);
 }

--- a/apps/desktop/src/services/audio-retention.test.ts
+++ b/apps/desktop/src/services/audio-retention.test.ts
@@ -61,14 +61,22 @@ describe("audio retention", () => {
   test("normalizes current and legacy values", () => {
     expect(normalizeAudioRetention("none")).toBe("none");
     expect(normalizeAudioRetention("oneWeek")).toBe("oneWeek");
+    expect(normalizeAudioRetention("forever")).toBe("forever");
     expect(normalizeAudioRetention(false)).toBe("none");
-    expect(normalizeAudioRetention(true)).toBe("oneMonth");
-    expect(normalizeAudioRetention("invalid")).toBe("oneMonth");
+    expect(normalizeAudioRetention(true)).toBe("forever");
+    expect(normalizeAudioRetention("invalid")).toBe("forever");
     expect(normalizeAudioRetention("invalid", undefined)).toBeUndefined();
   });
 
   test("expires immediately when retention is none", () => {
     expect(sessionAudioExpired("not-a-date", "none")).toBe(true);
+  });
+
+  test("never expires when retention is forever", () => {
+    expect(sessionAudioExpired("2026-01-01T00:00:00.000Z", "forever")).toBe(
+      false,
+    );
+    expect(sessionAudioExpired("not-a-date", "forever")).toBe(false);
   });
 
   test("expires after the selected retention window", () => {
@@ -183,6 +191,26 @@ describe("audio retention", () => {
     expect(audioDeleteMock).toHaveBeenCalledTimes(1);
     expect(audioDeleteMock).toHaveBeenCalledWith("processed");
     expect(deleted).toEqual(["processed"]);
+  });
+
+  test("does not delete session or orphaned audio when retention is forever", async () => {
+    const now = Date.parse("2026-05-13T00:00:00.000Z");
+    const store = createMainStore();
+    const settingsStore = createSettingsStore();
+
+    settingsStore.setValue("audio_retention", "forever");
+    store.setRow("sessions", "old", {
+      user_id: "user",
+      created_at: "2026-01-01T00:00:00.000Z",
+      title: "",
+      raw_md: "",
+    });
+
+    const deleted = await cleanupExpiredAudio(store, settingsStore, now);
+
+    expect(audioDeleteMock).not.toHaveBeenCalled();
+    expect(audioDeleteOrphanedExpiredMock).not.toHaveBeenCalled();
+    expect(deleted).toEqual([]);
   });
 
   test("uses legacy save_recordings when audio_retention is missing", async () => {

--- a/apps/desktop/src/services/audio-retention.ts
+++ b/apps/desktop/src/services/audio-retention.ts
@@ -4,6 +4,7 @@ import {
   AUDIO_RETENTION_DURATION_MS,
   normalizeAudioRetention as normalizeAudioRetentionPolicy,
   type AudioRetentionPolicy,
+  type ExpiringAudioRetentionPolicy,
 } from "./audio-retention-policy";
 
 import type * as main from "~/store/tinybase/store/main";
@@ -23,6 +24,10 @@ export function sessionAudioExpired(
   policy: AudioRetentionPolicy,
   nowMs = Date.now(),
 ) {
+  if (policy === "forever") {
+    return false;
+  }
+
   if (policy === "none") {
     return true;
   }
@@ -83,12 +88,20 @@ function sessionHasTranscriptWords(store: main.Store, sessionId: string) {
   return hasWords;
 }
 
+function audioRetentionDurationMs(policy: ExpiringAudioRetentionPolicy) {
+  return AUDIO_RETENTION_DURATION_MS[policy];
+}
+
 export async function cleanupExpiredAudio(
   store: main.Store,
   settingsStore: settings.Store,
   nowMs = Date.now(),
 ) {
   const policy = getAudioRetentionPolicy(settingsStore);
+  if (policy === "forever") {
+    return [];
+  }
+
   const deletes: Promise<void>[] = [];
   const knownSessionIds: string[] = [];
   const deletedSessionIds: string[] = [];
@@ -137,7 +150,7 @@ export async function cleanupExpiredAudio(
   try {
     const orphanedResult = await fsSyncCommands.audioDeleteOrphanedExpired(
       knownSessionIds,
-      AUDIO_RETENTION_DURATION_MS[policy],
+      audioRetentionDurationMs(policy),
       nowMs,
     );
 

--- a/apps/desktop/src/settings/general/storage/index.tsx
+++ b/apps/desktop/src/settings/general/storage/index.tsx
@@ -63,6 +63,11 @@ const AUDIO_RETENTION_OPTIONS = [
     label: "1 month",
     description: "Expire recordings after one month",
   },
+  {
+    value: "forever",
+    label: "Forever",
+    description: "Keep recordings until manually deleted",
+  },
 ];
 
 export function StorageSettingsView() {
@@ -137,7 +142,7 @@ export function StorageSettingsView() {
 }
 
 function AudioRetentionRow() {
-  const audioRetention = useConfigValue("audio_retention") || "oneMonth";
+  const audioRetention = useConfigValue("audio_retention") || "forever";
   const setAudioRetention = settings.UI.useSetPartialValuesCallback(
     (value: string) => ({
       audio_retention: value,

--- a/apps/desktop/src/shared/config/index.test.tsx
+++ b/apps/desktop/src/shared/config/index.test.tsx
@@ -39,7 +39,7 @@ describe("useConfigValue", () => {
     expect(result.current).toBe("none");
   });
 
-  test("keeps explicit default audio retention over legacy save_recordings", () => {
+  test("keeps explicit audio retention over legacy save_recordings", () => {
     const { result } = renderHook(() => useConfigValue("audio_retention"), {
       wrapper: createWrapper({
         save_recordings: false,

--- a/apps/desktop/src/store/tinybase/persister/settings/persister.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/settings/persister.test.ts
@@ -136,7 +136,7 @@ describe("settingsPersister roundtrip", () => {
     const [, valuesFromRemoteAlias] = settingsToContent({
       general: { saveAudioAfterMeeting: true },
     });
-    expect(valuesFromRemoteAlias.audio_retention).toBe("oneMonth");
+    expect(valuesFromRemoteAlias.audio_retention).toBe("forever");
   });
 
   test("store -> settings -> store preserves all data", () => {
@@ -639,7 +639,7 @@ describe("createSettingsPersister e2e", () => {
     expect(settingsLoad).toHaveBeenCalled();
     expect(store.getValue("autostart")).toBe(true);
     expect(store.getValue("save_recordings")).toBe(true);
-    expect(store.getValue("audio_retention")).toBe("oneMonth");
+    expect(store.getValue("audio_retention")).toBe("forever");
 
     await persister.stopAutoPersisting();
     persister.destroy();

--- a/apps/desktop/src/store/tinybase/store/settings.ts
+++ b/apps/desktop/src/store/tinybase/store/settings.ts
@@ -54,7 +54,7 @@ export const SETTINGS_MAPPING = {
     audio_retention: {
       type: "string",
       path: ["general", "audio_retention"],
-      default: "oneMonth" as string,
+      default: "forever" as string,
       schemaDefault: false,
     },
     notification_event: {

--- a/packages/store/src/zod.ts
+++ b/packages/store/src/zod.ts
@@ -267,7 +267,7 @@ export const generalSchema = z.object({
   floating_bar_enabled: z.boolean().default(true),
   telemetry_consent: z.boolean().default(true),
   save_recordings: z.boolean().default(true),
-  audio_retention: z.string().default("oneMonth"),
+  audio_retention: z.string().default("forever"),
   notification_event: z.boolean().default(true),
   notification_detect: z.boolean().default(true),
   respect_dnd: z.boolean().default(false),


### PR DESCRIPTION
Add a forever retention option, migrate legacy save-recordings settings to keep audio, and skip cleanup when retention is forever.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default retention and automatic deletion behavior for meeting audio; users who relied on implicit one-month expiry without an explicit setting will keep recordings longer unless they choose a timed policy.
> 
> **Overview**
> Introduces a **`forever`** audio retention policy so recordings are kept until manual deletion, and makes that the **default** instead of **`oneMonth`**.
> 
> **Retention behavior:** `sessionAudioExpired` never treats audio as expired when policy is `forever`; `cleanupExpiredAudio` returns immediately without deleting session or orphaned files. Legacy normalization maps `true` / unknown values to **`forever`** (was **`oneMonth`**); `saveAudioAfterMeeting: true` migration now yields **`forever`**.
> 
> **UI & settings:** Storage settings add a "Forever" option; `audio_retention` defaults update in Tinybase settings, Zod `generalSchema`, and the storage row fallback.
> 
> **Tests** cover forever expiry, cleanup no-ops, and updated migration/default expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ab65cc455e9b6ce79879ce87ac46f3b175dc3f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->