### PR TITLE
fix(timeline): open top notes in tabs

### DIFF
--- a/apps/desktop/src/main/top-meeting-timeline.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.tsx
@@ -341,7 +341,6 @@ const SessionTimelineBar = memo(
   ({ item, timezone }: { item: MeetingTimelineEntry; timezone?: string }) => {
     const store = main.UI.useStore(main.STORE_ID);
     const indexes = main.UI.useIndexes(main.STORE_ID);
-    const openCurrent = useTabs((state) => state.openCurrent);
     const openNew = useTabs((state) => state.openNew);
     const invalidateResource = useTabs((state) => state.invalidateResource);
     const addDeletion = useUndoDelete((state) => state.addDeletion);
@@ -367,19 +366,7 @@ const SessionTimelineBar = memo(
       [sessionRow?.event_json],
     );
 
-    const handleClick = useCallback(
-      (event: MouseEvent<HTMLButtonElement>) => {
-        if (event.metaKey || event.ctrlKey) {
-          openNew({ id: item.id, type: "sessions" });
-          return;
-        }
-
-        openCurrent({ id: item.id, type: "sessions" });
-      },
-      [item.id, openCurrent, openNew],
-    );
-
-    const handleOpenNewTab = useCallback(() => {
+    const openSession = useCallback(() => {
       openNew({ id: item.id, type: "sessions" });
     }, [item.id, openNew]);
 
@@ -426,7 +413,7 @@ const SessionTimelineBar = memo(
         {
           id: "open-new-tab",
           text: "Open in New Tab",
-          action: handleOpenNewTab,
+          action: openSession,
         },
         {
           id: "show",
@@ -440,7 +427,7 @@ const SessionTimelineBar = memo(
           action: handleDelete,
         },
       ],
-      [handleOpenNewTab, handleShowInFinder, handleDelete],
+      [openSession, handleShowInFinder, handleDelete],
     );
 
     return (
@@ -451,7 +438,7 @@ const SessionTimelineBar = memo(
             title={title || item.title || "Untitled"}
             timezone={timezone}
             showSpinner={showSpinner}
-            onClick={handleClick}
+            onClick={openSession}
             contextMenu={contextMenu}
           />
         </SessionPreviewCard>
@@ -463,38 +450,23 @@ const SessionTimelineBar = memo(
 const EventTimelineBar = memo(
   ({ item, timezone }: { item: MeetingTimelineEntry; timezone?: string }) => {
     const store = main.UI.useStore(main.STORE_ID);
-    const openCurrent = useTabs((state) => state.openCurrent);
     const openNew = useTabs((state) => state.openNew);
     const { ignoreEvent, ignoreSeries } = useIgnoredEvents();
 
-    const openEvent = useCallback(
-      (openInNewTab: boolean) => {
-        if (!store) {
-          return;
-        }
+    const openEvent = useCallback(() => {
+      if (!store) {
+        return;
+      }
 
-        const sessionId = getOrCreateSessionForEventId(
-          store,
-          item.id,
-          item.title,
-        );
-        const tab = { id: sessionId, type: "sessions" } as const;
+      const sessionId = getOrCreateSessionForEventId(
+        store,
+        item.id,
+        item.title,
+      );
+      const tab = { id: sessionId, type: "sessions" } as const;
 
-        openInNewTab ? openNew(tab) : openCurrent(tab);
-      },
-      [item.id, item.title, openCurrent, openNew, store],
-    );
-
-    const handleClick = useCallback(
-      (event: MouseEvent<HTMLButtonElement>) => {
-        openEvent(event.metaKey || event.ctrlKey);
-      },
-      [openEvent],
-    );
-
-    const handleOpenNewTab = useCallback(() => {
-      openEvent(true);
-    }, [openEvent]);
+      openNew(tab);
+    }, [item.id, item.title, openNew, store]);
 
     const handleIgnore = useCallback(() => {
       if (!item.trackingId) {
@@ -517,7 +489,7 @@ const EventTimelineBar = memo(
         {
           id: "open-new-tab",
           text: "Open in New Tab",
-          action: handleOpenNewTab,
+          action: openEvent,
         },
         { separator: true },
         {
@@ -536,12 +508,7 @@ const EventTimelineBar = memo(
       }
 
       return menu;
-    }, [
-      handleOpenNewTab,
-      handleIgnore,
-      handleIgnoreSeries,
-      item.recurrenceSeriesId,
-    ]);
+    }, [openEvent, handleIgnore, handleIgnoreSeries, item.recurrenceSeriesId]);
 
     return (
       <TimelineCarouselCard item={item}>
@@ -549,7 +516,7 @@ const EventTimelineBar = memo(
           item={item}
           title={item.title || "Untitled"}
           timezone={timezone}
-          onClick={handleClick}
+          onClick={openEvent}
           contextMenu={contextMenu}
         />
       </TimelineCarouselCard>


### PR DESCRIPTION
Open top timeline sessions and event-backed notes through the new-tab path so existing tabs are selected instead of replacing the current tab.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small desktop UI navigation change in the top timeline only; no auth, data, or API impact.
> 
> **Overview**
> **Top meeting timeline** cards no longer route primary clicks through `openCurrent` or treat Cmd/Ctrl as “open in new tab.” Session and calendar-event entries always call **`openNew`** for the main click and for **Open in New Tab**, so an already-open note tab is **focused** instead of replacing whatever tab is active.
> 
> The change is limited to `SessionTimelineBar` and `EventTimelineBar` in `top-meeting-timeline.tsx` (handlers collapsed to `openSession` / `openEvent`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 956fd78e7a0bbe7caa79538cdf100a52f151c196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->