### PR TITLE
fix(desktop): polish onboarding flow

### DIFF
--- a/apps/desktop/src/onboarding/calendar.tsx
+++ b/apps/desktop/src/onboarding/calendar.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, useState } from "react";
 import type { ConnectionItem } from "@hypr/api-client";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
 
-import { OnboardingButton, OnboardingAnarlogIcon } from "./shared";
+import { OnboardingButton } from "./shared";
 
 import { useAuth } from "~/auth";
 import { useBillingAccess } from "~/auth/billing";
@@ -390,8 +390,7 @@ function OutlookCalendarProvider({ onSignIn }: { onSignIn: () => void }) {
       {!isSignedIn ? (
         <span className="grid items-center overflow-hidden">
           <span className="invisible col-start-1 row-start-1 flex items-center justify-center gap-3">
-            <OnboardingAnarlogIcon />
-            Sign in to Anarlog
+            Sign in to connect
           </span>
 
           <motion.span
@@ -402,9 +401,6 @@ function OutlookCalendarProvider({ onSignIn }: { onSignIn: () => void }) {
             {OUTLOOK_PROVIDER.icon}
             <div className="flex flex-col items-start justify-center">
               <p className="text-md font-normal text-neutral-900">Outlook</p>
-              <span className="text-xs font-normal text-neutral-500">
-                Only in Pro
-              </span>
             </div>
           </motion.span>
 
@@ -413,8 +409,7 @@ function OutlookCalendarProvider({ onSignIn }: { onSignIn: () => void }) {
             animate={{ y: isHovered ? "0%" : "-150%" }}
             transition={{ type: "spring", bounce: 0.15, duration: 0.35 }}
           >
-            <OnboardingAnarlogIcon />
-            Sign in to Anarlog
+            Sign in to connect
           </motion.span>
         </span>
       ) : (
@@ -499,8 +494,7 @@ function GoogleCalendarProvider({ onSignIn }: { onSignIn: () => void }) {
         {!isSignedIn ? (
           <span className="grid items-center overflow-hidden">
             <span className="invisible col-start-1 row-start-1 flex items-center justify-center gap-3">
-              <OnboardingAnarlogIcon />
-              Sign in to Anarlog
+              Sign in to connect
             </span>
 
             <motion.span
@@ -511,9 +505,6 @@ function GoogleCalendarProvider({ onSignIn }: { onSignIn: () => void }) {
               {GOOGLE_PROVIDER.icon}
               <div className="flex flex-col items-start justify-center">
                 <p className="text-md font-normal text-neutral-900">Google</p>
-                <span className="text-xs font-normal text-neutral-500">
-                  Only in Pro
-                </span>
               </div>
             </motion.span>
 
@@ -522,8 +513,7 @@ function GoogleCalendarProvider({ onSignIn }: { onSignIn: () => void }) {
               animate={{ y: isHovered ? "0%" : "-140%" }}
               transition={{ type: "spring", bounce: 0.15, duration: 0.35 }}
             >
-              <OnboardingAnarlogIcon />
-              Sign in to Anarlog
+              Sign in to connect
             </motion.span>
           </span>
         ) : (
@@ -556,7 +546,7 @@ function CalendarSectionContent({
   return (
     <div className="flex flex-col gap-4">
       {hasAnyConnected ? (
-        <div className="flex flex-col gap-4">
+        <>
           {isMacos && (
             <AppleCalendarProvider
               isAuthorized={isAuthorized}
@@ -565,12 +555,17 @@ function CalendarSectionContent({
               onTroubleshoot={() => setShowTroubleshooting(true)}
             />
           )}
-          <GoogleCalendarProvider onSignIn={onSignIn} />
-          <OutlookCalendarProvider onSignIn={onSignIn} />
-        </div>
+          <div className="flex flex-wrap items-center gap-4">
+            <GoogleCalendarProvider onSignIn={onSignIn} />
+            <OutlookCalendarProvider onSignIn={onSignIn} />
+          </div>
+          {hasConnectedCalendar && (
+            <OnboardingButton onClick={onContinue}>Continue</OnboardingButton>
+          )}
+        </>
       ) : (
         // for the case when the user has no connected calendars yet we show the calendars in a row
-        <div className="flex flex-row items-stretch gap-4">
+        <div className="flex flex-wrap items-stretch gap-4">
           {isMacos && (
             <AppleCalendarProvider
               isAuthorized={isAuthorized}
@@ -593,10 +588,6 @@ function CalendarSectionContent({
           isPending={calendar.isPending}
           className="text-sm text-neutral-500"
         />
-      )}
-
-      {hasConnectedCalendar && (
-        <OnboardingButton onClick={onContinue}>Continue</OnboardingButton>
       )}
     </div>
   );

--- a/apps/desktop/src/onboarding/final.tsx
+++ b/apps/desktop/src/onboarding/final.tsx
@@ -13,51 +13,55 @@ const SOCIALS = [
   {
     label: "Discord",
     icon: "simple-icons:discord",
-    size: 23,
     url: "https://discord.gg/CX8gTH2tj9",
   },
   {
     label: "GitHub",
     icon: "simple-icons:github",
-    size: 23,
     url: "https://github.com/fastrepl/char",
   },
   {
     label: "X",
     icon: "simple-icons:x",
-    size: 23,
+    size: 14,
     url: "https://x.com/getcharnotes",
   },
 ] as const;
 
+const SOCIAL_ICON_SIZE = 18;
+
+export function FinalDescription() {
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+      <span>Join our community and stay updated:</span>
+      <div className="flex items-center gap-2">
+        {SOCIALS.map((social) => {
+          const iconSize = "size" in social ? social.size : SOCIAL_ICON_SIZE;
+
+          return (
+            <button
+              key={social.label}
+              onClick={() => void openerCommands.openUrl(social.url, null)}
+              className="inline-flex size-5 items-center justify-center rounded-md text-neutral-400 transition-colors duration-150 hover:text-neutral-700"
+              aria-label={social.label}
+            >
+              <Icon icon={social.icon} width={iconSize} height={iconSize} />
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export function FinalSection({ onContinue }: { onContinue: () => void }) {
   return (
-    <div className="flex flex-col gap-6">
-      <div className="items-left flex flex-col gap-4 text-sm text-neutral-500">
-        <span>Join our community and stay updated:</span>
-        <div className="flex items-center gap-4">
-          {SOCIALS.map(({ label, icon, size, url }) => {
-            return (
-              <button
-                key={label}
-                onClick={() => void openerCommands.openUrl(url, null)}
-                className="inline-flex size-6 items-center justify-center rounded-md text-neutral-400 transition-colors duration-150 hover:text-neutral-700"
-                aria-label={label}
-              >
-                <Icon icon={icon} width={size} height={size} />
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
-      <OnboardingButton
-        className="px-10 py-3.5 text-base"
-        onClick={() => void finishOnboarding(onContinue)}
-      >
-        Open Anarlog
-      </OnboardingButton>
-    </div>
+    <OnboardingButton
+      className="px-6 py-2 text-sm"
+      onClick={() => void finishOnboarding(onContinue)}
+    >
+      Open Anarlog
+    </OnboardingButton>
   );
 }
 

--- a/apps/desktop/src/onboarding/index.tsx
+++ b/apps/desktop/src/onboarding/index.tsx
@@ -16,7 +16,7 @@ import {
   getPrevStep,
   getStepStatus,
 } from "./config";
-import { FinalSection, finishOnboarding } from "./final";
+import { FinalDescription, FinalSection, finishOnboarding } from "./final";
 import { FolderLocationSection } from "./folder-location";
 import { PermissionsSection } from "./permissions";
 import { OnboardingSection } from "./shared";
@@ -81,7 +81,7 @@ function OnboardingScreen({ onFinish }: { onFinish: () => void }) {
   return (
     <OnboardingScreenContent
       onFinish={onFinish}
-      headerClassName="px-12 pb-8"
+      headerClassName="px-12 pt-4 pb-8"
       headerDragRegion
     />
   );
@@ -96,7 +96,7 @@ export function StandaloneOnboardingScreen({
     <StandaloneWindowShell>
       <OnboardingScreenContent
         onFinish={onFinish}
-        headerClassName="px-12 pb-8"
+        headerClassName="px-12 pt-4 pb-8"
         headerDragRegion
       />
     </StandaloneWindowShell>
@@ -204,7 +204,7 @@ function OnboardingScreenContent({
 
       <div
         data-tauri-drag-region={headerDragRegion || undefined}
-        className="relative z-30 flex h-12 shrink-0 items-center justify-end pr-8 pl-12"
+        className="relative z-30 flex h-12 shrink-0 items-center justify-end pr-3 pl-12"
       >
         <button
           onClick={() => setIsMuted((prev) => !prev)}
@@ -232,7 +232,7 @@ function OnboardingScreenContent({
         </h1>
       </div>
 
-      <div className="relative z-10 flex-1 overflow-y-auto">
+      <div className="scroll-fade-y relative z-10 flex-1 overflow-y-auto">
         <div className="flex flex-col gap-4 px-12 pb-16">
           <OnboardingSection
             title="Start with permissions"
@@ -261,7 +261,6 @@ function OnboardingScreenContent({
                 event: "onboarding_login_skipped",
               });
             }}
-            contentClassName="-mt-4 pt-2"
           >
             <LoginSection
               onContinue={goNext}
@@ -296,6 +295,7 @@ function OnboardingScreenContent({
 
           <OnboardingSection
             title="Ready to go"
+            description={<FinalDescription />}
             status={getStepStatus("final", currentStep)}
             skippable={false}
             onBack={goBack}

--- a/apps/desktop/src/onboarding/shared.tsx
+++ b/apps/desktop/src/onboarding/shared.tsx
@@ -24,18 +24,16 @@ export function OnboardingSection({
   onNext,
   onSkip,
   skippable = true,
-  contentClassName,
   children,
 }: {
   title: string;
-  completedTitle?: string;
-  description?: string;
+  completedTitle?: ReactNode;
+  description?: ReactNode;
   status: SectionStatus | null;
   onBack?: () => void;
   onNext?: () => void;
   onSkip?: () => void;
   skippable?: boolean;
-  contentClassName?: string;
   children: ReactNode;
 }) {
   const sectionRef = useRef<HTMLElement>(null);
@@ -61,7 +59,7 @@ export function OnboardingSection({
       <div
         className={cn([
           "flex items-center gap-2 transition-all duration-300",
-          isActive && "mb-6 pt-4",
+          isActive && "mb-3 pt-4",
         ])}
       >
         {isCompleted && (
@@ -70,20 +68,20 @@ export function OnboardingSection({
             strokeWidth={2.5}
           />
         )}
-        <div className="flex min-w-0 flex-col gap-1">
+        <div className="flex min-w-0 flex-col gap-3">
           <div className="flex items-center gap-2">
             <h2
               className={cn([
                 "transition-all duration-300",
                 isCompleted
-                  ? "text-sm font-normal text-neutral-300"
-                  : "mb-2 font-sans text-2xl font-semibold text-neutral-900",
+                  ? "text-xs font-normal text-neutral-300"
+                  : "font-sans text-xl font-semibold text-neutral-900",
               ])}
             >
               {isCompleted ? (completedTitle ?? title) : title}
             </h2>
             {isActive && (
-              <div className="mb-1 flex items-center gap-2">
+              <div className="flex items-center gap-2">
                 {import.meta.env.DEV && onBack && (
                   <button
                     onClick={onBack}
@@ -118,7 +116,7 @@ export function OnboardingSection({
             )}
           </div>
           {isActive && description && (
-            <p className="text-sm text-neutral-500">{description}</p>
+            <div className="text-sm text-neutral-500">{description}</div>
           )}
         </div>
       </div>
@@ -131,10 +129,7 @@ export function OnboardingSection({
             animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={{ duration: 0.3, ease: "easeInOut" }}
-            className={cn([
-              "-mx-5 -mt-3 -mb-5 overflow-hidden px-5 pt-3 pb-5",
-              contentClassName,
-            ])}
+            className="-mx-5 -mb-5 overflow-hidden px-5 pt-3 pb-5"
           >
             {children}
           </motion.div>


### PR DESCRIPTION
Tune onboarding spacing, header sizing, scroll fade, and calendar sign-in button presentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to onboarding copy, layout, and styling with no auth, billing, or data-path changes.
> 
> **Overview**
> Polishes the **desktop onboarding** layout and copy so calendar and final steps read more clearly on smaller widths.
> 
> **Calendar step:** Unsigned Google/Outlook buttons no longer show the Anarlog icon, **“Only in Pro”** sublabels, or **“Sign in to Anarlog”**—hover copy is **“Sign in to connect”** with provider branding only. When something is already connected, Apple stays separate, OAuth providers sit in a **wrapping row**, and **Continue** appears in that branch (only after a cloud calendar is enabled), not below troubleshooting.
> 
> **Shell & sections:** Header gets extra top padding; the scroll area uses **`scroll-fade-y`**; the mute control is nudged (**`pr-3`**). **`OnboardingSection`** accepts **`ReactNode`** descriptions (used for the final step), drops **`contentClassName`**, and tightens active/completed title sizes and spacing. Login loses its custom content offset.
> 
> **Final step:** Community links move into **`FinalDescription`** in the section header; **`FinalSection`** is just the smaller **Open Anarlog** button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec0493d1d58d9369d9812cc78e659f1a83ca62ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->