### PR TITLE
fix(desktop): preserve dragged floating panel placement

### DIFF
--- a/plugins/windows/swift-lib/src/DevtoolsPanelManager.swift
+++ b/plugins/windows/swift-lib/src/DevtoolsPanelManager.swift
@@ -5,7 +5,7 @@ final class DevtoolsPanelManager {
   static let shared = DevtoolsPanelManager()
 
   private var panel: NSPanel?
-  private var activeScreenId: CGDirectDisplayID?
+  private let placement = FloatingPanelPositionController()
   private var displayChangeObserver: Any?
   private var followActiveScreenTimer: Timer?
 
@@ -45,7 +45,7 @@ final class DevtoolsPanelManager {
       self.stopFollowingActiveScreen()
       panel.orderOut(nil)
       self.panel = nil
-      self.activeScreenId = nil
+      self.placement.resetActiveScreen()
     }
   }
 
@@ -69,54 +69,17 @@ final class DevtoolsPanelManager {
     panel.hasShadow = true
     panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
     panel.isMovableByWindowBackground = true
+    panel.delegate = placement
     return panel
   }
 
   private func position(_ panel: NSPanel, force: Bool = false) {
-    let screen = activeScreen()
-    let screenId = displayId(for: screen)
-    if !force, screenId == activeScreenId {
-      return
+    placement.position(panel, force: force) { screen in
+      let frame = screen.visibleFrame
+      let x = frame.maxX - DevtoolsPanelLayout.containerWidth - DevtoolsPanelLayout.screenMargin
+      let y = frame.maxY - DevtoolsPanelLayout.containerHeight - DevtoolsPanelLayout.screenMargin
+      return NSPoint(x: x, y: y)
     }
-
-    let frame = screen.visibleFrame
-    let x = frame.maxX - DevtoolsPanelLayout.containerWidth - DevtoolsPanelLayout.screenMargin
-    let y = frame.maxY - DevtoolsPanelLayout.containerHeight - DevtoolsPanelLayout.screenMargin
-    panel.setFrameOrigin(NSPoint(x: x, y: y))
-    activeScreenId = screenId
-  }
-
-  private func activeScreen() -> NSScreen {
-    let mouse = NSEvent.mouseLocation
-    let screens = NSScreen.screens
-
-    if let exactScreen = screens.first(where: { $0.frame.contains(mouse) }) {
-      return exactScreen
-    }
-
-    if let activeScreenId,
-      let currentScreen = screens.first(where: { displayId(for: $0) == activeScreenId }),
-      currentScreen.frame.insetBy(dx: -80, dy: -80).contains(mouse)
-    {
-      return currentScreen
-    }
-
-    return screens.min { left, right in
-      distanceSquared(from: mouse, to: left.frame) < distanceSquared(from: mouse, to: right.frame)
-    } ?? NSScreen.main ?? screens.first!
-  }
-
-  private func displayId(for screen: NSScreen) -> CGDirectDisplayID? {
-    let key = NSDeviceDescriptionKey("NSScreenNumber")
-    return (screen.deviceDescription[key] as? NSNumber).map { CGDirectDisplayID($0.uint32Value) }
-  }
-
-  private func distanceSquared(from point: NSPoint, to rect: NSRect) -> CGFloat {
-    let clampedX = min(max(point.x, rect.minX), rect.maxX)
-    let clampedY = min(max(point.y, rect.minY), rect.maxY)
-    let dx = point.x - clampedX
-    let dy = point.y - clampedY
-    return dx * dx + dy * dy
   }
 
   private func startFollowingActiveScreen() {

--- a/plugins/windows/swift-lib/src/FloatingBarManager.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarManager.swift
@@ -6,7 +6,7 @@ final class FloatingBarManager {
 
   private var panel: NSPanel?
   private let model = FloatingBarViewModel()
-  private var activeScreenId: CGDirectDisplayID?
+  private let placement = FloatingPanelPositionController()
   private var displayChangeObserver: Any?
   private var followActiveScreenTimer: Timer?
 
@@ -48,7 +48,7 @@ final class FloatingBarManager {
       self.stopFollowingActiveScreen()
       panel.orderOut(nil)
       self.panel = nil
-      self.activeScreenId = nil
+      self.placement.resetActiveScreen()
     }
   }
 
@@ -80,54 +80,17 @@ final class FloatingBarManager {
     panel.hasShadow = false
     panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
     panel.isMovableByWindowBackground = true
+    panel.delegate = placement
     return panel
   }
 
   private func position(_ panel: NSPanel, force: Bool = false) {
-    let screen = activeScreen()
-    let screenId = displayId(for: screen)
-    if !force, screenId == activeScreenId {
-      return
+    placement.position(panel, force: force) { screen in
+      let frame = screen.visibleFrame
+      let x = frame.maxX - FloatingBarLayout.containerWidth - FloatingBarLayout.screenMargin
+      let y = frame.midY - FloatingBarLayout.containerHeight / 2
+      return NSPoint(x: x, y: y)
     }
-
-    let frame = screen.visibleFrame
-    let x = frame.maxX - FloatingBarLayout.containerWidth - FloatingBarLayout.screenMargin
-    let y = frame.midY - FloatingBarLayout.containerHeight / 2
-    panel.setFrameOrigin(NSPoint(x: x, y: y))
-    activeScreenId = screenId
-  }
-
-  private func activeScreen() -> NSScreen {
-    let mouse = NSEvent.mouseLocation
-    let screens = NSScreen.screens
-
-    if let exactScreen = screens.first(where: { $0.frame.contains(mouse) }) {
-      return exactScreen
-    }
-
-    if let activeScreenId,
-      let currentScreen = screens.first(where: { displayId(for: $0) == activeScreenId }),
-      currentScreen.frame.insetBy(dx: -80, dy: -80).contains(mouse)
-    {
-      return currentScreen
-    }
-
-    return screens.min { left, right in
-      distanceSquared(from: mouse, to: left.frame) < distanceSquared(from: mouse, to: right.frame)
-    } ?? NSScreen.main ?? screens.first!
-  }
-
-  private func displayId(for screen: NSScreen) -> CGDirectDisplayID? {
-    let key = NSDeviceDescriptionKey("NSScreenNumber")
-    return (screen.deviceDescription[key] as? NSNumber).map { CGDirectDisplayID($0.uint32Value) }
-  }
-
-  private func distanceSquared(from point: NSPoint, to rect: NSRect) -> CGFloat {
-    let clampedX = min(max(point.x, rect.minX), rect.maxX)
-    let clampedY = min(max(point.y, rect.minY), rect.maxY)
-    let dx = point.x - clampedX
-    let dy = point.y - clampedY
-    return dx * dx + dy * dy
   }
 
   private func startFollowingActiveScreen() {

--- a/plugins/windows/swift-lib/src/FloatingPanelPositionController.swift
+++ b/plugins/windows/swift-lib/src/FloatingPanelPositionController.swift
@@ -4,7 +4,9 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
   private var activeScreenId: CGDirectDisplayID?
   private var pinnedOrigin: NSPoint?
   private var isProgrammaticMove = false
+  private var programmaticMoveId = 0
   private var programmaticOrigin: NSPoint?
+  private let programmaticMoveSuppressionDelay: TimeInterval = 0.15
 
   func position(_ panel: NSPanel, force: Bool = false, defaultOrigin: (NSScreen) -> NSPoint) {
     if let pinnedOrigin {
@@ -33,27 +35,42 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
 
   func windowDidMove(_ notification: Notification) {
     guard let panel = notification.object as? NSPanel else { return }
-
     let origin = panel.frame.origin
+
+    if isProgrammaticMove {
+      programmaticOrigin = origin
+      return
+    }
+
     if let programmaticOrigin, pointsAreClose(origin, programmaticOrigin) {
       return
     }
 
-    if programmaticOrigin != nil {
-      self.programmaticOrigin = nil
+    guard isPointerButtonPressed else {
+      programmaticOrigin = origin
+      return
     }
 
-    guard !isProgrammaticMove else { return }
-
+    programmaticOrigin = nil
     pinnedOrigin = origin
     activeScreenId = panel.screen.flatMap { displayId(for: $0) }
   }
 
   private func move(_ panel: NSPanel, to origin: NSPoint) {
+    programmaticMoveId += 1
+    let moveId = programmaticMoveId
+
     isProgrammaticMove = true
     programmaticOrigin = origin
     panel.setFrameOrigin(origin)
-    isProgrammaticMove = false
+    programmaticOrigin = panel.frame.origin
+
+    // AppKit can deliver move notifications shortly after setFrameOrigin returns.
+    DispatchQueue.main.asyncAfter(deadline: .now() + programmaticMoveSuppressionDelay) {
+      [weak self] in
+      guard let self, self.programmaticMoveId == moveId else { return }
+      self.isProgrammaticMove = false
+    }
   }
 
   private func activeScreen() -> NSScreen {
@@ -130,5 +147,9 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
 
   private func pointsAreClose(_ left: NSPoint, _ right: NSPoint) -> Bool {
     abs(left.x - right.x) < 0.5 && abs(left.y - right.y) < 0.5
+  }
+
+  private var isPointerButtonPressed: Bool {
+    NSEvent.pressedMouseButtons != 0
   }
 }

--- a/plugins/windows/swift-lib/src/FloatingPanelPositionController.swift
+++ b/plugins/windows/swift-lib/src/FloatingPanelPositionController.swift
@@ -1,0 +1,134 @@
+import Cocoa
+
+final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
+  private var activeScreenId: CGDirectDisplayID?
+  private var pinnedOrigin: NSPoint?
+  private var isProgrammaticMove = false
+  private var programmaticOrigin: NSPoint?
+
+  func position(_ panel: NSPanel, force: Bool = false, defaultOrigin: (NSScreen) -> NSPoint) {
+    if let pinnedOrigin {
+      if force {
+        let origin = clampedOrigin(pinnedOrigin, for: panel)
+        move(panel, to: origin)
+        self.pinnedOrigin = origin
+        activeScreenId = panel.screen.flatMap { displayId(for: $0) }
+      }
+      return
+    }
+
+    let screen = activeScreen()
+    let screenId = displayId(for: screen)
+    if !force, screenId == activeScreenId {
+      return
+    }
+
+    move(panel, to: defaultOrigin(screen))
+    activeScreenId = screenId
+  }
+
+  func resetActiveScreen() {
+    activeScreenId = nil
+  }
+
+  func windowDidMove(_ notification: Notification) {
+    guard let panel = notification.object as? NSPanel else { return }
+
+    let origin = panel.frame.origin
+    if let programmaticOrigin, pointsAreClose(origin, programmaticOrigin) {
+      return
+    }
+
+    if programmaticOrigin != nil {
+      self.programmaticOrigin = nil
+    }
+
+    guard !isProgrammaticMove else { return }
+
+    pinnedOrigin = origin
+    activeScreenId = panel.screen.flatMap { displayId(for: $0) }
+  }
+
+  private func move(_ panel: NSPanel, to origin: NSPoint) {
+    isProgrammaticMove = true
+    programmaticOrigin = origin
+    panel.setFrameOrigin(origin)
+    isProgrammaticMove = false
+  }
+
+  private func activeScreen() -> NSScreen {
+    let mouse = NSEvent.mouseLocation
+    let screens = NSScreen.screens
+
+    if let exactScreen = screens.first(where: { $0.frame.contains(mouse) }) {
+      return exactScreen
+    }
+
+    if let activeScreenId,
+      let currentScreen = screens.first(where: { displayId(for: $0) == activeScreenId }),
+      currentScreen.frame.insetBy(dx: -80, dy: -80).contains(mouse)
+    {
+      return currentScreen
+    }
+
+    return nearestScreen(to: mouse) ?? NSScreen.main ?? screens.first!
+  }
+
+  private func clampedOrigin(_ origin: NSPoint, for panel: NSPanel) -> NSPoint {
+    let size = panel.frame.size
+    let rect = NSRect(origin: origin, size: size)
+    guard
+      let screen = screen(containing: rect) ?? nearestScreen(to: center(of: rect)) ?? NSScreen.main
+    else {
+      return origin
+    }
+
+    let frame = screen.visibleFrame
+    let maxX = max(frame.minX, frame.maxX - size.width)
+    let maxY = max(frame.minY, frame.maxY - size.height)
+
+    return NSPoint(
+      x: clamped(origin.x, lowerBound: frame.minX, upperBound: maxX),
+      y: clamped(origin.y, lowerBound: frame.minY, upperBound: maxY)
+    )
+  }
+
+  private func screen(containing rect: NSRect) -> NSScreen? {
+    let screens = NSScreen.screens
+    let center = center(of: rect)
+    return screens.first(where: { $0.frame.contains(center) })
+      ?? screens.first(where: { $0.frame.intersects(rect) })
+  }
+
+  private func nearestScreen(to point: NSPoint) -> NSScreen? {
+    let screens = NSScreen.screens
+    return screens.min { left, right in
+      distanceSquared(from: point, to: left.frame) < distanceSquared(from: point, to: right.frame)
+    }
+  }
+
+  private func displayId(for screen: NSScreen) -> CGDirectDisplayID? {
+    let key = NSDeviceDescriptionKey("NSScreenNumber")
+    return (screen.deviceDescription[key] as? NSNumber).map { CGDirectDisplayID($0.uint32Value) }
+  }
+
+  private func distanceSquared(from point: NSPoint, to rect: NSRect) -> CGFloat {
+    let clampedX = clamped(point.x, lowerBound: rect.minX, upperBound: rect.maxX)
+    let clampedY = clamped(point.y, lowerBound: rect.minY, upperBound: rect.maxY)
+    let dx = point.x - clampedX
+    let dy = point.y - clampedY
+    return dx * dx + dy * dy
+  }
+
+  private func center(of rect: NSRect) -> NSPoint {
+    NSPoint(x: rect.midX, y: rect.midY)
+  }
+
+  private func clamped(_ value: CGFloat, lowerBound: CGFloat, upperBound: CGFloat) -> CGFloat {
+    min(max(value, lowerBound), upperBound)
+  }
+
+  private func pointsAreClose(_ left: NSPoint, _ right: NSPoint) -> Bool {
+    abs(left.x - right.x) < 0.5 && abs(left.y - right.y) < 0.5
+  }
+}


### PR DESCRIPTION
Pin native floating panels after manual moves and share placement logic across devtools and meeting controls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop UI positioning only; no auth, data, or network paths. Behavior change is localized to native floating panels.
> 
> **Overview**
> Introduces **`FloatingPanelPositionController`** and wires it as each floating panel’s **`NSWindowDelegate`**, replacing duplicated screen-tracking and positioning code in the devtools and meeting-control floating bar managers.
> 
> **Manual drags are preserved:** when the user moves a panel with the mouse button down, the new origin is **pinned** so periodic “follow active screen” repositioning no longer overwrites it. Programmatic moves (timers, display changes) are ignored for pinning via move-suppression around **`setFrameOrigin`**. On forced reposition (e.g. screen layout change), a pinned panel is **clamped** to the visible frame instead of jumping back to the default corner/center placement.
> 
> Each manager only supplies its **default origin** closure (devtools: top-right; bar: right, vertically centered); shared logic handles active display selection, screen-id caching, and reset on hide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a1dfaa68c9dc85b00a5bfb8ce24f31857a2b9de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->