### PR TITLE
fix(title): align empty title enhance button

### DIFF
--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -89,17 +89,15 @@ describe("TitleInput", () => {
     expect(hoisted.runEscapeShortcut).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the empty title layout at placeholder width", () => {
+  it("positions the empty title generate button next to the placeholder", () => {
     hoisted.store.getCell.mockReturnValueOnce("");
 
     renderTitleInput({ onGenerateTitle: vi.fn() });
 
     const input = screen.getByPlaceholderText("Untitled");
-    expect(input.parentElement?.className).toContain("min-w-fit");
-    expect(input.parentElement?.className).toContain("flex-none");
-    expect(
-      screen.getByRole("button", { name: "Regenerate title" }),
-    ).toBeTruthy();
+    const button = screen.getByRole("button", { name: "Regenerate title" });
+    expect(input.parentElement?.className).toContain("relative");
+    expect(button.className).toContain("left-[84px]");
   });
 
   it("uses the flexible title layout for whitespace-only titles", () => {
@@ -108,8 +106,7 @@ describe("TitleInput", () => {
     renderTitleInput({ onGenerateTitle: vi.fn() });
 
     const input = screen.getByPlaceholderText("Untitled");
-    expect(input.parentElement?.className).toContain("min-w-0");
-    expect(input.parentElement?.className).toContain("flex-1");
+    expect(input.className).toContain("w-full");
     expect(
       screen.queryByRole("button", { name: "Regenerate title" }),
     ).toBeNull();

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -332,59 +332,43 @@ const TitleInputInner = memo(
         localTitle.length === 0 ? onGenerateTitle : undefined;
 
       return (
-        <div className="flex w-full items-center gap-2">
-          <div
+        <div className="relative flex h-8 w-full items-center">
+          <input
+            ref={setInputRef}
+            id={`title-input-${sessionId}-${editorId}`}
+            placeholder="Untitled"
+            type="text"
+            onChange={(e) => {
+              const value = e.target.value;
+              setLocalTitle(value);
+              setLiveTitle(sessionId, value);
+              setIsOverflowing(e.target.scrollWidth > e.target.clientWidth + 1);
+            }}
+            onKeyDown={handleKeyDown}
+            onFocus={() => {
+              isFocused.current = true;
+              setIsTitleFocused(true);
+            }}
+            onBlur={(e) => {
+              isFocused.current = false;
+              setIsTitleFocused(false);
+              setStoreTitle(localTitle);
+              clearLiveTitle(sessionId);
+              setIsOverflowing(e.target.scrollWidth > e.target.clientWidth + 1);
+            }}
+            value={localTitle}
+            style={overflowFadeStyle}
             className={cn([
-              "grid items-center",
-              generateTitleHandler ? "min-w-fit flex-none" : "min-w-0 flex-1",
+              "w-full min-w-0 transition-opacity duration-200",
+              "border-none bg-transparent focus:outline-hidden",
+              "placeholder:text-muted-foreground text-xl font-semibold",
             ])}
-          >
-            {generateTitleHandler && (
-              <span
-                aria-hidden="true"
-                className="invisible col-start-1 row-start-1 text-xl font-semibold whitespace-pre"
-              >
-                Untitled
-              </span>
-            )}
-            <input
-              ref={setInputRef}
-              id={`title-input-${sessionId}-${editorId}`}
-              placeholder="Untitled"
-              type="text"
-              onChange={(e) => {
-                const value = e.target.value;
-                setLocalTitle(value);
-                setLiveTitle(sessionId, value);
-                setIsOverflowing(
-                  e.target.scrollWidth > e.target.clientWidth + 1,
-                );
-              }}
-              onKeyDown={handleKeyDown}
-              onFocus={() => {
-                isFocused.current = true;
-                setIsTitleFocused(true);
-              }}
-              onBlur={(e) => {
-                isFocused.current = false;
-                setIsTitleFocused(false);
-                setStoreTitle(localTitle);
-                clearLiveTitle(sessionId);
-                setIsOverflowing(
-                  e.target.scrollWidth > e.target.clientWidth + 1,
-                );
-              }}
-              value={localTitle}
-              style={overflowFadeStyle}
-              className={cn([
-                "col-start-1 row-start-1 w-full min-w-0 transition-opacity duration-200",
-                "border-none bg-transparent focus:outline-hidden",
-                "placeholder:text-muted-foreground text-xl font-semibold",
-              ])}
-            />
-          </div>
+          />
           {generateTitleHandler && (
-            <GenerateButton onGenerateTitle={generateTitleHandler} />
+            <GenerateButton
+              className="absolute top-1/2 left-[84px] -translate-y-1/2"
+              onGenerateTitle={generateTitleHandler}
+            />
           )}
         </div>
       );
@@ -393,8 +377,10 @@ const TitleInputInner = memo(
 );
 
 const GenerateButton = memo(function GenerateButton({
+  className,
   onGenerateTitle,
 }: {
+  className?: string;
   onGenerateTitle: () => void;
 }) {
   return (
@@ -412,6 +398,7 @@ const GenerateButton = memo(function GenerateButton({
             "shrink-0",
             "text-muted-foreground hover:text-foreground",
             "opacity-50 transition-opacity hover:opacity-100",
+            className,
           ])}
         >
           <SparklesIcon className="h-4 w-4" />


### PR DESCRIPTION
Pin the generate-title button beside the Untitled placeholder and update the title input test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop session title UI and tests only; no auth, data, or API changes.
> 
> **Overview**
> **Session title input** layout is simplified: the grid + invisible “Untitled” sizing wrapper is removed in favor of a **relative** full-width row and a single `w-full` input.
> 
> When the title is empty, **Regenerate title** is no longer in a flex sibling; it is **absolutely positioned** at `left-[84px]` (via new optional `className` on `GenerateButton`) so it sits beside the placeholder. Whitespace-only titles still hide the button and keep a full-width field.
> 
> Tests now assert the relative container, button offset, and `w-full` on the input instead of the old `min-w-fit` / `flex-1` wrapper classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 001dc7499dfbd00392cf9f4ccbf9d426f5e0c7a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->