### PR TITLE
fix(desktop): expand onboarding to full window

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -67,7 +67,7 @@ export function ClassicMainBody() {
 
   return (
     <div className="relative flex h-full min-w-0 flex-1 flex-col">
-      {showSidebarTimeline ? (
+      {isOnboarding ? null : showSidebarTimeline ? (
         <div
           data-tauri-drag-region
           className="absolute top-0 left-0 z-40 h-12 w-[200px]"

--- a/apps/desktop/src/main/shell-frame.test.tsx
+++ b/apps/desktop/src/main/shell-frame.test.tsx
@@ -100,4 +100,15 @@ describe("ClassicMainShellFrame", () => {
         .getAttribute("data-main-surface-chrome"),
     ).toBe("left");
   });
+
+  it("uses the full shell surface for onboarding", () => {
+    mocks.currentTab = { type: "onboarding" };
+
+    render(<ClassicMainShellFrame />);
+
+    const scaffold = screen.getByTestId("main-shell-scaffold");
+
+    expect(scaffold.getAttribute("data-edge-to-edge")).toBe("true");
+    expect(scaffold.getAttribute("data-main-surface-chrome")).toBeNull();
+  });
 });

--- a/apps/desktop/src/main/shell-frame.tsx
+++ b/apps/desktop/src/main/shell-frame.tsx
@@ -38,7 +38,10 @@ export function ClassicMainShellFrame() {
         : "default";
 
   return (
-    <MainShellScaffold mainSurfaceChrome={mainSurfaceChrome}>
+    <MainShellScaffold
+      edgeToEdge={isOnboarding}
+      mainSurfaceChrome={isOnboarding ? undefined : mainSurfaceChrome}
+    >
       <MainShellBodyFrame>
         <ClassicMainBody />
       </MainShellBodyFrame>

--- a/apps/desktop/src/onboarding/account/before-login.tsx
+++ b/apps/desktop/src/onboarding/account/before-login.tsx
@@ -1,87 +1,31 @@
-import { CalendarIcon, Puzzle, Sparkle } from "lucide-react";
-
-import { cn } from "@hypr/utils";
-
-import { OnboardingButton, OnboardingAnarlogIcon } from "../shared";
+import { OnboardingButton } from "../shared";
 
 import { useAuth } from "~/auth";
-
-const FEATURES = [
-  {
-    label: "Cloud Services",
-    icon: Sparkle,
-    benefit:
-      "Get hosted transcription and language models without managing API keys.",
-    accent: { icon: "text-blue-900", label: "text-blue-950" },
-  },
-  {
-    label: "Integrations",
-    icon: Puzzle,
-    benefit: "Connect tools and pull context into Anarlog with less busywork.",
-    accent: { icon: "text-purple-700", label: "text-purple-900" },
-  },
-  {
-    label: "Calendar Sync",
-    icon: CalendarIcon,
-    benefit:
-      "Sync your Google Calendar or Microsoft Outlook to stay on top of meetings.",
-    accent: { icon: "text-emerald-700", label: "text-emerald-900" },
-  },
-] as const;
 
 export function BeforeLogin({ onContinue: _ }: { onContinue: () => void }) {
   const auth = useAuth();
 
   return (
-    <div className="flex flex-col">
-      <div className="mb-8 flex flex-col items-start justify-start gap-8 py-4">
-        {FEATURES.map((f) => (
-          <FeatureItem key={f.label} feature={f} />
-        ))}
-      </div>
+    <div className="flex flex-col items-start pt-8">
+      <div className="flex flex-row items-center gap-4">
+        <OnboardingButton
+          onClick={() => {
+            void auth?.signIn();
+          }}
+          className="px-8 py-3 text-base"
+        >
+          Get started for free
+        </OnboardingButton>
 
-      <div className="flex flex-col items-start">
-        <div className="flex flex-row items-center gap-4">
-          <OnboardingButton
-            onClick={() => {
-              void auth?.signIn();
-            }}
-            className="flex items-center gap-2 px-8 py-3 text-base"
-          >
-            <OnboardingAnarlogIcon />
-            Get started for free
-          </OnboardingButton>
-
-          <button
-            type="button"
-            onClick={() => {
-              void auth?.signIn();
-            }}
-            className="text-md rounded-full border border-neutral-300 bg-transparent px-8 py-3 font-medium text-neutral-500 transition-colors hover:text-neutral-700"
-          >
-            Login with existing account
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function FeatureItem({ feature }: { feature: (typeof FEATURES)[number] }) {
-  const Icon = feature.icon;
-
-  return (
-    <div className="flex flex-row items-center gap-3 text-left">
-      <div className="flex items-center justify-center">
-        <Icon className={cn(["h-5 w-5", feature.accent.icon])} />
-      </div>
-      <div className="flex flex-col items-start">
-        <p className={cn(["text-sm font-medium", feature.accent.label])}>
-          {feature.label}
-        </p>
-        <p className="text-xs leading-[1.45] text-neutral-500">
-          {feature.benefit}
-        </p>
+        <button
+          type="button"
+          onClick={() => {
+            void auth?.signIn();
+          }}
+          className="text-md rounded-full border border-white/60 bg-white/55 px-8 py-3 font-medium text-neutral-600 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-sm transition-colors hover:bg-white/75 hover:text-neutral-800"
+        >
+          Login with existing account
+        </button>
       </div>
     </div>
   );

--- a/apps/desktop/src/onboarding/index.tsx
+++ b/apps/desktop/src/onboarding/index.tsx
@@ -22,7 +22,6 @@ import { PermissionsSection } from "./permissions";
 import { OnboardingSection } from "./shared";
 
 import { useAuth } from "~/auth";
-import { StandardTabWrapper } from "~/shared/main";
 import { type TabItem, TabItemBase } from "~/shared/tabs";
 import { StandaloneWindowShell } from "~/shared/window-shell";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
@@ -83,6 +82,7 @@ function OnboardingScreen({ onFinish }: { onFinish: () => void }) {
     <OnboardingScreenContent
       onFinish={onFinish}
       headerClassName="px-12 pt-12 pb-8"
+      headerDragRegion
     />
   );
 }
@@ -173,141 +173,135 @@ function OnboardingScreenContent({
   }, [onFinish, queryClient]);
 
   return (
-    <StandardTabWrapper noBorder>
-      <div className="relative flex h-full flex-col">
-        <div className="pointer-events-none absolute inset-0 overflow-hidden">
-          <motion.div
-            className="absolute inset-0"
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 2, ease: [0.22, 1, 0.36, 1], delay: 0.4 }}
-          >
-            <video
-              ref={onboardingVideoRef}
-              className="absolute inset-0 h-full w-full object-cover object-bottom opacity-28"
-              autoPlay
-              loop
-              muted
-              playsInline
-              preload="auto"
-              aria-hidden="true"
-            >
-              <source src="/assets/onboarding-video.mp4" type="video/mp4" />
-            </video>
-            <div className="absolute inset-0 bg-linear-to-t from-stone-50/8 via-stone-50/18 to-transparent" />
-          </motion.div>
-          <div className="absolute inset-x-0 top-0 h-[80%] [mask-image:linear-gradient(to_bottom,black,black_18%,rgba(0,0,0,0.9)_36%,rgba(0,0,0,0.6)_58%,transparent)] backdrop-blur-[32px]" />
-          <div className="absolute inset-x-0 top-0 h-[92%] [mask-image:linear-gradient(to_bottom,black,rgba(0,0,0,0.8)_34%,rgba(0,0,0,0.35)_62%,transparent)] backdrop-blur-[12px]" />
-          <div className="absolute inset-x-0 top-0 h-[84%] bg-linear-to-b from-stone-50 via-stone-50/82 via-stone-50/97 via-18% via-42% to-stone-50/0" />
-          <motion.div
-            className="absolute inset-0 bg-stone-50"
-            initial={{ opacity: 1 }}
-            animate={{ opacity: 0 }}
-            transition={{ duration: 1.0, ease: "easeOut", delay: 0.1 }}
-          />
-        </div>
-
-        <div
-          data-tauri-drag-region={headerDragRegion || undefined}
-          className={cn([
-            "sticky top-0 z-10 flex items-center justify-between",
-            headerClassName,
-          ])}
+    <div className="relative flex h-full min-h-0 flex-col overflow-hidden bg-white">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <motion.div
+          className="absolute inset-0"
+          initial={{ opacity: 0, y: 40 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 2, ease: [0.22, 1, 0.36, 1], delay: 0.4 }}
         >
-          <h1 className="font-sans text-3xl font-semibold text-neutral-900">
-            Welcome to Anarlog
-          </h1>
-          <button
-            onClick={() => setIsMuted((prev) => !prev)}
-            data-tauri-drag-region="false"
-            className="rounded-full p-1.5 transition-colors hover:bg-neutral-100"
-            aria-label={isMuted ? "Unmute" : "Mute"}
+          <video
+            ref={onboardingVideoRef}
+            className="absolute inset-0 h-full w-full object-cover object-bottom opacity-28"
+            autoPlay
+            loop
+            muted
+            playsInline
+            preload="auto"
+            aria-hidden="true"
           >
-            {isMuted ? (
-              <VolumeXIcon size={16} className="text-neutral-400" />
-            ) : (
-              <Volume2Icon size={16} className="text-neutral-600" />
-            )}
-          </button>
-        </div>
+            <source src="/assets/onboarding-video.mp4" type="video/mp4" />
+          </video>
+          <div className="absolute inset-0 bg-linear-to-t from-stone-50/8 via-stone-50/18 to-transparent" />
+        </motion.div>
+        <div className="absolute inset-x-0 top-0 h-[80%] [mask-image:linear-gradient(to_bottom,black,black_18%,rgba(0,0,0,0.9)_36%,rgba(0,0,0,0.6)_58%,transparent)] backdrop-blur-[32px]" />
+        <div className="absolute inset-x-0 top-0 h-[92%] [mask-image:linear-gradient(to_bottom,black,rgba(0,0,0,0.8)_34%,rgba(0,0,0,0.35)_62%,transparent)] backdrop-blur-[12px]" />
+        <div className="absolute inset-x-0 top-0 h-[84%] bg-linear-to-b from-stone-50 via-stone-50/82 via-stone-50/97 via-18% via-42% to-stone-50/0" />
+        <motion.div
+          className="absolute inset-0 bg-stone-50"
+          initial={{ opacity: 1 }}
+          animate={{ opacity: 0 }}
+          transition={{ duration: 1.0, ease: "easeOut", delay: 0.1 }}
+        />
+      </div>
 
-        <div className="relative z-10 flex-1 overflow-y-auto">
-          <div className="flex flex-col gap-4 px-12 pb-16">
-            <OnboardingSection
-              title="Start with permissions"
-              completedTitle="Permissions granted"
-              description="Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
-              status={getStepStatus("permissions", currentStep)}
-              skippable={false}
-              onBack={goBack}
-              onNext={goNext}
-            >
-              <PermissionsSection onContinue={goNext} />
-            </OnboardingSection>
+      <div
+        data-tauri-drag-region={headerDragRegion || undefined}
+        className={cn([
+          "sticky top-0 z-10 flex items-center justify-between",
+          headerClassName,
+        ])}
+      >
+        <h1 className="font-sans text-3xl font-semibold text-neutral-900">
+          Welcome to Anarlog
+        </h1>
+        <button
+          onClick={() => setIsMuted((prev) => !prev)}
+          data-tauri-drag-region="false"
+          className="rounded-full p-1.5 transition-colors hover:bg-neutral-100"
+          aria-label={isMuted ? "Unmute" : "Mute"}
+        >
+          {isMuted ? (
+            <VolumeXIcon size={16} className="text-neutral-400" />
+          ) : (
+            <Volume2Icon size={16} className="text-neutral-600" />
+          )}
+        </button>
+      </div>
 
-            <OnboardingSection
-              title="Create account"
-              description="Sign in to unlock powerful Al models, sync across devices, personalization, and workflow integrations."
-              completedTitle={
-                auth.session
-                  ? "Signed in"
-                  : didSkipLogin
-                    ? "Skipped"
-                    : "Account"
-              }
-              status={getStepStatus("login", currentStep)}
-              onBack={goBack}
-              onNext={goNext}
-              onSkip={() => {
-                setDidSkipLogin(true);
-                void analyticsCommands.event({
-                  event: "onboarding_login_skipped",
-                });
-              }}
-            >
-              <LoginSection
-                onContinue={goNext}
-                onSkip={() => setDidSkipLogin(true)}
-              />
-            </OnboardingSection>
+      <div className="relative z-10 flex-1 overflow-y-auto">
+        <div className="flex flex-col gap-4 px-12 pb-16">
+          <OnboardingSection
+            title="Start with permissions"
+            completedTitle="Permissions granted"
+            description="Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
+            status={getStepStatus("permissions", currentStep)}
+            skippable={false}
+            onBack={goBack}
+            onNext={goNext}
+          >
+            <PermissionsSection onContinue={goNext} />
+          </OnboardingSection>
 
-            <OnboardingSection
-              title="Connect calendar"
-              description="Anarlog will sync your calendar to get meeting reminders"
-              completedTitle="Calendar connected"
-              status={getStepStatus("calendar", currentStep)}
-              onBack={goBack}
-              onNext={goNext}
-            >
-              <CalendarSection
-                onContinue={goNext}
-                onSignIn={handleCalendarSignIn}
-              />
-            </OnboardingSection>
+          <OnboardingSection
+            title="Create account"
+            description="Sign in to unlock powerful AI models, sync across devices, and personalization."
+            completedTitle={
+              auth.session ? "Signed in" : didSkipLogin ? "Skipped" : "Account"
+            }
+            status={getStepStatus("login", currentStep)}
+            onBack={goBack}
+            onNext={goNext}
+            onSkip={() => {
+              setDidSkipLogin(true);
+              void analyticsCommands.event({
+                event: "onboarding_login_skipped",
+              });
+            }}
+          >
+            <LoginSection
+              onContinue={goNext}
+              onSkip={() => setDidSkipLogin(true)}
+            />
+          </OnboardingSection>
 
-            <OnboardingSection
-              title="Storage"
-              description="Where your notes and recordings are stored"
-              completedTitle="Storage configured"
-              status={getStepStatus("folder-location", currentStep)}
-              onBack={goBack}
-              onNext={goNext}
-            >
-              <FolderLocationSection onContinue={goNext} />
-            </OnboardingSection>
+          <OnboardingSection
+            title="Connect calendar"
+            description="Anarlog will sync your calendar to get meeting reminders"
+            completedTitle="Calendar connected"
+            status={getStepStatus("calendar", currentStep)}
+            onBack={goBack}
+            onNext={goNext}
+          >
+            <CalendarSection
+              onContinue={goNext}
+              onSignIn={handleCalendarSignIn}
+            />
+          </OnboardingSection>
 
-            <OnboardingSection
-              title="Ready to go"
-              status={getStepStatus("final", currentStep)}
-              skippable={false}
-              onBack={goBack}
-              onNext={() => void finishOnboarding(handleFinish)}
-            >
-              <FinalSection onContinue={handleFinish} />
-            </OnboardingSection>
-          </div>
+          <OnboardingSection
+            title="Storage"
+            description="Where your notes and recordings are stored"
+            completedTitle="Storage configured"
+            status={getStepStatus("folder-location", currentStep)}
+            onBack={goBack}
+            onNext={goNext}
+          >
+            <FolderLocationSection onContinue={goNext} />
+          </OnboardingSection>
+
+          <OnboardingSection
+            title="Ready to go"
+            status={getStepStatus("final", currentStep)}
+            skippable={false}
+            onBack={goBack}
+            onNext={() => void finishOnboarding(handleFinish)}
+          >
+            <FinalSection onContinue={handleFinish} />
+          </OnboardingSection>
         </div>
       </div>
-    </StandardTabWrapper>
+    </div>
   );
 }

--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { Puzzle, RefreshCw, Sparkle } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
+import { RefreshCw, Sparkle } from "lucide-react";
 import {
   type ReactNode,
   useCallback,
@@ -29,27 +28,16 @@ import { useBillingAccess } from "~/auth/billing";
 import { env } from "~/env";
 import { waitForBillingUpdate } from "~/shared/billing";
 import { buildWebAppUrl } from "~/shared/utils";
-const ACCOUNT_FEATURES = [
-  {
-    label: "Cloud Services",
-    icon: Sparkle,
-    benefit:
-      "Get hosted transcription and language models without managing API keys.",
-    accent: {
-      icon: "text-blue-900",
-      label: "text-blue-950",
-    },
+const ACCOUNT_FEATURE = {
+  label: "Cloud Services",
+  icon: Sparkle,
+  benefit:
+    "Get hosted transcription and language models without managing API keys.",
+  accent: {
+    icon: "text-blue-900",
+    label: "text-blue-950",
   },
-  {
-    label: "Integrations",
-    icon: Puzzle,
-    benefit: "Connect tools and pull context into Anarlog with less busywork.",
-    accent: {
-      icon: "text-purple-700",
-      label: "text-purple-900",
-    },
-  },
-] as const;
+} as const;
 
 export function SettingsAccount() {
   const auth = useAuth();
@@ -123,7 +111,7 @@ export function SettingsAccount() {
                 <h3 className="text-sm font-medium">Sign in to Anarlog</h3>
                 <div className="text-sm text-neutral-600">
                   Sign in to unlock cloud transcription and AI models, plus Pro
-                  features like integrations and sharing.
+                  features like sharing.
                 </div>
               </div>
               <button
@@ -596,99 +584,30 @@ function PlanTierList({
 }
 
 function FeatureSpotlight() {
-  const [activeIndex, setActiveIndex] = useState(0);
-  const [isPaused, setIsPaused] = useState(false);
-
-  useEffect(() => {
-    if (isPaused) {
-      return;
-    }
-
-    const interval = window.setInterval(() => {
-      setActiveIndex((current) => (current + 1) % ACCOUNT_FEATURES.length);
-    }, 2200);
-
-    return () => window.clearInterval(interval);
-  }, [isPaused]);
-
-  const { label, icon: Icon, benefit, accent } = ACCOUNT_FEATURES[activeIndex];
+  const { label, icon: Icon, benefit, accent } = ACCOUNT_FEATURE;
 
   return (
     <div className="group relative flex w-full max-w-[220px] min-w-[180px] items-center justify-center p-2">
       <div className="relative min-h-[88px] w-full">
-        <AnimatePresence mode="wait" initial={false}>
-          <motion.div
-            key={label}
-            initial={{ opacity: 0, y: 10, scale: 0.96 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: -10, scale: 0.96 }}
-            transition={{ duration: 0.22, ease: "easeOut" }}
-            className="absolute inset-0"
-          >
-            <motion.button
-              type="button"
-              initial={{ opacity: 0, y: 10, scale: 0.96 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: -10, scale: 0.96 }}
-              transition={{ duration: 0.22, ease: "easeOut" }}
-              onMouseEnter={() => setIsPaused(true)}
-              onMouseLeave={() => setIsPaused(false)}
-              onFocus={() => setIsPaused(true)}
-              onBlur={() => setIsPaused(false)}
-              className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-center outline-none"
-              aria-label={`${label}. ${benefit}`}
-            >
-              <motion.div
-                initial={{ scale: 0.86, rotate: -10 }}
-                animate={{
-                  scale: isPaused ? 1.08 : 1,
-                  rotate: 0,
-                  y: isPaused ? -2 : 0,
-                }}
-                exit={{ scale: 0.9, rotate: 10 }}
-                transition={{ duration: 0.28, ease: "easeOut" }}
-                className="flex h-12 w-12 items-center justify-center"
-              >
-                <motion.div
-                  animate={
-                    isPaused ? { rotate: [0, -4, 4, 0] } : { y: [0, -2, 0] }
-                  }
-                  transition={{
-                    duration: isPaused ? 0.9 : 1.6,
-                    repeat: Number.POSITIVE_INFINITY,
-                    ease: "easeInOut",
-                  }}
-                >
-                  <Icon className={cn(["h-5 w-5", accent.icon])} />
-                </motion.div>
-              </motion.div>
-              <p className={cn(["text-sm font-medium", accent.label])}>
-                {label}
-              </p>
-            </motion.button>
-          </motion.div>
-        </AnimatePresence>
+        <button
+          type="button"
+          className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-center outline-none"
+          aria-label={`${label}. ${benefit}`}
+        >
+          <div className="flex h-12 w-12 items-center justify-center transition-transform group-focus-within:-translate-y-0.5 group-focus-within:scale-105 group-hover:-translate-y-0.5 group-hover:scale-105">
+            <Icon className={cn(["h-5 w-5", accent.icon])} />
+          </div>
+          <p className={cn(["text-sm font-medium", accent.label])}>{label}</p>
+        </button>
       </div>
-      <AnimatePresence>
-        {isPaused ? (
-          <motion.div
-            initial={{ opacity: 0, y: 8, scale: 0.98 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: 6, scale: 0.98 }}
-            transition={{ duration: 0.18, ease: "easeOut" }}
-            className="pointer-events-none absolute top-full right-0 z-10 mt-1.5 w-[208px] rounded-xl border border-neutral-200 bg-white/95 p-2.5 text-left shadow-lg backdrop-blur-sm"
-          >
-            <div className="flex items-center justify-between gap-3">
-              <p className={cn(["text-sm font-medium", accent.label])}>
-                {label}
-              </p>
-            </div>
-            <p className="mt-1 text-xs leading-[1.45] text-neutral-600">
-              {benefit}
-            </p>
-          </motion.div>
-        ) : null}
-      </AnimatePresence>
+      <div className="pointer-events-none absolute top-full right-0 z-10 mt-1.5 w-[208px] rounded-xl border border-neutral-200 bg-white/95 p-2.5 text-left opacity-0 shadow-lg backdrop-blur-sm transition-all duration-150 group-focus-within:translate-y-0 group-focus-within:opacity-100 group-hover:translate-y-0 group-hover:opacity-100">
+        <div className="flex items-center justify-between gap-3">
+          <p className={cn(["text-sm font-medium", accent.label])}>{label}</p>
+        </div>
+        <p className="mt-1 text-xs leading-[1.45] text-neutral-600">
+          {benefit}
+        </p>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -132,6 +132,29 @@ describe("ClassicMainBody", () => {
     );
   });
 
+  it("does not reserve top shell chrome for onboarding", () => {
+    mocks.currentTab = {
+      active: true,
+      pinned: false,
+      slotId: "slot-1",
+      type: "onboarding",
+    };
+
+    const { container } = render(<ClassicMainBody />);
+    const body = container.firstElementChild;
+    const firstBodyChild = body?.firstElementChild;
+
+    expect(screen.queryByTestId("top-meeting-timeline")).toBeNull();
+    expect(screen.queryByTestId("toast-area")).toBeNull();
+    expect(firstBodyChild?.className).toContain(
+      "flex min-h-0 min-w-0 flex-1 gap-1",
+    );
+    expect(firstBodyChild?.hasAttribute("data-tauri-drag-region")).toBe(false);
+    expect(screen.getByTestId("main-tab-content").textContent).toContain(
+      "onboarding",
+    );
+  });
+
   it("hides the top timeline when the sidebar timeline is enabled", () => {
     mocks.sidebarTimelineEnabled = true;
 


### PR DESCRIPTION
Remove the stale top shell chrome for onboarding and render onboarding outside the tab surface wrapper. Cover edge-to-edge shell behavior with regression tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and layout changes for onboarding and account settings only, with targeted regression tests and no auth or data-path changes.
> 
> **Overview**
> Onboarding now uses the **full window** instead of sitting inside the normal tab chrome. When the active tab is onboarding, the main shell enables **edge-to-edge** layout and drops **main surface chrome**; the main body also skips the top timeline, floating toasts, and the sidebar timeline drag strip so content starts at the main column immediately.
> 
> The onboarding screen is rendered **outside** `StandardTabWrapper` as a full-height layout with its own background/video treatment, and the in-tab flow turns on a **Tauri drag region** on the header. The pre-login step is trimmed to **sign-in CTAs** only (feature bullets and icon removed), with updated glass-style styling on the secondary button.
> 
> Settings **Account** copy and marketing UI are aligned: integrations are de-emphasized in sign-in text, and the rotating feature carousel becomes a single **Cloud Services** spotlight with a hover/focus tooltip. **Regression tests** cover onboarding shell props and the absence of top chrome in `ClassicMainBody`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 450018cef0d4ec182fef6c5085b335892f0c9ccb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5394 
- <kbd>&nbsp;1&nbsp;</kbd> #5393 👈 
<!-- GitButler Footer Boundary Bottom -->

