### PR TITLE
fix(editor): always show paragraph below images

### DIFF
--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -49,9 +49,11 @@ import {
   SearchQuery,
   clearMarksOnEnterPlugin,
   clipPastePlugin,
+  ensureImageTrailingParagraphs,
   fileHandlerPlugin,
   getSearchState,
   hashtagPlugin,
+  imageTrailingParagraphPlugin,
   linkBoundaryGuardPlugin,
   placeholderPlugin,
   searchPlugin,
@@ -368,20 +370,24 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       [initialContent],
     );
     const reconciledInitialContent = useMemo(() => {
-      if (!normalizedInitialContent || !taskSource || !taskStorage) {
+      if (!normalizedInitialContent) {
         return normalizedInitialContent;
       }
 
-      const sourceTasks = taskStorage.getTasksForSource(taskSource);
-      if (sourceTasks.length === 0) {
-        return normalizedInitialContent;
-      }
+      const hydrated =
+        taskSource && taskStorage
+          ? (() => {
+              const sourceTasks = taskStorage.getTasksForSource(taskSource);
+              if (sourceTasks.length === 0) return normalizedInitialContent;
+              return hydrateTaskContent({
+                content: normalizedInitialContent,
+                sourceTasks,
+                getTask: taskStorage.getTask,
+              });
+            })()
+          : normalizedInitialContent;
 
-      return hydrateTaskContent({
-        content: normalizedInitialContent,
-        sourceTasks,
-        getTask: taskStorage.getTask,
-      });
+      return ensureImageTrailingParagraphs(hydrated);
     }, [normalizedInitialContent, taskSource, taskStorage]);
     const previousContentRef = useRef<JSONContent | undefined>(
       reconciledInitialContent,
@@ -440,6 +446,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         dropCursor(),
         gapCursor(),
         hashtagPlugin(),
+        imageTrailingParagraphPlugin(),
         searchPlugin(),
         placeholderPlugin(placeholderComponent),
         clearMarksOnEnterPlugin(),

--- a/packages/editor/src/plugins/image-trailing-paragraph.ts
+++ b/packages/editor/src/plugins/image-trailing-paragraph.ts
@@ -1,0 +1,57 @@
+import { Plugin, PluginKey } from "prosemirror-state";
+
+type JSONContent = {
+  type?: string;
+  content?: JSONContent[];
+};
+
+export function ensureImageTrailingParagraphs<T extends JSONContent>(
+  content: T,
+): T {
+  if (content.type !== "doc" || !content.content) return content;
+
+  const next: JSONContent[] = [];
+  for (let i = 0; i < content.content.length; i++) {
+    const child = content.content[i];
+    next.push(child);
+    if (child.type === "image") {
+      const after = content.content[i + 1];
+      if (!after || after.type !== "paragraph") {
+        next.push({ type: "paragraph" });
+      }
+    }
+  }
+  if (next.length === content.content.length) return content;
+  return { ...content, content: next as T["content"] };
+}
+
+export function imageTrailingParagraphPlugin() {
+  return new Plugin({
+    key: new PluginKey("imageTrailingParagraph"),
+    appendTransaction(transactions, _oldState, newState) {
+      if (!transactions.some((tr) => tr.docChanged)) return null;
+
+      const { doc, schema } = newState;
+      const imageType = schema.nodes.image;
+      const paragraphType = schema.nodes.paragraph;
+      if (!imageType || !paragraphType) return null;
+
+      const insertions: number[] = [];
+      doc.content.forEach((child, offset, index) => {
+        if (child.type !== imageType) return;
+        const next = doc.maybeChild(index + 1);
+        if (!next || next.type !== paragraphType) {
+          insertions.push(offset + child.nodeSize);
+        }
+      });
+
+      if (insertions.length === 0) return null;
+
+      const tr = newState.tr;
+      for (let i = insertions.length - 1; i >= 0; i--) {
+        tr.insert(insertions[i], paragraphType.create());
+      }
+      return tr;
+    },
+  });
+}

--- a/packages/editor/src/plugins/index.ts
+++ b/packages/editor/src/plugins/index.ts
@@ -10,6 +10,10 @@ export {
 } from "./clip-paste";
 export { type FileHandlerConfig, fileHandlerPlugin } from "./file-handler";
 export { findHashtags, hashtagPlugin, hashtagPluginKey } from "./hashtag";
+export {
+  ensureImageTrailingParagraphs,
+  imageTrailingParagraphPlugin,
+} from "./image-trailing-paragraph";
 export { linkBoundaryGuardPlugin } from "./link-boundary-guard";
 export {
   type PlaceholderFunction,


### PR DESCRIPTION
Always keep an empty paragraph after image blocks so the slash-command placeholder is visible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized editor document-shape fix with no auth, persistence, or API surface changes.
> 
> **Overview**
> The note editor now **guarantees an empty paragraph immediately after every top-level image block**, so users always have a textblock to focus in and see slash-command / empty-block placeholders below images.
> 
> A new **`image-trailing-paragraph`** helper runs in two places: **`ensureImageTrailingParagraphs`** mutates loaded JSON (including after task hydration) before the doc is created, and **`imageTrailingParagraphPlugin`** uses `appendTransaction` to insert missing paragraphs whenever the document changes. **`NoteEditor`** registers the plugin and applies the JSON normalizer in the existing initial-content reconciliation path (task hydration logic is unchanged in behavior, only reorganized).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dae9515061aa9566905eb0afbf188e482765d738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->