### PR TITLE
Show left-sidebar controls in collapsed note header

### DIFF
--- a/apps/desktop/src/contexts/shell/leftsidebar.test.tsx
+++ b/apps/desktop/src/contexts/shell/leftsidebar.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  sidebarTimelineEnabled: false,
+  useHotkeys: vi.fn(),
+}));
+
+vi.mock("react-hotkeys-hook", () => ({
+  useHotkeys: mocks.useHotkeys,
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValue: () => mocks.sidebarTimelineEnabled,
+}));
+
+import { useLeftSidebar } from "./leftsidebar";
+
+describe("useLeftSidebar", () => {
+  beforeEach(() => {
+    mocks.sidebarTimelineEnabled = false;
+    mocks.useHotkeys.mockClear();
+  });
+
+  it("disables the toggle hotkey outside sidebar timeline mode", () => {
+    renderHook(() => useLeftSidebar());
+
+    expect(mocks.useHotkeys).toHaveBeenCalledWith(
+      "mod+\\",
+      expect.any(Function),
+      expect.objectContaining({ enabled: false }),
+      expect.any(Array),
+    );
+  });
+
+  it("enables the toggle hotkey in sidebar timeline mode", () => {
+    mocks.sidebarTimelineEnabled = true;
+
+    renderHook(() => useLeftSidebar());
+
+    expect(mocks.useHotkeys).toHaveBeenCalledWith(
+      "mod+\\",
+      expect.any(Function),
+      expect.objectContaining({ enabled: true }),
+      expect.any(Array),
+    );
+  });
+});

