### PR TITLE
fix(desktop): add compact calendar horizontal scroll

### DIFF
--- a/apps/desktop/src/calendar/components/calendar-view.tsx
+++ b/apps/desktop/src/calendar/components/calendar-view.tsx
@@ -40,6 +40,9 @@ const VIEW_BREAKPOINTS = [
   { minWidth: 0, cols: 1 },
 ] as const;
 
+const COMPACT_SCROLL_PAST_DAYS = 42;
+const COMPACT_SCROLL_FUTURE_DAYS = 42;
+
 function useVisibleCols(ref: React.RefObject<HTMLDivElement | null>) {
   const [cols, setCols] = useState(7);
 
@@ -68,7 +71,12 @@ export function CalendarView() {
   const weekOpts = useMemo(() => ({ weekStartsOn }), [weekStartsOn]);
   const [currentMonth, setCurrentMonth] = useState(now);
   const [visibleStart, setVisibleStart] = useState(() => startOfDay(now));
+  const [compactVisibleStart, setCompactVisibleStart] = useState(() =>
+    startOfDay(now),
+  );
   const containerRef = useRef<HTMLDivElement>(null);
+  const compactScrollRef = useRef<HTMLDivElement>(null);
+  const compactBaseRef = useRef(startOfDay(now));
   const cols = useVisibleCols(containerRef);
   const calendarData = useCalendarData();
 
@@ -78,25 +86,37 @@ export function CalendarView() {
 
   const isMonthView = cols === 7;
 
+  const advanceCompact = useCallback(
+    (direction: -1 | 1) => {
+      const next = addDays(compactBaseRef.current, direction * cols);
+      compactBaseRef.current = next;
+      setVisibleStart(next);
+    },
+    [cols],
+  );
+
   const goToPrev = useCallback(() => {
     if (isMonthView) {
       setCurrentMonth((m) => subMonths(m, 1));
     } else {
-      setVisibleStart((d) => addDays(d, -cols));
+      advanceCompact(-1);
     }
-  }, [isMonthView, cols]);
+  }, [isMonthView, advanceCompact]);
 
   const goToNext = useCallback(() => {
     if (isMonthView) {
       setCurrentMonth((m) => addMonths(m, 1));
     } else {
-      setVisibleStart((d) => addDays(d, cols));
+      advanceCompact(1);
     }
-  }, [isMonthView, cols]);
+  }, [isMonthView, advanceCompact]);
 
   const goToToday = useCallback(() => {
+    const todayStart = startOfDay(now);
+    compactBaseRef.current = todayStart;
     setCurrentMonth(now);
-    setVisibleStart(startOfDay(now));
+    setVisibleStart(todayStart);
+    setCompactVisibleStart(todayStart);
   }, [now]);
 
   const days = useMemo(() => {
@@ -109,17 +129,56 @@ export function CalendarView() {
     }
 
     return eachDayOfInterval({
-      start: visibleStart,
-      end: addDays(visibleStart, cols - 1),
+      start: addDays(visibleStart, -COMPACT_SCROLL_PAST_DAYS),
+      end: addDays(visibleStart, COMPACT_SCROLL_FUTURE_DAYS - 1),
     });
-  }, [currentMonth, isMonthView, cols, visibleStart, weekOpts]);
+  }, [currentMonth, isMonthView, visibleStart, weekOpts]);
 
