### PR TITLE
fix(desktop): differentiate session menu icons

### DIFF
--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -1,6 +1,7 @@
 import {
   AudioLinesIcon,
-  FileTextIcon,
+  FileDownIcon,
+  FileUpIcon,
   MoreHorizontalIcon,
   PictureInPicture2Icon,
 } from "lucide-react";
@@ -19,7 +20,7 @@ import {
 import { DeleteNote, DeleteRecording } from "./delete";
 import { ExportModal } from "./export-modal";
 import { Listening } from "./listening";
-import { Copy, ShowInFinder } from "./misc";
+import { ShowInFinder } from "./misc";
 
 import { useAudioPlayer } from "~/audio-player";
 import { openFloatingMeetingPanel } from "~/meeting-float/host";
@@ -80,12 +81,11 @@ export function OverflowButton({
         </DropdownMenuTrigger>
         <DropdownMenuContent variant="app" align="end" className="w-56">
           <AppFloatingPanel className="overflow-hidden p-1">
-            <Copy />
             <DropdownMenuItem
               onClick={openExportModal}
               className="cursor-pointer"
             >
-              <FileTextIcon />
+              <FileDownIcon />
               <span>Export</span>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
@@ -101,7 +101,7 @@ export function OverflowButton({
               onClick={handleUploadTranscript}
               className="cursor-pointer"
             >
-              <FileTextIcon />
+              <FileUpIcon />
               <span>Upload transcript</span>
             </DropdownMenuItem>
             {canOpenFloatingPanel && (


### PR DESCRIPTION
Use distinct file down and file up icons for export and transcript upload actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Icon and menu presentation changes only; no behavior, auth, or data paths are modified.
> 
> **Overview**
> Updates the session overflow menu so **Export** and **Upload transcript** no longer share the same generic file icon: export uses a **download** icon and transcript upload uses an **upload** icon.
> 
> The disabled **Copy link** entry is removed from the top of the menu so the dropdown no longer shows that placeholder action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a89ffd5878ae5c29b6bd4746deb4207f330b7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->