### PR TITLE
fix(desktop): simplify empty transcript panel

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -93,12 +93,6 @@ vi.mock("~/stt/useRunBatch", () => ({
   isStoppedTranscriptionError: vi.fn(() => false),
 }));
 
-vi.mock("~/stt/useUploadFile", () => ({
-  useUploadFile: vi.fn(() => ({
-    uploadAudio: vi.fn(),
-  })),
-}));
-
 describe("PostSessionAccessory", () => {
   beforeEach(() => {
     cleanup();
@@ -147,7 +141,7 @@ describe("PostSessionAccessory", () => {
     expect(handleBatchFailedMock).not.toHaveBeenCalled();
   });
 
-  it("shows Generate button in empty panel when audio is present but screen state is not 'empty'", async () => {
+  it("shows Regenerate button without upload or reserved height in empty panel", async () => {
     useTranscriptScreenMock.mockReturnValue({
       kind: "ready",
       transcriptIds: [],
@@ -161,10 +155,20 @@ describe("PostSessionAccessory", () => {
         hasAudio
         hasTranscript={false}
         isTranscriptExpanded
+        fillHeight
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Generate/ }));
+    const noTranscript = screen.getByText("No transcript yet");
+    const transcriptCard = noTranscript.parentElement?.parentElement;
+    const transcriptSlot = transcriptCard?.parentElement;
+    expect(transcriptCard?.className).not.toContain("min-h-[114px]");
+    expect(transcriptCard?.className).not.toContain("min-h-[96px]");
+    expect(transcriptSlot?.className).not.toContain("min-h-[114px]");
+    expect(transcriptSlot?.className).toContain("shrink-0");
+    expect(screen.queryByRole("button", { name: "Upload audio" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Regenerate/ }));
 
     await waitFor(() => {
       expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav");

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -23,7 +23,6 @@ import { Transcript } from "~/session/components/note-input/transcript";
 import { useTranscriptScreen } from "~/session/components/note-input/transcript/state";
 import { useListener } from "~/stt/contexts";
 import { isStoppedTranscriptionError, useRunBatch } from "~/stt/useRunBatch";
-import { useUploadFile } from "~/stt/useUploadFile";
 
 export function PostSessionAccessory({
   sessionId,
@@ -40,6 +39,7 @@ export function PostSessionAccessory({
 }) {
   const screen = useTranscriptScreen({ sessionId });
   const isBatching = screen.kind === "running_batch";
+  const shouldFillTranscriptPanel = fillHeight && (hasTranscript || isBatching);
   const timeline = isBatching ? (
     <BatchProgressTimeline sessionId={sessionId} screen={screen} />
   ) : hasAudio ? (
@@ -60,7 +60,9 @@ export function PostSessionAccessory({
       {isTranscriptExpanded ? (
         <div
           className={cn([
-            fillHeight ? "min-h-[114px] flex-1 overflow-hidden" : "shrink-0",
+            shouldFillTranscriptPanel
+              ? "min-h-[114px] flex-1 overflow-hidden"
+              : "shrink-0",
           ])}
         >
           <TranscriptPanel
@@ -69,7 +71,7 @@ export function PostSessionAccessory({
             hasAudio={hasAudio}
             hasTranscript={hasTranscript}
             isExpanded={isTranscriptExpanded}
-            fillHeight={fillHeight}
+            fillHeight={shouldFillTranscriptPanel}
           />
         </div>
       ) : null}
@@ -462,7 +464,6 @@ function TranscriptEmptyPanel({
   fillHeight: boolean;
 }) {
   const screen = useTranscriptScreen({ sessionId });
-  const { uploadAudio } = useUploadFile(sessionId);
   const regenerate = useRegenerateTranscript(sessionId);
 
   const error = screen.kind === "empty" ? screen.error : null;
@@ -472,7 +473,7 @@ function TranscriptEmptyPanel({
   }
 
   return (
-    <TranscriptCard fillHeight={fillHeight}>
+    <TranscriptCard fillHeight={fillHeight} reserveMinHeight={false}>
       <div className="flex min-h-0 flex-1 items-center justify-between px-4 py-3">
         {error ? (
           <span className="text-xs text-red-500">{error}</span>
@@ -489,17 +490,9 @@ function TranscriptEmptyPanel({
               onClick={regenerate}
             >
               <RefreshCw size={12} />
-              Generate
+              Regenerate
             </Button>
           )}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 text-xs text-neutral-500"
-            onClick={uploadAudio}
-          >
-            Upload audio
-          </Button>
         </div>
       </div>
     </TranscriptCard>
@@ -528,15 +521,19 @@ function TranscriptScrollArea({
 function TranscriptCard({
   children,
   fillHeight = false,
+  reserveMinHeight = true,
 }: {
   children: ReactNode;
   fillHeight?: boolean;
+  reserveMinHeight?: boolean;
 }) {
   return (
     <div
       className={cn([
         "overflow-hidden rounded-b-xl border-x border-b border-neutral-200 bg-white",
-        fillHeight ? "flex h-full min-h-[114px] flex-col" : "min-h-[96px]",
+        fillHeight && "flex h-full flex-col",
+        fillHeight && reserveMinHeight && "min-h-[114px]",
+        !fillHeight && reserveMinHeight && "min-h-[96px]",
       ])}
     >
       {children}


### PR DESCRIPTION
Remove the upload action, use Regenerate copy, and avoid reserved transcript height when no transcript exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop UI and layout-only changes in the post-session accessory; transcription flow still uses existing regenerate/batch paths.
> 
> **Overview**
> The post-session **empty transcript** state is simplified: the **Upload audio** action and `useUploadFile` wiring are removed, and the primary action is labeled **Regenerate** (aligned with the ready transcript panel).
> 
> Layout no longer reserves a tall empty transcript area when there is no transcript and batching is not running. `PostSessionAccessory` only applies **flex fill** and `min-h-[114px]` when `fillHeight` is set **and** there is a transcript or an active batch; the empty panel uses `TranscriptCard` with **`reserveMinHeight={false}`** so `min-h-[96px]` / `min-h-[114px]` are skipped.
> 
> Tests assert the empty panel has no upload control, no reserved min-heights, a **shrink-0** transcript slot, and that **Regenerate** still runs batch transcription from session audio.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c769313635667c7f73667745081e58ed8a3dd39f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->