### PR TITLE
fix(desktop): set preview card width

### DIFF
--- a/apps/desktop/src/session/components/session-preview-card.tsx
+++ b/apps/desktop/src/session/components/session-preview-card.tsx
@@ -357,7 +357,7 @@ export function SessionPreviewCard({
         side={side}
         sideOffset={8}
         followStyle={style}
-        className={cn(["w-72 pb-0!", "pointer-events-none"])}
+        className={cn(["w-[228px] pb-0!", "pointer-events-none"])}
       >
         <div className="flex flex-col gap-1">
           {dateDisplay && (


### PR DESCRIPTION
Use a fixed 228px width for session preview hover cards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only width tweak on a hover card; no logic, data, or security impact.
> 
> **Overview**
> Sets the session preview **hover card** to a fixed **228px** width instead of Tailwind’s `w-72` (~288px), so preview popovers stay a consistent size in the desktop app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64fe6b52b342ef82512af1f680a903df2c4e2b6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->