### PR TITLE
fix(desktop): center empty home actions

### DIFF
--- a/apps/desktop/src/main/empty.test.tsx
+++ b/apps/desktop/src/main/empty.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import type React from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("~/shared/main", () => ({
   StandardTabWrapper: ({
@@ -41,6 +41,10 @@ vi.mock("~/store/zustand/tabs", () => ({
 import { TabContentEmpty } from "./empty";
 
 describe("TabContentEmpty", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it("shows the home actions and global chat FAB", () => {
     render(
       <TabContentEmpty
@@ -57,5 +61,35 @@ describe("TabContentEmpty", () => {
     expect(
       screen.getByRole("button", { name: "Ask Anarlog anything" }),
     ).toBeTruthy();
+  });
+
+  it("centers actions in a draggable empty surface while keeping actions clickable", () => {
+    render(
+      <TabContentEmpty
+        tab={{
+          active: true,
+          pinned: false,
+          slotId: "slot-home",
+          type: "empty",
+        }}
+      />,
+    );
+
+    const newNoteButton = screen.getByRole("button", { name: /New Note/ });
+    const dragSurface = newNoteButton.parentElement?.parentElement;
+
+    expect(dragSurface?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(dragSurface?.className).not.toContain("mb-12");
+    expect(newNoteButton.getAttribute("data-tauri-drag-region")).toBe("false");
+    expect(
+      screen
+        .getByRole("button", { name: /Start Recording/ })
+        .getAttribute("data-tauri-drag-region"),
+    ).toBe("false");
+    expect(
+      screen
+        .getByRole("button", { name: /Settings/ })
+        .getAttribute("data-tauri-drag-region"),
+    ).toBe("false");
   });
 });

--- a/apps/desktop/src/main/empty.tsx
+++ b/apps/desktop/src/main/empty.tsx
@@ -61,7 +61,10 @@ function EmptyView() {
   );
 
   return (
-    <div className="mb-12 flex h-full flex-col items-center justify-center gap-6 text-neutral-600">
+    <div
+      data-tauri-drag-region
+      className="flex h-full flex-col items-center justify-center gap-6 text-neutral-600"
+    >
       <div className="flex min-w-[280px] flex-col gap-1 text-center">
         <ActionItem label="New Note" shortcut={["⌘", "N"]} onClick={newNote} />
         <ActionItem
@@ -94,6 +97,7 @@ function ActionItem({
   return (
     <button
       onClick={onClick}
+      data-tauri-drag-region="false"
       className={cn([
         "group",
         "flex items-center justify-between gap-8",


### PR DESCRIPTION
Center the empty home actions in the full surface and make the empty background draggable while preserving action clicks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only empty-tab layout and Tauri drag-region attributes with no auth, data, or backend impact.
> 
> **Overview**
> The empty home tab layout is adjusted so quick actions stay vertically centered in the full tab area and the surrounding chrome can move the window.
> 
> **`EmptyView`** drops the bottom `mb-12` offset and marks the outer flex container with `data-tauri-drag-region`. **`ActionItem`** buttons set `data-tauri-drag-region="false"` so New Note, Start Recording, and Settings still receive clicks inside the draggable surface.
> 
> Tests add `afterEach(cleanup)` and assert the drag region on the action wrapper, removal of `mb-12`, and non-draggable behavior on each action button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55a7a168ff534c1ddc9b87c954b78be29d714003. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->