### PR TITLE
fix(transcription): stop Soniox on listener errors

### DIFF
--- a/crates/listener-core/src/actors/session/supervisor.rs
+++ b/crates/listener-core/src/actors/session/supervisor.rs
@@ -6,6 +6,7 @@ use tracing::Instrument;
 
 use crate::DegradedError;
 use crate::actors::session::types::{SessionContext, session_span, session_supervisor_name};
+use owhisper_client::AdapterKind;
 
 use self::children::{ChildKind, RESTART_BUDGET};
 use self::mode::SessionModeState;
@@ -264,7 +265,7 @@ async fn handle_listener_failure(
     degraded: DegradedError,
 ) {
     if should_stop_on_listener_failure(state) {
-        tracing::warn!("soniqo_listener_failed_stopping_session");
+        tracing::warn!("listener_failed_stopping_session");
         stop_after_listener_failure(myself, state, degraded).await;
     } else {
         enter_batch_fallback(state, degraded).await;
@@ -273,6 +274,14 @@ async fn handle_listener_failure(
 
 fn should_stop_on_listener_failure(state: &SessionState) -> bool {
     state.ctx.params.uses_local_soniqo_live_model()
+        || matches!(
+            AdapterKind::from_url_and_languages(
+                &state.ctx.params.base_url,
+                &state.ctx.params.languages,
+                Some(&state.ctx.params.model),
+            ),
+            AdapterKind::Soniox
+        )
 }
 
 async fn stop_after_listener_failure(
@@ -488,6 +497,26 @@ mod tests {
         let state = test_state(ctx);
 
         assert!(should_stop_on_listener_failure(&state));
+    }
+
+    #[test]
+    fn direct_soniox_listener_failure_stops_session() {
+        let mut ctx = test_ctx();
+        ctx.params.base_url = "https://api.soniox.com".to_string();
+        ctx.params.model = "stt-v4".to_string();
+        let state = test_state(ctx);
+
+        assert!(should_stop_on_listener_failure(&state));
+    }
+
+    #[test]
+    fn hyprnote_proxy_soniox_listener_failure_enters_batch_fallback() {
+        let mut ctx = test_ctx();
+        ctx.params.base_url = "https://api.hyprnote.com/stt?provider=soniox".to_string();
+        ctx.params.model = "cloud".to_string();
+        let state = test_state(ctx);
+
+        assert!(!should_stop_on_listener_failure(&state));
     }
 
     #[test]


### PR DESCRIPTION
Stop direct Soniox live capture instead of falling back to record-only when the live listener fails, and cover the policy with listener-core tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live-session failure handling for a transcription provider; misclassification of URL/adapter could stop sessions or allow unintended batch fallback.
> 
> **Overview**
> **Direct Soniox live** sessions now **stop the whole session** when the live listener fails or cannot be spawned, instead of switching to record-only batch fallback—matching existing behavior for local Soniqo live.
> 
> The decision uses `AdapterKind::from_url_and_languages` so **Hyprnote STT proxy URLs** (e.g. `?provider=soniox`) still **fall back to batch** because they resolve to `AdapterKind::Hyprnote`, not direct Soniox. Tests cover direct Soniox stop, proxy fallback, and a generic listener log rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dde2e9ef75c7da50d17548f4b57c84836c686ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->