### PR TITLE
fix(desktop): trim left transcript card chrome

### DIFF
--- a/apps/desktop/src/shared/main/shell-scaffold.test.tsx
+++ b/apps/desktop/src/shared/main/shell-scaffold.test.tsx
@@ -100,5 +100,11 @@ describe("MainShellScaffold", () => {
     expect(shell.className).toContain(
       "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-t-0",
     );
+    expect(shell.className).toContain(
+      "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-r-0",
+    );
+    expect(shell.className).toContain(
+      "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:rounded-br-none",
+    );
   });
 });

--- a/apps/desktop/src/shared/main/shell-scaffold.tsx
+++ b/apps/desktop/src/shared/main/shell-scaffold.tsx
@@ -45,6 +45,8 @@ export function MainShellScaffold({
             "[&_[data-chat-floating-anchor]]:border-r-0",
             "[&_[data-chat-floating-anchor]]:border-l",
             "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-t-0",
+            "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-r-0",
+            "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:rounded-br-none",
           ],
         ])}
         data-testid="main-app-shell"


### PR DESCRIPTION
Summary:
- Remove the extra right border and bottom-right radius from merged transcript cards in left-edge main chrome.
- Extend shell scaffold coverage for the left-edge transcript card chrome classes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped Tailwind class additions and unit test expectations only; no auth, data, or runtime logic changes.
> 
> **Overview**
> For **left-edge** main surface chrome, merged session transcript cards now drop the **right border** and **bottom-right corner radius** so they visually line up with the adjacent shell edge (matching the intent of the existing `border-t-0` merge styling).
> 
> `MainShellScaffold` tests for `mainSurfaceChrome="left"` were updated to assert the new `border-r-0` and `rounded-br-none` descendant selector classes on the shell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ca32b680192d8cc5ab5b0f806d174831d4078d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->