### PR TITLE
fix(desktop): tune session header spacing

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -22,9 +22,9 @@ export function OuterHeader({
 }) {
   return (
     <div className="flex h-12 w-full items-center">
-      <div className="flex w-full min-w-0 items-center justify-between gap-3">
+      <div className="flex w-full min-w-0 items-center justify-between gap-0">
         {title ? <div className="min-w-0 flex-1">{title}</div> : null}
-        <div className="flex shrink-0 items-center gap-1">
+        <div className="flex shrink-0 items-center gap-0 pr-1">
           <SidebarModeStopButton sessionId={sessionId} />
           <MetadataButton sessionId={sessionId} />
           <OverflowButton sessionId={sessionId} currentView={currentView} />

--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -1,5 +1,8 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { type ComponentProps } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TooltipProvider } from "@hypr/ui/components/ui/tooltip";
 
 import { TitleInput } from "./title-input";
 
@@ -47,13 +50,11 @@ vi.mock("~/store/zustand/live-title", () => ({
     }),
 }));
 
-describe("TitleInput", () => {
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("runs the main escape shortcut directly from the title field", () => {
-    render(
+const renderTitleInput = (
+  props: Partial<ComponentProps<typeof TitleInput>> = {},
+) =>
+  render(
+    <TooltipProvider>
       <TitleInput
         tab={{
           active: true,
@@ -63,13 +64,54 @@ describe("TitleInput", () => {
           state: { autoStart: null, view: null },
           type: "sessions",
         }}
-      />,
-    );
+        {...props}
+      />
+    </TooltipProvider>,
+  );
+
+describe("TitleInput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.store.getCell.mockImplementation(() => "Untitled");
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("runs the main escape shortcut directly from the title field", () => {
+    renderTitleInput();
 
     fireEvent.keyDown(screen.getByPlaceholderText("Untitled"), {
       key: "Escape",
     });
 
     expect(hoisted.runEscapeShortcut).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the empty title layout at placeholder width", () => {
+    hoisted.store.getCell.mockReturnValueOnce("");
+
+    renderTitleInput({ onGenerateTitle: vi.fn() });
+
+    const input = screen.getByPlaceholderText("Untitled");
+    expect(input.parentElement?.className).toContain("min-w-fit");
+    expect(input.parentElement?.className).toContain("flex-none");
+    expect(
+      screen.getByRole("button", { name: "Regenerate title" }),
+    ).toBeTruthy();
+  });
+
+  it("uses the flexible title layout for whitespace-only titles", () => {
+    hoisted.store.getCell.mockReturnValueOnce("          ");
+
+    renderTitleInput({ onGenerateTitle: vi.fn() });
+
+    const input = screen.getByPlaceholderText("Untitled");
+    expect(input.parentElement?.className).toContain("min-w-0");
+    expect(input.parentElement?.className).toContain("flex-1");
+    expect(
+      screen.queryByRole("button", { name: "Regenerate title" }),
+    ).toBeNull();
   });
 });

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -328,42 +328,63 @@ const TitleInputInner = memo(
           }
         }
       };
+      const generateTitleHandler =
+        localTitle.length === 0 ? onGenerateTitle : undefined;
 
       return (
         <div className="flex w-full items-center gap-2">
-          <input
-            ref={setInputRef}
-            id={`title-input-${sessionId}-${editorId}`}
-            placeholder="Untitled"
-            type="text"
-            onChange={(e) => {
-              const value = e.target.value;
-              setLocalTitle(value);
-              setLiveTitle(sessionId, value);
-              setIsOverflowing(e.target.scrollWidth > e.target.clientWidth + 1);
-            }}
-            onKeyDown={handleKeyDown}
-            onFocus={() => {
-              isFocused.current = true;
-              setIsTitleFocused(true);
-            }}
-            onBlur={(e) => {
-              isFocused.current = false;
-              setIsTitleFocused(false);
-              setStoreTitle(localTitle);
-              clearLiveTitle(sessionId);
-              setIsOverflowing(e.target.scrollWidth > e.target.clientWidth + 1);
-            }}
-            value={localTitle}
-            style={overflowFadeStyle}
+          <div
             className={cn([
-              "min-w-0 flex-1 transition-opacity duration-200",
-              "border-none bg-transparent focus:outline-hidden",
-              "placeholder:text-muted-foreground text-xl font-semibold",
+              "grid items-center",
+              generateTitleHandler ? "min-w-fit flex-none" : "min-w-0 flex-1",
             ])}
-          />
-          {onGenerateTitle && !localTitle.trim() && (
-            <GenerateButton onGenerateTitle={onGenerateTitle} />
+          >
+            {generateTitleHandler && (
+              <span
+                aria-hidden="true"
+                className="invisible col-start-1 row-start-1 text-xl font-semibold whitespace-pre"
+              >
+                Untitled
+              </span>
+            )}
+            <input
+              ref={setInputRef}
+              id={`title-input-${sessionId}-${editorId}`}
+              placeholder="Untitled"
+              type="text"
+              onChange={(e) => {
+                const value = e.target.value;
+                setLocalTitle(value);
+                setLiveTitle(sessionId, value);
+                setIsOverflowing(
+                  e.target.scrollWidth > e.target.clientWidth + 1,
+                );
+              }}
+              onKeyDown={handleKeyDown}
+              onFocus={() => {
+                isFocused.current = true;
+                setIsTitleFocused(true);
+              }}
+              onBlur={(e) => {
+                isFocused.current = false;
+                setIsTitleFocused(false);
+                setStoreTitle(localTitle);
+                clearLiveTitle(sessionId);
+                setIsOverflowing(
+                  e.target.scrollWidth > e.target.clientWidth + 1,
+                );
+              }}
+              value={localTitle}
+              style={overflowFadeStyle}
+              className={cn([
+                "col-start-1 row-start-1 w-full min-w-0 transition-opacity duration-200",
+                "border-none bg-transparent focus:outline-hidden",
+                "placeholder:text-muted-foreground text-xl font-semibold",
+              ])}
+            />
+          </div>
+          {generateTitleHandler && (
+            <GenerateButton onGenerateTitle={generateTitleHandler} />
           )}
         </div>
       );
@@ -380,6 +401,7 @@ const GenerateButton = memo(function GenerateButton({
     <Tooltip>
       <TooltipTrigger asChild>
         <button
+          aria-label="Regenerate title"
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();


### PR DESCRIPTION
Remove gaps between session header controls, keep right-side breathing room, and place the empty-title generate action next to the placeholder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop session header UI and title-input layout only; no auth, data, or backend changes.
> 
> **Overview**
> Tightens the **session outer header** by removing flex gaps between the title area and control cluster (`gap-3`/`gap-1` → `gap-0`) while keeping a small right padding on the actions group.
> 
> **Title field layout** changes when the title is truly empty (`length === 0`): the input sits in a CSS grid with an invisible `Untitled` sizing span so it stays **placeholder-width**, and the sparkle **Regenerate title** control sits beside it instead of stretching across the header. Whitespace-only titles no longer count as empty—they use the full flexible width and hide the generate button. The generate button gets an explicit `aria-label`.
> 
> Tests wrap `TitleInput` in `TooltipProvider` and assert empty vs whitespace-only layout classes and button visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baf102f1b41bf03149668b52fad219f8ef0db268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->