### PR TITLE
fix(desktop): return settings to originating tab

### DIFF
--- a/apps/desktop/src/main/useTabsShortcuts.test.tsx
+++ b/apps/desktop/src/main/useTabsShortcuts.test.tsx
@@ -3,13 +3,29 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   chatMode: "FloatingClosed" as "FloatingClosed" | "FloatingOpen",
-  currentTab: null as null | { active: boolean; slotId: string; type: string },
+  currentTab: null as null | {
+    active: boolean;
+    id?: string;
+    returnToSlotId?: string;
+    returnToTabId?: string;
+    slotId: string;
+    type: string;
+  },
+  canGoBack: false,
+  goBack: vi.fn(),
   handlers: new Map<string, (event?: { defaultPrevented: boolean }) => void>(),
   openCurrent: vi.fn(),
   openNew: vi.fn(),
   select: vi.fn(),
   sendEvent: vi.fn(),
-  tabs: [] as { active: boolean; slotId: string; type: string }[],
+  tabs: [] as {
+    active: boolean;
+    id?: string;
+    returnToSlotId?: string;
+    returnToTabId?: string;
+    slotId: string;
+    type: string;
+  }[],
 }));
 
 vi.mock("react-hotkeys-hook", () => ({
@@ -44,8 +60,10 @@ vi.mock("~/store/zustand/tabs", () => {
   const getTabsState = () => ({
     tabs: hoisted.tabs,
     currentTab: hoisted.currentTab,
+    canGoBack: hoisted.canGoBack,
     clearSelection: vi.fn(),
     close: vi.fn(),
+    goBack: hoisted.goBack,
     select: hoisted.select,
     selectNext: vi.fn(),
     selectPrev: vi.fn(),
@@ -64,7 +82,30 @@ vi.mock("~/store/zustand/tabs", () => {
 
   useTabs.getState = getTabsState;
 
-  return { useTabs };
+  return {
+    uniqueIdfromTab: (tab: {
+      id?: string;
+      requestId?: string;
+      slotId: string;
+      type: string;
+    }) => {
+      switch (tab.type) {
+        case "sessions":
+        case "humans":
+        case "organizations":
+        case "task":
+        case "daily_summary":
+          return `${tab.type}-${tab.id}`;
+        case "edit":
+          return `edit-${tab.requestId}`;
+        case "empty":
+          return `empty-${tab.slotId}`;
+        default:
+          return tab.type;
+      }
+    },
+    useTabs,
+  };
 });
 
 vi.mock("~/stt/contexts", () => ({
@@ -85,6 +126,8 @@ describe("useClassicMainTabsShortcuts", () => {
     vi.useFakeTimers();
     hoisted.chatMode = "FloatingClosed";
     hoisted.currentTab = null;
+    hoisted.canGoBack = false;
+    hoisted.goBack.mockClear();
     hoisted.handlers.clear();
     hoisted.openCurrent.mockClear();
     hoisted.openNew.mockClear();
@@ -326,6 +369,104 @@ describe("useClassicMainTabsShortcuts", () => {
 
     expect(hoisted.select).toHaveBeenCalledWith(homeTab);
     expect(hoisted.openCurrent).not.toHaveBeenCalled();
+  });
+
+  it("returns settings to the tab it opened from on escape", () => {
+    const sessionTab = {
+      active: false,
+      slotId: "slot-session",
+      type: "sessions",
+    };
+    hoisted.currentTab = {
+      active: true,
+      returnToSlotId: "slot-session",
+      slotId: "slot-settings",
+      type: "settings",
+    };
+    hoisted.tabs = [
+      sessionTab,
+      {
+        active: false,
+        slotId: "slot-home",
+        type: "empty",
+      },
+      hoisted.currentTab,
+    ];
+
+    renderHook(() => useClassicMainTabsShortcuts());
+
+    dispatchEscape();
+    vi.runOnlyPendingTimers();
+
+    expect(hoisted.select).toHaveBeenCalledWith(sessionTab);
+    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+    expect(hoisted.goBack).not.toHaveBeenCalled();
+  });
+
+  it("uses history when an origin-tracked tab replaced the current slot", () => {
+    hoisted.currentTab = {
+      active: true,
+      returnToSlotId: "slot-session",
+      slotId: "slot-session",
+      type: "settings",
+    };
+    hoisted.canGoBack = true;
+    hoisted.tabs = [hoisted.currentTab];
+
+    renderHook(() => useClassicMainTabsShortcuts());
+
+    dispatchEscape();
+    vi.runOnlyPendingTimers();
+
+    expect(hoisted.goBack).toHaveBeenCalledTimes(1);
+    expect(hoisted.select).not.toHaveBeenCalled();
+    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+  });
+
+  it("opens home when the return origin is gone instead of using unrelated history", () => {
+    hoisted.currentTab = {
+      active: true,
+      returnToSlotId: "slot-session",
+      slotId: "slot-settings",
+      type: "settings",
+    };
+    hoisted.canGoBack = true;
+    hoisted.tabs = [hoisted.currentTab];
+
+    renderHook(() => useClassicMainTabsShortcuts());
+
+    dispatchEscape();
+    vi.runOnlyPendingTimers();
+
+    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
+    expect(hoisted.goBack).not.toHaveBeenCalled();
+    expect(hoisted.select).not.toHaveBeenCalled();
+  });
+
+  it("opens home when the origin slot now contains a different tab", () => {
+    const reusedSlotTab = {
+      active: false,
+      id: "new-session",
+      slotId: "slot-session",
+      type: "sessions",
+    };
+    hoisted.currentTab = {
+      active: true,
+      returnToSlotId: "slot-session",
+      returnToTabId: "sessions-old-session",
+      slotId: "slot-settings",
+      type: "settings",
+    };
+    hoisted.tabs = [reusedSlotTab, hoisted.currentTab];
+
+    renderHook(() => useClassicMainTabsShortcuts());
+
+    dispatchEscape();
+    vi.runOnlyPendingTimers();
+
+    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
+    expect(hoisted.select).not.toHaveBeenCalled();
+    expect(hoisted.goBack).not.toHaveBeenCalled();
   });
 
   it("closes the floating chat before going home on escape", () => {

--- a/apps/desktop/src/shared/useTabsShortcuts.tsx
+++ b/apps/desktop/src/shared/useTabsShortcuts.tsx
@@ -5,7 +5,7 @@ import { useShallow } from "zustand/shallow";
 import { useShell } from "~/contexts/shell";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { useNewNote, useNewNoteAndListen } from "~/shared/useNewNote";
-import { useTabs } from "~/store/zustand/tabs";
+import { uniqueIdfromTab, useTabs } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
 
 export function useMainTabsShortcuts({ onModT }: { onModT: () => void }) {
@@ -230,9 +230,30 @@ export function useMainEscapeShortcutAction() {
       return;
     }
 
-    const { tabs, currentTab, openCurrent, select } = useTabs.getState();
+    const { tabs, currentTab, openCurrent, select, goBack, canGoBack } =
+      useTabs.getState();
 
     if (currentTab?.type === "onboarding" || currentTab?.type === "empty") {
+      return;
+    }
+
+    const returnToSlotId = currentTab?.returnToSlotId;
+    const returnToTab = returnToSlotId
+      ? tabs.find(
+          (tab) =>
+            tab.slotId === returnToSlotId &&
+            tab.slotId !== currentTab?.slotId &&
+            (!currentTab?.returnToTabId ||
+              uniqueIdfromTab(tab) === currentTab.returnToTabId),
+        )
+      : null;
+    if (returnToTab) {
+      select(returnToTab);
+      return;
+    }
+
+    if (returnToSlotId === currentTab?.slotId && canGoBack) {
+      goBack();
       return;
     }
 

--- a/apps/desktop/src/store/zustand/tabs/basic.test.ts
+++ b/apps/desktop/src/store/zustand/tabs/basic.test.ts
@@ -131,6 +131,105 @@ describe("Basic Tab Actions", () => {
     });
   });
 
+  test("openNew tracks where settings was opened from", () => {
+    const session = createSessionTab({ id: "tab1", active: false });
+
+    useTabs.getState().openNew(session);
+    const openedSession = useTabs.getState().currentTab!;
+    useTabs.getState().openNew({ type: "settings" });
+
+    expect(useTabs.getState()).toHaveCurrentTab({
+      type: "settings",
+      returnToSlotId: openedSession.slotId,
+      returnToTabId: `sessions-${session.id}`,
+    });
+  });
+
+  test("openNew refreshes settings return target when reusing its tab", () => {
+    const session1 = createSessionTab({ id: "tab1", active: false });
+    const session2 = createSessionTab({ id: "tab2", active: false });
+
+    useTabs.getState().openNew(session1);
+    useTabs.getState().openNew({ type: "settings" });
+    useTabs.getState().openNew(session2);
+    const openedSession2 = useTabs.getState().currentTab!;
+    useTabs.getState().openNew({
+      type: "settings",
+      state: { tab: "notifications" },
+    });
+
+    expect(useTabs.getState()).toHaveCurrentTab({
+      type: "settings",
+      state: { tab: "notifications" },
+      returnToSlotId: openedSession2.slotId,
+    });
+  });
+
+  test("openNew preserves settings return target while settings is already active", () => {
+    const session = createSessionTab({ id: "tab1", active: false });
+
+    useTabs.getState().openNew(session);
+    const openedSession = useTabs.getState().currentTab!;
+    useTabs.getState().openNew({ type: "settings" });
+    useTabs.getState().openNew({
+      type: "settings",
+      state: { tab: "notifications" },
+    });
+
+    expect(useTabs.getState()).toHaveCurrentTab({
+      type: "settings",
+      state: { tab: "notifications" },
+      returnToSlotId: openedSession.slotId,
+    });
+  });
+
+  test("openNew clears stale settings return target when reused without an origin", () => {
+    const session = createSessionTab({ id: "tab1", active: false });
+
+    useTabs.getState().openNew(session);
+    useTabs.getState().openNew({ type: "settings" });
+    useTabs.getState().clearSelection();
+    useTabs.getState().openNew({
+      type: "settings",
+      state: { tab: "notifications" },
+    });
+
+    expect(useTabs.getState()).toHaveCurrentTab({
+      type: "settings",
+      state: { tab: "notifications" },
+    });
+    expect(useTabs.getState().currentTab?.returnToSlotId).toBeUndefined();
+  });
+
+  test("openCurrent clears return targets when replacing their origin slot", () => {
+    const session1 = createSessionTab({ id: "tab1", active: false });
+    const session2 = createSessionTab({ id: "tab2", active: false });
+
+    useTabs.getState().openNew(session1);
+    const openedSession = useTabs.getState().currentTab!;
+    useTabs.getState().openNew({ type: "settings" });
+    useTabs.getState().select(openedSession);
+    useTabs.getState().openCurrent(session2);
+
+    const settingsTab = useTabs
+      .getState()
+      .tabs.find((tab) => tab.type === "settings");
+
+    expect(settingsTab?.returnToSlotId).toBeUndefined();
+  });
+
+  test("close clears return targets for the closed origin slot", () => {
+    const session = createSessionTab({ id: "tab1", active: false });
+
+    useTabs.getState().openNew(session);
+    const openedSession = useTabs.getState().currentTab!;
+    useTabs.getState().openNew({ type: "settings" });
+    useTabs.getState().close(openedSession);
+
+    expect(useTabs.getState()).toHaveCurrentTab({ type: "settings" });
+    expect(useTabs.getState().currentTab?.returnToSlotId).toBeUndefined();
+  });
+
   test("openNew defaults bare settings tabs to app", () => {
     useTabs.getState().openNew({ type: "settings" });
 

--- a/apps/desktop/src/store/zustand/tabs/basic.ts
+++ b/apps/desktop/src/store/zustand/tabs/basic.ts
@@ -10,10 +10,23 @@ import type {
   RecentlyOpenedActions,
   RecentlyOpenedState,
 } from "./recently-opened";
-import { getDefaultState, isSameTab, type Tab, type TabInput } from "./schema";
+import {
+  getDefaultState,
+  isSameTab,
+  type Tab,
+  type TabInput,
+  uniqueIdfromTab,
+} from "./schema";
 
 import { id } from "~/shared/utils";
 import { listenerStore } from "~/store/zustand/listener/instance";
+
+const RETURN_ORIGIN_TAB_TYPES: Tab["type"][] = [
+  "calendar",
+  "contacts",
+  "settings",
+  "templates",
+];
 
 export type BasicState = {
   tabs: Tab[];
@@ -143,7 +156,10 @@ export const createBasicSlice = <
       return;
     }
 
-    const remainingTabs = tabs.filter((t) => !isSameTab(t, tab));
+    const remainingTabs = clearReturnOriginsForSlot(
+      tabs.filter((t) => !isSameTab(t, tab)),
+      tabToClose.slotId,
+    );
 
     if (remainingTabs.length === 0) {
       set({
@@ -273,15 +289,31 @@ const openTab = <T extends BasicState & NavigationState>(
     active: false,
     slotId: id(),
   };
+  const activeOriginTab = tabs.find((tab) => tab.active);
+  const returnOrigin =
+    shouldTrackReturnOrigin(tabWithDefaults) &&
+    activeOriginTab &&
+    !isSameTab(activeOriginTab, tabWithDefaults)
+      ? {
+          returnToSlotId: activeOriginTab.slotId,
+          returnToTabId: uniqueIdfromTab(activeOriginTab),
+        }
+      : undefined;
+  const tabWithOrigin = returnOrigin
+    ? { ...tabWithDefaults, ...returnOrigin }
+    : tabWithDefaults;
 
   let nextTabs: Tab[];
   let activeTab: Tab;
 
-  const existingTab = tabs.find((t) => isSameTab(t, tabWithDefaults));
+  const existingTab = tabs.find((t) => isSameTab(t, tabWithOrigin));
   const isNewTab = !existingTab;
 
   if (!isNewTab) {
-    const nextExistingTab = reuseExistingTab(existingTab!, tabWithDefaults);
+    const nextExistingTab = reuseExistingTab(existingTab!, tabWithOrigin, {
+      preserveReturnOrigin:
+        existingTab!.active && !tabWithOrigin.returnToSlotId,
+    });
     nextTabs = tabs.map((tab) =>
       isSameTab(tab, existingTab!)
         ? { ...nextExistingTab, active: true }
@@ -301,26 +333,30 @@ const openTab = <T extends BasicState & NavigationState>(
 
     if (existingActiveIdx !== -1 && currentActiveTab) {
       activeTab = {
-        ...tabWithDefaults,
+        ...tabWithOrigin,
         active: true,
         slotId: currentActiveTab.slotId,
       };
 
-      nextTabs = tabs.map((t, idx) => {
+      const tabsWithFreshOrigins = clearReturnOriginsForSlot(
+        tabs,
+        currentActiveTab.slotId,
+      );
+      nextTabs = tabsWithFreshOrigins.map((t, idx) => {
         if (idx === existingActiveIdx) {
           return activeTab;
         }
         return { ...t, active: false };
       });
     } else {
-      activeTab = { ...tabWithDefaults, active: true, slotId: id() };
+      activeTab = { ...tabWithOrigin, active: true, slotId: id() };
       const deactivated = deactivateAll(tabs);
       nextTabs = [...deactivated, activeTab];
     }
 
     return updateWithHistory(nextTabs, activeTab, history);
   } else {
-    activeTab = { ...tabWithDefaults, active: true, slotId: id() };
+    activeTab = { ...tabWithOrigin, active: true, slotId: id() };
     const deactivated = deactivateAll(tabs);
 
     if (position === "start") {
@@ -338,13 +374,67 @@ const openTab = <T extends BasicState & NavigationState>(
   }
 };
 
-const reuseExistingTab = (existingTab: Tab, requestedTab: Tab): Tab => {
+const reuseExistingTab = (
+  existingTab: Tab,
+  requestedTab: Tab,
+  {
+    preserveReturnOrigin,
+  }: {
+    preserveReturnOrigin: boolean;
+  },
+): Tab => {
   if (existingTab.type === "settings" && requestedTab.type === "settings") {
+    const nextTab = applyReturnOriginForReuse(
+      existingTab,
+      requestedTab,
+      preserveReturnOrigin,
+    );
+
     return {
-      ...existingTab,
+      ...nextTab,
       state: requestedTab.state,
     };
   }
 
-  return existingTab;
+  return applyReturnOriginForReuse(
+    existingTab,
+    requestedTab,
+    preserveReturnOrigin,
+  );
+};
+
+const shouldTrackReturnOrigin = (tab: Tab): boolean =>
+  RETURN_ORIGIN_TAB_TYPES.includes(tab.type);
+
+const clearReturnOriginsForSlot = (tabs: Tab[], slotId: string): Tab[] => {
+  return tabs.map((tab) =>
+    tab.returnToSlotId === slotId ? clearReturnOrigin(tab) : tab,
+  );
+};
+
+const applyReturnOriginForReuse = <T extends Tab>(
+  existingTab: T,
+  requestedTab: Tab,
+  preserveReturnOrigin: boolean,
+): T => {
+  if (requestedTab.returnToSlotId) {
+    return {
+      ...existingTab,
+      returnToSlotId: requestedTab.returnToSlotId,
+      returnToTabId: requestedTab.returnToTabId,
+    };
+  }
+
+  return preserveReturnOrigin ? existingTab : clearReturnOrigin(existingTab);
+};
+
+const clearReturnOrigin = <T extends Tab>(tab: T): T => {
+  if (!tab.returnToSlotId && !tab.returnToTabId) {
+    return tab;
+  }
+
+  const nextTab = { ...tab };
+  delete nextTab.returnToSlotId;
+  delete nextTab.returnToTabId;
+  return nextTab;
 };

--- a/apps/desktop/src/store/zustand/tabs/pinned-persistence.ts
+++ b/apps/desktop/src/store/zustand/tabs/pinned-persistence.ts
@@ -17,11 +17,14 @@ const serializePinnedTabs = (tabs: Tab[]): string => {
   const pinnedTabs = tabs
     .filter((t) => t.pinned)
     .map((tab): PinnedTab => {
-      const { active, slotId, pinned, ...rest } = tab as Tab & {
-        active: boolean;
-        slotId: string;
-        pinned: boolean;
-      };
+      const { active, slotId, pinned, returnToSlotId, returnToTabId, ...rest } =
+        tab as Tab & {
+          active: boolean;
+          slotId: string;
+          pinned: boolean;
+          returnToSlotId?: string;
+          returnToTabId?: string;
+        };
       return { ...rest, pinned: true } as PinnedTab;
     });
   return JSON.stringify(pinnedTabs);

--- a/apps/desktop/src/store/zustand/tabs/restore.ts
+++ b/apps/desktop/src/store/zustand/tabs/restore.ts
@@ -13,11 +13,14 @@ export type RestoreActions = {
 };
 
 const tabToTabInput = (tab: Tab): TabInput => {
-  const { active, slotId, pinned, ...rest } = tab as Tab & {
-    active: boolean;
-    slotId: string;
-    pinned: boolean;
-  };
+  const { active, slotId, pinned, returnToSlotId, returnToTabId, ...rest } =
+    tab as Tab & {
+      active: boolean;
+      slotId: string;
+      pinned: boolean;
+      returnToSlotId?: string;
+      returnToTabId?: string;
+    };
   return rest as TabInput;
 };
 

--- a/apps/desktop/src/store/zustand/tabs/schema.ts
+++ b/apps/desktop/src/store/zustand/tabs/schema.ts
@@ -92,6 +92,8 @@ type BaseTab = {
   active: boolean;
   slotId: string;
   pinned: boolean;
+  returnToSlotId?: string;
+  returnToTabId?: string;
 };
 
 export type Tab =


### PR DESCRIPTION
Track origin slots for sidebar-style tabs so settings back and escape return to the tab that opened it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only behavior with broad unit tests; no auth, data, or persistence of ephemeral return metadata beyond the session.
> 
> **Overview**
> Tabs opened from another tab (settings, calendar, contacts, templates) now record **where they came from** via `returnToSlotId` and `returnToTabId`. The tab store sets and refreshes that metadata on `openNew` / reuse, clears it when the origin tab is closed or its slot is reused, and omits it from pinned-tab persistence and closed-tab restore.
> 
> **Escape** no longer always jumps home: it returns to the originating tab when it still exists and matches; if the overlay replaced the same slot, it uses **back** history when available; otherwise it falls back to selecting or opening the empty home tab. Tests cover store edge cases and escape routing (missing origin, slot reuse, history).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfe348d5a26e1f8cef647dea5588d154f0dd64d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->