### PR TITLE
fix(desktop): use document icon for transcript upload

### DIFF
--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -1,7 +1,7 @@
 import {
   AudioLinesIcon,
   FileDownIcon,
-  FileUpIcon,
+  FileTextIcon,
   MoreHorizontalIcon,
   PictureInPicture2Icon,
 } from "lucide-react";
@@ -101,7 +101,7 @@ export function OverflowButton({
               onClick={handleUploadTranscript}
               className="cursor-pointer"
             >
-              <FileUpIcon />
+              <FileTextIcon />
               <span>Upload transcript</span>
             </DropdownMenuItem>
             {canOpenFloatingPanel && (


### PR DESCRIPTION
Use the document icon for the transcript upload menu item.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Icon-only UI change in the overflow menu with no behavior or data impact.
> 
> **Overview**
> Updates the **Upload transcript** entry in the session overflow menu to use Lucide’s `FileTextIcon` instead of `FileUpIcon`, so the control reads as a document/transcript action rather than a generic upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4129324e4a4cbda9f1af8195d50076ead7560ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->