### PR TITLE
fix(web): restore handwritten website fonts

### DIFF
--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Cabin+Sketch:wght@400;700&display=swap");
 @import "./scrollbar.css" layer(base);
 @import "./scrollbar.utilities.css";
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -23,6 +23,10 @@ interface RouterContext {
   queryClient: QueryClient;
 }
 
+const FONT_STYLESHEETS = [
+  "https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Patrick+Hand&display=swap",
+] as const;
+
 export const Route = createRootRouteWithContext<RouterContext>()({
   head: () => ({
     meta: [
@@ -104,6 +108,15 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        {FONT_STYLESHEETS.map((href) => (
+          <link key={href} rel="stylesheet" href={href} />
+        ))}
         <link rel="stylesheet" href={appCss} />
         <HeadContent />
       </head>

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -36,7 +36,7 @@ function Component() {
         </header>
 
         <section className="pt-24 pb-16 md:pt-32">
-          <h1 className="font-sans text-6xl leading-[0.98] font-semibold tracking-normal text-balance text-black md:text-8xl">
+          <h1 className="font-hand text-6xl leading-[0.98] font-semibold tracking-normal text-balance text-black md:text-8xl">
             Blog
           </h1>
           <p className="mt-6 max-w-2xl text-xl leading-9 text-[#363029]">
@@ -54,7 +54,7 @@ function Component() {
                 className="group block"
               >
                 <article className="grid gap-3 border-t border-[#eee8df] pt-6">
-                  <h2 className="font-sans text-3xl leading-[1.05] font-semibold tracking-normal text-balance text-[#756b5d] group-hover:text-[#4f4940]">
+                  <h2 className="font-hand text-3xl leading-[1.05] font-semibold tracking-normal text-balance text-[#756b5d] group-hover:text-[#4f4940]">
                     {article.title}
                   </h2>
                   {article.meta_description && (

--- a/apps/web/src/routes/changelog/index.tsx
+++ b/apps/web/src/routes/changelog/index.tsx
@@ -33,7 +33,7 @@ function Component() {
         </header>
 
         <section className="pt-24 pb-16 md:pt-32">
-          <h1 className="font-sans text-6xl leading-[0.98] font-semibold tracking-normal text-balance text-black md:text-8xl">
+          <h1 className="font-hand text-6xl leading-[0.98] font-semibold tracking-normal text-balance text-black md:text-8xl">
             Changelog
           </h1>
           <p className="mt-6 max-w-2xl text-xl leading-9 text-[#363029]">
@@ -56,7 +56,7 @@ function Component() {
                       params={{ version: entry.version }}
                       className="group"
                     >
-                      <h2 className="font-sans text-4xl leading-none font-semibold tracking-normal text-[#756b5d] group-hover:text-[#4f4940]">
+                      <h2 className="font-hand text-4xl leading-none font-semibold tracking-normal text-[#756b5d] group-hover:text-[#4f4940]">
                         v{entry.version}
                       </h2>
                     </Link>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -147,7 +147,7 @@ function Component() {
           </header>
 
           <section className="pt-24 pb-16 md:pt-32">
-            <h1 className="max-w-3xl font-sans text-6xl leading-[0.98] font-semibold tracking-normal text-balance md:text-8xl">
+            <h1 className="font-hand max-w-3xl text-6xl leading-[0.98] font-semibold tracking-normal text-balance md:text-8xl">
               AI notepad for private meetings.
             </h1>
             <p className="mt-6 max-w-2xl text-xl leading-9 text-[#363029]">
@@ -175,7 +175,7 @@ function Component() {
           </section>
 
           <section className="py-10">
-            <h2 className="font-sans text-3xl leading-none font-semibold text-[#756b5d]">
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
               Why Anarlog exists
             </h2>
             <ul className="mt-6 grid gap-8">
@@ -194,7 +194,7 @@ function Component() {
           </section>
 
           <section id="manifesto" className="py-10">
-            <h2 className="font-sans text-3xl leading-none font-semibold text-[#756b5d]">
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
               Manifesto
             </h2>
             <div className="mt-7 max-w-3xl">
@@ -204,7 +204,7 @@ function Component() {
                 ))}
               </div>
               <div className="mt-10">
-                <p className="font-sans text-3xl leading-none font-normal">
+                <p className="font-signature text-3xl leading-none font-normal">
                   {manifestoLetter.at(-1)}
                 </p>
                 <p className="mt-5 font-sans text-base leading-none font-normal text-[#4f4940]">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13,6 +13,8 @@
   --font-mono:
     ui-monospace, "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono",
     Menlo, monospace;
+  --font-hand: "Caveat", cursive;
+  --font-signature: "Patrick Hand", cursive;
 
   /* ── Layout ──────────────────────────────────── */
   --breakpoint-laptop: 72rem;


### PR DESCRIPTION
Load handwritten display fonts on the web shell, apply them to marketing/blog/changelog headings, and keep desktop CSS on the system sans stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only typography and external font loading on marketing routes; no auth, data, or business-logic changes.
> 
> **Overview**
> Restores the marketing site’s handwritten look by loading **Caveat** and **Patrick Hand** on the web app only, and wiring them through new Tailwind theme tokens `font-hand` and `font-signature`.
> 
> The web shell now **preconnects** to Google Fonts and injects a stylesheet in `RootDocument` (alongside `appCss`). Home, blog, and changelog **headings** use `font-hand` instead of `font-sans`; the manifesto closing line uses `font-signature`. Desktop drops the old **Cabin Sketch** `@import` so the desktop app stays on the **system sans** stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fec18eae23b14e8ef8cf76c70c304408b623bf47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->