### PR TITLE
fix(desktop): remove pointer cursors

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,4 +1,5 @@
 import "./styles/globals.css";
+import "./styles/cursor.css";
 
 import * as Sentry from "@sentry/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/apps/desktop/src/styles/cursor.css
+++ b/apps/desktop/src/styles/cursor.css
@@ -1,0 +1,117 @@
+@layer base {
+  *,
+  *::before,
+  *::after {
+    cursor: default !important;
+  }
+
+  :where([contenteditable="true"]),
+  :where([contenteditable="true"] *) {
+    cursor: text !important;
+  }
+
+  :where([contenteditable="true"] [contenteditable="false"]),
+  :where([contenteditable="true"] [contenteditable="false"] *),
+  :where([contenteditable="true"] button),
+  :where([contenteditable="true"] button *),
+  :where([contenteditable="true"] input[type="button"]),
+  :where([contenteditable="true"] input[type="checkbox"]),
+  :where([contenteditable="true"] input[type="color"]),
+  :where([contenteditable="true"] input[type="file"]),
+  :where([contenteditable="true"] input[type="image"]),
+  :where([contenteditable="true"] input[type="radio"]),
+  :where([contenteditable="true"] input[type="range"]),
+  :where([contenteditable="true"] input[type="reset"]),
+  :where([contenteditable="true"] input[type="submit"]),
+  :where([contenteditable="true"] select),
+  :where([contenteditable="true"] select *) {
+    cursor: default !important;
+  }
+
+  :where(input:not([type])),
+  :where(input[type="date"]),
+  :where(input[type="datetime-local"]),
+  :where(input[type="email"]),
+  :where(input[type="month"]),
+  :where(input[type="number"]),
+  :where(input[type="password"]),
+  :where(input[type="search"]),
+  :where(input[type="tel"]),
+  :where(input[type="text"]),
+  :where(input[type="time"]),
+  :where(input[type="url"]),
+  :where(input[type="week"]),
+  :where(textarea),
+  :where(.cursor-text) {
+    cursor: text !important;
+  }
+
+  :where(.cursor-not-allowed),
+  :where(.cursor-not-allowed *),
+  :where(.cursor-not-allowed)::before,
+  :where(.cursor-not-allowed)::after,
+  :where(.cursor-not-allowed *)::before,
+  :where(.cursor-not-allowed *)::after,
+  :where(.disabled\:cursor-not-allowed:disabled),
+  :where(.disabled\:cursor-not-allowed:disabled *),
+  :where(.disabled\:cursor-not-allowed:disabled)::before,
+  :where(.disabled\:cursor-not-allowed:disabled)::after,
+  :where(.disabled\:cursor-not-allowed:disabled *)::before,
+  :where(.disabled\:cursor-not-allowed:disabled *)::after {
+    cursor: not-allowed !important;
+  }
+
+  :where(.cursor-col-resize),
+  :where(.cursor-col-resize *),
+  :where(.cursor-col-resize)::before,
+  :where(.cursor-col-resize)::after,
+  :where(.cursor-col-resize *)::before,
+  :where(.cursor-col-resize *)::after,
+  :where(.ProseMirror.resize-cursor),
+  :where(.ProseMirror.resize-cursor *),
+  :where(.ProseMirror.resize-cursor)::before,
+  :where(.ProseMirror.resize-cursor)::after,
+  :where(.ProseMirror.resize-cursor *)::before,
+  :where(.ProseMirror.resize-cursor *)::after {
+    cursor: col-resize !important;
+  }
+
+  :where(.cursor-col-resize[data-panel-group-direction="vertical"]),
+  :where(.cursor-col-resize[data-panel-group-direction="vertical"] *),
+  :where(.cursor-col-resize[data-panel-group-direction="vertical"])::before,
+  :where(.cursor-col-resize[data-panel-group-direction="vertical"])::after,
+  :where(.cursor-col-resize[data-panel-group-direction="vertical"] *)::before,
+  :where(.cursor-col-resize[data-panel-group-direction="vertical"] *)::after,
+  :where(.cursor-row-resize),
+  :where(.cursor-row-resize *),
+  :where(.cursor-row-resize)::before,
+  :where(.cursor-row-resize)::after,
+  :where(.cursor-row-resize *)::before,
+  :where(.cursor-row-resize *)::after {
+    cursor: row-resize !important;
+  }
+
+  :where(.cursor-ew-resize, .cursor-ew-resize *),
+  :where(.cursor-ew-resize, .cursor-ew-resize *)::before,
+  :where(.cursor-ew-resize, .cursor-ew-resize *)::after {
+    cursor: ew-resize !important;
+  }
+
+  :where(.cursor-nwse-resize, .cursor-nwse-resize *),
+  :where(.cursor-nwse-resize, .cursor-nwse-resize *)::before,
+  :where(.cursor-nwse-resize, .cursor-nwse-resize *)::after {
+    cursor: nwse-resize !important;
+  }
+
+  :where(.cursor-nesw-resize, .cursor-nesw-resize *),
+  :where(.cursor-nesw-resize, .cursor-nesw-resize *)::before,
+  :where(.cursor-nesw-resize, .cursor-nesw-resize *)::after {
+    cursor: nesw-resize !important;
+  }
+
+  :where(.cursor-move, .cursor-move *),
+  :where(.cursor-move, .cursor-move *)::before,
+  :where(.cursor-move, .cursor-move *)::after {
+    cursor: move !important;
+  }
+}


### PR DESCRIPTION
Add a desktop-only cursor reset so controls keep the default cursor while preserving text and resize cursors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS with targeted exceptions; no auth, data, or business logic changes.
> 
> **Overview**
> The desktop app now loads a new **`cursor.css`** stylesheet from **`main.tsx`** (alongside **`globals.css`**).
> 
> That sheet sets **`cursor: default`** on all elements with **`!important`**, overriding web-style **`pointer`** cursors on controls and links. It keeps **I-beam** cursors for text fields, **`contenteditable`**, and **`.cursor-text`**, and preserves **not-allowed**, **panel/editor resize** (including **ProseMirror**), and **move** cursor classes where the UI already signals those interactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a43f2ffb27b4610a2f0cfbd484bba586c9e8cfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->