### PR TITLE
fix(desktop): align audio waveform padding

### DIFF
--- a/apps/desktop/src/audio-player/timeline.tsx
+++ b/apps/desktop/src/audio-player/timeline.tsx
@@ -175,8 +175,8 @@ export function Timeline() {
       main={
         <div
           ref={registerContainer}
-          className="min-w-0 flex-1"
-          style={{ minHeight: "24px", width: "100%" }}
+          className="h-6 min-w-0 flex-1 -translate-y-px"
+          style={{ width: "100%" }}
         />
       }
     />


### PR DESCRIPTION
Give the waveform host a fixed height and nudge it up inside the audio timeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic layout-only change to the waveform container; no playback, auth, or data logic touched.
> 
> **Overview**
> Tweaks the **waveform mount** in the desktop audio timeline so it lines up with the play control and time labels.
> 
> The host `div` now uses a fixed **`h-6`** height (replacing inline `minHeight: 24px`) and a **`-translate-y-px`** nudge so the waveform sits correctly inside the row. Layout behavior is otherwise unchanged (`registerContainer` still targets the same element).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9362cb92d5bb8f5fa99dd187343d13f4cd820b5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->