### PR TITLE
chore(changelog): add 1.0.33 release notes

### DIFF
--- a/packages/changelog/content/1.0.33.md
+++ b/packages/changelog/content/1.0.33.md
@@ -1,0 +1,39 @@
+---
+date: "2026-06-01"
+summary: "Floating chat, expanded language options, sidebar timeline controls, and more reliable calendar, recording, editor, and transcription behavior."
+---
+
+## Chat
+
+- Chat now opens as a floating, resizable panel instead of widening the main window
+- The chat panel can expand to fill the workspace when you want more room, then collapse back to the floating view
+- New chats now get cleaner titles from the first message, with a concise fallback when title generation is unavailable
+
+## Timeline & Calendar
+
+- A new General setting lets you move the meeting timeline into the left sidebar instead of keeping it across the top
+- The top timeline now has a live Now marker, follows active recordings more accurately, and shows an inline stop control on live recording cards
+- Compact calendar views now scroll horizontally across more days instead of jumping one fixed week at a time
+- Calendar event and note chips now support context menus for opening in a new tab, deleting events, deleting recurring events, showing note files in Finder, and deleting notes
+- Calendar navigation, provider rows, and timeline controls have been tightened for smaller windows
+
+## Notes & Editor
+
+- Note titles are larger and easier to read, and pressing Escape from the title follows the normal app navigation behavior
+- Images in notes now require an explicit click before they select, making nearby editing less accidental
+- Notes now keep an editable paragraph after images so you can continue writing below inserted images
+- The note menu now keeps upload actions easy to reach with separate Upload audio and Upload transcript options
+
+## Onboarding & Settings
+
+- Onboarding now uses the full window with a simpler permissions, account, calendar, storage, and finish flow
+- The app language picker now includes many more display languages
+- Settings pages now have clearer section titles, and App settings separate general app options from meeting controls
+- Account and billing screens now show plan details more compactly with clearer Pro trial messaging
+
+## Audio & Transcription
+
+- Resumed recordings now append to the existing saved audio more reliably, including sessions that have both old encoded audio and a stale WAV file
+- Local Soniqo batch transcription is more reliable for short audio and trailing chunks
+- Direct Soniox listener errors now stop the session cleanly instead of falling into an unsuitable batch fallback
+- Large transcript queries now use bounded memory, improving reliability for long sessions


### PR DESCRIPTION
Add the next desktop changelog entry covering the latest user-facing desktop changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no runtime or build impact.
> 
> **Overview**
> Adds **`packages/changelog/content/1.0.33.md`**, the desktop release notes for version **1.0.33** (dated 2026-06-01), using the same frontmatter + bullet layout as earlier changelog entries.
> 
> The new entry documents user-facing changes across **chat** (floating/resizable panel, workspace expand/collapse, chat titles), **timeline & calendar** (sidebar timeline setting, Now marker, horizontal compact scroll, context menus), **notes & editor**, **onboarding & settings** (full-window flow, more languages, settings layout), and **audio & transcription** reliability fixes—without modifying application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f7025d428edbd0168607f4f5706e8edf40f8785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->