### PR TITLE
fix(desktop): bound transcript query memory

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -14,6 +14,7 @@ import {
 } from "~/stt/live-segment";
 import {
   buildRenderTranscriptRequestFromStore,
+  getRenderTranscriptRequestKey,
   renderTranscriptSegments,
 } from "~/stt/render-transcript";
 import {
@@ -278,9 +279,13 @@ function useLiveTranscriptSegments(sessionId: string): Segment[] {
     humansTable,
     selfHumanId,
   ]);
+  const requestKey = useMemo(
+    () => getRenderTranscriptRequestKey(request),
+    [request],
+  );
 
   const { data: renderedSegments = [] } = useQuery({
-    queryKey: ["live-transcript-footer-segments", sessionId, request],
+    queryKey: ["live-transcript-footer-segments", sessionId, requestKey],
     queryFn: async () => {
       if (!request) {
         return [];
@@ -289,6 +294,7 @@ function useLiveTranscriptSegments(sessionId: string): Segment[] {
       return renderTranscriptSegments(request);
     },
     enabled: !!request,
+    gcTime: 0,
   });
 
   return useMemo(() => {

--- a/apps/desktop/src/session/components/note-input/transcript/export-data.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/export-data.ts
@@ -6,6 +6,7 @@ import type { TranscriptItem } from "@hypr/plugin-export";
 import * as main from "~/store/tinybase/store/main";
 import {
   buildRenderTranscriptRequestFromStore,
+  getRenderTranscriptRequestKey,
   renderTranscriptSegments,
 } from "~/stt/render-transcript";
 
@@ -63,9 +64,13 @@ export function useTranscriptExportSegments(sessionId: string): {
     humansTable,
     selfHumanId,
   ]);
+  const requestKey = useMemo(
+    () => getRenderTranscriptRequestKey(request),
+    [request],
+  );
 
   const { data = [], isLoading } = useQuery({
-    queryKey: ["transcript-export-segments", sessionId, request],
+    queryKey: ["transcript-export-segments", sessionId, requestKey],
     queryFn: async () => {
       if (!request) {
         return [];
@@ -73,6 +78,7 @@ export function useTranscriptExportSegments(sessionId: string): {
       return buildTranscriptExportSegments(request);
     },
     enabled: !!request,
+    gcTime: 0,
   });
 
   return { data, isLoading };

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
@@ -5,6 +5,7 @@ import * as main from "~/store/tinybase/store/main";
 import type { Segment } from "~/stt/live-segment";
 import {
   buildRenderTranscriptRequestFromStore,
+  getRenderTranscriptRequestKey,
   renderTranscriptSegments,
 } from "~/stt/render-transcript";
 
@@ -32,9 +33,13 @@ export function useRenderedTranscriptSegments(transcriptId: string): Segment[] {
     humansTable,
     selfHumanId,
   ]);
+  const requestKey = useMemo(
+    () => getRenderTranscriptRequestKey(request),
+    [request],
+  );
 
   const { data = [] } = useQuery({
-    queryKey: ["rendered-transcript-segments", transcriptId, request],
+    queryKey: ["rendered-transcript-segments", transcriptId, requestKey],
     queryFn: async () => {
       if (!request) {
         return [];
@@ -43,6 +48,7 @@ export function useRenderedTranscriptSegments(transcriptId: string): Segment[] {
       return renderTranscriptSegments(request);
     },
     enabled: !!request,
+    gcTime: 0,
   });
 
   return data;

--- a/apps/desktop/src/stt/render-transcript.test.ts
+++ b/apps/desktop/src/stt/render-transcript.test.ts
@@ -12,6 +12,7 @@ vi.mock("@hypr/plugin-transcription", () => ({
 
 import {
   buildRenderTranscriptRequestFromStore,
+  getRenderTranscriptRequestKey,
   renderTranscriptSegments,
 } from "./render-transcript";
 
@@ -267,5 +268,70 @@ describe("buildRenderTranscriptRequestFromStore", () => {
         source: "synthetic_text",
       },
     });
+  });
+});
+
+describe("getRenderTranscriptRequestKey", () => {
+  it("keeps large transcript payloads out of query keys", () => {
+    const request = buildRenderTranscriptRequestFromStore(
+      createStore() as never,
+      ["late", "early"],
+    );
+
+    expect(getRenderTranscriptRequestKey(request)).toMatch(/^\d+:\d+:\d+:/);
+  });
+
+  it("changes when rendered transcript inputs change", () => {
+    const request = buildRenderTranscriptRequestFromStore(
+      createStore() as never,
+      ["late", "early"],
+    );
+    const changedRequest = {
+      ...request!,
+      transcripts: request!.transcripts.map((transcript, index) =>
+        index === 0
+          ? {
+              ...transcript,
+              words: transcript.words.map((word, wordIndex) =>
+                wordIndex === 0 ? { ...word, text: " changed" } : word,
+              ),
+            }
+          : transcript,
+      ),
+    };
+
+    expect(getRenderTranscriptRequestKey(changedRequest)).not.toBe(
+      getRenderTranscriptRequestKey(request),
+    );
+  });
+
+  it("changes when speaker assignments change", () => {
+    const request = buildRenderTranscriptRequestFromStore(
+      createStore() as never,
+      ["late", "early"],
+    );
+    const changedRequest = {
+      ...request!,
+      transcripts: request!.transcripts.map((transcript, index) =>
+        index === 0
+          ? {
+              ...transcript,
+              assignments: [
+                {
+                  human_id: "third",
+                  scope: {
+                    kind: "channel",
+                    channel: "RemoteParty",
+                  },
+                } as const,
+              ],
+            }
+          : transcript,
+      ),
+    };
+
+    expect(getRenderTranscriptRequestKey(changedRequest)).not.toBe(
+      getRenderTranscriptRequestKey(request),
+    );
   });
 });

--- a/apps/desktop/src/stt/render-transcript.ts
+++ b/apps/desktop/src/stt/render-transcript.ts
@@ -57,6 +57,88 @@ export async function renderTranscriptSegments(
   return attachWordMetadata(result.data, metadataByWordId);
 }
 
+export function getRenderTranscriptRequestKey(
+  request: RenderTranscriptRequest | null | undefined,
+): string {
+  if (!request) {
+    return "empty";
+  }
+
+  let hash = 2_166_136_261;
+  let wordCount = 0;
+  let assignmentCount = 0;
+
+  const writeString = (value: string) => {
+    for (let index = 0; index < value.length; index += 1) {
+      hash = Math.imul(hash ^ value.charCodeAt(index), 16_777_619) >>> 0;
+    }
+    hash = Math.imul(hash ^ 31, 16_777_619) >>> 0;
+  };
+
+  const writeValue = (value: unknown) => {
+    if (value == null) {
+      writeString("");
+      return;
+    }
+
+    if (typeof value === "object") {
+      try {
+        writeString(JSON.stringify(value));
+      } catch {
+        writeString("[object]");
+      }
+      return;
+    }
+
+    writeString(String(value));
+  };
+
+  writeValue(request.self_human_id);
+
+  for (const humanId of request.participant_human_ids) {
+    writeValue(humanId);
+  }
+
+  for (const human of request.humans) {
+    writeValue(human.human_id);
+    writeValue(human.name);
+  }
+
+  for (const transcript of request.transcripts) {
+    writeValue(transcript.started_at);
+    wordCount += transcript.words.length;
+    assignmentCount += transcript.assignments.length;
+
+    for (const word of transcript.words) {
+      writeValue(word.id);
+      writeValue(word.text);
+      writeValue(word.start_ms);
+      writeValue(word.end_ms);
+      writeValue(word.channel);
+      writeValue(word.speaker_index);
+      writeValue((word as { metadata?: unknown }).metadata);
+    }
+
+    for (const assignment of transcript.assignments) {
+      writeValue(assignment.human_id);
+      writeValue(assignment.scope.kind);
+      writeValue(assignment.scope.channel);
+      writeValue(
+        "speaker_index" in assignment.scope
+          ? assignment.scope.speaker_index
+          : null,
+      );
+    }
+  }
+
+  return [
+    request.transcripts.length,
+    wordCount,
+    assignmentCount,
+    hash.toString(36),
+  ].join(":");
+}
+
 export function buildRenderTranscriptRequestFromStore(
   store: NonNullable<ReturnType<typeof main.UI.useStore>>,
   transcriptIds: string[],


### PR DESCRIPTION
Use compact transcript render request fingerprints for query keys and drop obsolete cached transcript render queries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Caching and query-key behavior only; render logic still uses the full request in queryFn. Low risk of stale UI if the fingerprint ever collides, mitigated by tests on input changes.
> 
> **Overview**
> Stops embedding full **transcript render requests** in TanStack Query keys by hashing them into a compact fingerprint via **`getRenderTranscriptRequestKey`**, so live footer, note transcript, and export flows no longer retain huge key objects in the cache.
> 
> All three transcript render queries now use that fingerprint in **`queryKey`** and set **`gcTime: 0`** so obsolete render results are dropped instead of accumulating in memory. Unit tests cover stable key shape, invalidation on word edits, and on speaker assignment changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3baf9736af8a9b61c2ff8b01009e2e898a886b2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->