### PR TITLE
fix(stt): route Soniqo batch safely

### DIFF
--- a/apps/desktop/src/stt/capabilities.test.ts
+++ b/apps/desktop/src/stt/capabilities.test.ts
@@ -38,10 +38,10 @@ describe("getOnDeviceTranscriptionMode", () => {
     ).toBe("batch");
   });
 
-  test("falls back to batch when realtime local model has no supported language", () => {
+  test("keeps live mode when realtime local model has no Soniqo-supported language", () => {
     expect(
       getOnDeviceTranscriptionMode("soniqo-parakeet-streaming", ["ko"]),
-    ).toBe("batch");
+    ).toBe("live");
   });
 
   test("falls back to batch for non-English Soniqo streaming languages", () => {
@@ -67,6 +67,15 @@ describe("getOnDeviceTranscriptionConfig", () => {
     ).toEqual({
       languages: ["de", "en"],
       transcriptionMode: "batch",
+    });
+  });
+
+  test("drops unsupported Soniqo language hints instead of forcing batch", () => {
+    expect(
+      getOnDeviceTranscriptionConfig("soniqo-parakeet-streaming", ["ko"]),
+    ).toEqual({
+      languages: [],
+      transcriptionMode: "live",
     });
   });
 });

--- a/apps/desktop/src/stt/capabilities.ts
+++ b/apps/desktop/src/stt/capabilities.ts
@@ -9,6 +9,33 @@ type LiveTranscriptionConfig = {
 };
 
 const SONIQO_STREAMING_LANGUAGE_CODES = new Set(["en"]);
+const SONIQO_PARAKEET_BATCH_LANGUAGE_CODES = new Set([
+  "bg",
+  "cs",
+  "da",
+  "de",
+  "el",
+  "en",
+  "es",
+  "et",
+  "fi",
+  "fr",
+  "hr",
+  "hu",
+  "it",
+  "lt",
+  "lv",
+  "mt",
+  "nl",
+  "pl",
+  "pt",
+  "ro",
+  "ru",
+  "sk",
+  "sl",
+  "sv",
+  "uk",
+]);
 
 export function isRealtimeLocalModel(model?: string | null) {
   return model === "soniqo-parakeet-streaming";
@@ -72,13 +99,16 @@ export function getOnDeviceTranscriptionConfig(
   }
 
   const primaryLanguage = languages[0];
-  const primaryLanguageSupported =
+  const primaryLanguageLiveSupported =
     !primaryLanguage ||
     SONIQO_STREAMING_LANGUAGE_CODES.has(baseLanguageCode(primaryLanguage));
+  const primaryLanguageBatchSupported =
+    !!primaryLanguage &&
+    SONIQO_PARAKEET_BATCH_LANGUAGE_CODES.has(baseLanguageCode(primaryLanguage));
 
   // The Soniqo streaming session API does not accept a language hint, so keep
-  // non-English primary languages on batch instead of relying on live auto-detect.
-  if (!primaryLanguageSupported) {
+  // non-English Parakeet languages on batch instead of relying on live auto-detect.
+  if (!primaryLanguageLiveSupported && primaryLanguageBatchSupported) {
     return {
       languages: [...languages],
       transcriptionMode: "batch",
@@ -91,8 +121,8 @@ export function getOnDeviceTranscriptionConfig(
 
   if (languages.length > 0 && supportedLiveLanguages.length === 0) {
     return {
-      languages: [...languages],
-      transcriptionMode: "batch",
+      languages: [],
+      transcriptionMode: "live",
     };
   }
 

--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -113,7 +113,8 @@ pub(super) async fn run_soniqo_batch(
             .map_err(|e| crate::BatchFailure::DirectRequestFailed {
                 provider: "soniqo".to_string(),
                 message: e.to_string(),
-            })?;
+            })?
+            .batch_model();
 
         let file_path = params.file_path.clone();
         let language = listen_params

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -146,6 +146,13 @@ impl SoniqoModel {
         self.supports_live() && self.is_available_on_current_platform()
     }
 
+    pub const fn batch_model(self) -> Self {
+        match self {
+            Self::ParakeetStreaming => Self::ParakeetBatch,
+            model => model,
+        }
+    }
+
     pub fn supports_language(self, language: &hypr_language::Language) -> bool {
         match self {
             Self::ParakeetStreaming | Self::ParakeetBatch => {
@@ -857,6 +864,18 @@ mod tests {
             cfg!(all(target_os = "macos", target_arch = "aarch64")),
         );
         assert!(!SoniqoModel::ParakeetBatch.supports_live_on_current_platform());
+    }
+
+    #[test]
+    fn streaming_model_uses_batch_model_for_file_transcription() {
+        assert_eq!(
+            SoniqoModel::ParakeetStreaming.batch_model(),
+            SoniqoModel::ParakeetBatch
+        );
+        assert_eq!(
+            SoniqoModel::ParakeetBatch.batch_model(),
+            SoniqoModel::ParakeetBatch
+        );
     }
 
     #[test]


### PR DESCRIPTION
Keep unsupported Soniqo language defaults out of forced batch mode and map streaming-triggered batch runs to the batch model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when live vs batch runs and which model handles file transcription; wrong routing would affect transcription quality or failures for edge language settings.
> 
> **Overview**
> **Soniqo on-device routing** no longer forces **batch** when the user picks an unsupported language like Korean on `soniqo-parakeet-streaming`. Those hints are **cleared** and the app stays in **live** mode. **Non-English Parakeet languages** (e.g. German) still go to **batch**, using an explicit allowlist of batch-capable codes instead of treating “not English” as batch-only.
> 
> **File batch transcription** now maps `soniqo-parakeet-streaming` to **`soniqo-parakeet-batch`** via `SoniqoModel::batch_model()` so batch runs use the correct CoreML model instead of the streaming variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c5fc6d60c385b1e62d3a98ad15201643d09258c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->