### PR TITLE
fix(desktop): use handwritten font for headings

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -6,6 +6,12 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&display=swap"
+    />
     <title>Anarlog</title>
     <style>
       html, body, #root {

--- a/apps/desktop/src/onboarding/index.tsx
+++ b/apps/desktop/src/onboarding/index.tsx
@@ -81,7 +81,7 @@ function OnboardingScreen({ onFinish }: { onFinish: () => void }) {
   return (
     <OnboardingScreenContent
       onFinish={onFinish}
-      headerClassName="px-12 pt-12 pb-8"
+      headerClassName="px-12 pb-8"
       headerDragRegion
     />
   );
@@ -92,15 +92,11 @@ export function StandaloneOnboardingScreen({
 }: {
   onFinish: () => void;
 }) {
-  const isMacOS = platform() === "macos";
-
   return (
     <StandaloneWindowShell>
       <OnboardingScreenContent
         onFinish={onFinish}
-        headerClassName={
-          isMacOS ? "pt-12 pr-12 pb-8 pl-20" : "px-12 pt-12 pb-8"
-        }
+        headerClassName="px-12 pb-8"
         headerDragRegion
       />
     </StandaloneWindowShell>
@@ -208,14 +204,8 @@ function OnboardingScreenContent({
 
       <div
         data-tauri-drag-region={headerDragRegion || undefined}
-        className={cn([
-          "sticky top-0 z-10 flex items-center justify-between",
-          headerClassName,
-        ])}
+        className="relative z-30 flex h-12 shrink-0 items-center justify-end px-12"
       >
-        <h1 className="font-sans text-3xl font-semibold text-neutral-900">
-          Welcome to Anarlog
-        </h1>
         <button
           onClick={() => setIsMuted((prev) => !prev)}
           data-tauri-drag-region="false"
@@ -228,6 +218,18 @@ function OnboardingScreenContent({
             <Volume2Icon size={16} className="text-neutral-600" />
           )}
         </button>
+      </div>
+
+      <div
+        data-tauri-drag-region={headerDragRegion || undefined}
+        className={cn([
+          "relative z-10 flex shrink-0 items-center",
+          headerClassName,
+        ])}
+      >
+        <h1 className="font-hand text-4xl leading-none font-semibold tracking-normal text-neutral-900">
+          Welcome to Anarlog
+        </h1>
       </div>
 
       <div className="relative z-10 flex-1 overflow-y-auto">

--- a/apps/desktop/src/settings/page-title.tsx
+++ b/apps/desktop/src/settings/page-title.tsx
@@ -1,3 +1,7 @@
 export function SettingsPageTitle({ title }: { title: string }) {
-  return <h2 className="font-sans text-lg font-semibold">{title}</h2>;
+  return (
+    <h2 className="font-hand text-3xl leading-none font-semibold tracking-normal">
+      {title}
+    </h2>
+  );
 }

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -10,6 +10,7 @@
 @theme {
   --font-sans:
     system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-hand: "Caveat", cursive;
 
   --animate-shimmer: shimmer 2s infinite;
   --animate-reveal-left: reveal-left 0.5s ease-out forwards;


### PR DESCRIPTION
Load the landing page Caveat font in desktop and apply it to onboarding and settings display headings.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5395 
- <kbd>&nbsp;1&nbsp;</kbd> #5394 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and font-loading changes only; no auth, data, or business-logic impact.
> 
> **Overview**
> Desktop onboarding and settings **display headings** now use the **Caveat** handwritten style (aligned with the landing page) instead of the default sans stack.
> 
> **Caveat** is loaded from Google Fonts in `index.html`, exposed as Tailwind’s `font-hand` via `--font-hand` in `globals.css`, and applied to the onboarding “Welcome to Anarlog” title and `SettingsPageTitle`. Onboarding layout is adjusted: a fixed-height top bar holds only the mute control, the welcome title sits in its own row below, and macOS-specific top padding on the header is removed in favor of uniform horizontal padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78127221f11e41b22191d00d13de604e57cade14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->