### PR TITLE
fix(sidebar): enforce sidebar timeline open

### DIFF
--- a/apps/desktop/src/contexts/shell/leftsidebar.test.tsx
+++ b/apps/desktop/src/contexts/shell/leftsidebar.test.tsx
@@ -1,0 +1,77 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  sidebarTimelineEnabled: false,
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValue: () => mocks.sidebarTimelineEnabled,
+}));
+
+import { useLeftSidebar } from "./leftsidebar";
+
+describe("useLeftSidebar", () => {
+  beforeEach(() => {
+    mocks.sidebarTimelineEnabled = false;
+  });
+
+  it("toggles expansion outside sidebar timeline mode", () => {
+    const { result } = renderHook(() => useLeftSidebar());
+
+    expect(result.current.expanded).toBe(true);
+
+    act(() => result.current.toggleExpanded());
+
+    expect(result.current.expanded).toBe(false);
+
+    act(() => result.current.setExpanded(true));
+
+    expect(result.current.expanded).toBe(true);
+  });
+
+  it("keeps the sidebar open and locked in sidebar timeline mode", () => {
+    const { result, rerender } = renderHook(() => useLeftSidebar());
+
+    act(() => result.current.setExpanded(false));
+
+    expect(result.current.expanded).toBe(false);
+
+    mocks.sidebarTimelineEnabled = true;
+    rerender();
+
+    expect(result.current.expanded).toBe(true);
+    expect(result.current.locked).toBe(true);
+
+    act(() => result.current.setExpanded(false));
+
+    expect(result.current.expanded).toBe(true);
+
+    act(() => result.current.toggleExpanded());
+
+    expect(result.current.expanded).toBe(true);
+  });
+
+  it("preserves collapsed preference while sidebar timeline mode forces expansion", () => {
+    const { result, rerender } = renderHook(() => useLeftSidebar());
+
+    act(() => result.current.setExpanded(false));
+
+    expect(result.current.expanded).toBe(false);
+
+    mocks.sidebarTimelineEnabled = true;
+    rerender();
+
+    const forcedExpanded = result.current.expanded;
+    expect(forcedExpanded).toBe(true);
+
+    act(() => result.current.setExpanded(forcedExpanded));
+
+    expect(result.current.expanded).toBe(true);
+
+    mocks.sidebarTimelineEnabled = false;
+    rerender();
+
+    expect(result.current.expanded).toBe(false);
+  });
+});

--- a/apps/desktop/src/contexts/shell/leftsidebar.ts
+++ b/apps/desktop/src/contexts/shell/leftsidebar.ts
@@ -1,30 +1,37 @@
-import { useCallback, useState } from "react";
-import { useHotkeys } from "react-hotkeys-hook";
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useState,
+} from "react";
+
+import { useConfigValue } from "~/shared/config";
 
 export function useLeftSidebar() {
-  const [expanded, setExpanded] = useState(true);
+  const sidebarTimelineEnabled = useConfigValue("sidebar_timeline_enabled");
+  const [storedExpanded, setStoredExpanded] = useState(true);
   const [locked, setLocked] = useState(false);
+  const expanded = sidebarTimelineEnabled || storedExpanded;
+  const effectiveLocked = sidebarTimelineEnabled || locked;
+
+  const setExpanded: Dispatch<SetStateAction<boolean>> = useCallback(
+    (next) => {
+      if (sidebarTimelineEnabled) return;
+
+      setStoredExpanded(next);
+    },
+    [sidebarTimelineEnabled],
+  );
 
   const toggleExpanded = useCallback(() => {
-    if (locked) return;
-    setExpanded((prev) => !prev);
-  }, [locked]);
-
-  useHotkeys(
-    "mod+\\",
-    toggleExpanded,
-    {
-      preventDefault: true,
-      enableOnFormTags: true,
-      enableOnContentEditable: true,
-    },
-    [toggleExpanded],
-  );
+    if (effectiveLocked) return;
+    setStoredExpanded((prev) => !prev);
+  }, [effectiveLocked]);
 
   return {
     expanded,
     setExpanded,
-    locked,
+    locked: effectiveLocked,
     setLocked,
     toggleExpanded,
   };


### PR DESCRIPTION
Keep the left sidebar open and locked while sidebar timeline mode is enabled; remove the Cmd+\ toggle shortcut.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized shell UI state and shortcut removal with no auth, data, or backend impact.
> 
> **Overview**
> When **`sidebar_timeline_enabled`** is on, the left sidebar is always **expanded** and treated as **locked**; collapse, `setExpanded`, and `toggleExpanded` no longer change visibility until that mode is off. User expand/collapse preference is kept in separate state so turning timeline mode off restores the prior collapsed state.
> 
> The **`mod+\`** keyboard shortcut for toggling the sidebar was removed from `useLeftSidebar`. New hook tests cover normal toggling, forced-open behavior in timeline mode, and preference restoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7beb7c0ac4e362a30de69db8f2d1c3eb2f602a2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->