### PR TITLE
fix(desktop): keep transcript upload accessible

### DIFF
--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OverflowButton } from "./index";
+
+import type { EditorView } from "~/store/zustand/tabs/schema";
+
+const {
+  uploadAudioMock,
+  uploadTranscriptMock,
+  useHasTranscriptMock,
+  useListenerMock,
+  useConfigValueMock,
+} = vi.hoisted(() => ({
+  uploadAudioMock: vi.fn(),
+  uploadTranscriptMock: vi.fn(),
+  useHasTranscriptMock: vi.fn(),
+  useListenerMock: vi.fn(),
+  useConfigValueMock: vi.fn(),
+}));
+
+vi.mock("@hypr/ui/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@hypr/ui/components/ui/dropdown-menu", () => ({
+  AppFloatingPanel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("./delete", () => ({
+  DeleteNote: () => <button type="button">Delete note</button>,
+  DeleteRecording: () => <button type="button">Delete recording</button>,
+}));
+
+vi.mock("./export-modal", () => ({
+  ExportModal: () => null,
+}));
+
+vi.mock("./listening", () => ({
+  Listening: () => <button type="button">Resume listening</button>,
+}));
+
+vi.mock("./misc", () => ({
+  Copy: () => <button type="button">Copy link</button>,
+  ShowInFinder: () => <button type="button">Show in Finder</button>,
+}));
+
+vi.mock("~/audio-player", () => ({
+  useAudioPlayer: () => ({
+    audioExists: true,
+  }),
+}));
+
+vi.mock("~/meeting-float/host", () => ({
+  openFloatingMeetingPanel: vi.fn(),
+}));
+
+vi.mock("~/session/components/shared", () => ({
+  useHasTranscript: useHasTranscriptMock,
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValue: useConfigValueMock,
+}));
+
+vi.mock("~/stt/contexts", () => ({
+  useListener: useListenerMock,
+}));
+
+vi.mock("~/stt/useUploadFile", () => ({
+  useUploadFile: vi.fn(() => ({
+    uploadAudio: uploadAudioMock,
+    uploadTranscript: uploadTranscriptMock,
+  })),
+}));
+
+describe("OverflowButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useHasTranscriptMock.mockReturnValue(true);
+    useConfigValueMock.mockReturnValue(false);
+    useListenerMock.mockImplementation((selector) =>
+      selector({
+        getSessionMode: () => "inactive",
+      }),
+    );
+  });
+
+  it("keeps upload actions available when a transcript already exists", () => {
+    render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Upload audio" }));
+    fireEvent.click(screen.getByRole("button", { name: "Upload transcript" }));
+
+    expect(uploadAudioMock).toHaveBeenCalledTimes(1);
+    expect(uploadTranscriptMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -1,4 +1,5 @@
 import {
+  AudioLinesIcon,
   FileTextIcon,
   MoreHorizontalIcon,
   PictureInPicture2Icon,
@@ -26,6 +27,7 @@ import { useHasTranscript } from "~/session/components/shared";
 import { useConfigValue } from "~/shared/config";
 import type { EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
+import { useUploadFile } from "~/stt/useUploadFile";
 
 export function OverflowButton({
   sessionId,
@@ -37,6 +39,7 @@ export function OverflowButton({
   const [open, setOpen] = useState(false);
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
   const hasTranscript = useHasTranscript(sessionId);
+  const { uploadAudio, uploadTranscript } = useUploadFile(sessionId);
   const { audioExists } = useAudioPlayer();
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const floatingBarEnabled = useConfigValue("floating_bar_enabled");
@@ -46,6 +49,14 @@ export function OverflowButton({
   const openExportModal = () => {
     setOpen(false);
     requestAnimationFrame(() => setIsExportModalOpen(true));
+  };
+  const handleUploadAudio = () => {
+    setOpen(false);
+    uploadAudio();
+  };
+  const handleUploadTranscript = () => {
+    setOpen(false);
+    uploadTranscript();
   };
   const handleOpenFloatingPanel = () => {
     setOpen(false);
@@ -79,6 +90,20 @@ export function OverflowButton({
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <Listening sessionId={sessionId} hasTranscript={hasTranscript} />
+            <DropdownMenuItem
+              onClick={handleUploadAudio}
+              className="cursor-pointer"
+            >
+              <AudioLinesIcon />
+              <span>Upload audio</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={handleUploadTranscript}
+              className="cursor-pointer"
+            >
+              <FileTextIcon />
+              <span>Upload transcript</span>
+            </DropdownMenuItem>
             {canOpenFloatingPanel && (
               <DropdownMenuItem
                 onClick={handleOpenFloatingPanel}


### PR DESCRIPTION
Add audio and transcript upload actions to the session overflow menu so they remain available after transcripts or generated notes exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only menu entries reusing existing upload hooks; no auth, data model, or backend changes.
> 
> **Overview**
> **Upload audio** and **Upload transcript** are now in the session header overflow menu (`OverflowButton`), wired through `useUploadFile` with handlers that close the menu before invoking upload—matching patterns used elsewhere (e.g. floating options).
> 
> A Vitest test asserts both actions stay visible and callable when a transcript already exists (`useHasTranscript` true), covering the regression this PR fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f6a9c6aa5b619e1e37566aa762dce9c4649b54e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->