### PR TITLE
chore(changelog): add 1.0.34 release notes

### DIFF
--- a/packages/changelog/content/1.0.34.md
+++ b/packages/changelog/content/1.0.34.md
@@ -1,0 +1,24 @@
+---
+date: "2026-06-01"
+summary: "Left sidebar mode now has cleaner collapsed-window controls, with tidier note titles, changelog headers, and sidebar rows."
+---
+
+## Left Sidebar Mode
+
+- Left sidebar mode now keeps the sidebar, back, and forward controls anchored in the same window-chrome position when the sidebar is expanded or collapsed
+- Collapsed left sidebar mode now lets the note area fill the window without the extra top gap or left border
+- `Cmd+\` now toggles the left sidebar only when left sidebar mode is enabled
+- Icon-only controls without filled backgrounds now share the same subtle hover treatment
+
+## Notes
+
+- Empty note titles now keep the title enhancement button aligned beside the Untitled placeholder
+- Sidebar timeline note rows are back to the softer rounded-rectangle shape
+
+## Changelog
+
+- The in-app changelog now uses a simpler header with the version title and a close button
+
+## Maintenance
+
+- Removed unused desktop and UI package code to keep the app bundle leaner


### PR DESCRIPTION
Add the desktop 1.0.34 changelog entry covering the latest sidebar, note title, changelog, and maintenance updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition of a changelog markdown file with no runtime or security impact.
> 
> **Overview**
> Adds the **1.0.34** desktop release notes at `packages/changelog/content/1.0.34.md`, using the usual frontmatter (`date`, `summary`) and user-facing sections.
> 
> The entry documents shipped work: left sidebar window-chrome and collapse behavior, `Cmd+\` gating, note title and timeline row polish, a simpler in-app changelog header, and maintenance cleanup—not new application code in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81bf0f6a038887016d75af9871aab90b117fb115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->