--- a/apps/desktop/src/contexts/shell/leftsidebar.ts
+++ b/apps/desktop/src/contexts/shell/leftsidebar.ts
@@ -1,9 +1,12 @@
 import { useCallback, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
+import { useConfigValue } from "~/shared/config";
+
 export function useLeftSidebar() {
   const [expanded, setExpanded] = useState(true);
   const [locked, setLocked] = useState(false);
+  const sidebarTimelineEnabled = useConfigValue("sidebar_timeline_enabled");
 
   const toggleExpanded = useCallback(() => {
     if (locked) return;
@@ -14,11 +17,12 @@ export function useLeftSidebar() {
     "mod+\\",
     toggleExpanded,
     {
+      enabled: sidebarTimelineEnabled,
       preventDefault: true,
       enableOnFormTags: true,
       enableOnContentEditable: true,
     },
-    [toggleExpanded],
+    [sidebarTimelineEnabled, toggleExpanded],
   );
 
   return {

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -1,6 +1,11 @@
 import { isTauri } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  PanelLeftCloseIcon,
+  PanelLeftOpenIcon,
+} from "lucide-react";
 import { type MouseEvent, type PointerEvent, useCallback, useRef } from "react";
 
 import { cn } from "@hypr/utils";
@@ -43,11 +48,9 @@ export function ClassicMainBody() {
   const hasCustomSidebar = hasCustomSidebarTab(currentTab);
   const hasLeftSurfaceCustomSidebar =
     hasLeftSurfaceCustomSidebarTab(currentTab);
-  const showSidebarTimeline =
-    sidebarTimelineEnabled &&
-    leftsidebar.expanded &&
-    !hasCustomSidebar &&
-    !isOnboarding;
+  const showSidebarTimelineChrome =
+    sidebarTimelineEnabled && !hasCustomSidebar && !isOnboarding;
+  const showSidebarTimeline = showSidebarTimelineChrome && leftsidebar.expanded;
   const showTopTimeline =
     leftsidebar.expanded &&
     !showSidebarTimeline &&
@@ -56,25 +59,30 @@ export function ClassicMainBody() {
     !isOnboarding;
   const showLeftSurfaceChromeBack = hasLeftSurfaceCustomSidebar;
   const enableMainAreaTopDrag =
-    showSidebarTimeline || hasLeftSurfaceCustomSidebar;
+    showSidebarTimelineChrome || hasLeftSurfaceCustomSidebar;
   const mainAreaTopDrag = useMainAreaTopWindowDrag(enableMainAreaTopDrag);
 
   return (
     <div className="relative flex h-full min-w-0 flex-1 flex-col">
-      {isOnboarding ? null : showSidebarTimeline ? (
+      {isOnboarding ? null : showSidebarTimelineChrome ? (
         <div
           data-tauri-drag-region
-          className="absolute top-0 left-0 z-40 h-12 w-[200px]"
+          className={cn([
+            "absolute top-0 z-40 h-12 w-[200px]",
+            leftsidebar.expanded ? "left-0" : "left-1",
+          ])}
         >
           <div
             data-tauri-drag-region
             className="flex h-full min-w-0 items-start pt-[9px] pl-[76px]"
           >
             <SidebarTimelineChrome
+              sidebarExpanded={leftsidebar.expanded}
               canGoBack={canGoBack}
               canGoNext={canGoNext}
               onBack={goBack}
               onForward={goNext}
+              onToggleSidebar={leftsidebar.toggleExpanded}
             />
           </div>
         </div>
@@ -112,12 +120,12 @@ export function ClassicMainBody() {
             data-tauri-drag-region
             className="flex h-full min-w-0 items-start pt-[9px] pl-[76px]"
           >
-            <SidebarTimelineChromeButton
+            <LeftSurfaceChromeButton
               ariaLabel="Go back"
               onClick={runEscapeShortcut}
             >
               <ArrowLeftIcon size={14} />
-            </SidebarTimelineChromeButton>
+            </LeftSurfaceChromeButton>
           </div>
         </div>
       ) : null}
@@ -257,33 +265,47 @@ function SidebarTimelineChrome({
   canGoNext,
   onBack,
   onForward,
+  onToggleSidebar,
+  sidebarExpanded,
 }: {
   canGoBack: boolean;
   canGoNext: boolean;
   onBack: () => void;
   onForward: () => void;
+  onToggleSidebar: () => void;
+  sidebarExpanded: boolean;
 }) {
   return (
-    <div className="flex items-center gap-1">
-      <SidebarTimelineChromeButton
+    <div className="flex items-center gap-0">
+      <LeftSurfaceChromeButton
+        ariaLabel={sidebarExpanded ? "Hide sidebar" : "Show sidebar"}
+        onClick={onToggleSidebar}
+      >
+        {sidebarExpanded ? (
+          <PanelLeftCloseIcon size={14} />
+        ) : (
+          <PanelLeftOpenIcon size={14} />
+        )}
+      </LeftSurfaceChromeButton>
+      <LeftSurfaceChromeButton
         ariaLabel="Go back"
         disabled={!canGoBack}
         onClick={onBack}
       >
         <ArrowLeftIcon size={14} />
-      </SidebarTimelineChromeButton>
-      <SidebarTimelineChromeButton
+      </LeftSurfaceChromeButton>
+      <LeftSurfaceChromeButton
         ariaLabel="Go forward"
         disabled={!canGoNext}
         onClick={onForward}
       >
         <ArrowRightIcon size={14} />
-      </SidebarTimelineChromeButton>
+      </LeftSurfaceChromeButton>
     </div>
   );
 }
 
-function SidebarTimelineChromeButton({
+function LeftSurfaceChromeButton({
   ariaLabel,
   children,
   disabled = false,

--- a/apps/desktop/src/main/shell-frame.test.tsx
+++ b/apps/desktop/src/main/shell-frame.test.tsx
@@ -24,7 +24,7 @@ vi.mock("~/shared/main", () => ({
   }: {
     children: React.ReactNode;
     edgeToEdge?: boolean;
-    mainSurfaceChrome?: "default" | "top" | "left";
+    mainSurfaceChrome?: "default" | "top" | "top-borderless" | "left";
   }) => (
     <div
       data-edge-to-edge={String(edgeToEdge)}
@@ -90,6 +90,19 @@ describe("ClassicMainShellFrame", () => {
         .getByTestId("main-shell-scaffold")
         .getAttribute("data-main-surface-chrome"),
     ).toBe("left");
+  });
+
+  it("uses borderless top-edge main surface chrome for collapsed sidebar timeline mode", () => {
+    mocks.sidebarTimelineEnabled = true;
+    mocks.leftsidebar.expanded = false;
+
+    render(<ClassicMainShellFrame />);
+
+    expect(
+      screen
+        .getByTestId("main-shell-scaffold")
+        .getAttribute("data-main-surface-chrome"),
+    ).toBe("top-borderless");
   });
 
   it("uses left-edge main surface chrome for custom sidebar tabs", () => {

--- a/apps/desktop/src/main/shell-frame.tsx
+++ b/apps/desktop/src/main/shell-frame.tsx
@@ -2,7 +2,11 @@ import { ClassicMainBody } from "./body";
 
 import { useShell } from "~/contexts/shell";
 import { useConfigValue } from "~/shared/config";
-import { MainShellBodyFrame, MainShellScaffold } from "~/shared/main";
+import {
+  type MainSurfaceChrome,
+  MainShellBodyFrame,
+  MainShellScaffold,
+} from "~/shared/main";
 import { ToastArea } from "~/sidebar/toast";
 import {
   hasCustomSidebarTab,
@@ -20,24 +24,26 @@ export function ClassicMainShellFrame() {
   const hasCustomSidebar = hasCustomSidebarTab(currentTab);
   const hasLeftSurfaceCustomSidebar =
     hasLeftSurfaceCustomSidebarTab(currentTab);
-  const showSidebarTimeline =
-    sidebarTimelineEnabled &&
-    leftsidebar.expanded &&
-    !hasCustomSidebar &&
-    !isOnboarding;
+  const showSidebarTimelineChrome =
+    sidebarTimelineEnabled && !hasCustomSidebar && !isOnboarding;
+  const showSidebarTimeline = showSidebarTimelineChrome && leftsidebar.expanded;
+  const showCollapsedSidebarTimelineChrome =
+    showSidebarTimelineChrome && !leftsidebar.expanded;
   const showTopTimeline =
     leftsidebar.expanded &&
     !showSidebarTimeline &&
     !hasCustomSidebar &&
     !isOnboarding;
-  const mainSurfaceChrome =
-    isChangelog && !showSidebarTimeline
-      ? "top"
-      : showSidebarTimeline || hasLeftSurfaceCustomSidebar
-        ? "left"
-        : showTopTimeline
-          ? "top"
-          : "default";
+  const mainSurfaceChrome: MainSurfaceChrome =
+    showCollapsedSidebarTimelineChrome
+      ? "top-borderless"
+      : isChangelog && !showSidebarTimeline
+        ? "top"
+        : showSidebarTimeline || hasLeftSurfaceCustomSidebar
+          ? "left"
+          : showTopTimeline
+            ? "top"
+            : "default";
 
   return (
     <MainShellScaffold

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -390,7 +390,7 @@ function HeaderTabEnhanced({
             type="button"
             onClick={handleCancelClick}
             className={cn([
-              "inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-xs hover:bg-neutral-200",
+              "inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-xs hover:bg-neutral-100",
               !isActive && "opacity-50",
             ])}
             aria-label="Cancel enhancement"
@@ -423,7 +423,7 @@ function HeaderTabEnhanced({
           ? [
               "text-red-600 hover:bg-red-50 hover:text-neutral-900 focus-visible:bg-red-50 focus-visible:text-neutral-900",
             ]
-          : ["hover:bg-neutral-200 focus-visible:bg-neutral-200"],
+          : ["hover:bg-neutral-100 focus-visible:bg-neutral-100"],
       ])}
     >
       {isError && (

--- a/apps/desktop/src/session/components/note-input/search/bar.tsx
+++ b/apps/desktop/src/session/components/note-input/search/bar.tsx
@@ -40,7 +40,7 @@ function ToggleButton({
             "rounded-sm p-0.5 transition-colors",
             active
               ? "bg-neutral-300 text-neutral-700"
-              : "text-neutral-400 hover:bg-neutral-200 hover:text-neutral-500",
+              : "text-neutral-400 hover:bg-neutral-100 hover:text-neutral-500",
           ])}
         >
           {children}
@@ -72,7 +72,7 @@ function IconButton({
         "rounded-sm p-0.5 transition-colors",
         disabled
           ? "cursor-not-allowed text-neutral-300"
-          : "text-neutral-500 hover:bg-neutral-200",
+          : "text-neutral-500 hover:bg-neutral-100",
       ])}
     >
       {children}

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -6,7 +6,12 @@ import type { EditorView } from "~/store/zustand/tabs/schema";
 const mocks = vi.hoisted(() => ({
   leftsidebar: {
     expanded: true,
+    toggleExpanded: vi.fn(),
   },
+  canGoBack: false,
+  canGoNext: false,
+  goBack: vi.fn(),
+  goNext: vi.fn(),
   sessionModes: {} as Record<string, string>,
   sidebarTimelineEnabled: false,
   stopListening: vi.fn(),
@@ -34,6 +39,17 @@ vi.mock("~/shared/config", () => ({
   useConfigValue: () => mocks.sidebarTimelineEnabled,
 }));
 
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: vi.fn((selector: (state: unknown) => unknown) =>
+    selector({
+      canGoBack: mocks.canGoBack,
+      canGoNext: mocks.canGoNext,
+      goBack: mocks.goBack,
+      goNext: mocks.goNext,
+    }),
+  ),
+}));
+
 vi.mock("~/stt/contexts", () => ({
   useListener: vi.fn((selector: (state: unknown) => unknown) =>
     selector({
@@ -57,6 +73,11 @@ import { OuterHeader } from "./index";
 describe("OuterHeader", () => {
   beforeEach(() => {
     mocks.leftsidebar.expanded = true;
+    mocks.leftsidebar.toggleExpanded.mockClear();
+    mocks.canGoBack = false;
+    mocks.canGoNext = false;
+    mocks.goBack.mockClear();
+    mocks.goNext.mockClear();
     mocks.sessionModes = {};
     mocks.sidebarTimelineEnabled = false;
     mocks.stopListening.mockClear();
@@ -90,6 +111,47 @@ describe("OuterHeader", () => {
     expect(stopButton.className).toContain("rounded-full");
     expect(stopButton.textContent).toContain("Stop");
     expect(mocks.stopListening).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds a left gutter for anchored sidebar chrome when collapsed", () => {
+    mocks.sidebarTimelineEnabled = true;
+    mocks.leftsidebar.expanded = false;
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    const title = screen.getByText("Session title");
+    const header =
+      title.parentElement?.parentElement?.parentElement?.parentElement;
+    const titleRow = title.parentElement?.parentElement;
+
+    expect(header?.className).toContain("pl-[156px]");
+    expect(titleRow?.className).toContain("items-center");
+    expect(screen.queryByRole("button", { name: "Show sidebar" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();
+  });
+
+  it("keeps sidebar timeline header controls hidden while the sidebar is expanded", () => {
+    mocks.sidebarTimelineEnabled = true;
+
+    const { container } = render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Hide sidebar" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();
+    expect(container.firstElementChild?.className).not.toContain("pl-[156px]");
   });
 
   it("keeps the session header at 48px tall", () => {

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -20,10 +20,22 @@ export function OuterHeader({
   currentView: EditorView;
   title?: React.ReactNode;
 }) {
+  const { leftsidebar } = useShell();
+  const sidebarTimelineEnabled = useConfigValue("sidebar_timeline_enabled");
+  const showSidebarTimelineHeaderGutter =
+    sidebarTimelineEnabled && !leftsidebar.expanded;
+
   return (
-    <div className="flex h-12 w-full items-center">
+    <div
+      className={cn([
+        "flex h-12 w-full items-center",
+        showSidebarTimelineHeaderGutter && "pl-[156px]",
+      ])}
+    >
       <div className="flex w-full min-w-0 items-center justify-between gap-0">
-        {title ? <div className="min-w-0 flex-1">{title}</div> : null}
+        <div className="flex min-w-0 flex-1 items-center gap-1">
+          {title ? <div className="min-w-0 flex-1">{title}</div> : null}
+        </div>
         <div className="flex shrink-0 items-center gap-0 pr-1">
           <SidebarModeStopButton sessionId={sessionId} />
           <MetadataButton sessionId={sessionId} />

--- a/apps/desktop/src/session/components/outer-header/metadata/date.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/date.tsx
@@ -32,7 +32,7 @@ export function DateEditor({ sessionId }: { sessionId: string }) {
           type="button"
           variant="ghost"
           size="icon"
-          className="size-7 rounded-md text-neutral-500 hover:text-neutral-900"
+          className="size-7 rounded-md text-neutral-500 hover:bg-neutral-100 hover:text-neutral-900"
           onClick={() => setIsEditing(true)}
           aria-label="Edit date"
         >

--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -72,7 +72,7 @@ const TriggerInner = forwardRef<
       size="sm"
       className={cn([
         "rounded-full px-3",
-        "text-neutral-600 hover:text-black",
+        "text-neutral-600 hover:bg-neutral-100 hover:text-black",
         open && "bg-neutral-100",
         hasEvent && "max-w-50",
       ])}

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -74,7 +74,7 @@ export function OverflowButton({
           <Button
             size="icon"
             variant="ghost"
-            className="rounded-full text-neutral-600 hover:text-black"
+            className="rounded-full text-neutral-600 hover:bg-neutral-100 hover:text-black"
           >
             <MoreHorizontalIcon size={16} />
           </Button>

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -12,10 +12,12 @@ const mocks = vi.hoisted(() => ({
   goBack: vi.fn(),
   goNext: vi.fn(),
   runEscapeShortcut: vi.fn(),
+  toggleLeftSidebar: vi.fn(),
   isTauri: vi.fn(() => true),
   startDragging: vi.fn().mockResolvedValue(undefined),
   canGoBack: false,
   canGoNext: false,
+  leftSidebarExpanded: true,
   currentTab: {
     active: true,
     pinned: false,
@@ -58,7 +60,8 @@ vi.mock("~/main/shell-sidebar", () => ({
 vi.mock("~/contexts/shell", () => ({
   useShell: () => ({
     leftsidebar: {
-      expanded: true,
+      expanded: mocks.leftSidebarExpanded,
+      toggleExpanded: mocks.toggleLeftSidebar,
     },
   }),
 }));
@@ -94,10 +97,12 @@ describe("ClassicMainBody", () => {
     mocks.goBack.mockClear();
     mocks.goNext.mockClear();
     mocks.runEscapeShortcut.mockClear();
+    mocks.toggleLeftSidebar.mockClear();
     mocks.isTauri.mockReturnValue(true);
     mocks.startDragging.mockClear();
     mocks.canGoBack = false;
     mocks.canGoNext = false;
+    mocks.leftSidebarExpanded = true;
     mocks.currentTab = {
       active: true,
       pinned: false,
@@ -162,10 +167,12 @@ describe("ClassicMainBody", () => {
     expect(screen.queryByTestId("top-meeting-timeline")).toBeNull();
     expect(screen.queryByTestId("toast-area")).toBeNull();
     const sidebar = screen.getByTestId("main-sidebar");
+    const sidebarToggle = screen.getByRole("button", { name: "Hide sidebar" });
     const backButton = screen.getByRole("button", { name: "Go back" });
     const topArea = backButton.parentElement?.parentElement?.parentElement;
 
     expect(sidebar).toBeTruthy();
+    expect(sidebarToggle).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Open calendar" })).toBeNull();
     expect(backButton.hasAttribute("disabled")).toBe(true);
     expect(
@@ -173,13 +180,43 @@ describe("ClassicMainBody", () => {
         .getByRole("button", { name: "Go forward" })
         .hasAttribute("disabled"),
     ).toBe(true);
+    expect(backButton.parentElement?.className).toContain("gap-0");
     expect(topArea?.className).toContain("h-12");
     expect(topArea?.className).toContain("absolute");
-    expect(backButton.parentElement?.parentElement?.className).toContain(
-      "pt-[9px]",
-    );
+    expect(topArea?.className).toContain("left-0");
     expect(sidebar.parentElement?.className).toContain("flex min-h-0");
     expect(sidebar.parentElement?.className).not.toContain("pt-12");
+  });
+
+  it("expands the main area to the full window when sidebar timeline mode is collapsed", () => {
+    mocks.sidebarTimelineEnabled = true;
+    mocks.leftSidebarExpanded = false;
+    mocks.canGoBack = true;
+    mocks.canGoNext = true;
+
+    const { container } = render(<ClassicMainBody />);
+    const body = container.firstElementChild;
+    const contentRow = body?.lastElementChild;
+    const sidebarToggle = screen.getByRole("button", { name: "Show sidebar" });
+    const backButton = screen.getByRole("button", { name: "Go back" });
+    const topArea = backButton.parentElement?.parentElement?.parentElement;
+
+    fireEvent.click(sidebarToggle);
+    fireEvent.click(backButton);
+    fireEvent.click(screen.getByRole("button", { name: "Go forward" }));
+
+    expect(screen.queryByTestId("top-meeting-timeline")).toBeNull();
+    expect(backButton.parentElement?.className).toContain("gap-0");
+    expect(topArea?.className).toContain("absolute");
+    expect(topArea?.className).toContain("h-12");
+    expect(topArea?.className).toContain("left-1");
+    expect(contentRow?.className).toContain(
+      "flex min-h-0 min-w-0 flex-1 gap-1",
+    );
+    expect(contentRow?.hasAttribute("data-tauri-drag-region")).toBe(false);
+    expect(mocks.toggleLeftSidebar).toHaveBeenCalledTimes(1);
+    expect(mocks.goBack).toHaveBeenCalledTimes(1);
+    expect(mocks.goNext).toHaveBeenCalledTimes(1);
   });
 
   it("hides timeline chrome for changelog tabs without collapsing the sidebar state", () => {
@@ -218,6 +255,7 @@ describe("ClassicMainBody", () => {
 
     expect(screen.queryByTestId("top-meeting-timeline")).toBeNull();
     expect(backButton.hasAttribute("disabled")).toBe(true);
+    expect(backButton.parentElement?.className).toContain("gap-0");
     expect(topArea?.className).toContain("h-12");
     expect(topArea?.className).toContain("absolute");
     expect(screen.getByTestId("main-tab-content").textContent).toContain(

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -18,7 +18,7 @@ export {
   SessionStatusBannerProvider,
   useSessionStatusBanner,
 } from "./session-status-banner";
-export { MainShellScaffold } from "./shell-scaffold";
+export { MainShellScaffold, type MainSurfaceChrome } from "./shell-scaffold";
 export { useScrollActiveTabIntoView } from "./tab-scroll";
 
 export function StandardTabWrapper({

--- a/apps/desktop/src/shared/main/shell-scaffold.test.tsx
+++ b/apps/desktop/src/shared/main/shell-scaffold.test.tsx
@@ -1,9 +1,20 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const mocks = vi.hoisted(() => ({
+  currentTab: { type: "empty" } as { type: string } | null,
+}));
+
+vi.mock("~/calendar/components/context", () => ({
+  SyncProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sync-provider">{children}</div>
+  ),
+}));
+
 vi.mock("~/store/zustand/tabs", () => ({
-  useTabs: (selector: (state: { currentTab: { type: string } }) => unknown) =>
-    selector({ currentTab: { type: "empty" } }),
+  useTabs: (
+    selector: (state: { currentTab: typeof mocks.currentTab }) => unknown,
+  ) => selector({ currentTab: mocks.currentTab }),
 }));
 
 import { MainShellScaffold } from "./shell-scaffold";
@@ -11,100 +22,38 @@ import { MainShellScaffold } from "./shell-scaffold";
 describe("MainShellScaffold", () => {
   afterEach(() => {
     cleanup();
+    mocks.currentTab = { type: "empty" };
   });
 
-  it("keeps only the left outer padding by default", () => {
+  it("keeps the top border for regular top chrome", () => {
     render(
-      <MainShellScaffold>
-        <div />
+      <MainShellScaffold mainSurfaceChrome="top">
+        <div data-chat-floating-anchor data-testid="main-surface" />
       </MainShellScaffold>,
     );
 
     const shell = screen.getByTestId("main-app-shell");
 
-    expect(shell.className).toContain("pl-1");
-    expect(shell.className).not.toContain("px-1");
-    expect(shell.className).not.toContain("pb-1");
-  });
-
-  it("removes outer padding for the top-edge main surface", () => {
-    render(
-      <MainShellScaffold edgeToEdge>
-        <div />
-      </MainShellScaffold>,
-    );
-
-    const shell = screen.getByTestId("main-app-shell");
-
-    expect(shell.className).not.toContain("px-1");
-    expect(shell.className).not.toContain("pb-1");
-    expect(shell.className).toContain(
-      "[&_[data-chat-floating-anchor]]:rounded-t-xl",
-    );
-    expect(shell.className).toContain(
-      "[&_[data-chat-floating-anchor]]:rounded-b-none",
-    );
-    expect(shell.className).toContain(
-      "[&_[data-chat-floating-anchor]]:border-x-0",
-    );
-    expect(shell.className).toContain(
-      "[&_[data-chat-floating-anchor]]:border-b-0",
-    );
-    expect(shell.className).toContain(
-      "[&_[data-chat-floating-anchor][data-main-show-after-border-divider]]:!border-b",
-    );
-    expect(shell.className).toContain(
-      "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-x-0",
-    );
-    expect(shell.className).toContain(
-      "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-t-0",
-    );
     expect(shell.className).toContain(
       "[&_[data-chat-floating-anchor]]:border-t",
     );
+    expect(shell.className).not.toContain(
+      "[&_[data-chat-floating-anchor]]:!border-t-0",
+    );
   });
 
-  it("keeps only left chrome for the left-edge main surface", () => {
+  it("removes the top border for borderless top chrome", () => {
     render(
-      <MainShellScaffold mainSurfaceChrome="left">
-        <div />
+      <MainShellScaffold mainSurfaceChrome="top-borderless">
+        <div data-chat-floating-anchor data-testid="main-surface" />
       </MainShellScaffold>,
     );
 
     const shell = screen.getByTestId("main-app-shell");
 
-    expect(shell.className).toContain("pl-1");
-    expect(shell.className).not.toContain("pb-1");
-    expect(shell.className).not.toContain("px-1");
     expect(shell.className).toContain(
-      "[&_[data-chat-floating-anchor]]:rounded-l-xl",
+      "[&_[data-chat-floating-anchor]]:!border-t-0",
     );
-    expect(shell.className).toContain(
-      "[&_[data-chat-floating-anchor]]:rounded-r-none",
-    );
-    expect(shell.className).toContain(
-      "[&_[data-chat-floating-anchor][data-main-has-after-border]]:rounded-bl-none",
-    );
-    expect(shell.className).toContain(
-      "[&_[data-chat-floating-anchor]]:border-y-0",
-    );
-    expect(shell.className).toContain(
-      "[&_[data-chat-floating-anchor][data-main-show-after-border-divider]]:!border-b",
-    );
-    expect(shell.className).toContain(
-      "[&_[data-chat-floating-anchor]]:border-r-0",
-    );
-    expect(shell.className).toContain(
-      "[&_[data-chat-floating-anchor]]:border-l",
-    );
-    expect(shell.className).toContain(
-      "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-t-0",
-    );
-    expect(shell.className).toContain(
-      "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-r-0",
-    );
-    expect(shell.className).toContain(
-      "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:rounded-br-none",
-    );
+    expect(shell.className).not.toContain("pl-1");
   });
 });

--- a/apps/desktop/src/shared/main/shell-scaffold.tsx
+++ b/apps/desktop/src/shared/main/shell-scaffold.tsx
@@ -5,6 +5,8 @@ import { cn } from "@hypr/utils";
 import { SyncProvider } from "~/calendar/components/context";
 import { useTabs } from "~/store/zustand/tabs";
 
+export type MainSurfaceChrome = "default" | "top" | "top-borderless" | "left";
+
 export function MainShellScaffold({
   children,
   edgeToEdge = false,
@@ -12,25 +14,30 @@ export function MainShellScaffold({
 }: {
   children: React.ReactNode;
   edgeToEdge?: boolean;
-  mainSurfaceChrome?: "default" | "top" | "left";
+  mainSurfaceChrome?: MainSurfaceChrome;
 }) {
   const currentTab = useTabs((state) => state.currentTab);
   const isCalendarMode = currentTab?.type === "calendar";
   const SyncWrapper = isCalendarMode ? SyncProvider : Fragment;
   const resolvedMainSurfaceChrome =
     mainSurfaceChrome ?? (edgeToEdge ? "top" : "default");
+  const hasTopMainSurfaceChrome =
+    resolvedMainSurfaceChrome === "top" ||
+    resolvedMainSurfaceChrome === "top-borderless";
 
   return (
     <SyncWrapper>
       <div
         className={cn([
           "flex h-full gap-1 overflow-hidden bg-stone-50",
-          resolvedMainSurfaceChrome !== "top" && "pl-1",
-          resolvedMainSurfaceChrome === "top" && [
+          !hasTopMainSurfaceChrome && "pl-1",
+          hasTopMainSurfaceChrome && [
             "[&_[data-chat-floating-anchor]]:rounded-t-xl",
             "[&_[data-chat-floating-anchor]]:rounded-b-none",
             "[&_[data-chat-floating-anchor]]:border-x-0",
-            "[&_[data-chat-floating-anchor]]:border-t",
+            resolvedMainSurfaceChrome === "top"
+              ? "[&_[data-chat-floating-anchor]]:border-t"
+              : "[&_[data-chat-floating-anchor]]:!border-t-0",
             "[&_[data-chat-floating-anchor]]:border-b-0",
             "[&_[data-chat-floating-anchor][data-main-show-after-border-divider]]:!border-b",
             "[&_[data-main-after-border-content][data-main-after-border-merged]_[data-session-transcript-card]]:border-x-0",

--- a/apps/desktop/src/sidebar/custom-sidebar-header.tsx
+++ b/apps/desktop/src/sidebar/custom-sidebar-header.tsx
@@ -116,7 +116,7 @@ function CustomSidebarHeaderButton({
       disabled={disabled}
       className={cn([
         "relative z-50 flex size-6 shrink-0 items-center justify-center rounded-full",
-        "text-neutral-600 transition-colors hover:bg-neutral-200/60 hover:text-neutral-900",
+        "text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-neutral-900",
         "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
         "disabled:text-neutral-300 disabled:hover:bg-transparent disabled:hover:text-neutral-300",
       ])}


### PR DESCRIPTION
- Restrict the Cmd+\ sidebar toggle hotkey to left sidebar mode.
- Keep the sidebar, back, and forward controls anchored in the same left chrome position while expanded or collapsed.
- Let the collapsed left-sidebar note area fill the window, with the outer header merged under the anchored chrome and no visible top or left border.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly layout, styling, and feature-flagged hotkey behavior in the desktop shell; no auth, data, or backend changes.
> 
> **Overview**
> Improves **sidebar timeline** behavior when the left sidebar is **collapsed**: navigation chrome stays in a fixed top-left strip, the note header lines up under it, and the main surface can go **edge-to-edge** without a top border.
> 
> **`useLeftSidebar`** only registers **Cmd+\\** when `sidebar_timeline_enabled` is on. **`ClassicMainBody`** keeps sidebar/back/forward controls in that strip whether expanded or collapsed, adds a **show/hide sidebar** control, and shifts the strip slightly when collapsed. **`ClassicMainShellFrame`** selects a new **`top-borderless`** `MainSurfaceChrome` in collapsed sidebar-timeline mode so the shell drops the top border and left padding on the main panel. **`OuterHeader`** adds left padding (`pl-[156px]`) when collapsed so session titles clear the anchored chrome (controls stay in the body chrome, not duplicated in the header).
> 
> Several UI surfaces switch ghost/hover backgrounds from **`neutral-200`** to **`neutral-100`** for consistency. Tests cover hotkey gating, shell chrome modes, collapsed layout, and header gutter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3a199834a58af55c2173374fe5fb2daaced9e60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->