### PR TITLE
fix(desktop): simplify contacts and calendar entry points

### DIFF
--- a/apps/desktop/src/main/empty.tsx
+++ b/apps/desktop/src/main/empty.tsx
@@ -54,14 +54,6 @@ function EmptyView() {
   const newNoteAndListen = useNewNoteAndListen({ behavior: "current" });
   const openCurrent = useTabs((state) => state.openCurrent);
 
-  const openCalendar = useCallback(
-    () => openCurrent({ type: "calendar" }),
-    [openCurrent],
-  );
-  const openContacts = useCallback(
-    () => openCurrent({ type: "contacts" }),
-    [openCurrent],
-  );
   const openSettings = useCallback(
     () => openCurrent({ type: "settings" }),
     [openCurrent],
@@ -75,17 +67,6 @@ function EmptyView() {
           label="Start Recording"
           shortcut={["⌘", "⇧", "N"]}
           onClick={newNoteAndListen}
-        />
-        <div className="my-1 h-px bg-neutral-200" />
-        <ActionItem
-          label="Contacts"
-          shortcut={["⌘", "⇧", "O"]}
-          onClick={openContacts}
-        />
-        <ActionItem
-          label="Calendar"
-          shortcut={["⌘", "⇧", "C"]}
-          onClick={openCalendar}
         />
         <div className="my-1 h-px bg-neutral-200" />
         <ActionItem

--- a/apps/desktop/src/shared/useTabsShortcuts.tsx
+++ b/apps/desktop/src/shared/useTabsShortcuts.tsx
@@ -158,32 +158,6 @@ export function useMainTabsShortcuts({ onModT }: { onModT: () => void }) {
   );
 
   useHotkeys(
-    "mod+shift+c",
-    () => openNew({ type: "calendar" }),
-    {
-      preventDefault: true,
-      enableOnFormTags: true,
-      enableOnContentEditable: true,
-    },
-    [openNew],
-  );
-
-  useHotkeys(
-    "mod+shift+o",
-    () =>
-      openNew({
-        type: "contacts",
-        state: { selected: null },
-      }),
-    {
-      preventDefault: true,
-      enableOnFormTags: true,
-      enableOnContentEditable: true,
-    },
-    [openNew],
-  );
-
-  useHotkeys(
     "mod+shift+comma",
     () => openNew({ type: "settings", state: { tab: "transcription" } }),
     {

--- a/apps/desktop/src/sidebar/profile/index.tsx
+++ b/apps/desktop/src/sidebar/profile/index.tsx
@@ -61,13 +61,11 @@ export function ProfileMenu() {
       icon: UsersIcon,
       label: "People",
       onClick: handleClickContacts,
-      badge: <Kbd className={kbdClass}>⌘ ⇧ O</Kbd>,
     },
     {
       icon: CalendarIcon,
       label: "Calendar",
       onClick: handleClickCalendar,
-      badge: <Kbd className={kbdClass}>⌘ ⇧ C</Kbd>,
     },
     {
       icon: SettingsIcon,

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -10,6 +10,7 @@ import {
   SmartphoneIcon,
   SparklesIcon,
   UserIcon,
+  UsersIcon,
 } from "lucide-react";
 import { useCallback } from "react";
 
@@ -20,7 +21,7 @@ import { type SettingsTab, useTabs } from "~/store/zustand/tabs";
 type SettingsNavItem =
   | { id: SettingsTab; label: string; icon: typeof SmartphoneIcon }
   | {
-      action: "open-templates" | "open-calendar";
+      action: "open-templates" | "open-calendar" | "open-contacts";
       label: string;
       icon: typeof SmartphoneIcon;
     };
@@ -82,6 +83,10 @@ export function SettingsNav() {
     openNew({ type: "calendar" });
   }, [openNew]);
 
+  const handleOpenContacts = useCallback(() => {
+    openNew({ type: "contacts", state: { selected: null } });
+  }, [openNew]);
+
   const groups = getBaseGroups();
   const isMacos = platform() === "macos";
   if (isMacos) {
@@ -96,6 +101,11 @@ export function SettingsNav() {
     action: "open-calendar",
     label: "Calendar",
     icon: CalendarIcon,
+  });
+  groups[0].items.push({
+    action: "open-contacts",
+    label: "Contacts",
+    icon: UsersIcon,
   });
 
   return (
@@ -120,8 +130,10 @@ export function SettingsNav() {
                       if (!isSettingsItem) {
                         if (item.action === "open-templates") {
                           handleOpenTemplates();
-                        } else {
+                        } else if (item.action === "open-calendar") {
                           handleOpenCalendar();
+                        } else {
+                          handleOpenContacts();
                         }
                         return;
                       }


### PR DESCRIPTION
Remove Contacts and Calendar from the empty-state action list and global shortcuts, then add Contacts alongside Calendar in Settings navigation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and shortcut UX only; no changes to auth, data, or core business logic.
> 
> **Overview**
> **Contacts** and **Calendar** are no longer promoted from the empty-tab quick actions or global **`⌘⇧O` / `⌘⇧C`** shortcuts. The empty state now only surfaces note creation, recording, and **Settings**.
> 
> **Contacts** is added to the **Settings** sidebar (next to the existing **Calendar** link), opening a contacts tab via the same pattern as calendar/templates. The profile menu still offers **People** and **Calendar**, but their keyboard hint badges are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5848fcc1f576d8fe660dd07afe38a7a3fcbb2bcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->