### PR TITLE
fix(desktop): speed up top timeline

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -19,11 +19,7 @@ export function ClassicMainBody() {
     })),
   );
 
-  if (!currentTab) {
-    return null;
-  }
-
-  const isOnboarding = currentTab.type === "onboarding";
+  const isOnboarding = currentTab?.type === "onboarding";
   const hasCustomSidebar = hasCustomSidebarTab(currentTab);
   const showTopTimeline =
     leftsidebar.expanded &&
@@ -40,10 +36,12 @@ export function ClassicMainBody() {
       <div className="flex min-h-0 min-w-0 flex-1 gap-1">
         <ClassicMainSidebar />
         <div className="min-h-0 min-w-0 flex-1 overflow-auto">
-          <ClassicMainTabContent
-            key={uniqueIdfromTab(currentTab)}
-            tab={currentTab as Tab}
-          />
+          {currentTab ? (
+            <ClassicMainTabContent
+              key={uniqueIdfromTab(currentTab)}
+              tab={currentTab as Tab}
+            />
+          ) : null}
         </div>
       </div>
       {showFloatingToast ? (

--- a/apps/desktop/src/main/top-meeting-timeline.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.tsx
@@ -73,6 +73,8 @@ const TIMELINE_HEIGHT = 44;
 const TIMELINE_CAROUSEL_CARD_WIDTH = 188;
 const TIMELINE_CAROUSEL_PADDING = 0;
 const TIMELINE_CAROUSEL_GAP = 4;
+const TIMELINE_PAST_DAYS = 6;
+const TIMELINE_FUTURE_DAYS = 1;
 type TodayChipDirection = "left" | "right";
 
 export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
@@ -98,6 +100,16 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
   ) as TimelineTranscriptsTable;
 
   const { isIgnored } = useIgnoredEvents();
+  const today = getTimelineDayStart(new Date(), timezone);
+  const todayMs = today.getTime();
+  const timelineStart = useMemo(
+    () => addDays(new Date(todayMs), -TIMELINE_PAST_DAYS),
+    [todayMs],
+  );
+  const timelineEnd = useMemo(
+    () => addDays(new Date(todayMs), TIMELINE_FUTURE_DAYS + 1),
+    [todayMs],
+  );
 
   const sessionRecordingRanges = useMemo(
     () => buildSessionRecordingRanges(transcriptsTable),
@@ -133,24 +145,47 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
     [entries, selectedSessionId],
   );
 
-  const todayMs = getTimelineDayStart(new Date(), timezone).getTime();
   const [todayChipDirection, setTodayChipDirection] =
     useState<TodayChipDirection | null>(null);
   const createNewMeeting = useNewNoteAndListen({ behavior: "current" });
   const openNew = useTabs((state) => state.openNew);
 
   const renderItems = useMemo(
-    () => buildTimelineRenderItems(entries),
-    [entries],
+    () =>
+      buildTimelineRenderItems(entries, {
+        startInclusive: timelineStart,
+        endExclusive: timelineEnd,
+      }),
+    [entries, timelineStart, timelineEnd],
+  );
+  const hasHiddenPastItems = useMemo(
+    () => hasTimelineEntriesBefore(entries, timelineStart),
+    [entries, timelineStart],
+  );
+  const hasHiddenFutureItems = useMemo(
+    () => hasTimelineEntriesAfter(entries, timelineEnd),
+    [entries, timelineEnd],
   );
   const carouselItems = useMemo(
     () =>
       buildTimelineCarouselItems({
         renderItems,
         currentDate: new Date(todayMs),
+        startInclusive: timelineStart,
+        endExclusive: timelineEnd,
+        hasHiddenPastItems,
+        hasHiddenFutureItems,
         timezone,
       }),
-    [renderItems, todayMs, timezone],
+    [
+      renderItems,
+      todayMs,
+      timelineStart,
+      timelineEnd,
+      hasHiddenPastItems,
+      hasHiddenFutureItems,
+      timezone,
+    ],
   );
   const carouselWidth = getTimelineCarouselWidth(carouselItems);
   const openCalendar = useCallback(
@@ -318,8 +353,8 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
           <button
             type="button"
             className={cn([
-              "absolute top-1/2 z-40 flex h-6 -translate-y-1/2 items-center gap-1 rounded-full border border-neutral-200 bg-white/95 px-2.5 text-xs font-medium text-neutral-700 shadow-xs backdrop-blur",
-              "transition-colors hover:border-neutral-300 hover:bg-white hover:text-neutral-900",
+              "absolute top-1/2 z-40 flex h-6 -translate-y-1/2 items-center gap-1 rounded-full border border-neutral-300 bg-neutral-200 px-2.5 text-xs font-semibold text-neutral-900 shadow-md",
+              "transition-colors hover:border-neutral-400 hover:bg-neutral-300 hover:text-neutral-950",
               "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
               todayChipDirection === "left" ? "left-3" : "right-3",
             ])}
@@ -724,7 +759,9 @@ function TimelineCardButton({
             <Spinner size={12} />
           </span>
         ) : null}
-        {item.calendarId ? <CalendarDot calendarId={item.calendarId} /> : null}
+        {item.type === "session" && item.calendarId ? (
+          <CalendarDot calendarId={item.calendarId} />
+        ) : null}
         <FadedTimelineLabel className="min-w-0 flex-1 text-xs font-semibold">
           {title}
         </FadedTimelineLabel>
@@ -735,8 +772,25 @@ function TimelineCardButton({
 
 function buildTimelineRenderItems(
   items: MeetingTimelineEntry[],
+  range: {
+    startInclusive: Date;
+    endExclusive: Date;
+  },
 ): TimelineRenderItem[] {
+  const startInclusiveMs = range.startInclusive.getTime();
+  const endExclusiveMs = range.endExclusive.getTime();
+
   return [...items]
+    .filter((item) => {
+      if (item.selected) {
+        return true;
+      }
+
+      const startMs = item.start.getTime();
+      const endMs = normalizeEndMs(item.start, item.end);
+
+      return startMs < endExclusiveMs && endMs >= startInclusiveMs;
+    })
     .sort((a, b) => {
       const startDiff = a.start.getTime() - b.start.getTime();
       if (startDiff !== 0) {
@@ -756,24 +810,21 @@ function buildTimelineRenderItems(
 function buildTimelineCarouselItems({
   renderItems,
   currentDate,
+  startInclusive,
+  endExclusive,
+  hasHiddenPastItems,
+  hasHiddenFutureItems,
   timezone,
 }: {
   renderItems: TimelineRenderItem[];
   currentDate: Date;
+  startInclusive: Date;
+  endExclusive: Date;
+  hasHiddenPastItems: boolean;
+  hasHiddenFutureItems: boolean;
   timezone?: string;
 }): TimelineCarouselItem[] {
-  const startInclusive = getTimelineDayStart(currentDate, timezone);
-  const endExclusive = addDays(startInclusive, 2);
-  const items: TimelineCarouselItem[] = renderItems.filter((item) => {
-    const startMs = getTimelineCarouselItemStart(item).getTime();
-    const beforeEnd = startMs < endExclusive.getTime();
-
-    if (item.item.type === "session") {
-      return beforeEnd || item.item.selected;
-    }
-
-    return startMs >= startInclusive.getTime() && beforeEnd;
-  });
+  const items: TimelineCarouselItem[] = [...renderItems];
   const hasToday = items.some((item) =>
     isSameTimelineDay(
       getTimelineCarouselItemStart(item),
@@ -795,28 +846,51 @@ function buildTimelineCarouselItems({
       getTimelineCarouselItemStart(a).getTime() -
       getTimelineCarouselItemStart(b).getTime(),
   );
-  const hasHiddenFutureItems = renderItems.some((item) => {
-    if (item.item.selected) {
-      return false;
-    }
 
-    return (
-      getTimelineCarouselItemStart(item).getTime() >= endExclusive.getTime()
-    );
-  });
+  const result: TimelineCarouselItem[] = hasHiddenPastItems
+    ? [
+        {
+          kind: "open-calendar",
+          id: `open-calendar-${startInclusive.getTime()}`,
+          start: startInclusive,
+        },
+        ...sortedItems,
+      ]
+    : sortedItems;
 
-  if (!hasHiddenFutureItems) {
-    return sortedItems;
-  }
-
-  return [
-    ...sortedItems,
-    {
+  if (hasHiddenFutureItems) {
+    result.push({
       kind: "open-calendar",
       id: `open-calendar-${endExclusive.getTime()}`,
       start: endExclusive,
-    },
-  ];
+    });
+  }
+
+  return result;
+}
+
+function hasTimelineEntriesBefore(
+  entries: MeetingTimelineEntry[],
+  startInclusive: Date,
+): boolean {
+  const startInclusiveMs = startInclusive.getTime();
+
+  return entries.some(
+    (entry) =>
+      !entry.selected &&
+      normalizeEndMs(entry.start, entry.end) < startInclusiveMs,
+  );
+}
+
+function hasTimelineEntriesAfter(
+  entries: MeetingTimelineEntry[],
+  endExclusive: Date,
+): boolean {
+  const endExclusiveMs = endExclusive.getTime();
+
+  return entries.some(
+    (entry) => !entry.selected && entry.start.getTime() >= endExclusiveMs,
+  );
 }
 
 function getTimelineCarouselWidth(items: TimelineCarouselItem[]): number {

--- a/apps/desktop/src/services/calendar/ctx.test.ts
+++ b/apps/desktop/src/services/calendar/ctx.test.ts
@@ -1,5 +1,5 @@
-import { createMergeableStore } from "tinybase/with-schemas";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createMergeableStore, createQueries } from "tinybase/with-schemas";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { SCHEMA } from "@hypr/store";
 
@@ -13,7 +13,9 @@ vi.mock("@hypr/plugin-calendar", () => ({
   },
 }));
 
-import { syncCalendars } from "./ctx";
+import { createCtx, syncCalendars } from "./ctx";
+
+import { QUERIES } from "~/store/tinybase/store/main";
 
 function createStore() {
   const store = createMergeableStore()
@@ -38,6 +40,41 @@ function getCalendarsByConnection(
 describe("syncCalendars", () => {
   beforeEach(() => {
     pluginCalendar.listCalendars.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("limits event sync range to six days ago through tomorrow", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 4, 29, 13, 30));
+
+    const store = createStore();
+    store.setRow("calendars", "cal-1", {
+      user_id: "user-1",
+      created_at: "2026-05-01T00:00:00.000Z",
+      tracking_id_calendar: "primary",
+      name: "Work",
+      enabled: true,
+      provider: "google",
+      source: "work@example.com",
+      color: "#4285f4",
+      connection_id: "conn-work",
+    });
+    const queries = createQueries(store).setQueryDefinition(
+      QUERIES.enabledCalendars,
+      "calendars",
+      ({ select, where }) => {
+        select("provider");
+        where("enabled", true);
+      },
+    );
+
+    const ctx = createCtx(store, queries, "google", "conn-work");
+
+    expect(ctx?.from).toEqual(new Date(2026, 4, 23, 0, 0, 0, 0));
+    expect(ctx?.to).toEqual(new Date(2026, 4, 31, 0, 0, 0, 0));
   });
 
   test("keeps Google calendars isolated per connection when ids overlap", async () => {

--- a/apps/desktop/src/services/calendar/ctx.ts
+++ b/apps/desktop/src/services/calendar/ctx.ts
@@ -197,8 +197,10 @@ export async function syncCalendars(
 const getRange = () => {
   const now = new Date();
   const from = new Date(now);
-  from.setDate(from.getDate() - 7);
+  from.setHours(0, 0, 0, 0);
+  from.setDate(from.getDate() - 6);
   const to = new Date(now);
-  to.setDate(to.getDate() + 30);
+  to.setHours(0, 0, 0, 0);
+  to.setDate(to.getDate() + 2);
   return { from, to };
 };

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("~/main/tab-chrome", () => ({
@@ -61,7 +61,7 @@ describe("ClassicMainBody", () => {
     );
   });
 
-  it("returns nothing when there is no current tab", async () => {
+  it("renders shell chrome while the initial tab is still loading", async () => {
     const { useTabs } = await import("~/store/zustand/tabs");
 
     vi.mocked(useTabs).mockImplementationOnce(((
@@ -73,7 +73,10 @@ describe("ClassicMainBody", () => {
       })) as typeof useTabs);
 
     const { container } = render(<ClassicMainBody />);
+    const view = within(container);
 
-    expect(container.firstChild).toBeNull();
+    expect(view.getByTestId("main-tab-chrome")).toBeTruthy();
+    expect(view.getByTestId("top-meeting-timeline")).toBeTruthy();
+    expect(view.queryByTestId("main-tab-content")).toBeNull();
   });
 });


### PR DESCRIPTION
Render the top timeline before tab restore finishes, limit timeline/calendar sync to one week back through tomorrow, and add a leading See more entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows calendar event fetch/sync windows and changes initial shell rendering when no tab is loaded; selected sessions still appear outside the visible range but older events may only be reachable via calendar.
> 
> **Overview**
> The desktop main shell no longer waits for a restored tab before painting: **tab chrome and the top meeting timeline** render while `currentTab` is still null, and only tab body content stays gated.
> 
> The **top timeline** is capped to roughly **six days back through tomorrow** (aligned with calendar event sync), with interval overlap filtering, **leading and trailing “See more”** carousel entries when items fall outside that window, and a stronger **Today** chip style. Calendar dots on timeline cards are limited to **sessions**.
> 
> **Calendar sync** `getRange` shrinks from ~7 days back / 30 days forward to the same **midnight-aligned ~week window** (6 days ago through start of day after tomorrow), with a unit test on `createCtx` bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7adf89ff68736c591f4c19232cce2dbd46ef41e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5364 
- <kbd>&nbsp;2&nbsp;</kbd> #5362 
- <kbd>&nbsp;1&nbsp;</kbd> #5353 👈 
<!-- GitButler Footer Boundary Bottom -->

