### PR TITLE
fix(audio): append resumed recordings

### DIFF
--- a/crates/fs-sync-core/src/audio/mod.rs
+++ b/crates/fs-sync-core/src/audio/mod.rs
@@ -8,11 +8,12 @@ use crate::runtime::{AudioImportEvent, AudioImportRuntime};
 use chrono::{DateTime, Utc};
 
 const AUDIO_FORMATS: [&str; 3] = ["audio.mp3", "audio.wav", "audio.ogg"];
-const AUDIO_ARTIFACTS: [&str; 6] = [
+const AUDIO_ARTIFACTS: [&str; 7] = [
     "audio.mp3",
     "audio.wav",
     "audio.ogg",
     "audio.mp3.tmp",
+    "audio.wav.tmp",
     "audio_mic.wav",
     "audio_spk.wav",
 ];

--- a/crates/listener-core/src/actors/recorder/disk.rs
+++ b/crates/listener-core/src/actors/recorder/disk.rs
@@ -152,9 +152,10 @@ fn prepare_existing_audio_state(
     ogg_path: &Path,
     wav_path: &Path,
 ) -> Result<bool, ActorProcessingErr> {
-    if encoded_path.exists() && !wav_path.exists() {
-        hypr_mp3::decode_to_wav(encoded_path, wav_path).map_err(into_actor_err)?;
+    if encoded_path.exists() {
+        decode_mp3_to_wav(encoded_path, wav_path)?;
         std::fs::remove_file(encoded_path)?;
+        return Ok(wav_is_stereo(wav_path)?);
     }
 
     if ogg_path.exists() {
@@ -169,11 +170,30 @@ fn prepare_existing_audio_state(
     }
 
     if wav_path.exists() {
-        let reader = hound::WavReader::open(wav_path)?;
-        return Ok(reader.spec().channels == 2);
+        return Ok(wav_is_stereo(wav_path)?);
     }
 
     Ok(true)
+}
+
+fn decode_mp3_to_wav(encoded_path: &Path, wav_path: &Path) -> Result<(), ActorProcessingErr> {
+    let tmp_path = wav_path.with_extension("wav.tmp");
+    if tmp_path.exists() {
+        std::fs::remove_file(&tmp_path)?;
+    }
+
+    hypr_mp3::decode_to_wav(encoded_path, &tmp_path).map_err(into_actor_err)?;
+
+    if wav_path.exists() {
+        std::fs::remove_file(wav_path)?;
+    }
+    std::fs::rename(tmp_path, wav_path)?;
+    Ok(())
+}
+
+fn wav_is_stereo(wav_path: &Path) -> Result<bool, hound::Error> {
+    let reader = hound::WavReader::open(wav_path)?;
+    Ok(reader.spec().channels == 2)
 }
 
 fn is_debug_mode() -> bool {
@@ -272,6 +292,8 @@ fn sync_dir(path: &Path) {
 mod tests {
     use tempfile::tempdir;
 
+    use crate::actors::SAMPLE_RATE;
+
     use super::*;
 
     #[test]
@@ -292,6 +314,26 @@ mod tests {
     }
 
     #[test]
+    fn create_disk_sink_prefers_existing_mp3_over_stale_wav() {
+        let dir = tempdir().unwrap();
+        let session_dir = dir.path().join("session");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        let encoded_path = session_dir.join(FINAL_AUDIO_FILE);
+        let wav_path = session_dir.join(WAV_FILE);
+        std::fs::copy(hypr_data::english_1::AUDIO_MP3_PATH, &encoded_path).unwrap();
+        write_test_wav(&wav_path, 128);
+        let original_frames = decoded_frame_count(&encoded_path);
+
+        let mut sink = create_disk_sink(&session_dir).unwrap();
+        write_single(&mut sink, &vec![0.0; SAMPLE_RATE as usize]).unwrap();
+        finalize_disk_sink(&mut sink).unwrap();
+
+        assert!(!wav_path.exists());
+        assert!(encoded_path.exists());
+        assert!(decoded_frame_count(&encoded_path) > original_frames);
+    }
+
+    #[test]
     fn create_disk_sink_keeps_legacy_wav_for_append() {
         let dir = tempdir().unwrap();
         let session_dir = dir.path().join("session");
@@ -302,5 +344,27 @@ mod tests {
 
         assert!(session_dir.join(WAV_FILE).exists());
         assert!(!session_dir.join(FINAL_AUDIO_FILE).exists());
+    }
+
+    fn decoded_frame_count(path: &Path) -> usize {
+        use hypr_audio_utils::Source;
+
+        let source = hypr_audio_utils::source_from_path(path).unwrap();
+        let channels = u16::from(source.channels()).max(1) as usize;
+        source.count() / channels
+    }
+
+    fn write_test_wav(path: &Path, frames: usize) {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: SAMPLE_RATE,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        let mut writer = hound::WavWriter::create(path, spec).unwrap();
+        for _ in 0..frames {
+            writer.write_sample(0.0f32).unwrap();
+        }
+        writer.finalize().unwrap();
     }
 }


### PR DESCRIPTION
Prefer existing MP3 recordings over stale WAV artifacts before appending resumed audio and clean up temporary decode files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session startup and on-disk audio prep for resume; wrong behavior could truncate or duplicate recordings, but scope is localized to recorder disk prep and artifact cleanup.
> 
> **Overview**
> Fixes **resumed recording** so new audio appends to the real session content instead of a leftover `audio.wav`.
> 
> When **`audio.mp3`** is present, the recorder **always** decodes it to WAV for append (even if a WAV file already exists), then removes the MP3 for the recording phase. MP3→WAV decode uses **`audio.wav.tmp`** and an atomic rename so partial decodes do not corrupt the working file. **`audio.wav.tmp`** is included in fs-sync **artifact cleanup**.
> 
> A regression test covers the case where both MP3 and a short stale WAV exist: resume should extend the MP3-backed audio, not keep appending only to the stale WAV.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a132e23d3704f2dcb24665448f82d9e901e5e28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->