### PR TITLE
Fix Pro trial icon shadow

### DIFF
--- a/apps/desktop/src/billing/trial-dialog-icon.tsx
+++ b/apps/desktop/src/billing/trial-dialog-icon.tsx
@@ -8,7 +8,7 @@ export function TrialDialogIcon({ state }: { state: "started" | "ended" }) {
   return (
     <div
       className={cn([
-        "relative flex size-[76px] items-center justify-center overflow-visible",
+        "relative -my-2 flex size-[92px] items-center justify-center overflow-visible",
         isStarted
           ? "drop-shadow-[0_14px_22px_rgba(180,83,9,0.22)]"
           : "drop-shadow-[0_14px_22px_rgba(0,0,0,0.18)]",
@@ -17,7 +17,7 @@ export function TrialDialogIcon({ state }: { state: "started" | "ended" }) {
       <div
         aria-hidden="true"
         className={cn([
-          "absolute inset-2.5 rounded-[22px] blur-md",
+          "absolute size-14 rounded-[18px] blur-md",
           isStarted ? "bg-amber-200/55" : "bg-neutral-400/30",
         ])}
       />

--- a/apps/desktop/src/billing/trial-ended-dialog.tsx
+++ b/apps/desktop/src/billing/trial-ended-dialog.tsx
@@ -30,10 +30,8 @@ export function TrialEndedDialog({
             Your Pro trial has ended
           </DialogTitle>
           <DialogDescription className="max-w-[260px] text-center text-[13px] leading-[1.36] text-neutral-800">
-            You're back on the free plan. Your notes and recordings are safe.
-            You can keep using free local transcription forever, but it will be
-            significantly less accurate than Pro cloud transcription. Upgrade to
-            Pro to keep cloud AI, longer recordings, and premium templates.
+            Your notes and recordings are safe. Free local transcription still
+            works. Upgrade anytime to keep Pro features.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="grid grid-cols-2 gap-2 px-4 pt-4 pb-4 sm:grid-cols-2 sm:justify-normal">

--- a/apps/desktop/src/billing/trial-started-dialog.tsx
+++ b/apps/desktop/src/billing/trial-started-dialog.tsx
@@ -31,10 +31,8 @@ export function TrialStartedDialog({
           <DialogTitle className="text-[13px] leading-5 font-semibold tracking-normal text-neutral-900">
             Your Pro trial just started
           </DialogTitle>
-          <DialogDescription className="max-w-[260px] text-center text-[13px] leading-[1.36] text-neutral-800">
-            You have {days} {days === 1 ? "day" : "days"} of full Pro access —
-            unlimited cloud AI, longer recordings, and every premium template.
-            No payment needed during the trial.
+          <DialogDescription className="w-full text-center text-[13px] leading-[1.36] text-neutral-800">
+            Your {days}-day Pro trial starts now. No payment needed.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="px-4 pt-4 pb-4 sm:justify-center">


### PR DESCRIPTION
- Expand the trial dialog icon paint area so the app icon glow is not clipped.
- Shorten the Pro trial start and end dialog copy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop billing dialog UI and marketing copy only; no billing logic, auth, or data handling changes.
> 
> **Overview**
> **Trial dialog icon** — The shared `TrialDialogIcon` gets a larger paint area (`size-[92px]`, negative vertical margin) and a centered `size-14` glow layer so drop shadows and blur are not clipped in the dialog header.
> 
> **Copy** — Pro trial **started** and **ended** dialogs use shorter body text (fewer feature bullets; started dialog uses `w-full` on the description instead of `max-w-[260px]`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9087a2c45c03ced97da9615e26e3d9fed87368d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->