### PR TITLE
fix(desktop): hide chat fab on summary issues

### DIFF
--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FloatingActionButton } from "./index";
 
+import type { LLMConnectionStatus } from "~/ai/hooks";
 import type { Tab } from "~/store/zustand/tabs";
 
 const hoisted = vi.hoisted(() => ({
@@ -13,6 +14,13 @@ const hoisted = vi.hoisted(() => ({
         id: string;
       },
   hasTranscript: true,
+  enhanceTaskStatus: undefined as string | undefined,
+  enhancedContent: "Generated summary",
+  llmStatus: {
+    status: "success",
+    providerId: "hyprnote",
+    isHosted: true,
+  } as LLMConnectionStatus,
   isCaretNearBottom: false,
   sessionMode: "inactive",
 }));
@@ -28,6 +36,30 @@ vi.mock("~/shared/chat-cta", () => ({
 vi.mock("~/session/components/shared", () => ({
   useCurrentNoteTab: () => hoisted.currentTab,
   useHasTranscript: () => hoisted.hasTranscript,
+}));
+
+vi.mock("~/ai/contexts", () => ({
+  useAITask: (
+    selector: (state: {
+      tasks: Record<string, { status: string | undefined }>;
+    }) => unknown,
+  ) =>
+    selector({
+      tasks: hoisted.enhanceTaskStatus
+        ? { "note-1-enhance": { status: hoisted.enhanceTaskStatus } }
+        : {},
+    }),
+}));
+
+vi.mock("~/ai/hooks", () => ({
+  useLLMConnectionStatus: () => hoisted.llmStatus,
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useCell: () => hoisted.enhancedContent,
+  },
 }));
 
 vi.mock("../caret-position-context", () => ({
@@ -58,6 +90,13 @@ describe("FloatingActionButton", () => {
   beforeEach(() => {
     hoisted.currentTab = { type: "raw" };
     hoisted.hasTranscript = true;
+    hoisted.enhanceTaskStatus = undefined;
+    hoisted.enhancedContent = "Generated summary";
+    hoisted.llmStatus = {
+      status: "success",
+      providerId: "hyprnote",
+      isHosted: true,
+    };
     hoisted.isCaretNearBottom = false;
     hoisted.sessionMode = "inactive";
   });
@@ -76,6 +115,43 @@ describe("FloatingActionButton", () => {
 
   it("shows the chat FAB on enhanced summary views", () => {
     hoisted.currentTab = { type: "enhanced", id: "note-1" };
+
+    render(<FloatingActionButton tab={tab} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Ask Anarlog anything" }),
+    ).not.toBeNull();
+  });
+
+  it("hides the chat FAB when the visible summary has a generation issue", () => {
+    hoisted.currentTab = { type: "enhanced", id: "note-1" };
+    hoisted.enhanceTaskStatus = "error";
+
+    render(<FloatingActionButton tab={tab} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Ask Anarlog anything" }),
+    ).toBeNull();
+  });
+
+  it("hides the chat FAB when the visible summary has a setup issue", () => {
+    hoisted.currentTab = { type: "enhanced", id: "note-1" };
+    hoisted.enhanceTaskStatus = "idle";
+    hoisted.enhancedContent = "";
+    hoisted.llmStatus = { status: "pending", reason: "missing_provider" };
+
+    render(<FloatingActionButton tab={tab} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Ask Anarlog anything" }),
+    ).toBeNull();
+  });
+
+  it("shows the chat FAB while an empty enhanced summary is still generating", () => {
+    hoisted.currentTab = { type: "enhanced", id: "note-1" };
+    hoisted.enhanceTaskStatus = "generating";
+    hoisted.enhancedContent = "";
+    hoisted.llmStatus = { status: "pending", reason: "missing_provider" };
 
     render(<FloatingActionButton tab={tab} />);
 

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -6,11 +6,15 @@ import { cn } from "@hypr/utils";
 import { useCaretPosition } from "../caret-position-context";
 import { ListenButton } from "./listen";
 
+import { useAITask } from "~/ai/contexts";
+import { type LLMConnectionStatus, useLLMConnectionStatus } from "~/ai/hooks";
 import {
   useCurrentNoteTab,
   useHasTranscript,
 } from "~/session/components/shared";
 import { ChatCTA } from "~/shared/chat-cta";
+import * as main from "~/store/tinybase/store/main";
+import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import type { Tab } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
 
@@ -99,6 +103,42 @@ export function useShouldShowListeningFab(
 function useShouldShowChatFab(tab: Extract<Tab, { type: "sessions" }>) {
   const hasTranscript = useHasTranscript(tab.id);
   const sessionMode = useListener((state) => state.getSessionMode(tab.id));
+  const currentTab = useCurrentNoteTab(tab);
+  const enhancedNoteId = currentTab.type === "enhanced" ? currentTab.id : null;
+  const taskId = enhancedNoteId
+    ? createTaskId(enhancedNoteId, "enhance")
+    : null;
+  const taskStatus = useAITask((state) =>
+    taskId ? state.tasks[taskId]?.status : undefined,
+  );
+  const llmStatus = useLLMConnectionStatus();
+  const content = main.UI.useCell(
+    "enhanced_notes",
+    enhancedNoteId ?? "",
+    "content",
+    main.STORE_ID,
+  );
+  const visibleTaskStatus = taskStatus ?? "idle";
+  const hasContent = typeof content === "string" && content.trim().length > 0;
+  const hasVisibleIssue =
+    currentTab.type === "enhanced" &&
+    (visibleTaskStatus === "error" ||
+      (visibleTaskStatus === "idle" &&
+        !hasContent &&
+        isBlockingLLMStatus(llmStatus)));
 
-  return hasTranscript && sessionMode === "inactive";
+  return hasTranscript && sessionMode === "inactive" && !hasVisibleIssue;
+}
+
+function isBlockingLLMStatus(status: LLMConnectionStatus) {
+  if (status.status === "pending") {
+    return true;
+  }
+
+  return (
+    status.status === "error" &&
+    (status.reason === "missing_config" ||
+      status.reason === "not_pro" ||
+      status.reason === "unauthenticated")
+  );
 }


### PR DESCRIPTION
Hide the floating chat CTA while the visible enhanced summary is showing a generation or setup issue, and cover the FAB behavior with regression tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only visibility gating for the floating chat CTA with targeted unit tests; no auth or data-path changes.
> 
> **Overview**
> The floating **Ask Anarlog** chat CTA now stays hidden on the **enhanced summary** tab when that summary looks broken or not ready, instead of always appearing once a transcript exists.
> 
> `useShouldShowChatFab` reads the visible note’s enhance task status, enhanced note content, and LLM connection state. It suppresses the FAB when generation failed (`error`), or when the task is **idle** with empty content and a **blocking** LLM state (pending, or errors for missing config / not pro / unauthenticated). The FAB **remains** visible while status is **generating**, even if content is still empty.
> 
> Regression tests mock AI task, LLM status, and TinyBase content to cover generation errors, setup issues, and in-progress generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc6ba0722c2f4d3b2d6a2aab6e887537fb66433a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->