### PR TITLE
fix(sidebar): restore note row shape

### DIFF
--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -114,7 +114,7 @@ function ItemBase({
       onShiftClick={ignored ? undefined : onShiftClick}
       contextMenu={hasSelection ? undefined : contextMenu}
       className={cn([
-        "w-full rounded-full px-3 py-2 text-left",
+        "w-full rounded-lg px-3 py-2 text-left",
         ignored ? "cursor-default" : "cursor-pointer",
         multiSelected && "bg-neutral-200",
         !multiSelected && selected && "bg-neutral-200",


### PR DESCRIPTION
Use the previous rounded-lg styling for sidebar timeline note rows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on timeline row styling with no logic or data impact.
> 
> **Overview**
> Restores **rounded-lg** corner styling on sidebar timeline note/event rows in `ItemBase` (`apps/desktop/src/sidebar/timeline/item.tsx`), replacing **rounded-full** so rows match the prior pill-rectangle shape instead of fully circular ends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b8c950168d9c65f97af9ca233b80f6e0ad5a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->