### PR TITLE
fix(desktop): show today in compact calendar

### DIFF
--- a/apps/desktop/src/calendar/components/calendar-view.tsx
+++ b/apps/desktop/src/calendar/components/calendar-view.tsx
@@ -7,6 +7,7 @@ import {
   format,
   isSameMonth,
   startOfMonth,
+  startOfDay,
   startOfWeek,
   subMonths,
 } from "date-fns";
@@ -66,7 +67,7 @@ export function CalendarView() {
   const weekStartsOn = useWeekStartsOn();
   const weekOpts = useMemo(() => ({ weekStartsOn }), [weekStartsOn]);
   const [currentMonth, setCurrentMonth] = useState(now);
-  const [weekStart, setWeekStart] = useState(() => startOfWeek(now, weekOpts));
+  const [visibleStart, setVisibleStart] = useState(() => startOfDay(now));
   const containerRef = useRef<HTMLDivElement>(null);
   const cols = useVisibleCols(containerRef);
   const calendarData = useCalendarData();
@@ -81,7 +82,7 @@ export function CalendarView() {
     if (isMonthView) {
       setCurrentMonth((m) => subMonths(m, 1));
     } else {
-      setWeekStart((d) => addDays(d, -cols));
+      setVisibleStart((d) => addDays(d, -cols));
     }
   }, [isMonthView, cols]);
 
@@ -89,14 +90,14 @@ export function CalendarView() {
     if (isMonthView) {
       setCurrentMonth((m) => addMonths(m, 1));
     } else {
-      setWeekStart((d) => addDays(d, cols));
+      setVisibleStart((d) => addDays(d, cols));
     }
   }, [isMonthView, cols]);
 
   const goToToday = useCallback(() => {
     setCurrentMonth(now);
-    setWeekStart(startOfWeek(now, weekOpts));
-  }, [now, weekOpts]);
+    setVisibleStart(startOfDay(now));
+  }, [now]);
 
   const days = useMemo(() => {
     if (isMonthView) {
@@ -108,10 +109,10 @@ export function CalendarView() {
     }
 
     return eachDayOfInterval({
-      start: weekStart,
-      end: addDays(weekStart, cols - 1),
+      start: visibleStart,
+      end: addDays(visibleStart, cols - 1),
     });
-  }, [currentMonth, isMonthView, cols, weekStart, weekOpts]);
+  }, [currentMonth, isMonthView, cols, visibleStart, weekOpts]);
 
   const visibleHeaders = useMemo(() => {
     if (isMonthView) {


### PR DESCRIPTION
Start compact calendar ranges at the current day when returning to today.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5378 
- <kbd>&nbsp;2&nbsp;</kbd> #5377 
- <kbd>&nbsp;1&nbsp;</kbd> #5376 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ed35ea4bca42606c375b843237afdbd254718611. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->