### PR TITLE
fix(desktop): add calendar chip context menus

### DIFF
--- a/apps/desktop/src/calendar/components/day-cell.tsx
+++ b/apps/desktop/src/calendar/components/day-cell.tsx
@@ -96,7 +96,7 @@ export function DayCell({
     <div
       className={cn([
         "border-r border-b border-r-neutral-200 border-b-neutral-100",
-        "flex min-w-0 flex-col p-1.5",
+        "flex min-w-0 flex-col p-1.5 select-none",
         (day.getDay() === 0 || day.getDay() === 6) && "bg-neutral-50",
       ])}
     >

--- a/apps/desktop/src/calendar/components/event-chip.tsx
+++ b/apps/desktop/src/calendar/components/event-chip.tsx
@@ -1,5 +1,5 @@
 import { format } from "date-fns";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import { Button } from "@hypr/ui/components/ui/button";
 import {
@@ -12,7 +12,11 @@ import { cn } from "@hypr/utils";
 
 import { toTz, useCalendar, useTimezone } from "~/calendar/hooks";
 import { EventDisplay } from "~/session/components/outer-header/metadata";
-import { useEvent } from "~/store/tinybase/hooks";
+import {
+  type MenuItemDef,
+  useNativeContextMenu,
+} from "~/shared/hooks/useNativeContextMenu";
+import { useEvent, useIgnoredEvents } from "~/store/tinybase/hooks";
 import * as main from "~/store/tinybase/store/main";
 import { getOrCreateSessionForEventId } from "~/store/tinybase/store/sessions";
 import { useTabs } from "~/store/zustand/tabs";
@@ -24,6 +28,9 @@ function useCalendarColor(calendarId: string | null): string | null {
 
 export function EventChip({ eventId }: { eventId: string }) {
   const tz = useTimezone();
+  const store = main.UI.useStore(main.STORE_ID);
+  const openNew = useTabs((state) => state.openNew);
+  const { ignoreEvent, ignoreSeries } = useIgnoredEvents();
   const event = main.UI.useResultRow(
     main.QUERIES.timelineEvents,
     eventId,
@@ -32,17 +39,71 @@ export function EventChip({ eventId }: { eventId: string }) {
   const calendarColor = useCalendarColor(
     (event?.calendar_id as string) ?? null,
   );
-
-  if (!event || !event.title) {
-    return null;
-  }
-
-  const isAllDay = !!event.is_all_day;
+  const title = event?.title as string | undefined;
+  const trackingId = event?.tracking_id_event as string | undefined;
+  const recurrenceSeriesId = event?.recurrence_series_id as string | undefined;
+  const isAllDay = !!event?.is_all_day;
   const color = calendarColor ?? "#888";
 
-  const startedAt = event.started_at
+  const startedAt = event?.started_at
     ? format(toTz(event.started_at as string, tz), "h:mm a")
     : null;
+
+  const handleOpenNewTab = useCallback(() => {
+    if (!store || !title) {
+      return;
+    }
+
+    const sessionId = getOrCreateSessionForEventId(store, eventId, title);
+    openNew({ type: "sessions", id: sessionId });
+  }, [store, eventId, title, openNew]);
+
+  const handleIgnore = useCallback(() => {
+    if (!trackingId) {
+      return;
+    }
+
+    ignoreEvent(trackingId);
+  }, [trackingId, ignoreEvent]);
+
+  const handleIgnoreSeries = useCallback(() => {
+    if (!recurrenceSeriesId) {
+      return;
+    }
+
+    ignoreSeries(recurrenceSeriesId);
+  }, [recurrenceSeriesId, ignoreSeries]);
+
+  const contextMenu = useMemo<MenuItemDef[]>(() => {
+    const menu: MenuItemDef[] = [
+      {
+        id: "open-new-tab",
+        text: "Open in New Tab",
+        action: handleOpenNewTab,
+      },
+      { separator: true },
+      {
+        id: "ignore",
+        text: recurrenceSeriesId ? "Delete This Event" : "Delete Event",
+        action: handleIgnore,
+      },
+    ];
+
+    if (recurrenceSeriesId) {
+      menu.push({
+        id: "ignore-series",
+        text: "Delete All Recurring Events",
+        action: handleIgnoreSeries,
+      });
+    }
+
+    return menu;
+  }, [recurrenceSeriesId, handleOpenNewTab, handleIgnore, handleIgnoreSeries]);
+  const showContextMenu = useNativeContextMenu(contextMenu);
+
+  if (!event || !title) {
+    return null;
+  }
 
   return (
     <Popover>
@@ -51,24 +112,26 @@ export function EventChip({ eventId }: { eventId: string }) {
           <button
             className={cn([
               "w-full truncate rounded px-1.5 py-0.5 text-left text-xs leading-tight text-white",
-              "cursor-pointer hover:opacity-80",
+              "cursor-pointer select-none hover:opacity-80",
             ])}
             style={{ backgroundColor: color }}
+            onContextMenu={showContextMenu}
           >
-            {event.title as string}
+            {title}
           </button>
         ) : (
           <button
             className={cn([
               "flex w-full items-center gap-1 rounded pl-0.5 text-left text-xs leading-tight",
-              "cursor-pointer hover:opacity-80",
+              "cursor-pointer select-none hover:opacity-80",
             ])}
+            onContextMenu={showContextMenu}
           >
             <div
               className="w-[2.5px] shrink-0 self-stretch rounded-full"
               style={{ backgroundColor: color }}
             />
-            <span className="truncate">{event.title as string}</span>
+            <span className="truncate">{title}</span>
             {startedAt && (
               <span className="ml-auto shrink-0 font-mono text-neutral-400">
                 {startedAt}

--- a/apps/desktop/src/calendar/components/session-chip.tsx
+++ b/apps/desktop/src/calendar/components/session-chip.tsx
@@ -1,6 +1,8 @@
 import { format } from "date-fns";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
+import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
+import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { Button } from "@hypr/ui/components/ui/button";
 import {
   AppFloatingPanel,
@@ -11,24 +13,111 @@ import {
 import { cn } from "@hypr/utils";
 
 import { toTz, useTimezone } from "~/calendar/hooks";
+import { getSessionEvent } from "~/session/utils";
+import {
+  type MenuItemDef,
+  useNativeContextMenu,
+} from "~/shared/hooks/useNativeContextMenu";
+import { useIgnoredEvents } from "~/store/tinybase/hooks";
+import {
+  captureSessionData,
+  deleteSessionCascade,
+  finalizeSessionDeletion,
+} from "~/store/tinybase/store/deleteSession";
 import * as main from "~/store/tinybase/store/main";
 import { useTabs } from "~/store/zustand/tabs";
+import { useUndoDelete } from "~/store/zustand/undo-delete";
 
 export function SessionChip({ sessionId }: { sessionId: string }) {
   const tz = useTimezone();
+  const store = main.UI.useStore(main.STORE_ID);
+  const indexes = main.UI.useIndexes(main.STORE_ID);
+  const openNew = useTabs((state) => state.openNew);
+  const invalidateResource = useTabs((state) => state.invalidateResource);
+  const addDeletion = useUndoDelete((state) => state.addDeletion);
+  const { ignoreEvent } = useIgnoredEvents();
   const session = main.UI.useResultRow(
     main.QUERIES.timelineSessions,
     sessionId,
     main.STORE_ID,
   );
-
-  if (!session || !session.title) {
-    return null;
-  }
-
-  const createdAt = session.created_at
+  const title = session?.title as string | undefined;
+  const eventJson = session?.event_json as string | null | undefined;
+  const createdAt = session?.created_at
     ? format(toTz(session.created_at as string, tz), "h:mm a")
     : null;
+
+  const handleOpenNewTab = useCallback(() => {
+    openNew({ type: "sessions", id: sessionId });
+  }, [openNew, sessionId]);
+
+  const handleShowInFinder = useCallback(async () => {
+    const result = await fsSyncCommands.sessionDir(sessionId);
+    if (result.status === "ok") {
+      await openerCommands.openPath(result.data, null);
+    }
+  }, [sessionId]);
+
+  const handleDelete = useCallback(() => {
+    if (!store) {
+      return;
+    }
+
+    const sessionEvent = getSessionEvent({
+      event_json: eventJson,
+    });
+    if (sessionEvent?.tracking_id) {
+      ignoreEvent(sessionEvent.tracking_id);
+    }
+
+    const capturedData = captureSessionData(store, indexes, sessionId);
+
+    invalidateResource("sessions", sessionId);
+    void deleteSessionCascade(store, indexes, sessionId, {
+      deferFilesystemDelete: true,
+    });
+
+    if (capturedData) {
+      addDeletion(capturedData, () => {
+        void finalizeSessionDeletion(sessionId);
+      });
+    }
+  }, [
+    store,
+    indexes,
+    sessionId,
+    eventJson,
+    ignoreEvent,
+    invalidateResource,
+    addDeletion,
+  ]);
+
+  const contextMenu = useMemo<MenuItemDef[]>(
+    () => [
+      {
+        id: "open-new-tab",
+        text: "Open in New Tab",
+        action: handleOpenNewTab,
+      },
+      {
+        id: "show",
+        text: "Show in Finder",
+        action: handleShowInFinder,
+      },
+      { separator: true },
+      {
+        id: "delete",
+        text: "Delete Note",
+        action: handleDelete,
+      },
+    ],
+    [handleOpenNewTab, handleShowInFinder, handleDelete],
+  );
+  const showContextMenu = useNativeContextMenu(contextMenu);
+
+  if (!session || !title) {
+    return null;
+  }
 
   return (
     <Popover>
@@ -36,11 +125,12 @@ export function SessionChip({ sessionId }: { sessionId: string }) {
         <button
           className={cn([
             "flex w-full items-center gap-1 rounded pl-0.5 text-left text-xs leading-tight",
-            "cursor-pointer hover:opacity-80",
+            "cursor-pointer select-none hover:opacity-80",
           ])}
+          onContextMenu={showContextMenu}
         >
           <div className="w-[4px] shrink-0 self-stretch rounded-full border border-neutral-300 bg-transparent" />
-          <span className="truncate">{session.title as string}</span>
+          <span className="truncate">{title}</span>
           {createdAt && (
             <span className="ml-auto shrink-0 font-mono text-neutral-400">
               {createdAt}

--- a/apps/desktop/src/calendar/components/session-chip.tsx
+++ b/apps/desktop/src/calendar/components/session-chip.tsx
@@ -13,29 +13,19 @@ import {
 import { cn } from "@hypr/utils";
 
 import { toTz, useTimezone } from "~/calendar/hooks";
+import { useDeleteSession } from "~/session/hooks/useDeleteSession";
 import { getSessionEvent } from "~/session/utils";
 import {
   type MenuItemDef,
   useNativeContextMenu,
 } from "~/shared/hooks/useNativeContextMenu";
-import { useIgnoredEvents } from "~/store/tinybase/hooks";
-import {
-  captureSessionData,
-  deleteSessionCascade,
-  finalizeSessionDeletion,
-} from "~/store/tinybase/store/deleteSession";
 import * as main from "~/store/tinybase/store/main";
 import { useTabs } from "~/store/zustand/tabs";
-import { useUndoDelete } from "~/store/zustand/undo-delete";
 
 export function SessionChip({ sessionId }: { sessionId: string }) {
   const tz = useTimezone();
-  const store = main.UI.useStore(main.STORE_ID);
-  const indexes = main.UI.useIndexes(main.STORE_ID);
   const openNew = useTabs((state) => state.openNew);
-  const invalidateResource = useTabs((state) => state.invalidateResource);
-  const addDeletion = useUndoDelete((state) => state.addDeletion);
-  const { ignoreEvent } = useIgnoredEvents();
+  const deleteSession = useDeleteSession();
   const session = main.UI.useResultRow(
     main.QUERIES.timelineSessions,
     sessionId,
@@ -59,38 +49,9 @@ export function SessionChip({ sessionId }: { sessionId: string }) {
   }, [sessionId]);
 
   const handleDelete = useCallback(() => {
-    if (!store) {
-      return;
-    }
-
-    const sessionEvent = getSessionEvent({
-      event_json: eventJson,
-    });
-    if (sessionEvent?.tracking_id) {
-      ignoreEvent(sessionEvent.tracking_id);
-    }
-
-    const capturedData = captureSessionData(store, indexes, sessionId);
-
-    invalidateResource("sessions", sessionId);
-    void deleteSessionCascade(store, indexes, sessionId, {
-      deferFilesystemDelete: true,
-    });
-
-    if (capturedData) {
-      addDeletion(capturedData, () => {
-        void finalizeSessionDeletion(sessionId);
-      });
-    }
-  }, [
-    store,
-    indexes,
-    sessionId,
-    eventJson,
-    ignoreEvent,
-    invalidateResource,
-    addDeletion,
-  ]);
+    const sessionEvent = getSessionEvent({ event_json: eventJson });
+    deleteSession(sessionId, sessionEvent?.tracking_id);
+  }, [deleteSession, sessionId, eventJson]);
 
   const contextMenu = useMemo<MenuItemDef[]>(
     () => [

--- a/apps/desktop/src/main/top-meeting-timeline.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.tsx
@@ -48,6 +48,7 @@ import {
 } from "./meeting-timeline-recordings";
 
 import { SessionPreviewCard } from "~/session/components/session-preview-card";
+import { useDeleteSession } from "~/session/hooks/useDeleteSession";
 import { useIsSessionEnhancing } from "~/session/hooks/useEnhancedNotes";
 import { getSessionEvent } from "~/session/utils";
 import { useConfigValue } from "~/shared/config";
@@ -64,16 +65,10 @@ import type {
   TimelineSessionsTable,
 } from "~/sidebar/timeline/utils";
 import { useIgnoredEvents } from "~/store/tinybase/hooks";
-import {
-  captureSessionData,
-  deleteSessionCascade,
-  finalizeSessionDeletion,
-} from "~/store/tinybase/store/deleteSession";
 import * as main from "~/store/tinybase/store/main";
 import { getOrCreateSessionForEventId } from "~/store/tinybase/store/sessions";
 import { useSessionTitle } from "~/store/zustand/live-title";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
-import { useUndoDelete } from "~/store/zustand/undo-delete";
 import { useListener } from "~/stt/contexts";
 
 const TIMELINE_HEIGHT = 44;
@@ -531,12 +526,8 @@ function TopCurrentTimeIndicator({
 
 const SessionTimelineBar = memo(
   ({ item, timezone }: { item: MeetingTimelineEntry; timezone?: string }) => {
-    const store = main.UI.useStore(main.STORE_ID);
-    const indexes = main.UI.useIndexes(main.STORE_ID);
     const openNew = useTabs((state) => state.openNew);
-    const invalidateResource = useTabs((state) => state.invalidateResource);
-    const addDeletion = useUndoDelete((state) => state.addDeletion);
-    const { ignoreEvent } = useIgnoredEvents();
+    const deleteSession = useDeleteSession();
     const sessionRow = main.UI.useRow("sessions", item.id, main.STORE_ID) as
       | TimelineSessionRow
       | undefined;
@@ -568,35 +559,8 @@ const SessionTimelineBar = memo(
     }, [item.id, openNew]);
 
     const handleDelete = useCallback(() => {
-      if (!store) {
-        return;
-      }
-
-      if (sessionEvent?.tracking_id) {
-        ignoreEvent(sessionEvent.tracking_id);
-      }
-
-      const capturedData = captureSessionData(store, indexes, item.id);
-
-      invalidateResource("sessions", item.id);
-      void deleteSessionCascade(store, indexes, item.id, {
-        deferFilesystemDelete: true,
-      });
-
-      if (capturedData) {
-        addDeletion(capturedData, () => {
-          void finalizeSessionDeletion(item.id);
-        });
-      }
-    }, [
-      store,
-      indexes,
-      item.id,
-      sessionEvent,
-      ignoreEvent,
-      invalidateResource,
-      addDeletion,
-    ]);
+      deleteSession(item.id, sessionEvent?.tracking_id);
+    }, [deleteSession, item.id, sessionEvent]);
 
     const handleShowInFinder = useCallback(async () => {
       const result = await fsSyncCommands.sessionDir(item.id);

--- a/apps/desktop/src/session/hooks/useDeleteSession.ts
+++ b/apps/desktop/src/session/hooks/useDeleteSession.ts
@@ -1,0 +1,45 @@
+import { useCallback } from "react";
+
+import { useIgnoredEvents } from "~/store/tinybase/hooks";
+import {
+  captureSessionData,
+  deleteSessionCascade,
+  finalizeSessionDeletion,
+} from "~/store/tinybase/store/deleteSession";
+import * as main from "~/store/tinybase/store/main";
+import { useTabs } from "~/store/zustand/tabs";
+import { useUndoDelete } from "~/store/zustand/undo-delete";
+
+export function useDeleteSession() {
+  const store = main.UI.useStore(main.STORE_ID);
+  const indexes = main.UI.useIndexes(main.STORE_ID);
+  const invalidateResource = useTabs((state) => state.invalidateResource);
+  const addDeletion = useUndoDelete((state) => state.addDeletion);
+  const { ignoreEvent } = useIgnoredEvents();
+
+  return useCallback(
+    (sessionId: string, trackingId?: string | null) => {
+      if (!store) {
+        return;
+      }
+
+      if (trackingId) {
+        ignoreEvent(trackingId);
+      }
+
+      const capturedData = captureSessionData(store, indexes, sessionId);
+
+      invalidateResource("sessions", sessionId);
+      void deleteSessionCascade(store, indexes, sessionId, {
+        deferFilesystemDelete: true,
+      });
+
+      if (capturedData) {
+        addDeletion(capturedData, () => {
+          void finalizeSessionDeletion(sessionId);
+        });
+      }
+    },
+    [store, indexes, ignoreEvent, invalidateResource, addDeletion],
+  );
+}


### PR DESCRIPTION
Show native sidebar-style context menus for calendar event and session chips.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Context menus trigger ignore-event and cascade session deletion with undo; behavior is refactored into a shared hook but still mutates local store and filesystem on finalize.
> 
> **Overview**
> Adds **native (Tauri) context menus** to calendar **event** and **session** chips, aligned with the top meeting timeline: open in a new tab, delete/ignore calendar events (including recurring series), show session folder in Finder, and delete notes.
> 
> Session deletion logic is **centralized** in a new `useDeleteSession` hook and wired from the meeting timeline and calendar session chips instead of inlined store/undo code.
> 
> Calendar day cells and chip buttons get **`select-none`** to reduce accidental text selection when right-clicking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9de4a5e1b61880ae316c0a03b7d419563755e071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->