### PR TITLE
fix(web): filter changelog release entries

### DIFF
--- a/apps/web/src/lib/changelog-path.test.ts
+++ b/apps/web/src/lib/changelog-path.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getChangelogVersionFromPath } from "./changelog-path.ts";
+
+test("extracts versions only from changelog release files", () => {
+  assert.equal(
+    getChangelogVersionFromPath(
+      "../../../../packages/changelog/content/1.0.32.md",
+    ),
+    "1.0.32",
+  );
+  assert.equal(
+    getChangelogVersionFromPath("packages/changelog/content/AGENTS.md"),
+    null,
+  );
+  assert.equal(
+    getChangelogVersionFromPath("packages/changelog/content/1.0.md"),
+    null,
+  );
+  assert.equal(
+    getChangelogVersionFromPath("packages/changelog/content/1.0.32.mdx"),
+    null,
+  );
+});

--- a/apps/web/src/lib/changelog-path.ts
+++ b/apps/web/src/lib/changelog-path.ts
@@ -1,0 +1,5 @@
+const CHANGELOG_VERSION_FILE_PATTERN = /(?:^|\/)(\d+\.\d+\.\d+)\.md$/;
+
+export function getChangelogVersionFromPath(filePath: string) {
+  return filePath.match(CHANGELOG_VERSION_FILE_PATTERN)?.[1] ?? null;
+}

--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -1,5 +1,7 @@
 import { processContent } from "@hypr/changelog";
 
+import { getChangelogVersionFromPath } from "./changelog-path";
+
 const rawEntries = import.meta.glob(
   "../../../../packages/changelog/content/*.md",
   {
@@ -10,18 +12,21 @@ const rawEntries = import.meta.glob(
 ) as Record<string, string>;
 
 export const changelogEntries = Object.entries(rawEntries)
-  .map(([filePath, raw]) => {
-    const version = filePath.split("/").pop()?.replace(/\.md$/, "") ?? "";
+  .flatMap(([filePath, raw]) => {
+    const version = getChangelogVersionFromPath(filePath);
+    if (!version) return [];
+
     const { content, date, summary } = processContent(raw);
 
-    return {
-      version,
-      content,
-      date: normalizeDate(date),
-      summary,
-    };
+    return [
+      {
+        version,
+        content,
+        date: normalizeDate(date),
+        summary,
+      },
+    ];
   })
-  .filter((entry) => entry.version)
   .sort((a, b) => compareVersionsDesc(a.version, b.version));
 
 export function getChangelogEntry(version: string) {


### PR DESCRIPTION
Only include version-named changelog markdown files in the web changelog loader and cover the filename filter with a node test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow content-filtering change for the public changelog with unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> The web changelog loader no longer treats every `*.md` file under `packages/changelog/content` as a release. It now derives the version with `getChangelogVersionFromPath`, which only accepts paths ending in **`x.y.z.md`** (three numeric segments). Non-release files such as `AGENTS.md`, two-segment names like `1.0.md`, and `.mdx` paths are skipped instead of appearing in `changelogEntries` or version routes.
> 
> The previous “strip `.md` from the basename” logic and a follow-up `.filter((entry) => entry.version)` are replaced by **`flatMap`** that omits non-matching paths. A small **`changelog-path`** helper and a **Node test** document the filename rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c72649f29375fb099f762566d8995cab73c22bd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->