### PR TITLE
fix(desktop): restore top timeline now marker

### DIFF
--- a/apps/desktop/src/main/top-meeting-timeline.test.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.test.tsx
@@ -9,12 +9,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   createNewMeeting: vi.fn(),
+  liveSessionId: null as string | null,
   openNew: vi.fn(),
   startDragging: vi.fn().mockResolvedValue(undefined),
   stopListening: vi.fn(),
   sessionModes: {} as Record<string, string>,
   timelineEventsTable: {},
   timelineSessionsTable: {},
+  timelineTranscriptsTable: {} as Record<
+    string,
+    {
+      ended_at?: number | null;
+      session_id?: string | null;
+      started_at?: number | null;
+      words?: string | null;
+    }
+  >,
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -89,7 +99,8 @@ vi.mock("~/store/tinybase/store/main", () => ({
     },
     useRow: () => undefined,
     useStore: () => undefined,
-    useTable: () => ({}),
+    useTable: (table: string) =>
+      table === "transcripts" ? mocks.timelineTranscriptsTable : {},
   },
 }));
 
@@ -124,6 +135,7 @@ vi.mock("~/stt/contexts", () => ({
         mocks.sessionModes[sessionId] ?? "inactive",
       live: {
         amplitude: { mic: 0.5, speaker: 0.25 },
+        sessionId: mocks.liveSessionId,
       },
       stop: mocks.stopListening,
     }),
@@ -132,6 +144,7 @@ vi.mock("~/stt/contexts", () => ({
 
 import {
   formatTimelineStartLabel,
+  getTimelineCarouselNowDirection,
   TopMeetingTimeline,
 } from "~/main/top-meeting-timeline";
 
@@ -141,13 +154,16 @@ describe("TopMeetingTimeline", () => {
     mocks.openNew.mockClear();
     mocks.startDragging.mockClear();
     mocks.stopListening.mockClear();
+    mocks.liveSessionId = null;
     mocks.sessionModes = {};
     mocks.timelineEventsTable = {};
     mocks.timelineSessionsTable = {};
+    mocks.timelineTranscriptsTable = {};
   });
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
   });
 
   it("keeps timeline clicks working when the pointer does not drag", () => {
@@ -220,6 +236,7 @@ describe("TopMeetingTimeline", () => {
 
   it("shows active meetings as red with a stop suffix", () => {
     const start = new Date();
+    mocks.liveSessionId = "session-1";
     mocks.sessionModes = { "session-1": "active" };
     mocks.timelineSessionsTable = {
       "session-1": {
@@ -289,5 +306,167 @@ describe("TopMeetingTimeline", () => {
     expect(spinnerSuffix.className).toContain("text-white/70");
     expect(screen.getAllByTestId("timeline-spinner")).toHaveLength(1);
     expect(within(cardButton!).queryByTestId("timeline-spinner")).toBeNull();
+  });
+
+  it("shows the current time marker inside active timeline blocks", () => {
+    const now = new Date("2026-05-29T15:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    mocks.timelineEventsTable = {
+      "event-1": {
+        calendar_id: null,
+        ended_at: new Date(now.getTime() + 60 * 60 * 1000).toISOString(),
+        has_recurrence_rules: false,
+        started_at: new Date(now.getTime() - 60 * 60 * 1000).toISOString(),
+        title: "Active Event",
+      },
+    };
+
+    render(<TopMeetingTimeline currentTab={null} />);
+
+    expect(screen.getByTestId("top-timeline-now-indicator").style.left).toBe(
+      "94px",
+    );
+  });
+
+  it("uses the recording end for completed sessions linked to calendar events", () => {
+    const now = new Date("2026-05-29T11:30:00.000Z");
+    const recordingStart = new Date("2026-05-29T10:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    mocks.timelineSessionsTable = {
+      "session-1": {
+        created_at: recordingStart.toISOString(),
+        event_json: JSON.stringify({
+          calendar_id: null,
+          ended_at: new Date("2026-05-29T11:00:00.000Z").toISOString(),
+          started_at: recordingStart.toISOString(),
+          title: "Long-running sync",
+        }),
+        title: "Long-running sync",
+      },
+    };
+    mocks.timelineTranscriptsTable = {
+      "transcript-1": {
+        ended_at: new Date("2026-05-29T13:00:00.000Z").getTime(),
+        session_id: "session-1",
+        started_at: recordingStart.getTime(),
+      },
+    };
+
+    render(<TopMeetingTimeline currentTab={null} />);
+
+    const card = screen
+      .getByText("Long-running sync")
+      .closest("[data-timeline-start-ms]") as HTMLDivElement | null;
+    const cardWidth = Number.parseFloat(card?.style.width ?? "");
+    const indicatorX = Number.parseFloat(
+      screen.getByTestId("top-timeline-now-indicator").style.left,
+    );
+
+    expect(indicatorX).toBe(cardWidth / 2);
+  });
+
+  it("places the current time marker between open-ended notes and future meetings", () => {
+    const now = new Date("2026-05-29T15:41:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    mocks.timelineSessionsTable = {
+      "session-1": {
+        created_at: new Date("2026-05-29T15:28:00.000Z").toISOString(),
+        event_json: "",
+        title: "Untitled",
+      },
+    };
+    mocks.timelineEventsTable = {
+      "event-1": {
+        calendar_id: null,
+        ended_at: new Date("2026-05-29T18:00:00.000Z").toISOString(),
+        has_recurrence_rules: false,
+        started_at: new Date("2026-05-29T17:30:00.000Z").toISOString(),
+        title: "Design sync",
+      },
+    };
+
+    render(<TopMeetingTimeline currentTab={null} />);
+
+    expect(screen.getByTestId("top-timeline-now-indicator").style.left).toBe(
+      "190px",
+    );
+  });
+
+  it("places the current time marker at the edge of active ad-hoc meetings", () => {
+    const now = new Date("2026-05-29T15:41:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    mocks.liveSessionId = "session-1";
+    mocks.sessionModes = { "session-1": "active" };
+    mocks.timelineSessionsTable = {
+      "session-1": {
+        created_at: new Date("2026-05-29T15:28:00.000Z").toISOString(),
+        event_json: "",
+        title: "Live Ad-hoc",
+      },
+    };
+
+    render(<TopMeetingTimeline currentTab={null} />);
+
+    expect(screen.getByTestId("top-timeline-now-indicator").style.left).toBe(
+      "188px",
+    );
+  });
+
+  it("shows the now chip on the left when the current time marker is behind the viewport", () => {
+    expect(
+      getTimelineCarouselNowDirection({
+        nowX: 190,
+        scrollLeft: 250,
+        viewportWidth: 100,
+      }),
+    ).toBe("left");
+  });
+
+  it("scrolls the now chip to the current time marker", () => {
+    const now = new Date("2026-05-29T15:41:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    mocks.timelineSessionsTable = {
+      "session-1": {
+        created_at: new Date("2026-05-29T15:28:00.000Z").toISOString(),
+        event_json: "",
+        title: "Untitled",
+      },
+    };
+    mocks.timelineEventsTable = {
+      "event-1": {
+        calendar_id: null,
+        ended_at: new Date("2026-05-29T18:00:00.000Z").toISOString(),
+        has_recurrence_rules: false,
+        started_at: new Date("2026-05-29T17:30:00.000Z").toISOString(),
+        title: "Design sync",
+      },
+    };
+
+    render(<TopMeetingTimeline currentTab={null} />);
+
+    const indicator = screen.getByTestId("top-timeline-now-indicator");
+    const scrollContainer = indicator.parentElement?.parentElement;
+    expect(scrollContainer).toBeTruthy();
+
+    Object.defineProperty(scrollContainer, "clientWidth", {
+      configurable: true,
+      value: 100,
+    });
+    scrollContainer!.scrollLeft = 250;
+    fireEvent.scroll(scrollContainer!);
+
+    fireEvent.click(screen.getByRole("button", { name: "Now" }));
+
+    expect(scrollContainer!.scrollLeft).toBe(140);
   });
 });

--- a/apps/desktop/src/main/top-meeting-timeline.test.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.test.tsx
@@ -326,7 +326,7 @@ describe("TopMeetingTimeline", () => {
     render(<TopMeetingTimeline currentTab={null} />);
 
     expect(screen.getByTestId("top-timeline-now-indicator").style.left).toBe(
-      "94px",
+      "80px",
     );
   });
 
@@ -394,7 +394,7 @@ describe("TopMeetingTimeline", () => {
     render(<TopMeetingTimeline currentTab={null} />);
 
     expect(screen.getByTestId("top-timeline-now-indicator").style.left).toBe(
-      "190px",
+      "162px",
     );
   });
 
@@ -416,7 +416,7 @@ describe("TopMeetingTimeline", () => {
     render(<TopMeetingTimeline currentTab={null} />);
 
     expect(screen.getByTestId("top-timeline-now-indicator").style.left).toBe(
-      "188px",
+      "160px",
     );
   });
 
@@ -467,6 +467,6 @@ describe("TopMeetingTimeline", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Now" }));
 
-    expect(scrollContainer!.scrollLeft).toBe(140);
+    expect(scrollContainer!.scrollLeft).toBe(112);
   });
 });

--- a/apps/desktop/src/main/top-meeting-timeline.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.tsx
@@ -77,7 +77,7 @@ import { useUndoDelete } from "~/store/zustand/undo-delete";
 import { useListener } from "~/stt/contexts";
 
 const TIMELINE_HEIGHT = 44;
-const TIMELINE_CAROUSEL_CARD_WIDTH = 188;
+const TIMELINE_CAROUSEL_CARD_WIDTH = 160;
 const TIMELINE_CAROUSEL_PADDING = 0;
 const TIMELINE_CAROUSEL_GAP = 4;
 const TIMELINE_PAST_DAYS = 6;

--- a/apps/desktop/src/main/top-meeting-timeline.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.tsx
@@ -6,6 +6,7 @@ import {
   CalendarIcon,
   PlusIcon,
   SquareIcon,
+  SunIcon,
 } from "lucide-react";
 import {
   memo,
@@ -55,6 +56,7 @@ import {
   useNativeContextMenu,
 } from "~/shared/hooks/useNativeContextMenu";
 import { useNewNoteAndListen } from "~/shared/useNewNote";
+import { useCurrentTimeMs } from "~/sidebar/timeline/realtime";
 import type {
   TimelineEventRow,
   TimelineEventsTable,
@@ -115,6 +117,7 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
   ) as TimelineTranscriptsTable;
 
   const { isIgnored } = useIgnoredEvents();
+  const liveSessionId = useListener((state) => state.live.sessionId);
   const today = getTimelineDayStart(new Date(), timezone);
   const todayMs = today.getTime();
   const timelineStart = useMemo(
@@ -125,6 +128,7 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
     () => addDays(new Date(todayMs), TIMELINE_FUTURE_DAYS + 1),
     [todayMs],
   );
+  const currentTimeMs = useCurrentTimeMs();
 
   const sessionRecordingRanges = useMemo(
     () => buildSessionRecordingRanges(transcriptsTable),
@@ -138,6 +142,8 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
         timelineSessionsTable,
         sessionRecordingRanges,
         selectedSessionId,
+        liveSessionId,
+        now: currentTimeMs,
         isIgnored,
       }),
     [
@@ -145,6 +151,8 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
       timelineSessionsTable,
       sessionRecordingRanges,
       selectedSessionId,
+      liveSessionId,
+      currentTimeMs,
       isIgnored,
     ],
   );
@@ -203,6 +211,11 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
     ],
   );
   const carouselWidth = getTimelineCarouselWidth(carouselItems);
+  const nowIndicatorX = useMemo(
+    () =>
+      getTimelineCarouselNowX(carouselItems, new Date(currentTimeMs), timezone),
+    [carouselItems, currentTimeMs, timezone],
+  );
   const openCalendar = useCallback(
     () => openNew({ type: "calendar" }),
     [openNew],
@@ -216,19 +229,25 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
 
   const updateTodayChipFromScroll = useCallback(
     (node: HTMLDivElement) => {
-      const nextDirection = getTimelineCarouselDateDirection({
-        items: carouselItems,
-        date: new Date(todayMs),
-        timezone,
-        scrollLeft: node.scrollLeft,
-        viewportWidth: node.clientWidth,
-      });
+      const nextDirection =
+        getTimelineCarouselNowDirection({
+          nowX: nowIndicatorX,
+          scrollLeft: node.scrollLeft,
+          viewportWidth: node.clientWidth,
+        }) ??
+        getTimelineCarouselDateDirection({
+          items: carouselItems,
+          date: new Date(todayMs),
+          timezone,
+          scrollLeft: node.scrollLeft,
+          viewportWidth: node.clientWidth,
+        });
 
       setTodayChipDirection((previousDirection) =>
         previousDirection === nextDirection ? previousDirection : nextDirection,
       );
     },
-    [carouselItems, todayMs, timezone],
+    [carouselItems, nowIndicatorX, todayMs, timezone],
   );
 
   const handleWheel = useCallback(
@@ -298,14 +317,18 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
       return;
     }
 
-    const todayLeft = getTimelineCarouselDateX(
-      carouselItems,
-      new Date(todayMs),
-      timezone,
-    );
+    const todayLeft =
+      nowIndicatorX ??
+      getTimelineCarouselDateX(carouselItems, new Date(todayMs), timezone);
     node.scrollLeft = Math.max(0, todayLeft - node.clientWidth * 0.5);
     updateTodayChipFromScroll(node);
-  }, [carouselItems, todayMs, timezone, updateTodayChipFromScroll]);
+  }, [
+    carouselItems,
+    nowIndicatorX,
+    todayMs,
+    timezone,
+    updateTodayChipFromScroll,
+  ]);
 
   const handleTimelineContextMenu = useCallback<
     MouseEventHandler<HTMLDivElement>
