### PR TITLE
fix(desktop): hide timeline now marker while live

### DIFF
--- a/apps/desktop/src/main/top-meeting-timeline.test.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.test.tsx
@@ -398,7 +398,7 @@ describe("TopMeetingTimeline", () => {
     );
   });
 
-  it("places the current time marker at the edge of active ad-hoc meetings", () => {
+  it("hides the current time marker during active ad-hoc meetings", () => {
     const now = new Date("2026-05-29T15:41:00.000Z");
     vi.useFakeTimers();
     vi.setSystemTime(now);
@@ -415,9 +415,7 @@ describe("TopMeetingTimeline", () => {
 
     render(<TopMeetingTimeline currentTab={null} />);
 
-    expect(screen.getByTestId("top-timeline-now-indicator").style.left).toBe(
-      "160px",
-    );
+    expect(screen.queryByTestId("top-timeline-now-indicator")).toBeNull();
   });
 
   it("shows the now chip on the left when the current time marker is behind the viewport", () => {

--- a/apps/desktop/src/main/top-meeting-timeline.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.tsx
@@ -211,6 +211,7 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
       getTimelineCarouselNowX(carouselItems, new Date(currentTimeMs), timezone),
     [carouselItems, currentTimeMs, timezone],
   );
+  const showNowIndicator = nowIndicatorX !== null && !liveSessionId;
   const openCalendar = useCallback(
     () => openNew({ type: "calendar" }),
     [openNew],
@@ -431,7 +432,7 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
               width: carouselWidth,
             }}
           >
-            {nowIndicatorX !== null ? (
+            {showNowIndicator ? (
               <TopCurrentTimeIndicator
                 currentTimeMs={currentTimeMs}
                 left={nowIndicatorX}


### PR DESCRIPTION
Hide the top timeline now indicator during active listening sessions so it cannot overlap the live note stop control.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI gating change in the desktop timeline with an updated unit test; no auth, data, or API impact.
> 
> **Overview**
> **Hides the top meeting timeline “now” line while a live listening session is active**, so the red current-time marker no longer stacks on the live note card (including the stop control).
> 
> `TopMeetingTimeline` only renders `TopCurrentTimeIndicator` when `nowIndicatorX` is set **and** `liveSessionId` is absent. The ad-hoc live test now expects the now indicator to be missing instead of positioned on the live block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 180e9c872642960608933c8d337a988384346971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->