### PR TITLE
fix(desktop): tuck FAB near caret

### DIFF
--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -106,6 +106,24 @@ describe("FloatingActionButton", () => {
     expect(wrapper?.className).toContain("group-hover:translate-y-0");
   });
 
+  it("tucks the chat FAB near the editor caret and reveals it from the hover zone", () => {
+    hoisted.isCaretNearBottom = true;
+
+    render(<FloatingActionButton tab={tab} />);
+
+    const wrapper = screen.getByText("Ask Anarlog anything").parentElement;
+    const hoverZone = wrapper?.parentElement;
+
+    expect(hoverZone?.className).toContain("group");
+    expect(hoverZone?.className).toContain("pointer-events-auto");
+    expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
+    expect(wrapper?.style.getPropertyValue("--floating-fab-tuck-offset")).toBe(
+      "calc(100% - 0.5rem + 18px)",
+    );
+    expect(wrapper?.className).toContain("group-hover:pointer-events-auto");
+    expect(wrapper?.className).toContain("group-hover:translate-y-0");
+  });
+
   it("tucks the listen FAB near the editor caret instead of scroll state", () => {
     hoisted.hasTranscript = false;
     hoisted.isCaretNearBottom = true;

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -30,7 +30,8 @@ export function FloatingActionButton({
   const showAction = shouldShowListen || shouldShowChat;
   const tuckAction =
     !showSkipReason &&
-    ((shouldShowListen && isCaretNearBottom) || (shouldShowChat && hidden));
+    showAction &&
+    (isCaretNearBottom || (shouldShowChat && hidden));
 
   if (!showSkipReason && !showAction) {
     return null;


### PR DESCRIPTION
Tuck the active session floating button when the editor caret is near the bottom and cover the chat hover reveal behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop session UI and FAB positioning only; behavior is covered by new and existing unit tests.
> 
> **Overview**
> **Unifies when the session floating action button tucks** so any visible FAB (chat or listen) moves down when the editor caret is near the bottom, not only the listen button in that case or chat when scroll-hidden.
> 
> The `tuckAction` condition in `FloatingActionButton` now requires an active action and tucks on `isCaretNearBottom` **or** the existing chat-only `hidden` peek behavior. A new test covers the chat FAB tucking at the caret with the same hover-zone reveal (`group-hover:translate-y-0`) as the hidden-chat case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9999afa4f1b70afbcdf0e327ea2da7725c2a7c8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->