### PR TITLE
fix(desktop): separate calendar day columns

### DIFF
--- a/apps/desktop/src/calendar/components/calendar-view.tsx
+++ b/apps/desktop/src/calendar/components/calendar-view.tsx
@@ -177,6 +177,7 @@ export function CalendarView() {
             className={cn([
               "text-center text-xs font-medium",
               "py-2",
+              i < visibleHeaders.length - 1 && "border-r border-r-neutral-200",
               day === "Sat" || day === "Sun"
                 ? "text-neutral-400"
                 : "text-neutral-900",

--- a/apps/desktop/src/calendar/components/day-cell.tsx
+++ b/apps/desktop/src/calendar/components/day-cell.tsx
@@ -95,7 +95,7 @@ export function DayCell({
   return (
     <div
       className={cn([
-        "border-r border-b border-neutral-100",
+        "border-r border-b border-r-neutral-200 border-b-neutral-100",
         "flex min-w-0 flex-col p-1.5",
         (day.getDay() === 0 || day.getDay() === 6) && "bg-neutral-50",
       ])}


### PR DESCRIPTION
Add visible column dividers to calendar headers and day cells.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5378 
- <kbd>&nbsp;2&nbsp;</kbd> #5377 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5376 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only calendar layout tweaks with no logic, data, or security impact.
> 
> **Overview**
> The desktop calendar grid now shows clearer **vertical separators** between day columns.
> 
> Weekday header cells get a right border on every column except the last, using `border-r-neutral-200` so dividers align with the header row’s existing bottom border. **Day cells** use the same stronger right border while keeping the lighter bottom border (`border-b-neutral-100`), so column lines read consistently from the header through the grid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a04f5d130a9e1e9ee0d9657ab959e804b6afe46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->