@@ -407,12 +430,19 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
           style={{ height: TIMELINE_HEIGHT }}
         >
           <div
-            className="flex h-full min-w-full items-start gap-1"
+            className="group/timeline-strip relative flex h-full min-w-full items-start gap-1"
             onContextMenu={handleTimelineContextMenu}
             style={{
               width: carouselWidth,
             }}
           >
+            {nowIndicatorX !== null ? (
+              <TopCurrentTimeIndicator
+                currentTimeMs={currentTimeMs}
+                left={nowIndicatorX}
+                timezone={timezone}
+              />
+            ) : null}
             {carouselItems.map((renderItem) =>
               renderItem.kind === "create-meeting" ? (
                 <TimelineCreateMeetingCard
@@ -447,20 +477,53 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
           <button
             type="button"
             className={cn([
-              "absolute top-1/2 z-40 flex h-6 -translate-y-1/2 items-center gap-1 rounded-full border border-neutral-300 bg-neutral-200 px-2.5 text-xs font-semibold text-neutral-900 shadow-md",
-              "transition-colors hover:border-neutral-400 hover:bg-neutral-300 hover:text-neutral-950",
+              "absolute top-1/2 z-40 flex h-6 -translate-y-1/2 items-center gap-1 rounded-full border border-neutral-200 bg-white/95 px-2.5 text-xs font-semibold text-neutral-900 shadow-md backdrop-blur",
+              "transition-colors hover:border-neutral-300 hover:bg-white hover:text-neutral-950",
               "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
               todayChipDirection === "left" ? "left-3" : "right-3",
             ])}
             onClick={handleGoToToday}
           >
             {todayChipDirection === "left" ? <ArrowLeftIcon size={12} /> : null}
-            <span>Today</span>
+            <SunIcon size={13} className="shrink-0 text-yellow-400" />
+            <span>Now</span>
             {todayChipDirection === "right" ? (
               <ArrowRightIcon size={12} />
             ) : null}
           </button>
         ) : null}
+      </div>
+    </div>
+  );
+}
+
+function TopCurrentTimeIndicator({
+  currentTimeMs,
+  left,
+  timezone,
+}: {
+  currentTimeMs: number;
+  left: number;
+  timezone?: string;
+}) {
+  const label = useMemo(() => {
+    const now = timezone
+      ? new TZDate(new Date(currentTimeMs), timezone)
+      : new Date(currentTimeMs);
+    return format(now, "h:mm a").toUpperCase();
+  }, [currentTimeMs, timezone]);
+
+  return (
+    <div
+      aria-hidden
+      data-testid="top-timeline-now-indicator"
+      className="pointer-events-none absolute top-0 bottom-0 z-40 w-0"
+      style={{ left }}
+    >
+      <div className="absolute top-0 bottom-1 left-0 w-px -translate-x-1/2 bg-red-500/90 shadow-[0_0_0_1px_rgba(255,255,255,0.85)]" />
+      <div className="absolute top-0 left-0 size-1.5 -translate-x-1/2 rounded-full bg-red-500 shadow-[0_0_0_1px_rgba(255,255,255,0.95)]" />
+      <div className="absolute top-1/2 left-0 -translate-x-1/2 -translate-y-1/2 rounded-full bg-red-500 px-2 py-1 font-mono text-[10px] leading-none font-semibold whitespace-nowrap text-white opacity-0 shadow-xs transition-opacity group-hover/timeline-strip:opacity-100">
+        {label}
       </div>
     </div>
   );
@@ -700,7 +763,7 @@ function TimelineCarouselCard({
       data-timeline-start-ms={item.start.getTime()}
       className={cn([
         "group/timeline-card relative shrink-0 snap-start",
-        "transition-transform focus-within:z-30 focus-within:scale-[1.02] hover:z-30 hover:scale-[1.02]",
+        "origin-top transition-transform focus-within:z-30 focus-within:scale-[1.02] hover:z-30 hover:scale-[1.02]",
         item.selected && "z-20",
       ])}
       style={{ width: TIMELINE_CAROUSEL_CARD_WIDTH }}
@@ -869,9 +932,6 @@ function TimelineCardButton({
         ])}
       >
         <span className="flex min-w-0 items-center gap-1.5">
-          {item.type === "session" && item.calendarId ? (
-            <CalendarDot calendarId={item.calendarId} />
-          ) : null}
           <FadedTimelineLabel className="min-w-0 flex-1 text-xs font-semibold">
             {title}
           </FadedTimelineLabel>
@@ -1129,6 +1189,77 @@ function getTimelineCarouselDateX(
   return getTimelineCarouselX(items, date.getTime());
 }
 
+function getTimelineCarouselNowX(
+  items: TimelineCarouselItem[],
+  current: Date,
+  timezone?: string,
+): number | null {
+  const currentMs = current.getTime();
+  const positionedItems = getPositionedTimelineCarouselItems(items);
+
+  for (const positioned of positionedItems) {
+    if (positioned.item.kind !== "item") {
+      continue;
+    }
+
+    const startMs = positioned.item.item.start.getTime();
+    const end = positioned.item.item.end;
+    const endMs = end?.getTime();
+
+    if (endMs && startMs <= currentMs && currentMs <= endMs) {
+      if (endMs <= startMs) {
+        return positioned.right;
+      }
+
+      const progress = (currentMs - startMs) / (endMs - startMs);
+      return (
+        positioned.left + positioned.width * Math.min(Math.max(progress, 0), 1)
+      );
+    }
+  }
+
+  const todayItems = positionedItems.filter((positioned) =>
+    isSameTimelineDay(
+      getTimelineCarouselItemStart(positioned.item),
+      current,
+      timezone,
+    ),
+  );
+
+  if (todayItems.length === 0) {
+    return null;
+  }
+
+  const nextItem = todayItems.find(
+    (positioned) =>
+      getTimelineCarouselItemStart(positioned.item).getTime() > currentMs,
+  );
+  let previousItem: (typeof todayItems)[number] | undefined;
+  for (const positioned of todayItems) {
+    if (getTimelineCarouselItemStart(positioned.item).getTime() <= currentMs) {
+      previousItem = positioned;
+    }
+  }
+
+  if (previousItem && nextItem) {
+    return previousItem.right + (nextItem.left - previousItem.right) / 2;
+  }
+
+  if (nextItem) {
+    return nextItem.left;
+  }
+
+  if (!previousItem) {
+    return null;
+  }
+
+  if (previousItem.item.kind !== "item") {
+    return previousItem.left + previousItem.width / 2;
+  }
+
+  return previousItem.right;
+}
+
 function getTimelineCarouselDateDirection({
   items,
   date,
@@ -1162,6 +1293,32 @@ function getTimelineCarouselDateDirection({
   return null;
 }
 
+export function getTimelineCarouselNowDirection({
+  nowX,
+  scrollLeft,
+  viewportWidth,
+}: {
+  nowX: number | null;
+  scrollLeft: number;
+  viewportWidth: number;
+}): TodayChipDirection | null {
+  if (nowX === null) {
+    return null;
+  }
+
+  const viewportRight = scrollLeft + viewportWidth;
+
+  if (nowX < scrollLeft) {
+    return "left";
+  }
+
+  if (nowX > viewportRight) {
+    return "right";
+  }
+
+  return null;
+}
+
 function getTimelineCarouselDateRange(
   items: TimelineCarouselItem[],
   date: Date,
@@ -1187,6 +1344,25 @@ function getTimelineCarouselDateRange(
   }
 
   return range;
+}
+
+function getPositionedTimelineCarouselItems(
+  items: TimelineCarouselItem[],
+): Array<{
+  item: TimelineCarouselItem;
+  left: number;
+  right: number;
+  width: number;
+}> {
+  let left = TIMELINE_CAROUSEL_PADDING;
+
+  return items.map((item) => {
+    const width = getTimelineCarouselItemWidth(item);
+    const right = left + width;
+    const positionedItem = { item, left, right, width };
+    left = right + TIMELINE_CAROUSEL_GAP;
+    return positionedItem;
+  });
 }
 
 function getTimelineCarouselAnchorKey(
@@ -1227,30 +1403,21 @@ function isSameTimelineDay(
   return format(firstDate, "yyyy-MM-dd") === format(secondDate, "yyyy-MM-dd");
 }
 
-function CalendarDot({ calendarId }: { calendarId: string }) {
-  const calendar = main.UI.useRow("calendars", calendarId, main.STORE_ID);
-  const color = calendar?.color ? String(calendar.color) : "#888";
-
-  return (
-    <span
-      aria-hidden
-      className="size-2 shrink-0 rounded-full opacity-70"
-      style={{ backgroundColor: color }}
-    />
-  );
-}
-
 function buildMeetingTimelineEntries({
   timelineEventsTable,
   timelineSessionsTable,
   sessionRecordingRanges,
   selectedSessionId,
+  liveSessionId,
+  now,
   isIgnored,
 }: {
   timelineEventsTable: TimelineEventsTable;
   timelineSessionsTable: TimelineSessionsTable;
   sessionRecordingRanges: ReadonlyMap<string, SessionRecordingRange>;
   selectedSessionId: string | null;
+  liveSessionId: string | null;
+  now: number;
   isIgnored: (
     trackingId?: string | null,
     recurrenceSeriesId?: string | null,
@@ -1258,7 +1425,6 @@ function buildMeetingTimelineEntries({
 }): MeetingTimelineEntry[] {
   const entries: MeetingTimelineEntry[] = [];
   const sessionTrackingIds = new Set<string>();
-  const now = Date.now();
 
   if (timelineSessionsTable) {
     Object.entries(timelineSessionsTable).forEach(([sessionId, row]) => {
@@ -1267,6 +1433,7 @@ function buildMeetingTimelineEntries({
         row,
         recordingRange: sessionRecordingRanges.get(sessionId),
         selected: selectedSessionId === sessionId,
+        isLive: liveSessionId === sessionId,
         now,
       });
 
@@ -1315,12 +1482,14 @@ function getSessionTimelineEntry({
   row,
   recordingRange,
   selected,
+  isLive,
   now,
 }: {
   sessionId: string;
   row: TimelineSessionRow;
   recordingRange?: SessionRecordingRange;
   selected: boolean;
+  isLive: boolean;
   now: number;
 }): MeetingTimelineEntry | null {
   const event = getSessionEvent(row);
@@ -1331,7 +1500,9 @@ function getSessionTimelineEntry({
     return null;
   }
 
-  const end = recordingRange?.end ?? safeParseDate(event?.ended_at);
+  const eventEnd = safeParseDate(event?.ended_at);
+  const recordedOrScheduledEnd = recordingRange?.end ?? eventEnd ?? null;
+  const end = isLive && !eventEnd ? new Date(now) : recordedOrScheduledEnd;
 
   return {
     id: sessionId,

--- a/apps/desktop/src/sidebar/timeline/realtime.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/realtime.test.tsx
@@ -1,29 +1,52 @@
-import { render } from "@testing-library/react";
-import { describe, expect, test, vi } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { CurrentTimeIndicator } from "./realtime";
 
 describe("CurrentTimeIndicator", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
   test("renders inside-item progress from bottom to top", () => {
     vi.useFakeTimers();
-    try {
-      vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
 
-      const { container, rerender } = render(
-        <CurrentTimeIndicator variant="inside" progress={0} />,
-      );
+    vi.setSystemTime(new Date(2024, 0, 15, 12, 0, 0));
 
-      expect((container.firstChild as HTMLDivElement | null)?.style.top).toBe(
-        "100%",
-      );
+    const { container, rerender } = render(
+      <CurrentTimeIndicator variant="inside" progress={0} />,
+    );
 
-      rerender(<CurrentTimeIndicator variant="inside" progress={1} />);
+    expect((container.firstChild as HTMLDivElement | null)?.style.top).toBe(
+      "100%",
+    );
 
-      expect((container.firstChild as HTMLDivElement | null)?.style.top).toBe(
-        "0%",
-      );
-    } finally {
-      vi.useRealTimers();
-    }
+    rerender(<CurrentTimeIndicator variant="inside" progress={1} />);
+
+    expect((container.firstChild as HTMLDivElement | null)?.style.top).toBe(
+      "0%",
+    );
+  });
+
+  test("syncs the label at the next wall-clock minute", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 0, 15, 12, 0, 45));
+
+    render(<CurrentTimeIndicator />);
+
+    expect(screen.getByText("12:00 PM")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(15_099);
+    });
+
+    expect(screen.getByText("12:00 PM")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(screen.getByText("12:01 PM")).toBeTruthy();
   });
 });

--- a/apps/desktop/src/sidebar/timeline/realtime.tsx
+++ b/apps/desktop/src/sidebar/timeline/realtime.tsx
@@ -5,6 +5,10 @@ import { TZDate, format, safeParseDate } from "@hypr/utils";
 import type { TimelineEventsTable, TimelineSessionsTable } from "./utils";
 
 import { getSessionEvent } from "~/session/utils";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
+
+const MINUTE_MS = 60_000;
+const CURRENT_TIME_TICK_OFFSET_MS = 100;
 
 export const CurrentTimeIndicator = forwardRef<
   HTMLDivElement,
@@ -48,19 +52,53 @@ export const CurrentTimeIndicator = forwardRef<
 export function useCurrentTimeMs() {
   const [now, setNow] = useState(() => new Date().getTime());
 
-  useEffect(() => {
-    const update = () => {
-      const now = new Date().getTime();
-      setNow(now);
+  useMountEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const clearUpdate = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
     };
 
-    update();
+    const scheduleUpdate = () => {
+      clearUpdate();
+      timeoutId = setTimeout(update, getCurrentTimeTickDelay(Date.now()));
+    };
 
-    const interval = setInterval(update, 60_000);
-    return () => clearInterval(interval);
-  }, []);
+    const update = () => {
+      setNow(Date.now());
+      scheduleUpdate();
+    };
+
+    const sync = () => {
+      update();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        sync();
+      }
+    };
+
+    sync();
+    window.addEventListener("focus", sync);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      clearUpdate();
+      window.removeEventListener("focus", sync);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  });
 
   return now;
+}
+
+function getCurrentTimeTickDelay(nowMs: number): number {
+  const msIntoMinute = nowMs % MINUTE_MS;
+  return MINUTE_MS - msIntoMinute + CURRENT_TIME_TICK_OFFSET_MS;
 }
 
 export function useSmartCurrentTime(


### PR DESCRIPTION
Add a red current-time indicator to the top meeting carousel and cover active-block positioning.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5365 
- <kbd>&nbsp;2&nbsp;</kbd> #5364 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5362 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop timeline UI and time-positioning logic only, with expanded unit tests and no auth or data-persistence changes.
> 
> **Overview**
> Restores a **red current-time marker** on the desktop **top meeting timeline** carousel, with positioning that reflects real session/recording bounds and live recording state.
> 
> The strip renders `TopCurrentTimeIndicator` at an X computed by `getTimelineCarouselNowX` (inside timed blocks by progress, between open-ended notes and future events, or at the trailing edge for active ad-hoc sessions). Off-screen markers drive a **Now** chip (replacing **Today**) that scrolls to the marker; session entries use **live** `sessionId`, transcript recording ends, and `useCurrentTimeMs` so live notes without a calendar end extend to the current minute. Shared `useCurrentTimeMs` now ticks on wall-clock minute boundaries and resyncs on window focus/visibility. Carousel cards are slightly narrower and calendar dots on session cards were removed; coverage adds indicator and scroll tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b73443e61796de707a5429f8f525180417c00272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->