### PR TITLE
fix(desktop): set note card width

### DIFF
--- a/apps/desktop/src/main/top-meeting-timeline.test.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.test.tsx
@@ -315,7 +315,7 @@ describe("TopMeetingTimeline", () => {
     render(<TopMeetingTimeline currentTab={null} />);
 
     expect(screen.getByTestId("top-timeline-now-indicator").style.left).toBe(
-      "94px",
+      "80px",
     );
   });
 
@@ -344,7 +344,7 @@ describe("TopMeetingTimeline", () => {
     render(<TopMeetingTimeline currentTab={null} />);
 
     expect(screen.getByTestId("top-timeline-now-indicator").style.left).toBe(
-      "190px",
+      "162px",
     );
   });
 
@@ -366,7 +366,7 @@ describe("TopMeetingTimeline", () => {
     render(<TopMeetingTimeline currentTab={null} />);
 
     expect(screen.getByTestId("top-timeline-now-indicator").style.left).toBe(
-      "188px",
+      "160px",
     );
   });
 
@@ -417,6 +417,6 @@ describe("TopMeetingTimeline", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Now" }));
 
-    expect(scrollContainer!.scrollLeft).toBe(140);
+    expect(scrollContainer!.scrollLeft).toBe(112);
   });
 });

--- a/apps/desktop/src/main/top-meeting-timeline.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.tsx
@@ -77,7 +77,7 @@ import { useUndoDelete } from "~/store/zustand/undo-delete";
 import { useListener } from "~/stt/contexts";
 
 const TIMELINE_HEIGHT = 44;
-const TIMELINE_CAROUSEL_CARD_WIDTH = 188;
+const TIMELINE_CAROUSEL_CARD_WIDTH = 160;
 const TIMELINE_CAROUSEL_PADDING = 0;
 const TIMELINE_CAROUSEL_GAP = 4;
 const TIMELINE_PAST_DAYS = 6;


### PR DESCRIPTION
Use a fixed 160px width for top timeline note cards and update now-marker expectations.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5365 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #5364 
- <kbd>&nbsp;1&nbsp;</kbd> #5362 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only constant and test expectation changes; no auth, data, or API impact.
> 
> **Overview**
> The top meeting timeline carousel now uses a **fixed 160px** width per note/card (down from 188px) via `TIMELINE_CAROUSEL_CARD_WIDTH`, so session, event, create-meeting, and calendar cards all render narrower.
> 
> Tests were updated so **now-indicator** `left` values and the **Now** button scroll target match the new layout math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af2206b1ba5c515650424a932bed7b2575bd8eb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->