### PR TITLE
fix(desktop): show compact plan features

### DIFF
--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -506,9 +506,9 @@ function PlanTierList({
                   <span className="font-sans text-base font-medium text-stone-800">
                     {tier.name}
                   </span>
-                  {isCurrent && (
+                  {isCurrent && isTrialing && (
                     <span className="rounded-full bg-stone-600 px-2 py-0.5 text-[10px] font-medium tracking-wide text-white uppercase">
-                      {isTrialing ? "Trial" : "Current"}
+                      Trial
                     </span>
                   )}
                 </div>
@@ -552,25 +552,30 @@ function PlanTierList({
               <div
                 key={tier.id}
                 className={cn([
-                  "flex items-center justify-between border-b border-neutral-100 py-2.5 last:border-b-0",
+                  "border-b border-neutral-100 py-3 last:border-b-0",
                   isCurrent && "-mx-2 rounded-md bg-stone-50/60 px-2",
                 ])}
               >
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-stone-800">
-                    {tier.name}
-                  </span>
-                  <span className="text-sm text-neutral-500">
-                    {tier.price}
-                    {tier.period}
-                  </span>
-                  {isCurrent && (
-                    <span className="rounded-full bg-stone-600 px-1.5 py-px text-[10px] font-medium tracking-wide text-white uppercase">
-                      {isTrialing ? "Trial" : "Current"}
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                    <span className="text-sm font-medium text-stone-800">
+                      {tier.name}
                     </span>
-                  )}
+                    <span className="text-sm text-neutral-500">
+                      {tier.price}
+                      {tier.period}
+                    </span>
+                    {isCurrent && isTrialing && (
+                      <span className="rounded-full bg-stone-600 px-1.5 py-px text-[10px] font-medium tracking-wide text-white uppercase">
+                        Trial
+                      </span>
+                    )}
+                  </div>
+                  <div className="shrink-0">{renderAction(action, true)}</div>
                 </div>
-                <div className="shrink-0">{renderAction(action, true)}</div>
+                <div className="mt-2">
+                  <PlanFeatureList features={tier.features} dense />
+                </div>
               </div>
             );
           })}


### PR DESCRIPTION
Render plan feature points in the compact account settings pricing layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to account settings pricing layout and badge visibility; no auth, billing API, or data handling changes.
> 
> **Overview**
> The **narrow** Plan & Billing layout (under ~480px) now shows each tier’s feature bullets via **`PlanFeatureList`** with **`dense`**, matching the wide grid so users can compare plans without resizing.
> 
> Compact rows were reflowed: name/price and the action sit on one line (with wrapping), features sit below, and the tier pill only appears as **Trial** when the user is on that tier **and** trialing—paid/current plans no longer get a **Current** badge in either layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46a1bb8bd759c64f3eeab18bd123d5f38f9c4496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->