### PR TITLE
fix/soniqo-batch-coreml-crash

### DIFF
--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -1,3 +1,6 @@
+use std::path::Path;
+use std::time::Instant;
+
 use owhisper_client::{
     AdapterKind, AquaVoiceAdapter, ArgmaxAdapter, AssemblyAIAdapter, BatchSttAdapter,
     DeepgramAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, HyprnoteAdapter,
@@ -117,23 +120,64 @@ pub(super) async fn run_soniqo_batch(
             .batch_model();
 
         let file_path = params.file_path.clone();
+        let file_extension = Path::new(&file_path)
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .unwrap_or_default()
+            .to_string();
         let language = listen_params
             .languages
             .first()
             .map(hypr_language::Language::bcp47_code);
+        let language_label = language.as_deref().unwrap_or("auto").to_string();
+        let started_at = Instant::now();
+
+        tracing::info!(
+            hyprnote.stt.provider.name = "soniqo",
+            hyprnote.stt.model = %model,
+            hyprnote.stt.language = %language_label,
+            file.extension = %file_extension,
+            "soniqo_batch_start"
+        );
 
         let transcribed = tokio::task::spawn_blocking(move || {
             transcribe_soniqo_file(model, &file_path, language.as_deref())
         })
         .await
-        .map_err(|e| crate::BatchFailure::DirectRequestFailed {
-            provider: "soniqo".to_string(),
-            message: format!("Soniqo transcription task failed: {e}"),
+        .map_err(|e| {
+            tracing::error!(
+                hyprnote.stt.provider.name = "soniqo",
+                hyprnote.stt.model = %model,
+                error = %e,
+                "soniqo_batch_task_join_failed"
+            );
+            crate::BatchFailure::DirectRequestFailed {
+                provider: "soniqo".to_string(),
+                message: format!("Soniqo transcription task failed: {e}"),
+            }
         })?
-        .map_err(|e| crate::BatchFailure::DirectRequestFailed {
-            provider: "soniqo".to_string(),
-            message: format_user_friendly_error(&e),
+        .map_err(|e| {
+            let message = format_user_friendly_error(&e);
+            tracing::error!(
+                hyprnote.stt.provider.name = "soniqo",
+                hyprnote.stt.model = %model,
+                error = %e,
+                hyprnote.error.user_message = %message,
+                "soniqo_batch_failed"
+            );
+            crate::BatchFailure::DirectRequestFailed {
+                provider: "soniqo".to_string(),
+                message,
+            }
         })?;
+
+        tracing::info!(
+            hyprnote.stt.provider.name = "soniqo",
+            hyprnote.stt.model = %model,
+            elapsed_ms = started_at.elapsed().as_millis() as u64,
+            transcript.channel_count = transcribed.len(),
+            "soniqo_batch_completed"
+        );
 
         let response = hypr_transcribe_soniqo::batch_response_from_channels(model, transcribed);
 
@@ -154,36 +198,127 @@ fn transcribe_soniqo_file(
 ) -> std::result::Result<Vec<hypr_transcribe_soniqo::FileTranscript>, String> {
     let source = hypr_audio_utils::source_from_path(file_path).map_err(|e| e.to_string())?;
     let channel_count = u16::from(source.channels()).max(1) as usize;
+    let sample_rate = u32::from(source.sample_rate());
+    let duration_ms = source
+        .total_duration()
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64);
+
+    tracing::info!(
+        hyprnote.stt.provider.name = "soniqo",
+        hyprnote.stt.model = %model,
+        hyprnote.stt.language = %language.unwrap_or("auto"),
+        audio.channel_count = channel_count,
+        audio.sample_rate_hz = sample_rate,
+        audio.duration_ms = duration_ms.unwrap_or_default(),
+        audio.duration_known = duration_ms.is_some(),
+        "soniqo_audio_file_loaded"
+    );
 
     if channel_count <= 1 {
+        tracing::info!(
+            hyprnote.stt.provider.name = "soniqo",
+            hyprnote.stt.model = %model,
+            "soniqo_single_channel_native_inference_start"
+        );
         return hypr_transcribe_soniqo::transcribe_file(model, file_path, language)
             .map(|transcript| vec![transcript])
             .map_err(|e| e.to_string());
     }
 
+    let resample_started_at = Instant::now();
     let samples =
         hypr_audio_utils::resample_audio(source, TARGET_SAMPLE_RATE).map_err(|e| e.to_string())?;
+    tracing::info!(
+        hyprnote.stt.provider.name = "soniqo",
+        hyprnote.stt.model = %model,
+        elapsed_ms = resample_started_at.elapsed().as_millis() as u64,
+        audio.source_sample_rate_hz = sample_rate,
+        audio.target_sample_rate_hz = TARGET_SAMPLE_RATE,
+        audio.resampled_sample_count = samples.len(),
+        "soniqo_audio_resampled"
+    );
+
     let channel_samples =
         collapse_identical_channels(split_resampled_channels(&samples, channel_count));
+    tracing::info!(
+        hyprnote.stt.provider.name = "soniqo",
+        hyprnote.stt.model = %model,
+        audio.source_channel_count = channel_count,
+        audio.transcribed_channel_count = channel_samples.len(),
+        "soniqo_channels_prepared"
+    );
 
     channel_samples
         .into_iter()
-        .map(|samples| transcribe_soniqo_channel(model, &samples, language))
+        .enumerate()
+        .map(|(channel_index, samples)| {
+            transcribe_soniqo_channel(model, channel_index, &samples, language)
+        })
         .collect()
 }
 
 fn transcribe_soniqo_channel(
     model: hypr_transcribe_soniqo::SoniqoModel,
+    channel_index: usize,
     samples: &[f32],
     language: Option<&str>,
 ) -> std::result::Result<hypr_transcribe_soniqo::FileTranscript, String> {
     let duration_seconds = channel_duration_sec(samples);
     let chunks =
         chunk_channel_audio::<hypr_audio_chunking::Error>(samples).map_err(|e| e.to_string())?;
+    tracing::info!(
+        hyprnote.stt.provider.name = "soniqo",
+        hyprnote.stt.model = %model,
+        channel.index = channel_index,
+        channel.duration_seconds = duration_seconds,
+        channel.sample_count = samples.len(),
+        chunk.count = chunks.len(),
+        "soniqo_channel_chunked"
+    );
+
     let mut texts = Vec::new();
 
-    for chunk in chunks {
-        let text = transcribe_soniqo_samples(model, &chunk.samples, language)?.text;
+    for (chunk_index, chunk) in chunks.into_iter().enumerate() {
+        let chunk_duration_ms =
+            (chunk.sample_end - chunk.sample_start) * 1000 / TARGET_SAMPLE_RATE as usize;
+        let chunk_started_at = Instant::now();
+        tracing::info!(
+            hyprnote.stt.provider.name = "soniqo",
+            hyprnote.stt.model = %model,
+            channel.index = channel_index,
+            chunk.index = chunk_index,
+            chunk.sample_start = chunk.sample_start,
+            chunk.sample_end = chunk.sample_end,
+            chunk.sample_count = chunk.samples.len(),
+            chunk.duration_ms = chunk_duration_ms,
+            "soniqo_chunk_native_inference_start"
+        );
+
+        let text = transcribe_soniqo_samples(model, &chunk.samples, language)
+            .map_err(|e| {
+                tracing::error!(
+                    hyprnote.stt.provider.name = "soniqo",
+                    hyprnote.stt.model = %model,
+                    channel.index = channel_index,
+                    chunk.index = chunk_index,
+                    elapsed_ms = chunk_started_at.elapsed().as_millis() as u64,
+                    error = %e,
+                    "soniqo_chunk_native_inference_failed"
+                );
+                e
+            })?
+            .text;
+
+        tracing::info!(
+            hyprnote.stt.provider.name = "soniqo",
+            hyprnote.stt.model = %model,
+            channel.index = channel_index,
+            chunk.index = chunk_index,
+            elapsed_ms = chunk_started_at.elapsed().as_millis() as u64,
+            transcript.text_chars = text.chars().count(),
+            "soniqo_chunk_native_inference_completed"
+        );
+
         let text = text.trim();
         if !text.is_empty() {
             texts.push(text.to_string());

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::time::Instant;
 
 use owhisper_interface::{batch, stream};
 
@@ -330,7 +331,54 @@ pub fn transcribe_file(
     language: Option<&str>,
 ) -> Result<FileTranscript> {
     ensure_supported_platform(model)?;
-    platform::transcribe_file(model, path.as_ref(), language.unwrap_or_default())
+
+    let path = path.as_ref();
+    let language = language.unwrap_or_default();
+    let language_label = if language.is_empty() {
+        "auto"
+    } else {
+        language
+    };
+    let file_extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or_default();
+    let started_at = Instant::now();
+
+    tracing::info!(
+        hyprnote.stt.provider.name = "soniqo",
+        hyprnote.stt.model = %model,
+        hyprnote.stt.language = %language_label,
+        file.extension = %file_extension,
+        "soniqo_native_file_transcription_start"
+    );
+
+    let result = platform::transcribe_file(model, path, language);
+    let elapsed_ms = started_at.elapsed().as_millis() as u64;
+
+    match &result {
+        Ok(transcript) => {
+            tracing::info!(
+                hyprnote.stt.provider.name = "soniqo",
+                hyprnote.stt.model = %model,
+                elapsed_ms,
+                transcript.duration_seconds = transcript.duration_seconds,
+                transcript.text_chars = transcript.text.chars().count(),
+                "soniqo_native_file_transcription_completed"
+            );
+        }
+        Err(error) => {
+            tracing::error!(
+                hyprnote.stt.provider.name = "soniqo",
+                hyprnote.stt.model = %model,
+                elapsed_ms,
+                error = %error,
+                "soniqo_native_file_transcription_failed"
+            );
+        }
+    }
+
+    result
 }
 
 pub struct LiveTranscriptionSession {

--- a/crates/transcribe-soniqo/swift-lib/src/lib.swift
+++ b/crates/transcribe-soniqo/swift-lib/src/lib.swift
@@ -17,6 +17,10 @@ private enum SoniqoBridgeError: LocalizedError {
   }
 }
 
+private let soniqoFileTranscriptionSampleRate = 16_000
+private let parakeetBatchMinimumChunkSeconds = 5.0
+private let parakeetBatchMaximumChunkSeconds = 30.0
+
 private enum SpeechModelKind: String, CaseIterable {
   case parakeetStreaming = "soniqo-parakeet-streaming"
   case parakeetBatch = "soniqo-parakeet-batch"
@@ -70,6 +74,24 @@ private enum SpeechModelKind: String, CaseIterable {
       return 25
     case .omnilingual:
       return 35
+    }
+  }
+
+  var minimumFileTranscriptionChunkSeconds: Double? {
+    switch self {
+    case .parakeetBatch:
+      return parakeetBatchMinimumChunkSeconds
+    case .parakeetStreaming, .omnilingual, .qwen3Small, .qwen3Large:
+      return nil
+    }
+  }
+
+  var maximumFileTranscriptionChunkSeconds: Double? {
+    switch self {
+    case .parakeetBatch:
+      return parakeetBatchMaximumChunkSeconds
+    case .parakeetStreaming, .omnilingual, .qwen3Small, .qwen3Large:
+      return nil
     }
   }
 
@@ -558,20 +580,23 @@ private actor SoniqoBridge {
 
       let trimmedLanguage = language.trimmingCharacters(in: .whitespacesAndNewlines)
       let url = URL(fileURLWithPath: audioPath)
-      let audio = try AudioFileLoader.load(url: url, targetSampleRate: 16000)
+      let audio = try AudioFileLoader.load(
+        url: url,
+        targetSampleRate: soniqoFileTranscriptionSampleRate
+      )
       let model = try await ensureModelLoaded(kind)
       let text = try transcribeFileAudio(
         model: model,
         kind: kind,
         audio: audio,
-        sampleRate: 16000,
+        sampleRate: soniqoFileTranscriptionSampleRate,
         language: trimmedLanguage.isEmpty ? nil : trimmedLanguage
       )
 
       return encodeJSON(
         FileTranscriptionPayload(
           text: text,
-          durationSeconds: Double(audio.count) / 16000.0,
+          durationSeconds: Double(audio.count) / Double(soniqoFileTranscriptionSampleRate),
           error: nil
         )
       )
@@ -593,23 +618,54 @@ private actor SoniqoBridge {
     sampleRate: Int,
     language: String?
   ) throws -> String {
-    guard let chunkSeconds = kind.fileTranscriptionChunkSeconds else {
-      return try model.transcribe(audio: audio, sampleRate: sampleRate, language: language)
+    guard !audio.isEmpty else {
+      return ""
     }
 
-    let chunkSampleCount = max(sampleRate, Int(Double(sampleRate) * chunkSeconds))
-    guard audio.count > chunkSampleCount else {
-      return try model.transcribe(audio: audio, sampleRate: sampleRate, language: language)
+    guard let chunkSeconds = kind.fileTranscriptionChunkSeconds else {
+      return try transcribeFileAudioChunk(
+        model: model,
+        kind: kind,
+        audio: audio,
+        sampleRate: sampleRate,
+        language: language
+      )
+    }
+
+    let chunkSampleCount = max(sampleRate, Int((Double(sampleRate) * chunkSeconds).rounded(.up)))
+    let minimumTrailingSamples =
+      kind.minimumFileTranscriptionChunkSeconds.map {
+        max(sampleRate, Int((Double(sampleRate) * $0).rounded(.up)))
+      } ?? 0
+    let maximumChunkSamples =
+      kind.maximumFileTranscriptionChunkSeconds.map {
+        max(chunkSampleCount, Int((Double(sampleRate) * $0).rounded(.up)))
+      } ?? chunkSampleCount
+    let ranges = fileTranscriptionChunkRanges(
+      sampleCount: audio.count,
+      preferredChunkSamples: chunkSampleCount,
+      minimumTrailingSamples: minimumTrailingSamples,
+      maximumChunkSamples: maximumChunkSamples
+    )
+
+    guard ranges.count > 1 else {
+      return try transcribeFileAudioChunk(
+        model: model,
+        kind: kind,
+        audio: audio,
+        sampleRate: sampleRate,
+        language: language
+      )
     }
 
     var chunks: [String] = []
-    var start = 0
 
-    while start < audio.count {
-      let end = min(audio.count, start + chunkSampleCount)
+    for range in ranges {
       let text = try autoreleasepool {
-        try model.transcribe(
-          audio: Array(audio[start..<end]),
+        try transcribeFileAudioChunk(
+          model: model,
+          kind: kind,
+          audio: Array(audio[range]),
           sampleRate: sampleRate,
           language: language
         )
@@ -618,10 +674,86 @@ private actor SoniqoBridge {
       if !trimmed.isEmpty {
         chunks.append(trimmed)
       }
-      start = end
     }
 
     return chunks.joined(separator: " ")
+  }
+
+  private func transcribeFileAudioChunk(
+    model: LoadedSpeechModel,
+    kind: SpeechModelKind,
+    audio: [Float],
+    sampleRate: Int,
+    language: String?
+  ) throws -> String {
+    let normalizedAudio = normalizedFileTranscriptionAudio(
+      kind: kind,
+      audio: audio,
+      sampleRate: sampleRate
+    )
+    return try model.transcribe(audio: normalizedAudio, sampleRate: sampleRate, language: language)
+  }
+
+  private func normalizedFileTranscriptionAudio(
+    kind: SpeechModelKind,
+    audio: [Float],
+    sampleRate: Int
+  ) -> [Float] {
+    guard kind == .parakeetBatch else {
+      return audio
+    }
+
+    let minimumSamples = max(
+      sampleRate,
+      Int((Double(sampleRate) * parakeetBatchMinimumChunkSeconds).rounded(.up))
+    )
+    guard audio.count < minimumSamples else {
+      return audio
+    }
+
+    var padded = audio
+    padded.append(contentsOf: repeatElement(Float.zero, count: minimumSamples - audio.count))
+    return padded
+  }
+
+  private func fileTranscriptionChunkRanges(
+    sampleCount: Int,
+    preferredChunkSamples: Int,
+    minimumTrailingSamples: Int,
+    maximumChunkSamples: Int
+  ) -> [Range<Int>] {
+    guard sampleCount > preferredChunkSamples else {
+      return [0..<sampleCount]
+    }
+
+    var ranges: [Range<Int>] = []
+    var start = 0
+
+    while start < sampleCount {
+      let end = min(sampleCount, start + preferredChunkSamples)
+      ranges.append(start..<end)
+      start = end
+    }
+
+    guard minimumTrailingSamples > 0, ranges.count >= 2, let trailingRange = ranges.last else {
+      return ranges
+    }
+
+    let trailingSamples = trailingRange.upperBound - trailingRange.lowerBound
+    guard trailingSamples < minimumTrailingSamples else {
+      return ranges
+    }
+
+    let previousIndex = ranges.count - 2
+    let previousRange = ranges[previousIndex]
+    let mergedSamples = trailingRange.upperBound - previousRange.lowerBound
+    guard mergedSamples <= maximumChunkSamples else {
+      return ranges
+    }
+
+    ranges.removeLast()
+    ranges[previousIndex] = previousRange.lowerBound..<trailingRange.upperBound
+    return ranges
   }
 
   private func ensureModelLoaded(_ kind: SpeechModelKind) async throws -> LoadedSpeechModel {

--- a/plugins/tracing/src/ext.rs
+++ b/plugins/tracing/src/ext.rs
@@ -55,12 +55,8 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Tracing<'a, R, M> {
             }
 
             if let Ok(content) = std::fs::read_to_string(log_path) {
-                let lines_needed = TARGET_LINES.saturating_sub(collected.len()) + TARGET_LINES;
-                let lines: Vec<String> = content
-                    .lines()
-                    .take(lines_needed)
-                    .map(|s| s.to_string())
-                    .collect();
+                let lines_needed = TARGET_LINES.saturating_sub(collected.len());
+                let lines = tail_lines(&content, lines_needed);
                 let mut new_collected = lines;
                 new_collected.extend(collected);
                 collected = new_collected;
@@ -74,6 +70,21 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Tracing<'a, R, M> {
         let start = collected.len().saturating_sub(TARGET_LINES);
         Ok(Some(collected[start..].join("\n")))
     }
+}
+
+fn tail_lines(content: &str, max_lines: usize) -> Vec<String> {
+    if max_lines == 0 {
+        return Vec::new();
+    }
+
+    let mut lines: Vec<_> = content
+        .lines()
+        .rev()
+        .take(max_lines)
+        .map(str::to_string)
+        .collect();
+    lines.reverse();
+    lines
 }
 
 pub trait TracingPluginExt<R: tauri::Runtime> {
@@ -141,6 +152,21 @@ pub const JS_INIT_SCRIPT: &str = r#"
 #[cfg(test)]
 mod tests {
     use rquickjs::{Context, Runtime};
+
+    #[test]
+    fn tail_lines_returns_recent_lines() {
+        let content = "line 1\nline 2\nline 3\nline 4";
+
+        assert_eq!(
+            super::tail_lines(content, 2),
+            vec!["line 3".to_string(), "line 4".to_string()]
+        );
+    }
+
+    #[test]
+    fn tail_lines_handles_zero_limit() {
+        assert!(super::tail_lines("line 1\nline 2", 0).is_empty());
+    }
 
     fn setup_runtime() -> (Runtime, Context) {
         let runtime = Runtime::new().unwrap();


### PR DESCRIPTION
- Fix crash by merging or padding short Parakeet file transcription chunks before CoreML inference
- Add structured breadcrumbs and diagnostic logging around Soniqo batch/native inference calls
- Return recent local log lines to improve batch issue visibility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native STT chunking and padding on the CoreML path (behavioral, not just logging); incorrect merge/pad logic could affect transcript quality, though scope is limited to Soniqo Parakeet batch on Apple Silicon.
> 
> **Overview**
> Fixes **Soniqo Parakeet batch** CoreML crashes on macOS by ensuring file audio sent to inference meets minimum duration and sane chunk boundaries.
> 
> The Swift bridge now **pads** sub–5s Parakeet batch segments with silence, **merges** a too-short final chunk into the previous one when it stays within a 30s cap, and routes chunked transcription through shared normalization helpers. Rust adds **structured tracing** (`hyprnote.stt.*`, channel/chunk timings) across batch and native `transcribe_file` paths for easier diagnosis.
> 
> The tracing plugin’s log export now pulls the **most recent** lines from rotated log files (`tail_lines`) instead of the file head, so batch failures surface current breadcrumbs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f3d69d6f38843b0700c9819676e8ba4fb9ea7f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->