### PR TITLE
fix(desktop): make calendar nav pill shaped

### DIFF
--- a/apps/desktop/src/calendar/components/calendar-view.tsx
+++ b/apps/desktop/src/calendar/components/calendar-view.tsx
@@ -15,7 +15,10 @@ import { ChevronLeftIcon, ChevronRightIcon, RefreshCwIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "@hypr/ui/components/ui/button";
-import { ButtonGroup } from "@hypr/ui/components/ui/button-group";
+import {
+  ButtonGroup,
+  ButtonGroupSeparator,
+} from "@hypr/ui/components/ui/button-group";
 import { Spinner } from "@hypr/ui/components/ui/spinner";
 import {
   Tooltip,
@@ -197,27 +200,38 @@ export function CalendarView() {
           </h2>
           <CalendarSyncHeaderControls />
         </div>
-        <ButtonGroup data-tauri-drag-region="false" className="rounded-full">
+        <ButtonGroup
+          data-tauri-drag-region="false"
+          className={cn([
+            "h-8 overflow-hidden rounded-full border border-neutral-200",
+            "bg-white shadow-xs",
+          ])}
+        >
           <Button
-            variant="outline"
+            variant="ghost"
             size="icon"
-            className="rounded-l-full shadow-none"
+            className="h-full w-10 rounded-none border-0 bg-transparent shadow-none hover:bg-neutral-50"
             onClick={goToPrev}
           >
             <ChevronLeftIcon className="h-4 w-4" />
           </Button>
+          <ButtonGroupSeparator className="bg-neutral-200" />
           <Button
-            variant="outline"
+            variant="ghost"
             size="sm"
-            className="px-3 shadow-none"
+            className={cn([
+              "h-full rounded-none border-0",
+              "bg-transparent px-3 text-sm shadow-none hover:bg-neutral-50",
+            ])}
             onClick={goToToday}
           >
             Today
           </Button>
+          <ButtonGroupSeparator className="bg-neutral-200" />
           <Button
-            variant="outline"
+            variant="ghost"
             size="icon"
-            className="rounded-r-full shadow-none"
+            className="h-full w-10 rounded-none border-0 bg-transparent shadow-none hover:bg-neutral-50"
             onClick={goToNext}
           >
             <ChevronRightIcon className="h-4 w-4" />


### PR DESCRIPTION
Render the calendar navigation controls as one clipped pill with internal separators.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to calendar header controls; no logic, sync, or data handling.
> 
> **Overview**
> The desktop calendar header **prev / Today / next** controls are restyled as a **single pill-shaped control** instead of separate outlined buttons.
> 
> The `ButtonGroup` now uses a fixed height, full rounding, white background, border, and shadow, with **`ButtonGroupSeparator`** dividers between segments. Navigation buttons switch to **ghost** styling with square inner corners and shared hover treatment so the group reads as one clipped pill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe3b0c95380550e98ef23e8818cead9ac615899f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->