-  const visibleHeaders = useMemo(() => {
+  const visibleHeaders =
+    weekStartsOn === 1 ? WEEKDAY_HEADERS_MON : WEEKDAY_HEADERS_SUN;
+
+  useEffect(() => {
     if (isMonthView) {
-      return weekStartsOn === 1 ? WEEKDAY_HEADERS_MON : WEEKDAY_HEADERS_SUN;
+      return;
     }
-    return days.slice(0, cols).map((d) => format(d, "EEE"));
-  }, [isMonthView, days, cols, weekStartsOn]);
+
+    const el = compactScrollRef.current;
+    if (el) {
+      const dayWidth = el.clientWidth / cols;
+      el.scrollTo({ left: COMPACT_SCROLL_PAST_DAYS * dayWidth });
+    }
+    compactBaseRef.current = visibleStart;
+    setCompactVisibleStart(visibleStart);
+  }, [isMonthView, visibleStart, cols]);
+
+  const handleCompactScroll = useCallback(() => {
+    const el = compactScrollRef.current;
+    if (!el || cols <= 0) {
+      return;
+    }
+
+    const dayWidth = el.clientWidth / cols;
+    if (dayWidth <= 0) {
+      return;
+    }
+
+    const maxStartIndex = Math.max(0, days.length - cols);
+    const startIndex = Math.min(
+      maxStartIndex,
+      Math.max(0, Math.round(el.scrollLeft / dayWidth)),
+    );
+    const nextStart = startOfDay(addDays(days[0], startIndex));
+
+    setCompactVisibleStart((prev) => {
+      if (prev.getTime() === nextStart.getTime()) {
+        return prev;
+      }
+      compactBaseRef.current = nextStart;
+      return nextStart;
+    });
+  }, [cols, days]);
+
+  const compactContentWidth = `${(days.length / cols) * 100}%`;
 
   return (
     <div ref={containerRef} className="flex h-full flex-col overflow-hidden">
@@ -133,9 +192,7 @@ export function CalendarView() {
           <h2 className="text-sm font-semibold text-neutral-900">
             {isMonthView
               ? format(currentMonth, "MMMM yyyy")
-              : days.length > 0
-                ? format(days[0], "MMMM yyyy")
-                : ""}
+              : format(compactVisibleStart, "MMMM yyyy")}
           </h2>
           <CalendarSyncHeaderControls />
         </div>
@@ -167,43 +224,88 @@ export function CalendarView() {
         </ButtonGroup>
       </div>
 
-      <div
-        className="grid border-b border-neutral-200"
-        style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
-      >
-        {visibleHeaders.map((day, i) => (
+      {isMonthView ? (
+        <>
           <div
-            key={`${day}-${i}`}
-            className={cn([
-              "text-center text-xs font-medium",
-              "py-2",
-              i < visibleHeaders.length - 1 && "border-r border-r-neutral-200",
-              day === "Sat" || day === "Sun"
-                ? "text-neutral-400"
-                : "text-neutral-900",
-            ])}
+            className="grid border-b border-neutral-200"
+            style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
           >
-            {day}
+            {visibleHeaders.map((day, i) => (
+              <div
+                key={`${day}-${i}`}
+                className={cn([
+                  "text-center text-xs font-medium",
+                  "py-2",
+                  i < visibleHeaders.length - 1 &&
+                    "border-r border-r-neutral-200",
+                  day === "Sat" || day === "Sun"
+                    ? "text-neutral-400"
+                    : "text-neutral-900",
+                ])}
+              >
+                {day}
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
 
-      <div
-        className={cn([
-          "grid flex-1 overflow-hidden",
-          isMonthView ? "auto-rows-fr" : "grid-rows-1",
-        ])}
-        style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
-      >
-        {days.map((day) => (
-          <DayCell
-            key={day.toISOString()}
-            day={day}
-            isCurrentMonth={isMonthView ? isSameMonth(day, currentMonth) : true}
-            calendarData={calendarData}
-          />
-        ))}
-      </div>
+          <div
+            className="grid flex-1 auto-rows-fr overflow-hidden"
+            style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+          >
+            {days.map((day) => (
+              <DayCell
+                key={day.toISOString()}
+                day={day}
+                isCurrentMonth={isSameMonth(day, currentMonth)}
+                calendarData={calendarData}
+              />
+            ))}
+          </div>
+        </>
+      ) : (
+        <div
+          ref={compactScrollRef}
+          className={cn([
+            "scrollbar-hide min-h-0 flex-1 overflow-x-auto overflow-y-hidden",
+            "snap-x snap-mandatory overscroll-x-contain",
+          ])}
+          onScroll={handleCompactScroll}
+        >
+          <div
+            className="grid h-full min-w-full grid-rows-[auto_minmax(0,1fr)]"
+            style={{
+              width: compactContentWidth,
+              gridTemplateColumns: `repeat(${days.length}, minmax(0, 1fr))`,
+            }}
+          >
+            {days.map((day) => {
+              const label = format(day, "EEE");
+              return (
+                <div
+                  key={`header-${day.toISOString()}`}
+                  className={cn([
+                    "snap-start border-r border-b border-r-neutral-200 border-b-neutral-200",
+                    "py-2 text-center text-xs font-medium",
+                    label === "Sat" || label === "Sun"
+                      ? "text-neutral-400"
+                      : "text-neutral-900",
+                  ])}
+                >
+                  {label}
+                </div>
+              );
+            })}
+            {days.map((day) => (
+              <DayCell
+                key={day.toISOString()}
+                day={day}
+                isCurrentMonth={true}
+                calendarData={calendarData}
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Render a snapping horizontal day strip for compact calendar widths while preserving the full month grid.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5378 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #5377 
- <kbd>&nbsp;1&nbsp;</kbd> #5376 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only calendar layout and scroll/navigation logic in one component, with no auth, sync, or data-layer changes.
> 
> **Overview**
> For **narrow calendar layouts** (fewer than seven columns), the desktop calendar no longer shows only a fixed `cols`-wide slice. It now renders a **horizontally scrollable day strip** with CSS scroll snapping, a hidden scrollbar, and roughly **42 days** of history and future around the anchor date so users can swipe through time.
> 
> **Navigation and header behavior** in compact mode are wired to that strip: prev/next advance by `cols` days via a shared base ref, **Today** resets scroll state, the title month follows **scroll position** (`compactVisibleStart`), and scroll handlers keep the visible start index in sync with snap positions. **Full month view** (`cols === 7`) is unchanged—a static weekday header row and month grid with `isCurrentMonth` dimming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6db7b389e0b82c45eb13d7319c863a18ff3b4b70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->