### PR TITLE
fix(desktop): add account plan separators

### DIFF
--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -485,7 +485,7 @@ function PlanTierList({
   return (
     <div ref={containerRef}>
       {isWide ? (
-        <div className="grid grid-cols-3 gap-px border-t border-neutral-100">
+        <div className="grid grid-cols-3 divide-x divide-neutral-100 border-t border-neutral-100">
           {PLAN_TIERS.map((tier) => {
             const isCurrent = tier.id === currentTier;
             const action = getActionForTier(


### PR DESCRIPTION
Show vertical dividers between plan columns in the account settings pricing grid.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class change on the account settings plan grid only; no billing or auth behavior changes.
> 
> **Overview**
> The wide **Plan & Billing** pricing grid in desktop account settings now draws **vertical separators** between the Free, Lite, and Pro columns.
> 
> Layout classes on the three-column grid switch from `gap-px` to Tailwind **`divide-x divide-neutral-100`**, so column boundaries are visible without changing plan logic or actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 829a81b2c7d5241dd01ca7e9fe1557379cf67434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->