### PR TITLE
fix(desktop): tighten onboarding account actions

### DIFF
--- a/apps/desktop/src/onboarding/account/before-login.tsx
+++ b/apps/desktop/src/onboarding/account/before-login.tsx
@@ -6,13 +6,13 @@ export function BeforeLogin({ onContinue: _ }: { onContinue: () => void }) {
   const auth = useAuth();
 
   return (
-    <div className="flex flex-col items-start pt-8">
+    <div className="flex flex-col items-start">
       <div className="flex flex-row items-center gap-4">
         <OnboardingButton
           onClick={() => {
             void auth?.signIn();
           }}
-          className="px-8 py-3 text-base"
+          className="px-6 py-2 text-sm"
         >
           Get started for free
         </OnboardingButton>
@@ -22,7 +22,7 @@ export function BeforeLogin({ onContinue: _ }: { onContinue: () => void }) {
           onClick={() => {
             void auth?.signIn();
           }}
-          className="text-md rounded-full border border-white/60 bg-white/55 px-8 py-3 font-medium text-neutral-600 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-sm transition-colors hover:bg-white/75 hover:text-neutral-800"
+          className="rounded-full border border-white/60 bg-white/55 px-6 py-2 text-sm font-medium text-neutral-600 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-sm transition-colors hover:bg-white/75 hover:text-neutral-800"
         >
           Login with existing account
         </button>

--- a/apps/desktop/src/onboarding/index.tsx
+++ b/apps/desktop/src/onboarding/index.tsx
@@ -204,7 +204,7 @@ function OnboardingScreenContent({
 
       <div
         data-tauri-drag-region={headerDragRegion || undefined}
-        className="relative z-30 flex h-12 shrink-0 items-center justify-end px-12"
+        className="relative z-30 flex h-12 shrink-0 items-center justify-end pr-8 pl-12"
       >
         <button
           onClick={() => setIsMuted((prev) => !prev)}
@@ -261,6 +261,7 @@ function OnboardingScreenContent({
                 event: "onboarding_login_skipped",
               });
             }}
+            contentClassName="-mt-4 pt-2"
           >
             <LoginSection
               onContinue={goNext}

--- a/apps/desktop/src/onboarding/shared.tsx
+++ b/apps/desktop/src/onboarding/shared.tsx
@@ -24,6 +24,7 @@ export function OnboardingSection({
   onNext,
   onSkip,
   skippable = true,
+  contentClassName,
   children,
 }: {
   title: string;
@@ -34,6 +35,7 @@ export function OnboardingSection({
   onNext?: () => void;
   onSkip?: () => void;
   skippable?: boolean;
+  contentClassName?: string;
   children: ReactNode;
 }) {
   const sectionRef = useRef<HTMLElement>(null);
@@ -129,7 +131,10 @@ export function OnboardingSection({
             animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={{ duration: 0.3, ease: "easeInOut" }}
-            className="-mx-5 -mt-3 -mb-5 overflow-hidden px-5 pt-3 pb-5"
+            className={cn([
+              "-mx-5 -mt-3 -mb-5 overflow-hidden px-5 pt-3 pb-5",
+              contentClassName,
+            ])}
           >
             {children}
           </motion.div>


### PR DESCRIPTION
Reduce the account step gap and shrink the sign-in button padding and labels.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5395 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5394 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only onboarding layout changes with no auth, data, or business-logic impact.
> 
> **Overview**
> Tightens desktop onboarding layout around the **Create account** step: smaller sign-in controls, less vertical gap in the account section, and a slight header padding tweak.
> 
> **Before login** drops top padding on the action row and shrinks both **Get started for free** and **Login with existing account** to `px-6 py-2 text-sm` (from larger padding/`text-base`).
> 
> **OnboardingSection** gains an optional `contentClassName` merged into the expandable content area; the login step uses `-mt-4 pt-2` to pull content closer to the title. The top mute bar uses `pr-8 pl-12` instead of uniform `px-12`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d717600ff2956447fed6304b4f44e3ac1598c266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->