### PR TITLE
fix(desktop): make buttons pill shaped

### DIFF
--- a/apps/desktop/src/main/empty.tsx
+++ b/apps/desktop/src/main/empty.tsx
@@ -102,7 +102,7 @@ function ActionItem({
         "group",
         "flex items-center justify-between gap-8",
         "text-sm",
-        "rounded-md px-4 py-2",
+        "rounded-full px-4 py-2",
         "cursor-pointer transition-colors hover:bg-neutral-100",
       ])}
     >

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -412,7 +412,7 @@ function TranscriptReadyPanel({
                 type="button"
                 disabled
                 className={cn([
-                  "flex items-center gap-1 rounded px-1.5 py-0.5",
+                  "flex items-center gap-1 rounded-full px-1.5 py-0.5",
                   "text-[11px] font-medium text-neutral-300",
                   "cursor-not-allowed",
                 ])}
@@ -429,7 +429,7 @@ function TranscriptReadyPanel({
             type="button"
             onClick={regenerate}
             className={cn([
-              "flex items-center gap-1 rounded px-1.5 py-0.5",
+              "flex items-center gap-1 rounded-full px-1.5 py-0.5",
               "text-[11px] font-medium text-neutral-500",
               "transition-colors hover:bg-neutral-200/60 hover:text-neutral-700",
             ])}
@@ -444,7 +444,7 @@ function TranscriptReadyPanel({
             onClick={() => void deleteRecording()}
             disabled={isDeletingRecording}
             className={cn([
-              "flex items-center gap-1 rounded px-1.5 py-0.5",
+              "flex items-center gap-1 rounded-full px-1.5 py-0.5",
               "text-[11px] font-medium text-red-600",
               "transition-colors hover:bg-red-50 hover:text-red-700",
               "disabled:cursor-not-allowed disabled:text-red-300",

--- a/apps/desktop/src/settings/ai/shared/model-combobox.tsx
+++ b/apps/desktop/src/settings/ai/shared/model-combobox.tsx
@@ -148,7 +148,7 @@ export function ModelCombobox({
           aria-expanded={open}
           className={cn([
             "w-full justify-between bg-white font-normal shadow-none focus-visible:ring-0",
-            "rounded-md px-3",
+            "rounded-full px-3",
           ])}
         >
           <span className="flex w-full min-w-0 items-center justify-between gap-2">

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -681,7 +681,7 @@ function LocalModelDropdownActions({ model }: { model: LocalModel }) {
         type="button"
         aria-label="Show in Finder"
         className={cn([
-          "flex size-6 items-center justify-center rounded-md",
+          "flex size-6 items-center justify-center rounded-full",
           "text-neutral-500 hover:text-neutral-900",
         ])}
         onPointerDown={stopSelect}
@@ -696,7 +696,7 @@ function LocalModelDropdownActions({ model }: { model: LocalModel }) {
         type="button"
         aria-label="Delete model"
         className={cn([
-          "flex size-6 items-center justify-center rounded-md",
+          "flex size-6 items-center justify-center rounded-full",
           "text-red-500 hover:text-red-600",
         ])}
         onPointerDown={stopSelect}

--- a/apps/desktop/src/settings/general/searchable-select.tsx
+++ b/apps/desktop/src/settings/general/searchable-select.tsx
@@ -81,7 +81,7 @@ export function SearchableSelect({
           aria-expanded={open}
           className={cn([
             "justify-between bg-white font-normal shadow-none focus-visible:ring-0",
-            "rounded-lg px-3",
+            "rounded-full px-3",
             className,
           ])}
         >

--- a/apps/desktop/src/settings/general/storage/index.tsx
+++ b/apps/desktop/src/settings/general/storage/index.tsx
@@ -306,7 +306,7 @@ function ChangeContentPathDialog({
                   <button
                     key={vault.path}
                     onClick={() => selectPath(vault.path)}
-                    className="flex cursor-pointer items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-left text-sm text-neutral-500 transition-colors hover:bg-neutral-100"
+                    className="flex cursor-pointer items-center gap-2 rounded-full border border-neutral-200 bg-neutral-50 px-3 py-2 text-left text-sm text-neutral-500 transition-colors hover:bg-neutral-100"
                   >
                     <img
                       src="/assets/obsidian-icon.svg"

--- a/apps/desktop/src/settings/general/storage/obsidian-vault-list.tsx
+++ b/apps/desktop/src/settings/general/storage/obsidian-vault-list.tsx
@@ -28,7 +28,7 @@ export function ObsidianVaultList({
           disabled={disabled}
           onClick={() => onSelect(vault.path)}
           className={cn([
-            "flex items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-left text-sm text-neutral-500 transition-colors hover:border-neutral-300 hover:bg-neutral-100 disabled:opacity-50",
+            "flex items-center gap-2 rounded-full border border-neutral-200 bg-neutral-50 px-3 py-2 text-left text-sm text-neutral-500 transition-colors hover:border-neutral-300 hover:bg-neutral-100 disabled:opacity-50",
           ])}
         >
           <img

--- a/apps/desktop/src/settings/todo/index.tsx
+++ b/apps/desktop/src/settings/todo/index.tsx
@@ -32,7 +32,7 @@ export function SettingsTodo() {
             value={provider.id}
             className="group/provider border-b border-neutral-100 last:border-none"
           >
-            <div className="group grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-md hover:bg-neutral-50">
+            <div className="group grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-full hover:bg-neutral-50">
               <AccordionHeader className="min-w-0">
                 <AccordionTriggerPrimitive className="flex w-full min-w-0 items-center gap-2 py-3 text-left text-sm font-medium transition-all hover:no-underline">
                   {provider.icon}

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -141,7 +141,7 @@ export function SettingsNav() {
                       setActiveTab(item.id as SettingsTab);
                     }}
                     className={cn([
-                      "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm",
+                      "flex w-full items-center gap-2 rounded-full px-3 py-2 text-left text-sm",
                       "transition-colors",
                       isSettingsItem && activeTab === item.id
                         ? "bg-neutral-200 font-medium text-neutral-900"

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -114,7 +114,7 @@ function ItemBase({
       onShiftClick={ignored ? undefined : onShiftClick}
       contextMenu={hasSelection ? undefined : contextMenu}
       className={cn([
-        "w-full rounded-lg px-3 py-2 text-left",
+        "w-full rounded-full px-3 py-2 text-left",
         ignored ? "cursor-default" : "cursor-pointer",
         multiSelected && "bg-neutral-200",
         !multiSelected && selected && "bg-neutral-200",

--- a/packages/ui/src/components/ui/button-group.tsx
+++ b/packages/ui/src/components/ui/button-group.tsx
@@ -5,7 +5,7 @@ import { Separator } from "@hypr/ui/components/ui/separator";
 import { cn } from "@hypr/utils";
 
 const buttonGroupVariants = cva(
-  "flex w-fit items-stretch focus-visible:*:relative focus-visible:*:z-10 has-[>[data-slot=button-group]]:gap-2 [&>[data-slot=select-trigger]:last-of-type]:has-[select[aria-hidden=true]:last-child]:rounded-r-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  "flex w-fit items-stretch focus-visible:*:relative focus-visible:*:z-10 has-[>[data-slot=button-group]]:gap-2 [&>[data-slot=select-trigger]:last-of-type]:has-[select[aria-hidden=true]:last-child]:rounded-r-full [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
   {
     variants: {
       orientation: {
@@ -49,7 +49,7 @@ function ButtonGroupText({
   return (
     <Comp
       className={cn([
-        "bg-muted flex items-center gap-2 rounded-md border px-4 text-sm font-medium shadow-2xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        "bg-muted flex items-center gap-2 rounded-full border px-4 text-sm font-medium shadow-2xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
         className,
       ])}
       {...props}

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@hypr/utils";
 
 const buttonVariants = cva(
-  "focus-visible:ring-ring inline-flex cursor-pointer items-center justify-center gap-2 rounded-lg text-sm font-medium whitespace-nowrap transition-all focus-visible:ring-1 focus-visible:outline-hidden disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "focus-visible:ring-ring inline-flex cursor-pointer items-center justify-center gap-2 rounded-full text-sm font-medium whitespace-nowrap transition-all focus-visible:ring-1 focus-visible:outline-hidden disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -23,7 +23,7 @@ const buttonVariants = cva(
       size: {
         default: "h-9 px-4 py-2",
         sm: "h-7 px-2 text-xs",
-        lg: "h-10 rounded-xl px-8",
+        lg: "h-10 px-8",
         icon: "size-7",
       },
     },


### PR DESCRIPTION
Use full-radius button styling in shared UI and settings/sidebar controls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class changes only; no logic, data, or API changes.
> 
> **Overview**
> This PR shifts interactive controls toward **pill-shaped** corners by replacing `rounded-md` / `rounded-lg` with **`rounded-full`** across the desktop app and shared UI.
> 
> The shared **`Button`** and **`button-group`** components now default to full radius (including removing the separate `rounded-xl` on large buttons). Desktop call sites that overrode corner radius—empty-tab actions, settings nav rows, timeline items, model comboboxes, Obsidian vault pickers, transcript toolbar chips, and STT model row icon buttons—are updated to match.
> 
> Behavior and layout are unchanged; only border-radius styling is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be8d18189bc9f1fc379ae4682b71a05bf8059424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->