### PR TITLE
fix(web): restore blog post handwritten headings

### DIFF
--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -60,7 +60,7 @@ function Component() {
         </Link>
 
         <header className="pt-10 pb-12">
-          <h1 className="font-sans text-5xl leading-[1.02] font-semibold tracking-normal text-balance text-black md:text-7xl">
+          <h1 className="font-hand text-5xl leading-[1.02] font-semibold tracking-normal text-balance text-black md:text-7xl">
             {article.title}
           </h1>
           <div className="mt-6 flex items-center gap-2 text-sm text-[#756b5d]">
@@ -81,16 +81,16 @@ function Component() {
             aria-label="TLDR"
             className="mb-12 border-y border-[#eee8df] py-5"
           >
-            <p className="font-sans text-xl font-semibold tracking-normal text-[#756b5d]">
+            <p className="font-hand text-xl font-semibold tracking-normal text-[#756b5d]">
               TL;DR
             </p>
-            <p className="mt-3 font-sans text-2xl leading-8 font-semibold text-[#363029]">
+            <p className="font-hand mt-3 text-2xl leading-8 font-semibold text-[#363029]">
               {tldr}
             </p>
           </aside>
         )}
 
-        <article className="blog-prose prose prose-stone prose-headings:font-sans prose-headings:font-semibold prose-headings:text-[#756b5d] prose-p:text-[#363029] prose-a:text-[#181613] prose-a:underline hover:prose-a:text-[#4f4940] prose-strong:text-[#181613] prose-li:text-[#363029] prose-img:rounded-md prose-img:border prose-img:border-[#eee8df] max-w-none">
+        <article className="blog-prose prose prose-stone prose-headings:font-hand prose-headings:font-semibold prose-headings:text-[#756b5d] prose-p:text-[#363029] prose-a:text-[#181613] prose-a:underline hover:prose-a:text-[#4f4940] prose-strong:text-[#181613] prose-li:text-[#363029] prose-img:rounded-md prose-img:border prose-img:border-[#eee8df] max-w-none">
           <MDXContent code={article.mdx} components={mdxComponents} />
         </article>
       </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -445,7 +445,7 @@
   :where(h2):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   margin-top: 4rem;
   margin-bottom: 1.25rem;
-  font-family: var(--font-sans);
+  font-family: var(--font-hand);
   font-size: 2.25rem;
   font-weight: 600;
   line-height: 1.05 !important;
@@ -457,7 +457,7 @@
   :where(h3):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   margin-top: 3.5rem;
   margin-bottom: 1rem;
-  font-family: var(--font-sans);
+  font-family: var(--font-hand);
   font-size: 1.875rem;
   font-weight: 600;
   line-height: 1.05;
@@ -469,7 +469,7 @@
   :where(h4):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   margin-top: 2.5rem;
   margin-bottom: 0.75rem;
-  font-family: var(--font-sans);
+  font-family: var(--font-hand);
   font-size: 1.5rem;
   font-weight: 600;
   line-height: 1.1;


### PR DESCRIPTION
Apply the handwritten display font to blog post titles, TL;DR callouts, and rendered article headings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only typography class swaps with no logic, auth, or data changes.
> 
> **Overview**
> Blog post detail pages now use the **Caveat** handwritten display font (`font-hand`) for the article title, TL;DR label and body, and in-article headings—matching the blog index listing style.
> 
> Changes swap `font-sans` / `prose-headings:font-sans` for `font-hand` / `prose-headings:font-hand` on `$slug.tsx`, and set `.blog-prose` `h2`–`h4` rules in `styles.css` to `var(--font-hand)` instead of `var(--font-sans)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 041f243465fd9d79ddc9b3495b14f87b2d3ef073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->