### PR TITLE
fix(changelog): simplify startup changelog header

### DIFF
--- a/apps/desktop/src/changelog/index.tsx
+++ b/apps/desktop/src/changelog/index.tsx
@@ -1,23 +1,15 @@
-import { CalendarIcon, ExternalLinkIcon } from "lucide-react";
-import { useEffect } from "react";
+import { XIcon } from "lucide-react";
 
 import { ChangelogContent } from "@hypr/changelog";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@hypr/ui/components/ui/breadcrumb";
 import { Button } from "@hypr/ui/components/ui/button";
-import { safeFormat } from "@hypr/utils";
 
 import { useChangelogContent } from "./data";
 
 import { useShell } from "~/contexts/shell";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { StandardTabWrapper } from "~/shared/main";
-import { type Tab } from "~/store/zustand/tabs";
+import { type Tab, useTabs } from "~/store/zustand/tabs";
 
 export { getLatestVersion } from "./data";
 
@@ -27,31 +19,25 @@ export function TabContentChangelog({
   tab: Extract<Tab, { type: "changelog" }>;
 }) {
   const { current } = tab.state;
-  const { leftsidebar, chat } = useShell();
+  const { chat } = useShell();
+  const close = useTabs((state) => state.close);
 
-  useEffect(() => {
-    leftsidebar.setExpanded(false);
+  useMountEffect(() => {
     if (chat.mode === "FloatingOpen") {
       chat.sendEvent({ type: "CLOSE" });
     }
-  }, []);
+  });
 
-  const { content, date, loading } = useChangelogContent(current);
+  const { content, loading } = useChangelogContent(current);
 
   return (
     <StandardTabWrapper>
       <div className="flex h-full flex-col">
-        <div className="shrink-0 pr-1 pl-2">
-          <ChangelogHeader version={current} date={date} />
+        <div className="shrink-0 pr-1 pl-3">
+          <ChangelogHeader version={current} onClose={() => close(tab)} />
         </div>
 
-        <div className="mt-2 shrink-0 px-3">
-          <h1 className="text-xl font-semibold text-neutral-900">
-            What's new in {current}?
-          </h1>
-        </div>
-
-        <div className="relative mt-4 min-h-0 flex-1 overflow-hidden">
+        <div className="relative mt-2 min-h-0 flex-1 overflow-hidden">
           <div className="scroll-fade-y h-full overflow-y-auto px-3 pb-4">
             <ChangelogBody content={content} loading={loading} />
           </div>
@@ -122,50 +108,30 @@ function ChangelogBody({
 
 function ChangelogHeader({
   version,
-  date,
+  onClose,
 }: {
   version: string;
-  date: string | null;
+  onClose: () => void;
 }) {
-  const formattedDate = date ? safeFormat(date, "MMM d, yyyy") : null;
-  const webUrl = `https://anarlog.so/changelog/${version}`;
-
   return (
-    <div className="w-full pt-1">
-      <div className="flex items-center gap-2">
+    <div className="flex h-12 w-full items-center">
+      <div className="flex w-full min-w-0 items-center justify-between gap-0">
         <div className="min-w-0 flex-1">
-          <Breadcrumb className="ml-1.5 min-w-0">
-            <BreadcrumbList className="flex-nowrap gap-0.5 overflow-hidden text-xs text-neutral-700">
-              <BreadcrumbItem className="shrink-0">
-                <span className="text-neutral-500">Changelog</span>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator className="shrink-0" />
-              <BreadcrumbItem className="overflow-hidden">
-                <BreadcrumbPage className="truncate">{version}</BreadcrumbPage>
-              </BreadcrumbItem>
-            </BreadcrumbList>
-          </Breadcrumb>
+          <h1 className="truncate text-xl font-semibold text-neutral-900">
+            What's new in {version}?
+          </h1>
         </div>
 
-        <div className="flex shrink-0 items-center">
-          {formattedDate && (
-            <Button
-              size="sm"
-              variant="ghost"
-              className="pointer-events-none text-neutral-600"
-            >
-              <CalendarIcon size={14} className="shrink-0" />
-              <span>{formattedDate}</span>
-            </Button>
-          )}
+        <div className="flex shrink-0 items-center gap-0 pr-1">
           <Button
-            size="sm"
+            size="icon"
             variant="ghost"
-            className="gap-1.5 text-neutral-600 hover:text-black"
-            onClick={() => openerCommands.openUrl(webUrl, null)}
+            className="text-neutral-500 hover:text-black"
+            aria-label="Close changelog"
+            title="Close"
+            onClick={onClose}
           >
-            <ExternalLinkIcon size={14} />
-            <span>Open in web</span>
+            <XIcon size={15} />
           </Button>
         </div>
       </div>

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -39,6 +39,7 @@ export function ClassicMainBody() {
   const { runEscapeShortcut } = useClassicMainTabsShortcuts();
 
   const isOnboarding = currentTab?.type === "onboarding";
+  const isChangelog = currentTab?.type === "changelog";
   const hasCustomSidebar = hasCustomSidebarTab(currentTab);
   const hasLeftSurfaceCustomSidebar =
     hasLeftSurfaceCustomSidebarTab(currentTab);
@@ -51,6 +52,7 @@ export function ClassicMainBody() {
     leftsidebar.expanded &&
     !showSidebarTimeline &&
     !hasCustomSidebar &&
+    !isChangelog &&
     !isOnboarding;
   const showLeftSurfaceChromeBack = hasLeftSurfaceCustomSidebar;
   const enableMainAreaTopDrag =

--- a/apps/desktop/src/main/shell-frame.test.tsx
+++ b/apps/desktop/src/main/shell-frame.test.tsx
@@ -104,6 +104,32 @@ describe("ClassicMainShellFrame", () => {
     ).toBe("left");
   });
 
+  it("uses top-edge main surface chrome for changelog tabs", () => {
+    mocks.currentTab = { type: "changelog" };
+    mocks.leftsidebar.expanded = false;
+
+    render(<ClassicMainShellFrame />);
+
+    expect(
+      screen
+        .getByTestId("main-shell-scaffold")
+        .getAttribute("data-main-surface-chrome"),
+    ).toBe("top");
+  });
+
+  it("keeps left-edge main surface chrome for changelog tabs in sidebar timeline mode", () => {
+    mocks.currentTab = { type: "changelog" };
+    mocks.sidebarTimelineEnabled = true;
+
+    render(<ClassicMainShellFrame />);
+
+    expect(
+      screen
+        .getByTestId("main-shell-scaffold")
+        .getAttribute("data-main-surface-chrome"),
+    ).toBe("left");
+  });
+
   it("uses the full shell surface for onboarding", () => {
     mocks.currentTab = { type: "onboarding" };
 

--- a/apps/desktop/src/main/shell-frame.tsx
+++ b/apps/desktop/src/main/shell-frame.tsx
@@ -16,6 +16,7 @@ export function ClassicMainShellFrame() {
   const sidebarTimelineEnabled = useConfigValue("sidebar_timeline_enabled");
 
   const isOnboarding = currentTab?.type === "onboarding";
+  const isChangelog = currentTab?.type === "changelog";
   const hasCustomSidebar = hasCustomSidebarTab(currentTab);
   const hasLeftSurfaceCustomSidebar =
     hasLeftSurfaceCustomSidebarTab(currentTab);
@@ -30,11 +31,13 @@ export function ClassicMainShellFrame() {
     !hasCustomSidebar &&
     !isOnboarding;
   const mainSurfaceChrome =
-    showSidebarTimeline || hasLeftSurfaceCustomSidebar
-      ? "left"
-      : showTopTimeline
-        ? "top"
-        : "default";
+    isChangelog && !showSidebarTimeline
+      ? "top"
+      : showSidebarTimeline || hasLeftSurfaceCustomSidebar
+        ? "left"
+        : showTopTimeline
+          ? "top"
+          : "default";
 
   return (
     <MainShellScaffold

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -182,6 +182,49 @@ describe("ClassicMainBody", () => {
     expect(sidebar.parentElement?.className).not.toContain("pt-12");
   });
 
+  it("hides timeline chrome for changelog tabs without collapsing the sidebar state", () => {
+    mocks.currentTab = {
+      active: true,
+      pinned: false,
+      slotId: "slot-1",
+      type: "changelog",
+    };
+
+    const { container } = render(<ClassicMainBody />);
+    const body = container.firstElementChild;
+    const topArea = body?.firstElementChild;
+
+    expect(screen.queryByTestId("top-meeting-timeline")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
+    expect(topArea?.className).toContain("h-10");
+    expect(screen.getByTestId("main-tab-content").textContent).toContain(
+      "changelog",
+    );
+  });
+
+  it("keeps sidebar timeline chrome for changelog tabs in sidebar timeline mode", () => {
+    mocks.currentTab = {
+      active: true,
+      pinned: false,
+      slotId: "slot-1",
+      type: "changelog",
+    };
+    mocks.sidebarTimelineEnabled = true;
+
+    render(<ClassicMainBody />);
+
+    const backButton = screen.getByRole("button", { name: "Go back" });
+    const topArea = backButton.parentElement?.parentElement?.parentElement;
+
+    expect(screen.queryByTestId("top-meeting-timeline")).toBeNull();
+    expect(backButton.hasAttribute("disabled")).toBe(true);
+    expect(topArea?.className).toContain("h-12");
+    expect(topArea?.className).toContain("absolute");
+    expect(screen.getByTestId("main-tab-content").textContent).toContain(
+      "changelog",
+    );
+  });
+
   it("navigates history from the sidebar timeline chrome", () => {
     mocks.sidebarTimelineEnabled = true;
     mocks.canGoBack = true;


### PR DESCRIPTION
Show the changelog title in the header and replace the date and web actions with a close button.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and layout-only changes in the desktop changelog tab and shell chrome, with no auth, data, or backend impact.
> 
> **Overview**
> The changelog tab gets a **simpler in-tab header**: the version title lives in the bar, and **date / “Open in web” / breadcrumb** are removed in favor of a **close** control that dismisses the tab via `useTabs().close`. Mount behavior still closes floating chat but no longer forces the left sidebar collapsed.
> 
> **Shell chrome** treats changelog like a focused surface: the **top meeting timeline is hidden** on changelog (sidebar timeline mode unchanged), and **`mainSurfaceChrome` prefers top-edge** for changelog unless sidebar timeline is active. Tests cover both layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c94f8413678b24d47262e73fb71d37774a881cf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->