### PR TITLE
fix(desktop): restore session panel divider

### DIFF
--- a/apps/desktop/src/audio-player/timeline.tsx
+++ b/apps/desktop/src/audio-player/timeline.tsx
@@ -175,7 +175,7 @@ export function Timeline() {
       main={
         <div
           ref={registerContainer}
-          className="h-6 min-w-0 flex-1 -translate-y-px"
+          className="h-6 min-w-0 flex-1"
           style={{ width: "100%" }}
         />
       }

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
@@ -78,6 +78,15 @@ describe("DuringSessionAccessory", () => {
     expect(view.container.firstChild).toBeNull();
   });
 
+  it("balances collapsed live transcript bottom padding with the top handle spacing", () => {
+    render(<DuringSessionAccessory sessionId="session-1" />);
+
+    const message = screen.getByText("All right, let's see.");
+    const row = message.parentElement?.parentElement;
+    expect(row?.className).toContain("pt-0.5");
+    expect(row?.className).toContain("pb-2");
+  });
+
   it("lets manual scrolling override expanded live transcript bottom pinning", () => {
     const view = render(
       <DuringSessionAccessory sessionId="session-1" isExpanded />,

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -235,7 +235,7 @@ function CollapsedFooterMessage({ message }: { message: string }) {
   return (
     <div
       className={cn([
-        "flex min-h-7 items-center gap-2 px-2 py-0.5",
+        "flex min-h-7 items-center gap-2 px-2 pt-0.5 pb-2",
         "w-full max-w-full",
       ])}
     >

--- a/apps/desktop/src/session/components/bottom-accessory/expand-toggle.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/expand-toggle.test.tsx
@@ -1,0 +1,18 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ExpandToggle } from "./expand-toggle";
+
+describe("ExpandToggle", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("masks only the divider segment under the handle", () => {
+    render(<ExpandToggle isExpanded onToggle={vi.fn()} label="Transcript" />);
+
+    expect(screen.getByRole("button").className).toContain("after:-bottom-px");
+    expect(screen.getByRole("button").className).toContain("after:h-0.5");
+    expect(screen.getByRole("button").className).toContain("after:bg-inherit");
+  });
+});

--- a/apps/desktop/src/session/components/bottom-accessory/expand-toggle.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/expand-toggle.tsx
@@ -28,6 +28,7 @@ export function ExpandToggle({
         "relative flex h-5 items-center justify-center gap-1",
         hasLabel ? "px-3" : "w-10",
         "rounded-t-[10px] rounded-b-none border-x border-t border-neutral-200",
+        "after:pointer-events-none after:absolute after:right-px after:-bottom-px after:left-px after:h-0.5 after:bg-inherit after:content-['']",
         "text-neutral-400",
         isExpanded
           ? (expandedClassName ?? "bg-white")

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -202,6 +202,7 @@ describe("PostSessionAccessory", () => {
     const collapsedSlotClassName =
       screen.getByTestId("timeline").parentElement?.className;
     expect(collapsedSlotClassName).toContain("h-10");
+    expect(collapsedSlotClassName).toContain("-mt-1.5");
 
     unmount();
 
@@ -215,9 +216,10 @@ describe("PostSessionAccessory", () => {
       />,
     );
 
-    expect(screen.getByTestId("timeline").parentElement?.className).toBe(
-      collapsedSlotClassName,
-    );
+    const expandedSlotClassName =
+      screen.getByTestId("timeline").parentElement?.className;
+    expect(expandedSlotClassName).toContain("h-10");
+    expect(expandedSlotClassName).not.toContain("-mt-1.5");
   });
 
   it("lets expanded transcript content fill the resizable bottom panel", () => {

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -75,14 +75,29 @@ export function PostSessionAccessory({
           />
         </div>
       ) : null}
-      {timeline ? <TimelineSlot>{timeline}</TimelineSlot> : null}
+      {timeline ? (
+        <TimelineSlot flushTop={!isTranscriptExpanded}>{timeline}</TimelineSlot>
+      ) : null}
     </div>
   );
 }
 
-function TimelineSlot({ children }: { children: ReactNode }) {
+function TimelineSlot({
+  children,
+  flushTop = false,
+}: {
+  children: ReactNode;
+  flushTop?: boolean;
+}) {
   return (
-    <div className="flex h-10 w-full shrink-0 items-center">{children}</div>
+    <div
+      className={cn([
+        "flex h-10 w-full shrink-0 items-center",
+        flushTop && "-mt-1.5",
+      ])}
+    >
+      {children}
+    </div>
   );
 }
 
@@ -529,6 +544,7 @@ function TranscriptCard({
 }) {
   return (
     <div
+      data-session-transcript-card
       className={cn([
         "overflow-hidden rounded-b-xl border border-neutral-200 bg-white",
         fillHeight && "flex h-full flex-col",

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -301,8 +301,15 @@ function TabContentNoteInner({
     bottomAccessoryState?.mode === "live" ||
     bottomAccessoryState?.mode === "playback" ||
     bottomAccessoryState?.mode === "transcript_only";
+  const hasResizableTranscriptSurface =
+    bottomAccessoryState?.mode === "live" ||
+    bottomAccessoryState?.mode === "transcript_only" ||
+    (bottomAccessoryState?.mode === "playback" &&
+      (hasTranscript || sessionMode === "running_batch"));
   const resizeTranscriptSurface =
-    bottomAccessoryState?.expanded === true && canResizeTranscriptSurface;
+    bottomAccessoryState?.expanded === true &&
+    canResizeTranscriptSurface &&
+    hasResizableTranscriptSurface;
 
   return (
     <SessionSurface

--- a/apps/desktop/src/shared/main/index.test.tsx
+++ b/apps/desktop/src/shared/main/index.test.tsx
@@ -97,6 +97,11 @@ describe("StandardTabWrapper", () => {
         .querySelector("[data-chat-floating-anchor]")
         ?.hasAttribute("data-main-has-after-border"),
     ).toBe(true);
+    expect(
+      document
+        .querySelector("[data-chat-floating-anchor]")
+        ?.hasAttribute("data-main-show-after-border-divider"),
+    ).toBe(true);
 
     const panels = screen.getAllByTestId("panel");
     expect(panels[0]?.dataset.defaultSize).toBe("78");
@@ -122,6 +127,16 @@ describe("StandardTabWrapper", () => {
     expect(screen.getByTestId("resize-handle").dataset.className).toContain(
       "data-[panel-group-direction=vertical]:h-0",
     );
+    expect(
+      document
+        .querySelector("[data-chat-floating-anchor]")
+        ?.hasAttribute("data-main-has-after-border"),
+    ).toBe(true);
+    expect(
+      document
+        .querySelector("[data-chat-floating-anchor]")
+        ?.hasAttribute("data-main-show-after-border-divider"),
+    ).toBe(true);
 
     const panels = screen.getAllByTestId("panel");
     expect(panels[1]?.dataset.className).toContain("min-h-[154px]");

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -147,6 +147,7 @@ function MainPanel({
       <div
         data-chat-floating-anchor
         data-main-has-after-border={afterBorder ? "" : undefined}
+        data-main-show-after-border-divider={afterBorder ? "" : undefined}
         className={cn([
           "relative flex min-h-0 flex-1 flex-col overflow-hidden bg-white",
           mergeAfterBorder && afterBorder
@@ -185,6 +186,8 @@ function AfterBorderContent({
 }) {
   return (
     <div
+      data-main-after-border-content
+      data-main-after-border-merged={mergeAfterBorder ? "" : undefined}
       className={cn([
         !mergeAfterBorder && (bottomBorderHandle ? "pt-1.5" : "mt-1"),
         fill && "flex h-full min-h-0 flex-col overflow-hidden",

--- a/apps/desktop/src/shared/main/shell-scaffold.test.tsx
+++ b/apps/desktop/src/shared/main/shell-scaffold.test.tsx
@@ -51,6 +51,15 @@ describe("MainShellScaffold", () => {
       "[&_[data-chat-floating-anchor]]:border-b-0",
     );
     expect(shell.className).toContain(
+      "[&_[data-chat-floating-anchor][data-main-show-after-border-divider]]:!border-b",
+    );
+    expect(shell.className).toContain(
+      "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-x-0",
+    );
+    expect(shell.className).toContain(
+      "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-t-0",
+    );
+    expect(shell.className).toContain(
       "[&_[data-chat-floating-anchor]]:border-t",
     );
   });
@@ -80,10 +89,16 @@ describe("MainShellScaffold", () => {
       "[&_[data-chat-floating-anchor]]:border-y-0",
     );
     expect(shell.className).toContain(
+      "[&_[data-chat-floating-anchor][data-main-show-after-border-divider]]:!border-b",
+    );
+    expect(shell.className).toContain(
       "[&_[data-chat-floating-anchor]]:border-r-0",
     );
     expect(shell.className).toContain(
       "[&_[data-chat-floating-anchor]]:border-l",
+    );
+    expect(shell.className).toContain(
+      "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-t-0",
     );
   });
 });

--- a/apps/desktop/src/shared/main/shell-scaffold.tsx
+++ b/apps/desktop/src/shared/main/shell-scaffold.tsx
@@ -32,14 +32,19 @@ export function MainShellScaffold({
             "[&_[data-chat-floating-anchor]]:border-x-0",
             "[&_[data-chat-floating-anchor]]:border-t",
             "[&_[data-chat-floating-anchor]]:border-b-0",
+            "[&_[data-chat-floating-anchor][data-main-show-after-border-divider]]:!border-b",
+            "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-x-0",
+            "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-t-0",
           ],
           resolvedMainSurfaceChrome === "left" && [
             "[&_[data-chat-floating-anchor]]:rounded-l-xl",
             "[&_[data-chat-floating-anchor]]:rounded-r-none",
             "[&_[data-chat-floating-anchor][data-main-has-after-border]]:rounded-bl-none",
             "[&_[data-chat-floating-anchor]]:border-y-0",
+            "[&_[data-chat-floating-anchor][data-main-show-after-border-divider]]:!border-b",
             "[&_[data-chat-floating-anchor]]:border-r-0",
             "[&_[data-chat-floating-anchor]]:border-l",
+            "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-t-0",
           ],
         ])}
         data-testid="main-app-shell"


### PR DESCRIPTION
Show the main surface bottom border when session bottom accessory content is attached so notes and the live/transcript panel remain visually separated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop session UI spacing, borders, and resize gating only; no auth, data, or backend changes.
> 
> **Overview**
> Restores a visible **separator between the notes area and the session bottom accessory** (live transcript / playback) by driving a bottom border on the main surface when bottom content is present, including in merged and edge-to-edge shell layouts.
> 
> **Layout polish** for the transcript handle and collapsed states: the expand control **masks the divider** under the tab, collapsed live preview **padding** is rebalanced, and the post-session **timeline row** uses a small negative top margin only when the transcript is collapsed so height stays stable when expanded.
> 
> **Resize behavior** is tightened so the vertical split applies only when there is something meaningful to resize (e.g. playback without a transcript is excluded unless batch transcription is running). Merged transcript surfaces drop redundant borders on the transcript card via new data attributes and shell selectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b067a902de440d21af3f141bc37d9cb62b7647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->