### PR TITLE
chore(changelog): add 1.0.32 release notes

### DIFF
--- a/packages/changelog/content/1.0.32.md
+++ b/packages/changelog/content/1.0.32.md
@@ -1,0 +1,29 @@
+---
+date: "2026-05-29"
+summary: "Manual titles are preserved, chat context and storage settings are clearer, and imports, local transcription, and timeline tabs are more reliable."
+---
+
+## Notes
+
+- Manually edited note titles now stay intact when title generation or note enhancement finishes in the background
+- Notes and calendar events opened from the top timeline now open in tabs, selecting an existing tab when possible instead of replacing the current note
+
+## Chat
+
+- The chat context picker now shows recent notes before you search and keeps results aligned with the latest saved note data
+- Searching from the chat context picker now shows progress while matching notes are loading
+
+## Audio & Storage
+
+- Recording retention now includes a Forever option for keeping audio until you delete it manually
+- Fresh installs now keep saved recordings by default, while existing "don't save" choices continue to be honored
+
+## Import
+
+- Legacy Hyprnote imports now copy the database before scanning or importing, making imports more reliable while the original database is still changing
+- Legacy import scans now use faster counts, and long-running scans or imports now show timeout errors instead of appearing to hang indefinitely
+
+## Transcription
+
+- Local Soniqo Parakeet now uses batch transcription for supported non-English languages when live transcription is not the right fit
+- Saved audio processed after Soniqo live sessions now uses the batch model for more reliable file transcription


### PR DESCRIPTION
Document user-facing desktop fixes for titles, chat context, audio retention, imports, transcription, and timeline tabs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no runtime or product code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.0.32.md`**, the **1.0.32** release notes for the desktop app. The entry documents user-facing fixes and improvements across **notes** (manual titles preserved; timeline opens notes/events in tabs), **chat** (context picker UX and fresher note data), **audio & storage** (Forever retention, default save behavior for new installs), **legacy Hyprnote import** (DB copy, faster scans, timeouts), and **local Soniqo Parakeet** transcription (batch path for non-English and post-live saved audio).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ebccdbc37b3c073d36368238195af0c885faaeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->