### PR TITLE
feat(updater): show update banner in timeline mode

### DIFF
--- a/apps/desktop/src/devtools-panel/host.tsx
+++ b/apps/desktop/src/devtools-panel/host.tsx
@@ -15,6 +15,10 @@ import { getLatestVersion } from "~/changelog";
 import { useDevtoolsStore, useDevtoolsUserId } from "~/devtools-panel/hooks";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import {
+  type DevtoolsOtaPreviewStatus,
+  useDevtoolsOtaPreview,
+} from "~/store/zustand/devtools-ota-preview";
+import {
   type DevtoolsToastPreview,
   useDevtoolsToastPreview,
 } from "~/store/zustand/devtools-toast-preview";
@@ -37,6 +41,11 @@ type DevtoolsPanelAction =
   | `toasts:preview:${DevtoolsToastPreview}`
   | "toasts:preview:clear"
   | "toasts:reset-dismissed"
+  | "ota:available"
+  | "ota:downloading"
+  | "ota:ready"
+  | "ota:failed"
+  | "ota:clear"
   | "notifications:calendar"
   | "notifications:mic-detected"
   | "notifications:mic-options"
@@ -124,6 +133,8 @@ function useDevtoolsPanelActions() {
   const clearToastPreview = useDevtoolsToastPreview(
     (state) => state.clearPreview,
   );
+  const showOtaPreview = useDevtoolsOtaPreview((state) => state.showPreview);
+  const clearOtaPreview = useDevtoolsOtaPreview((state) => state.clearPreview);
   const [trialStartedOpen, setTrialStartedOpen] = useState(false);
   const [trialEndedOpen, setTrialEndedOpen] = useState(false);
   const [shouldThrow, setShouldThrow] = useState(false);
@@ -177,6 +188,14 @@ function useDevtoolsPanelActions() {
       showToastPreview(preview);
     },
     [showMainWindow, showToastPreview],
+  );
+
+  const showOtaPreviewInMainWindow = useCallback(
+    async (preview: DevtoolsOtaPreviewStatus) => {
+      await showMainWindow();
+      showOtaPreview(preview);
+    },
+    [showMainWindow, showOtaPreview],
   );
 
   const showCalendarNotification = useCallback(async () => {
@@ -380,6 +399,21 @@ function useDevtoolsPanelActions() {
         case "toasts:reset-dismissed":
           void commands.setDismissedToasts([]);
           return;
+        case "ota:available":
+          void showOtaPreviewInMainWindow("available");
+          return;
+        case "ota:downloading":
+          void showOtaPreviewInMainWindow("downloading");
+          return;
+        case "ota:ready":
+          void showOtaPreviewInMainWindow("ready");
+          return;
+        case "ota:failed":
+          void showOtaPreviewInMainWindow("failed");
+          return;
+        case "ota:clear":
+          clearOtaPreview();
+          return;
         case "notifications:calendar":
           void showCalendarNotification();
           return;
@@ -438,6 +472,8 @@ function useDevtoolsPanelActions() {
       showOnboarding,
       showToastPreviewInMainWindow,
       clearToastPreview,
+      showOtaPreview,
+      clearOtaPreview,
     ],
   );
 

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -13,6 +13,12 @@ import { cn } from "@hypr/utils";
 import { ClassicMainSidebar } from "./shell-sidebar";
 import { ClassicMainTabContent } from "./tab-content";
 import { TopMeetingTimeline } from "./top-meeting-timeline";
+import {
+  type DesktopUpdateControl,
+  SidebarTimelineUpdateButton,
+  TimelineUpdateBanner,
+  useDesktopUpdateControl,
+} from "./update-banner";
 import { useClassicMainTabsShortcuts } from "./useTabsShortcuts";
 
 import { useShell } from "~/contexts/shell";
@@ -61,6 +67,7 @@ export function ClassicMainBody() {
   const enableMainAreaTopDrag =
     showSidebarTimelineChrome || hasLeftSurfaceCustomSidebar;
   const mainAreaTopDrag = useMainAreaTopWindowDrag(enableMainAreaTopDrag);
+  const update = useDesktopUpdateControl();
 
   return (
     <div className="relative flex h-full min-w-0 flex-1 flex-col">
@@ -74,7 +81,7 @@ export function ClassicMainBody() {
         >
           <div
             data-tauri-drag-region
-            className="flex h-full min-w-0 items-start pt-[9px] pl-[76px]"
+            className="flex h-full min-w-0 items-start pt-[9px] pr-3 pl-[76px]"
           >
             <SidebarTimelineChrome
               sidebarExpanded={leftsidebar.expanded}
@@ -83,6 +90,7 @@ export function ClassicMainBody() {
               onBack={goBack}
               onForward={goNext}
               onToggleSidebar={leftsidebar.toggleExpanded}
+              update={update}
             />
           </div>
         </div>
@@ -129,6 +137,7 @@ export function ClassicMainBody() {
           </div>
         </div>
       ) : null}
+      {showTopTimeline ? <TimelineUpdateBanner update={update} /> : null}
       <div className="flex min-h-0 min-w-0 flex-1 gap-1">
         <ClassicMainSidebar />
         <div
@@ -267,6 +276,7 @@ function SidebarTimelineChrome({
   onForward,
   onToggleSidebar,
   sidebarExpanded,
+  update,
 }: {
   canGoBack: boolean;
   canGoNext: boolean;
@@ -274,44 +284,53 @@ function SidebarTimelineChrome({
   onForward: () => void;
   onToggleSidebar: () => void;
   sidebarExpanded: boolean;
+  update: DesktopUpdateControl;
 }) {
+  const updateVisible = Boolean(update.status && update.version);
+
   return (
-    <div className="flex items-center gap-0">
-      <LeftSurfaceChromeButton
-        ariaLabel={sidebarExpanded ? "Hide sidebar" : "Show sidebar"}
-        onClick={onToggleSidebar}
-      >
-        {sidebarExpanded ? (
-          <PanelLeftCloseIcon size={14} />
-        ) : (
-          <PanelLeftOpenIcon size={14} />
-        )}
-      </LeftSurfaceChromeButton>
-      <LeftSurfaceChromeButton
-        ariaLabel="Go back"
-        disabled={!canGoBack}
-        onClick={onBack}
-      >
-        <ArrowLeftIcon size={14} />
-      </LeftSurfaceChromeButton>
-      <LeftSurfaceChromeButton
-        ariaLabel="Go forward"
-        disabled={!canGoNext}
-        onClick={onForward}
-      >
-        <ArrowRightIcon size={14} />
-      </LeftSurfaceChromeButton>
+    <div className="flex w-full items-center justify-between">
+      <div className="flex items-center gap-0">
+        <LeftSurfaceChromeButton
+          ariaLabel={sidebarExpanded ? "Hide sidebar" : "Show sidebar"}
+          badge={!sidebarExpanded && updateVisible}
+          onClick={onToggleSidebar}
+        >
+          {sidebarExpanded ? (
+            <PanelLeftCloseIcon size={14} />
+          ) : (
+            <PanelLeftOpenIcon size={14} />
+          )}
+        </LeftSurfaceChromeButton>
+        <LeftSurfaceChromeButton
+          ariaLabel="Go back"
+          disabled={!canGoBack}
+          onClick={onBack}
+        >
+          <ArrowLeftIcon size={14} />
+        </LeftSurfaceChromeButton>
+        <LeftSurfaceChromeButton
+          ariaLabel="Go forward"
+          disabled={!canGoNext}
+          onClick={onForward}
+        >
+          <ArrowRightIcon size={14} />
+        </LeftSurfaceChromeButton>
+      </div>
+      {sidebarExpanded ? <SidebarTimelineUpdateButton update={update} /> : null}
     </div>
   );
 }
 
 function LeftSurfaceChromeButton({
   ariaLabel,
+  badge = false,
   children,
   disabled = false,
   onClick,
 }: {
   ariaLabel: string;
+  badge?: boolean;
   children: React.ReactNode;
   disabled?: boolean;
   onClick: () => void;
@@ -323,7 +342,7 @@ function LeftSurfaceChromeButton({
       data-tauri-drag-region="false"
       disabled={disabled}
       className={cn([
-        "flex size-7 items-center justify-center rounded-full",
+        "relative flex size-7 items-center justify-center rounded-full",
         "text-neutral-700 transition-colors hover:bg-neutral-100 hover:text-neutral-900",
         "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
         "disabled:text-neutral-300 disabled:hover:bg-transparent disabled:hover:text-neutral-300",
@@ -331,6 +350,13 @@ function LeftSurfaceChromeButton({
       onClick={onClick}
     >
       {children}
+      {badge ? (
+        <span
+          aria-hidden="true"
+          data-testid="collapsed-sidebar-update-badge"
+          className="pointer-events-none absolute top-1 right-1 size-1.5 rounded-full bg-red-500 ring-2 ring-stone-50"
+        />
+      ) : null}
     </button>
   );
 }

--- a/apps/desktop/src/main/update-banner.test.tsx
+++ b/apps/desktop/src/main/update-banner.test.tsx
@@ -1,0 +1,383 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  checkMock,
+  downloadMock,
+  installMock,
+  isDownloadedMock,
+  postinstallMock,
+  updateDownloadingListenMock,
+  updateDownloadProgressListenMock,
+  updateReadyListenMock,
+  updateDownloadFailedListenMock,
+  updatedListenMock,
+  eventHandlers,
+} = vi.hoisted(() => ({
+  checkMock: vi.fn(),
+  downloadMock: vi.fn(),
+  installMock: vi.fn(),
+  isDownloadedMock: vi.fn(),
+  postinstallMock: vi.fn(),
+  updateDownloadingListenMock: vi.fn(),
+  updateDownloadProgressListenMock: vi.fn(),
+  updateReadyListenMock: vi.fn(),
+  updateDownloadFailedListenMock: vi.fn(),
+  updatedListenMock: vi.fn(),
+  eventHandlers: {
+    updateDownloading: null as
+      | null
+      | ((event: { payload: { version: string } }) => void),
+    updateDownloadProgress: null as
+      | null
+      | ((event: {
+          payload: {
+            version: string;
+            chunk_length: number;
+            content_length: number | null;
+          };
+        }) => void),
+    updateReady: null as
+      | null
+      | ((event: { payload: { version: string } }) => void),
+    updateDownloadFailed: null as
+      | null
+      | ((event: { payload: { version: string } }) => void),
+    updated: null as
+      | null
+      | ((event: {
+          payload: { previous: string | null; current: string };
+        }) => void),
+  },
+}));
+
+vi.mock("@hypr/plugin-updater2", () => ({
+  commands: {
+    check: checkMock,
+    download: downloadMock,
+    install: installMock,
+    isDownloaded: isDownloadedMock,
+    postinstall: postinstallMock,
+  },
+  events: {
+    updateDownloadingEvent: {
+      listen: updateDownloadingListenMock,
+    },
+    updateDownloadProgressEvent: {
+      listen: updateDownloadProgressListenMock,
+    },
+    updateReadyEvent: {
+      listen: updateReadyListenMock,
+    },
+    updateDownloadFailedEvent: {
+      listen: updateDownloadFailedListenMock,
+    },
+    updatedEvent: {
+      listen: updatedListenMock,
+    },
+  },
+}));
+
+import {
+  SidebarTimelineUpdateButton,
+  TimelineUpdateBanner,
+  useDesktopUpdateControl,
+} from "./update-banner";
+
+import { useDevtoolsOtaPreview } from "~/store/zustand/devtools-ota-preview";
+
+const queryClients: QueryClient[] = [];
+
+describe("TimelineUpdateBanner", () => {
+  beforeEach(() => {
+    checkMock.mockReset();
+    downloadMock.mockReset();
+    installMock.mockReset();
+    isDownloadedMock.mockReset();
+    postinstallMock.mockReset();
+    updateDownloadingListenMock.mockReset();
+    updateDownloadProgressListenMock.mockReset();
+    updateReadyListenMock.mockReset();
+    updateDownloadFailedListenMock.mockReset();
+    updatedListenMock.mockReset();
+
+    eventHandlers.updateDownloading = null;
+    eventHandlers.updateDownloadProgress = null;
+    eventHandlers.updateReady = null;
+    eventHandlers.updateDownloadFailed = null;
+    eventHandlers.updated = null;
+
+    checkMock.mockResolvedValue({ status: "ok", data: null });
+    downloadMock.mockResolvedValue({ status: "ok", data: null });
+    installMock.mockResolvedValue({
+      status: "ok",
+      data: { kind: "relaunch_current" },
+    });
+    isDownloadedMock.mockResolvedValue({ status: "ok", data: false });
+    postinstallMock.mockResolvedValue({ status: "ok", data: null });
+
+    updateDownloadingListenMock.mockImplementation(async (handler) => {
+      eventHandlers.updateDownloading = handler;
+      return () => {};
+    });
+    updateDownloadProgressListenMock.mockImplementation(async (handler) => {
+      eventHandlers.updateDownloadProgress = handler;
+      return () => {};
+    });
+    updateReadyListenMock.mockImplementation(async (handler) => {
+      eventHandlers.updateReady = handler;
+      return () => {};
+    });
+    updateDownloadFailedListenMock.mockImplementation(async (handler) => {
+      eventHandlers.updateDownloadFailed = handler;
+      return () => {};
+    });
+    updatedListenMock.mockImplementation(async (handler) => {
+      eventHandlers.updated = handler;
+      return () => {};
+    });
+
+    useDevtoolsOtaPreview.getState().clearPreview();
+  });
+
+  afterEach(() => {
+    cleanup();
+    queryClients.forEach((queryClient) => queryClient.clear());
+    queryClients.length = 0;
+    useDevtoolsOtaPreview.getState().clearPreview();
+  });
+
+  it("shows an available update from the updater check", async () => {
+    checkMock.mockResolvedValue({ status: "ok", data: "1.0.34" });
+
+    renderBanner();
+
+    expect(await screen.findByText("New version available")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Download/ })).toBeTruthy();
+  });
+
+  it("downloads and restarts from the banner", async () => {
+    checkMock.mockResolvedValue({ status: "ok", data: "1.0.34" });
+
+    renderBanner();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Download/ }));
+
+    await waitFor(() => expect(downloadMock).toHaveBeenCalledWith("1.0.34"));
+
+    await waitFor(() =>
+      expect(eventHandlers.updateReady).toBeTypeOf("function"),
+    );
+
+    act(() => {
+      eventHandlers.updateReady?.({ payload: { version: "1.0.34" } });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Restart/ }));
+
+    await waitFor(() => {
+      expect(installMock).toHaveBeenCalledWith("1.0.34");
+      expect(postinstallMock).toHaveBeenCalledWith({
+        kind: "relaunch_current",
+      });
+    });
+  });
+
+  it("shows restart when the checked update is already downloaded", async () => {
+    checkMock.mockResolvedValue({ status: "ok", data: "1.0.34" });
+    isDownloadedMock.mockResolvedValue({ status: "ok", data: true });
+
+    renderBanner();
+
+    expect(await screen.findByText("Update ready")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Restart/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Download/ })).toBeNull();
+  });
+
+  it("shows a failed state when postinstall returns an error result", async () => {
+    checkMock.mockResolvedValue({ status: "ok", data: "1.0.34" });
+    postinstallMock.mockResolvedValue({
+      status: "error",
+      error: "Restart failed",
+    });
+
+    renderBanner();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Download/ }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Restart/ })).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Restart/ }));
+
+    expect(await screen.findByText("Update failed")).toBeTruthy();
+  });
+
+  it("shows download progress from updater events", async () => {
+    renderBanner();
+
+    await waitFor(() =>
+      expect(eventHandlers.updateDownloadProgress).toBeTypeOf("function"),
+    );
+
+    act(() => {
+      eventHandlers.updateDownloading?.({ payload: { version: "1.0.34" } });
+      eventHandlers.updateDownloadProgress?.({
+        payload: {
+          version: "1.0.34",
+          chunk_length: 25,
+          content_length: 100,
+        },
+      });
+      eventHandlers.updateDownloadProgress?.({
+        payload: {
+          version: "1.0.34",
+          chunk_length: 25,
+          content_length: 100,
+        },
+      });
+    });
+
+    expect(screen.getByText("New version available")).toBeTruthy();
+    expect(screen.getByText("50%")).toBeTruthy();
+  });
+
+  it("clears the banner after the app reports it has updated", async () => {
+    checkMock.mockResolvedValue({ status: "ok", data: "1.0.34" });
+
+    renderBanner();
+
+    expect(await screen.findByText("New version available")).toBeTruthy();
+
+    await waitFor(() => expect(eventHandlers.updated).toBeTypeOf("function"));
+
+    act(() => {
+      eventHandlers.updated?.({
+        payload: { previous: "1.0.33", current: "1.0.34" },
+      });
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByText("New version available")).toBeNull(),
+    );
+  });
+
+  it("downloads from the sidebar update button", async () => {
+    checkMock.mockResolvedValue({ status: "ok", data: "1.0.34" });
+
+    renderSidebarUpdateButton();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Download update" }),
+    );
+
+    await waitFor(() => expect(downloadMock).toHaveBeenCalledWith("1.0.34"));
+  });
+
+  it("shows sidebar circular progress while downloading", async () => {
+    renderSidebarUpdateButton();
+
+    await waitFor(() =>
+      expect(eventHandlers.updateDownloadProgress).toBeTypeOf("function"),
+    );
+
+    act(() => {
+      eventHandlers.updateDownloading?.({ payload: { version: "1.0.34" } });
+      eventHandlers.updateDownloadProgress?.({
+        payload: {
+          version: "1.0.34",
+          chunk_length: 50,
+          content_length: 100,
+        },
+      });
+    });
+
+    const button = screen.getByRole("button", {
+      name: "Downloading update, 50% complete",
+    });
+
+    expect(button.hasAttribute("disabled")).toBe(true);
+    expect(button.querySelector(".lucide-download")).toBeNull();
+    expect(button.querySelector(".lucide-loader-circle")).toBeNull();
+  });
+
+  it("restarts from the sidebar update button when ready", async () => {
+    renderSidebarUpdateButton();
+
+    await waitFor(() =>
+      expect(eventHandlers.updateReady).toBeTypeOf("function"),
+    );
+
+    act(() => {
+      eventHandlers.updateReady?.({ payload: { version: "1.0.34" } });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Restart to update" }));
+
+    await waitFor(() => {
+      expect(installMock).toHaveBeenCalledWith("1.0.34");
+      expect(postinstallMock).toHaveBeenCalledWith({
+        kind: "relaunch_current",
+      });
+    });
+  });
+
+  it("shows the devtools OTA preview state without a real updater result", async () => {
+    useDevtoolsOtaPreview.getState().showPreview("available");
+
+    renderBanner();
+
+    expect(await screen.findByText("New version available")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /Download/ }));
+
+    expect(
+      await screen.findByLabelText("Downloading update, 58% complete"),
+    ).toBeTruthy();
+    expect(downloadMock).not.toHaveBeenCalled();
+  });
+});
+
+function renderBanner() {
+  return renderWithQueryClient(<TimelineUpdateBannerHarness />);
+}
+
+function renderSidebarUpdateButton() {
+  return renderWithQueryClient(<SidebarUpdateButtonHarness />);
+}
+
+function SidebarUpdateButtonHarness() {
+  const update = useDesktopUpdateControl();
+
+  return <SidebarTimelineUpdateButton update={update} />;
+}
+
+function TimelineUpdateBannerHarness() {
+  const update = useDesktopUpdateControl();
+
+  return <TimelineUpdateBanner update={update} />;
+}
+
+function renderWithQueryClient(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+  queryClients.push(queryClient);
+
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}

--- a/apps/desktop/src/main/update-banner.tsx
+++ b/apps/desktop/src/main/update-banner.tsx
@@ -1,0 +1,622 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { DownloadIcon, RefreshCwIcon, RotateCwIcon } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+
+import {
+  commands as updaterCommands,
+  events as updaterEvents,
+  type Result,
+} from "@hypr/plugin-updater2";
+import { cn } from "@hypr/utils";
+
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
+import { useDevtoolsOtaPreview } from "~/store/zustand/devtools-ota-preview";
+
+export type UpdateBannerStatus =
+  | "available"
+  | "downloading"
+  | "ready"
+  | "failed";
+
+export type DesktopUpdateControl = {
+  status: UpdateBannerStatus | null;
+  version: string | null;
+  progress: number | null;
+  errorMessage: string | null;
+  downloadStarting: boolean;
+  installing: boolean;
+  downloadUpdate: () => void;
+  installUpdate: () => void;
+};
+
+type UpdateEventState = {
+  status: UpdateBannerStatus;
+  version: string;
+  downloadedBytes: number;
+  contentLength: number | null;
+  errorMessage: string | null;
+};
+
+type UpdateCheckState = {
+  version: string;
+  ready: boolean;
+} | null;
+
+const UPDATE_CHECK_QUERY_KEY = ["updater2", "check"] as const;
+const UPDATE_CHECK_INTERVAL_MS = 30 * 60 * 1000;
+
+export function useDesktopUpdateControl(): DesktopUpdateControl {
+  const [eventState, setEventState] = useState<UpdateEventState | null>(null);
+  const [acknowledgedVersion, setAcknowledgedVersion] = useState<string | null>(
+    null,
+  );
+  const devtoolsPreview = useDevtoolsOtaPreview((state) => state.preview);
+  const showDevtoolsOtaPreview = useDevtoolsOtaPreview(
+    (state) => state.showPreview,
+  );
+  const clearDevtoolsOtaPreview = useDevtoolsOtaPreview(
+    (state) => state.clearPreview,
+  );
+
+  useMountEffect(() => {
+    let cancelled = false;
+    const unlistenFns: Array<() => void> = [];
+
+    const listen = async () => {
+      const [
+        unlistenDownloading,
+        unlistenProgress,
+        unlistenReady,
+        unlistenFailed,
+        unlistenUpdated,
+      ] = await Promise.all([
+        updaterEvents.updateDownloadingEvent.listen(({ payload }) => {
+          setEventState({
+            status: "downloading",
+            version: payload.version,
+            downloadedBytes: 0,
+            contentLength: null,
+            errorMessage: null,
+          });
+        }),
+        updaterEvents.updateDownloadProgressEvent.listen(({ payload }) => {
+          setEventState((current) => {
+            const downloadedBytes =
+              current?.version === payload.version
+                ? current.downloadedBytes + payload.chunk_length
+                : payload.chunk_length;
+
+            return {
+              status: "downloading",
+              version: payload.version,
+              downloadedBytes,
+              contentLength: payload.content_length,
+              errorMessage: null,
+            };
+          });
+        }),
+        updaterEvents.updateReadyEvent.listen(({ payload }) => {
+          setEventState({
+            status: "ready",
+            version: payload.version,
+            downloadedBytes: 0,
+            contentLength: null,
+            errorMessage: null,
+          });
+        }),
+        updaterEvents.updateDownloadFailedEvent.listen(({ payload }) => {
+          setEventState({
+            status: "failed",
+            version: payload.version,
+            downloadedBytes: 0,
+            contentLength: null,
+            errorMessage: "Failed to download update.",
+          });
+        }),
+        updaterEvents.updatedEvent.listen(({ payload }) => {
+          setAcknowledgedVersion(payload.current);
+          setEventState(null);
+        }),
+      ]);
+
+      if (cancelled) {
+        unlistenDownloading();
+        unlistenProgress();
+        unlistenReady();
+        unlistenFailed();
+        unlistenUpdated();
+        return;
+      }
+
+      unlistenFns.push(
+        unlistenDownloading,
+        unlistenProgress,
+        unlistenReady,
+        unlistenFailed,
+        unlistenUpdated,
+      );
+    };
+
+    void listen();
+
+    return () => {
+      cancelled = true;
+      unlistenFns.forEach((unlisten) => unlisten());
+    };
+  });
+
+  const updateCheck = useQuery({
+    queryKey: UPDATE_CHECK_QUERY_KEY,
+    queryFn: async (): Promise<UpdateCheckState> => {
+      const version = unwrapResult(await updaterCommands.check());
+
+      if (!version) {
+        return null;
+      }
+
+      return {
+        version,
+        ready: unwrapResult(await updaterCommands.isDownloaded(version)),
+      };
+    },
+    refetchInterval: UPDATE_CHECK_INTERVAL_MS,
+    retry: false,
+    staleTime: UPDATE_CHECK_INTERVAL_MS,
+  });
+
+  const { mutate: downloadUpdate, isPending: downloadStarting } = useMutation({
+    mutationFn: async (version: string) =>
+      unwrapResult(await updaterCommands.download(version)),
+    onMutate: (version) => {
+      setEventState({
+        status: "downloading",
+        version,
+        downloadedBytes: 0,
+        contentLength: null,
+        errorMessage: null,
+      });
+    },
+    onError: (error, version) => {
+      setEventState({
+        status: "failed",
+        version,
+        downloadedBytes: 0,
+        contentLength: null,
+        errorMessage: readErrorMessage(error),
+      });
+    },
+    onSuccess: (_data, version) => {
+      setEventState((current) =>
+        current?.status === "ready"
+          ? current
+          : {
+              status: "ready",
+              version,
+              downloadedBytes: 0,
+              contentLength: null,
+              errorMessage: null,
+            },
+      );
+    },
+  });
+
+  const { mutate: installUpdate, isPending: installing } = useMutation({
+    mutationFn: async (version: string) => {
+      const result = unwrapResult(await updaterCommands.install(version));
+      unwrapResult(await updaterCommands.postinstall(result));
+    },
+    onError: (error, version) => {
+      setEventState({
+        status: "failed",
+        version,
+        downloadedBytes: 0,
+        contentLength: null,
+        errorMessage: readErrorMessage(error),
+      });
+    },
+  });
+
+  const checkedUpdate =
+    updateCheck.data && updateCheck.data.version !== acknowledgedVersion
+      ? updateCheck.data
+      : null;
+  const version = eventState?.version ?? checkedUpdate?.version ?? null;
+  const status: UpdateBannerStatus | null = eventState
+    ? eventState.status
+    : checkedUpdate
+      ? checkedUpdate.ready
+        ? "ready"
+        : "available"
+      : null;
+  const progress = useMemo(() => {
+    if (
+      !eventState ||
+      eventState.status !== "downloading" ||
+      !eventState.contentLength
+    ) {
+      return null;
+    }
+
+    return Math.max(
+      0,
+      Math.min(1, eventState.downloadedBytes / eventState.contentLength),
+    );
+  }, [eventState]);
+
+  const handleDownload = useCallback(() => {
+    if (!version) {
+      return;
+    }
+    downloadUpdate(version);
+  }, [downloadUpdate, version]);
+
+  const handleInstall = useCallback(() => {
+    if (!version) {
+      return;
+    }
+    installUpdate(version);
+  }, [installUpdate, version]);
+
+  const handleDevtoolsDownload = useCallback(() => {
+    showDevtoolsOtaPreview("downloading");
+  }, [showDevtoolsOtaPreview]);
+
+  const handleDevtoolsInstall = useCallback(() => {
+    clearDevtoolsOtaPreview();
+  }, [clearDevtoolsOtaPreview]);
+
+  if (devtoolsPreview) {
+    return {
+      status: devtoolsPreview.status,
+      version: devtoolsPreview.version,
+      progress: devtoolsPreview.progress,
+      errorMessage:
+        devtoolsPreview.status === "failed"
+          ? "Devtools OTA failure preview."
+          : null,
+      downloadStarting: false,
+      installing: false,
+      downloadUpdate: handleDevtoolsDownload,
+      installUpdate: handleDevtoolsInstall,
+    };
+  }
+
+  return {
+    status,
+    version,
+    progress,
+    errorMessage: eventState?.errorMessage ?? null,
+    downloadStarting,
+    installing,
+    downloadUpdate: handleDownload,
+    installUpdate: handleInstall,
+  };
+}
+
+export function TimelineUpdateBanner({
+  update,
+}: {
+  update: DesktopUpdateControl;
+}) {
+  return (
+    <AnimatePresence initial={false}>
+      {update.status && update.version ? (
+        <motion.div
+          key="timeline-update-banner"
+          initial={{ height: 0, opacity: 0 }}
+          animate={{ height: "auto", opacity: 1 }}
+          exit={{ height: 0, opacity: 0 }}
+          transition={{ duration: 0.18, ease: "easeOut" }}
+          className="w-full shrink-0 overflow-hidden"
+        >
+          <UpdateBanner
+            status={update.status}
+            progress={update.progress}
+            errorMessage={update.errorMessage}
+            downloadStarting={update.downloadStarting}
+            installing={update.installing}
+            actionIcon={bannerActionIcon(update.status)}
+            onDownload={update.downloadUpdate}
+            onInstall={update.installUpdate}
+          />
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}
+
+export function SidebarTimelineUpdateButton({
+  update,
+}: {
+  update: DesktopUpdateControl;
+}) {
+  if (!update.status || !update.version) {
+    return null;
+  }
+
+  const isDownloading = update.status === "downloading";
+  const isReady = update.status === "ready";
+  const label = sidebarUpdateLabel(update.status, update.progress);
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      data-tauri-drag-region="false"
+      disabled={isDownloading || update.downloadStarting || update.installing}
+      className={cn([
+        "relative flex size-7 shrink-0 items-center justify-center rounded-full",
+        "text-neutral-700 transition-colors hover:bg-neutral-100 hover:text-neutral-900",
+        "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+        "disabled:cursor-default disabled:text-neutral-500 disabled:hover:bg-transparent disabled:hover:text-neutral-500",
+      ])}
+      onClick={isReady ? update.installUpdate : update.downloadUpdate}
+    >
+      {isDownloading ? (
+        <SidebarCircularProgress progress={update.progress} />
+      ) : (
+        <span className="relative z-10 flex items-center justify-center">
+          {sidebarActionIcon(update.status)}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function UpdateBanner({
+  status,
+  progress,
+  errorMessage,
+  downloadStarting,
+  installing,
+  actionIcon,
+  onDownload,
+  onInstall,
+}: {
+  status: UpdateBannerStatus;
+  progress: number | null;
+  errorMessage: string | null;
+  downloadStarting: boolean;
+  installing: boolean;
+  actionIcon?: ReactNode;
+  onDownload: () => void;
+  onInstall: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="timeline-update-banner"
+      className="flex h-9 w-full shrink-0 items-center justify-center border-y border-stone-200/70 bg-stone-100/80 px-3 font-mono text-xs text-neutral-800"
+    >
+      <div className="flex min-w-0 items-center justify-center gap-3">
+        <BannerBody status={status} errorMessage={errorMessage} />
+
+        <BannerAction
+          status={status}
+          progress={progress}
+          downloadStarting={downloadStarting}
+          installing={installing}
+          actionIcon={actionIcon}
+          onDownload={onDownload}
+          onInstall={onInstall}
+        />
+      </div>
+    </div>
+  );
+}
+
+function BannerBody({
+  status,
+  errorMessage,
+}: {
+  status: UpdateBannerStatus;
+  errorMessage: string | null;
+}) {
+  if (status === "available" || status === "downloading") {
+    return <span className="shrink-0">New version available</span>;
+  }
+
+  if (status === "ready") {
+    return <span className="shrink-0">Update ready</span>;
+  }
+
+  return (
+    <span className="shrink-0" title={errorMessage ?? undefined}>
+      Update failed
+    </span>
+  );
+}
+
+function BannerAction({
+  status,
+  progress,
+  downloadStarting,
+  installing,
+  actionIcon,
+  onDownload,
+  onInstall,
+}: {
+  status: UpdateBannerStatus;
+  progress: number | null;
+  downloadStarting: boolean;
+  installing: boolean;
+  actionIcon?: ReactNode;
+  onDownload: () => void;
+  onInstall: () => void;
+}) {
+  if (status === "available" || status === "failed") {
+    return (
+      <button
+        type="button"
+        data-tauri-drag-region="false"
+        onClick={onDownload}
+        disabled={downloadStarting}
+        className={cn([
+          "inline-flex h-7 w-[104px] shrink-0 items-center justify-center gap-1.5 overflow-hidden rounded-full px-3 font-medium",
+          "bg-neutral-950 text-white transition-colors hover:bg-neutral-800",
+          "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+          "disabled:cursor-not-allowed disabled:opacity-60",
+        ])}
+      >
+        <ActionIcon icon={actionIcon} />
+        {downloadStarting
+          ? "Starting..."
+          : status === "failed"
+            ? "Retry"
+            : "Download"}
+      </button>
+    );
+  }
+
+  if (status === "downloading") {
+    return <DownloadProgress progress={progress} />;
+  }
+
+  return (
+    <button
+      type="button"
+      data-tauri-drag-region="false"
+      onClick={onInstall}
+      disabled={installing}
+      className={cn([
+        "inline-flex h-7 shrink-0 items-center justify-center gap-1.5 overflow-hidden rounded-full px-3 font-medium",
+        "bg-neutral-950 text-white transition-colors hover:bg-neutral-800",
+        "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+        "disabled:cursor-not-allowed disabled:opacity-60",
+      ])}
+    >
+      <ActionIcon icon={actionIcon} />
+      {installing ? "Restarting" : "Restart"}
+    </button>
+  );
+}
+
+function DownloadProgress({ progress }: { progress: number | null }) {
+  const pct = Math.max(0, Math.min(100, Math.round((progress ?? 0) * 100)));
+
+  return (
+    <div
+      aria-label={
+        progress === null
+          ? "Downloading update"
+          : `Downloading update, ${pct}% complete`
+      }
+      className="relative inline-flex h-7 w-[104px] shrink-0 items-center justify-center overflow-hidden rounded-full border border-stone-300 bg-white px-3 font-medium text-neutral-800"
+    >
+      {progress === null ? null : (
+        <span
+          aria-hidden="true"
+          className="absolute inset-y-0 left-0 bg-neutral-950/15"
+          style={{ width: `${pct}%` }}
+        />
+      )}
+      <span className="relative z-10 tabular-nums">
+        {progress === null ? "Downloading" : `${pct}%`}
+      </span>
+    </div>
+  );
+}
+
+function ActionIcon({ icon }: { icon?: ReactNode }) {
+  return icon ? <span aria-hidden="true">{icon}</span> : null;
+}
+
+function SidebarCircularProgress({ progress }: { progress: number | null }) {
+  const pct = Math.max(0, Math.min(1, progress ?? 0));
+  const radius = 7.5;
+  const circumference = 2 * Math.PI * radius;
+
+  return (
+    <svg
+      aria-hidden="true"
+      className="pointer-events-none absolute top-1/2 left-1/2 size-[18px] -translate-x-1/2 -translate-y-1/2 -rotate-90"
+      viewBox="0 0 18 18"
+    >
+      <circle
+        cx="9"
+        cy="9"
+        r={radius}
+        fill="none"
+        stroke="currentColor"
+        strokeOpacity="0.14"
+        strokeWidth="1.5"
+      />
+      <circle
+        cx="9"
+        cy="9"
+        r={radius}
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.5"
+        strokeDasharray={circumference}
+        strokeDashoffset={circumference * (1 - pct)}
+        className="transition-[stroke-dashoffset] duration-200 ease-out"
+      />
+    </svg>
+  );
+}
+
+function sidebarUpdateLabel(
+  status: UpdateBannerStatus,
+  progress: number | null,
+): string {
+  if (status === "ready") {
+    return "Restart to update";
+  }
+
+  if (status === "downloading") {
+    if (progress === null) {
+      return "Downloading update";
+    }
+
+    return `Downloading update, ${Math.round(progress * 100)}% complete`;
+  }
+
+  if (status === "failed") {
+    return "Retry update";
+  }
+
+  return "Download update";
+}
+
+function sidebarActionIcon(status: UpdateBannerStatus): ReactNode {
+  if (status === "ready") {
+    return <RotateCwIcon size={14} aria-hidden="true" />;
+  }
+
+  return <DownloadIcon size={14} aria-hidden="true" />;
+}
+
+function bannerActionIcon(status: UpdateBannerStatus): ReactNode {
+  if (status === "failed") {
+    return <RefreshCwIcon size={12} aria-hidden="true" />;
+  }
+  if (status === "ready") {
+    return <RotateCwIcon size={12} aria-hidden="true" />;
+  }
+  return <DownloadIcon size={12} aria-hidden="true" />;
+}
+
+function unwrapResult<T>(result: Result<T, string>): T {
+  if (result.status === "ok") {
+    return result.data;
+  }
+
+  throw new Error(result.error);
+}
+
+function readErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return "Unknown update error.";
+}

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -18,6 +18,16 @@ const mocks = vi.hoisted(() => ({
   canGoBack: false,
   canGoNext: false,
   leftSidebarExpanded: true,
+  sidebarUpdateControl: {
+    status: null as null | "available" | "downloading" | "ready" | "failed",
+    version: null as string | null,
+    progress: null as number | null,
+    errorMessage: null as string | null,
+    downloadStarting: false,
+    installing: false,
+    downloadUpdate: vi.fn(),
+    installUpdate: vi.fn(),
+  },
   currentTab: {
     active: true,
     pinned: false,
@@ -51,6 +61,19 @@ vi.mock("~/main/tab-content", () => ({
 
 vi.mock("~/main/top-meeting-timeline", () => ({
   TopMeetingTimeline: () => <div data-testid="top-meeting-timeline" />,
+}));
+
+vi.mock("~/main/update-banner", () => ({
+  SidebarTimelineUpdateButton: ({
+    update,
+  }: {
+    update: { status: string | null; version: string | null };
+  }) =>
+    update.status && update.version ? (
+      <button type="button" data-testid="sidebar-update-button" />
+    ) : null,
+  TimelineUpdateBanner: () => <div data-testid="timeline-update-banner" />,
+  useDesktopUpdateControl: () => mocks.sidebarUpdateControl,
 }));
 
 vi.mock("~/main/shell-sidebar", () => ({
@@ -103,6 +126,14 @@ describe("ClassicMainBody", () => {
     mocks.canGoBack = false;
     mocks.canGoNext = false;
     mocks.leftSidebarExpanded = true;
+    mocks.sidebarUpdateControl.status = null;
+    mocks.sidebarUpdateControl.version = null;
+    mocks.sidebarUpdateControl.progress = null;
+    mocks.sidebarUpdateControl.errorMessage = null;
+    mocks.sidebarUpdateControl.downloadStarting = false;
+    mocks.sidebarUpdateControl.installing = false;
+    mocks.sidebarUpdateControl.downloadUpdate.mockClear();
+    mocks.sidebarUpdateControl.installUpdate.mockClear();
     mocks.currentTab = {
       active: true,
       pinned: false,
@@ -130,6 +161,7 @@ describe("ClassicMainBody", () => {
     expect(timeline.parentElement?.className).toContain("flex-1");
     expect(topArea?.className).toContain("h-12");
     expect(topArea?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(screen.getByTestId("timeline-update-banner")).toBeTruthy();
     expect(screen.getByTestId("main-sidebar")).toBeTruthy();
     expect(screen.getByTestId("main-tab-content").textContent).toContain(
       "empty",
@@ -149,6 +181,7 @@ describe("ClassicMainBody", () => {
     const firstBodyChild = body?.firstElementChild;
 
     expect(screen.queryByTestId("top-meeting-timeline")).toBeNull();
+    expect(screen.queryByTestId("timeline-update-banner")).toBeNull();
     expect(screen.queryByTestId("toast-area")).toBeNull();
     expect(firstBodyChild?.className).toContain(
       "flex min-h-0 min-w-0 flex-1 gap-1",
@@ -165,14 +198,17 @@ describe("ClassicMainBody", () => {
     render(<ClassicMainBody />);
 
     expect(screen.queryByTestId("top-meeting-timeline")).toBeNull();
+    expect(screen.queryByTestId("timeline-update-banner")).toBeNull();
     expect(screen.queryByTestId("toast-area")).toBeNull();
     const sidebar = screen.getByTestId("main-sidebar");
     const sidebarToggle = screen.getByRole("button", { name: "Hide sidebar" });
     const backButton = screen.getByRole("button", { name: "Go back" });
-    const topArea = backButton.parentElement?.parentElement?.parentElement;
+    const chrome = sidebarToggle.parentElement?.parentElement;
+    const topArea = chrome?.parentElement?.parentElement;
 
     expect(sidebar).toBeTruthy();
     expect(sidebarToggle).toBeTruthy();
+    expect(screen.queryByTestId("sidebar-update-button")).toBeNull();
     expect(screen.queryByRole("button", { name: "Open calendar" })).toBeNull();
     expect(backButton.hasAttribute("disabled")).toBe(true);
     expect(
@@ -181,6 +217,8 @@ describe("ClassicMainBody", () => {
         .hasAttribute("disabled"),
     ).toBe(true);
     expect(backButton.parentElement?.className).toContain("gap-0");
+    expect(chrome?.className).toContain("justify-between");
+    expect(chrome?.className).toContain("w-full");
     expect(topArea?.className).toContain("h-12");
     expect(topArea?.className).toContain("absolute");
     expect(topArea?.className).toContain("left-0");
@@ -199,13 +237,16 @@ describe("ClassicMainBody", () => {
     const contentRow = body?.lastElementChild;
     const sidebarToggle = screen.getByRole("button", { name: "Show sidebar" });
     const backButton = screen.getByRole("button", { name: "Go back" });
-    const topArea = backButton.parentElement?.parentElement?.parentElement;
+    const chrome = sidebarToggle.parentElement?.parentElement;
+    const topArea = chrome?.parentElement?.parentElement;
 
     fireEvent.click(sidebarToggle);
     fireEvent.click(backButton);
     fireEvent.click(screen.getByRole("button", { name: "Go forward" }));
 
     expect(screen.queryByTestId("top-meeting-timeline")).toBeNull();
+    expect(screen.queryByTestId("timeline-update-banner")).toBeNull();
+    expect(screen.queryByTestId("sidebar-update-button")).toBeNull();
     expect(backButton.parentElement?.className).toContain("gap-0");
     expect(topArea?.className).toContain("absolute");
     expect(topArea?.className).toContain("h-12");
@@ -217,6 +258,45 @@ describe("ClassicMainBody", () => {
     expect(mocks.toggleLeftSidebar).toHaveBeenCalledTimes(1);
     expect(mocks.goBack).toHaveBeenCalledTimes(1);
     expect(mocks.goNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the update button at the far end of expanded sidebar timeline chrome", () => {
+    mocks.sidebarTimelineEnabled = true;
+    mocks.sidebarUpdateControl.status = "available";
+    mocks.sidebarUpdateControl.version = "1.0.34";
+
+    render(<ClassicMainBody />);
+
+    const sidebarToggle = screen.getByRole("button", { name: "Hide sidebar" });
+    const chrome = sidebarToggle.parentElement?.parentElement;
+
+    expect(screen.getByTestId("sidebar-update-button")).toBeTruthy();
+    expect(chrome?.className).toContain("justify-between");
+    expect(chrome?.lastElementChild?.getAttribute("data-testid")).toBe(
+      "sidebar-update-button",
+    );
+    expect(
+      within(sidebarToggle).queryByTestId("collapsed-sidebar-update-badge"),
+    ).toBeNull();
+  });
+
+  it("shows an update badge on the collapsed sidebar timeline toggle", () => {
+    mocks.sidebarTimelineEnabled = true;
+    mocks.leftSidebarExpanded = false;
+    mocks.sidebarUpdateControl.status = "available";
+    mocks.sidebarUpdateControl.version = "1.0.34";
+
+    render(<ClassicMainBody />);
+
+    const sidebarToggle = screen.getByRole("button", { name: "Show sidebar" });
+
+    fireEvent.click(sidebarToggle);
+
+    expect(screen.queryByTestId("sidebar-update-button")).toBeNull();
+    expect(
+      within(sidebarToggle).getByTestId("collapsed-sidebar-update-badge"),
+    ).toBeTruthy();
+    expect(mocks.toggleLeftSidebar).toHaveBeenCalledTimes(1);
   });
 
   it("hides timeline chrome for changelog tabs without collapsing the sidebar state", () => {
@@ -232,6 +312,7 @@ describe("ClassicMainBody", () => {
     const topArea = body?.firstElementChild;
 
     expect(screen.queryByTestId("top-meeting-timeline")).toBeNull();
+    expect(screen.queryByTestId("timeline-update-banner")).toBeNull();
     expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
     expect(topArea?.className).toContain("h-10");
     expect(screen.getByTestId("main-tab-content").textContent).toContain(
@@ -251,9 +332,11 @@ describe("ClassicMainBody", () => {
     render(<ClassicMainBody />);
 
     const backButton = screen.getByRole("button", { name: "Go back" });
-    const topArea = backButton.parentElement?.parentElement?.parentElement;
+    const chrome = backButton.parentElement?.parentElement;
+    const topArea = chrome?.parentElement?.parentElement;
 
     expect(screen.queryByTestId("top-meeting-timeline")).toBeNull();
+    expect(screen.queryByTestId("timeline-update-banner")).toBeNull();
     expect(backButton.hasAttribute("disabled")).toBe(true);
     expect(backButton.parentElement?.className).toContain("gap-0");
     expect(topArea?.className).toContain("h-12");
@@ -296,6 +379,7 @@ describe("ClassicMainBody", () => {
       fireEvent.click(backButton);
 
       expect(screen.queryByTestId("top-meeting-timeline")).toBeNull();
+      expect(screen.queryByTestId("timeline-update-banner")).toBeNull();
       expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();
       expect(backButton.hasAttribute("disabled")).toBe(false);
       expect(topArea?.className).toContain("h-12");
@@ -385,6 +469,7 @@ describe("ClassicMainBody", () => {
 
     expect(view.getByTestId("main-sidebar")).toBeTruthy();
     expect(view.getByTestId("top-meeting-timeline")).toBeTruthy();
+    expect(view.getByTestId("timeline-update-banner")).toBeTruthy();
     expect(view.queryByTestId("main-tab-content")).toBeNull();
   });
 });

--- a/apps/desktop/src/store/zustand/devtools-ota-preview.ts
+++ b/apps/desktop/src/store/zustand/devtools-ota-preview.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+
+export type DevtoolsOtaPreviewStatus =
+  | "available"
+  | "downloading"
+  | "ready"
+  | "failed";
+
+type ActiveDevtoolsOtaPreview = {
+  status: DevtoolsOtaPreviewStatus;
+  version: string;
+  progress: number | null;
+  key: number;
+};
+
+type DevtoolsOtaPreviewState = {
+  preview: ActiveDevtoolsOtaPreview | null;
+  showPreview: (status: DevtoolsOtaPreviewStatus) => void;
+  clearPreview: () => void;
+};
+
+const DEVTOOLS_OTA_VERSION = "99.99.99-dev";
+
+export const useDevtoolsOtaPreview = create<DevtoolsOtaPreviewState>((set) => ({
+  preview: null,
+  showPreview: (status) =>
+    set((state) => ({
+      preview: {
+        status,
+        version: DEVTOOLS_OTA_VERSION,
+        progress: status === "downloading" ? 0.58 : null,
+        key: (state.preview?.key ?? 0) + 1,
+      },
+    })),
+  clearPreview: () => set({ preview: null }),
+}));

--- a/plugins/updater2/Cargo.toml
+++ b/plugins/updater2/Cargo.toml
@@ -16,7 +16,7 @@ specta-typescript = { workspace = true }
 [dependencies]
 tauri-plugin-store2 = { workspace = true }
 tauri-plugin-updater = { workspace = true }
-tokio = { workspace = true, features = ["macros", "time"] }
+tokio = { workspace = true, features = ["macros", "time", "sync"] }
 
 tauri = { workspace = true, features = ["test"] }
 tauri-specta = { workspace = true, features = ["derive", "typescript"] }

--- a/plugins/updater2/build.rs
+++ b/plugins/updater2/build.rs
@@ -1,4 +1,10 @@
-const COMMANDS: &[&str] = &["check", "download", "install", "postinstall"];
+const COMMANDS: &[&str] = &[
+    "check",
+    "download",
+    "install",
+    "is_downloaded",
+    "postinstall",
+];
 
 fn main() {
     tauri_plugin::Builder::new(COMMANDS).build();

--- a/plugins/updater2/js/bindings.gen.ts
+++ b/plugins/updater2/js/bindings.gen.ts
@@ -30,6 +30,14 @@ async install(version: string) : Promise<Result<InstallResult, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async isDownloaded(version: string) : Promise<Result<boolean, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:updater2|is_downloaded", { version }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async postinstall(result: InstallResult) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("plugin:updater2|postinstall", { result }) };

--- a/plugins/updater2/permissions/autogenerated/commands/is_downloaded.toml
+++ b/plugins/updater2/permissions/autogenerated/commands/is_downloaded.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-is-downloaded"
+description = "Enables the is_downloaded command without any pre-configured scope."
+commands.allow = ["is_downloaded"]
+
+[[permission]]
+identifier = "deny-is-downloaded"
+description = "Denies the is_downloaded command without any pre-configured scope."
+commands.deny = ["is_downloaded"]

--- a/plugins/updater2/permissions/autogenerated/reference.md
+++ b/plugins/updater2/permissions/autogenerated/reference.md
@@ -7,6 +7,7 @@ Default permissions for the plugin
 - `allow-check`
 - `allow-download`
 - `allow-install`
+- `allow-is-downloaded`
 - `allow-postinstall`
 - `allow-maybe-emit-updated`
 
@@ -93,6 +94,32 @@ Enables the install command without any pre-configured scope.
 <td>
 
 Denies the install command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`updater2:allow-is-downloaded`
+
+</td>
+<td>
+
+Enables the is_downloaded command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`updater2:deny-is-downloaded`
+
+</td>
+<td>
+
+Denies the is_downloaded command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/updater2/permissions/default.toml
+++ b/plugins/updater2/permissions/default.toml
@@ -1,3 +1,3 @@
 [default]
 description = "Default permissions for the plugin"
-permissions = ["allow-check", "allow-download", "allow-install", "allow-postinstall", "allow-maybe-emit-updated"]
+permissions = ["allow-check", "allow-download", "allow-install", "allow-is-downloaded", "allow-postinstall", "allow-maybe-emit-updated"]

--- a/plugins/updater2/permissions/schemas/schema.json
+++ b/plugins/updater2/permissions/schemas/schema.json
@@ -331,6 +331,18 @@
           "markdownDescription": "Denies the install command without any pre-configured scope."
         },
         {
+          "description": "Enables the is_downloaded command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-is-downloaded",
+          "markdownDescription": "Enables the is_downloaded command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_downloaded command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-is-downloaded",
+          "markdownDescription": "Denies the is_downloaded command without any pre-configured scope."
+        },
+        {
           "description": "Enables the maybe_emit_updated command without any pre-configured scope.",
           "type": "string",
           "const": "allow-maybe-emit-updated",
@@ -355,10 +367,10 @@
           "markdownDescription": "Denies the postinstall command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-postinstall`\n- `allow-maybe-emit-updated`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-is-downloaded`\n- `allow-postinstall`\n- `allow-maybe-emit-updated`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-postinstall`\n- `allow-maybe-emit-updated`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-is-downloaded`\n- `allow-postinstall`\n- `allow-maybe-emit-updated`"
         }
       ]
     }

--- a/plugins/updater2/src/commands.rs
+++ b/plugins/updater2/src/commands.rs
@@ -34,6 +34,15 @@ pub(crate) async fn install<R: tauri::Runtime>(
 
 #[tauri::command]
 #[specta::specta]
+pub(crate) fn is_downloaded<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    version: String,
+) -> Result<bool, String> {
+    Ok(app.updater2().has_cached_update(&version))
+}
+
+#[tauri::command]
+#[specta::specta]
 pub(crate) async fn postinstall<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
     result: InstallResult,

--- a/plugins/updater2/src/ext.rs
+++ b/plugins/updater2/src/ext.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::LazyLock};
 
 use tauri::Manager;
 use tauri_plugin_store2::Store2PluginExt;
@@ -9,6 +9,9 @@ use crate::events::{
     UpdateDownloadFailedEvent, UpdateDownloadProgressEvent, UpdateDownloadingEvent,
     UpdateReadyEvent, UpdatedEvent,
 };
+
+static DOWNLOAD_MUTEX: LazyLock<tokio::sync::Mutex<()>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(()));
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -101,13 +104,15 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Updater2<'a, R, M> {
         Ok(update.map(|u| u.version))
     }
 
-    fn has_cached_update(&self, version: &str) -> bool {
+    pub fn has_cached_update(&self, version: &str) -> bool {
         get_cache_path(self.manager, version)
             .map(|p| p.exists())
             .unwrap_or(false)
     }
 
     pub async fn download(&self, version: &str) -> Result<(), crate::Error> {
+        let _download_guard = DOWNLOAD_MUTEX.lock().await;
+
         if self.has_cached_update(version) {
             let _ = UpdateReadyEvent {
                 version: version.to_string(),

--- a/plugins/updater2/src/lib.rs
+++ b/plugins/updater2/src/lib.rs
@@ -20,6 +20,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::check::<tauri::Wry>,
             commands::download::<tauri::Wry>,
             commands::install::<tauri::Wry>,
+            commands::is_downloaded::<tauri::Wry>,
             commands::postinstall::<tauri::Wry>,
             commands::maybe_emit_updated::<tauri::Wry>,
         ])

--- a/plugins/windows/swift-lib/src/DevtoolsPanelView.swift
+++ b/plugins/windows/swift-lib/src/DevtoolsPanelView.swift
@@ -17,6 +17,7 @@ struct DevtoolsPanelView: View {
         VStack(spacing: 10) {
           navigationSection
           toastsSection
+          otaSection
           notificationsSection
           billingSection
           countdownSection
@@ -150,6 +151,26 @@ struct DevtoolsPanelView: View {
       }
       DevtoolsActionButton("Clear") {
         RustBridge.devtoolsPanelAction("notifications:clear")
+      }
+    }
+  }
+
+  private var otaSection: some View {
+    DevtoolsSection(title: "OTA") {
+      DevtoolsActionButton("Available") {
+        RustBridge.devtoolsPanelAction("ota:available")
+      }
+      DevtoolsActionButton("Downloading") {
+        RustBridge.devtoolsPanelAction("ota:downloading")
+      }
+      DevtoolsActionButton("Ready") {
+        RustBridge.devtoolsPanelAction("ota:ready")
+      }
+      DevtoolsActionButton("Failed") {
+        RustBridge.devtoolsPanelAction("ota:failed")
+      }
+      DevtoolsActionButton("Clear") {
+        RustBridge.devtoolsPanelAction("ota:clear")
       }
     }
   }


### PR DESCRIPTION
Add a timeline-mode update banner that checks for available desktop updates, tracks updater progress events, and sits between the top timeline and main content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the live app update path (download, install, relaunch via postinstall) and new native command surface; mitigated by tests and dev-only preview paths.
> 
> **Overview**
> Adds **in-app desktop OTA UI** for classic main **timeline** layouts: a shared `useDesktopUpdateControl` hook drives periodic `updater2` checks, listens for download/progress/ready/failed/updated events, and exposes download/restart actions.
> 
> **Top timeline mode** shows an animated `TimelineUpdateBanner` between the meeting timeline and content (hidden for onboarding, changelog, and sidebar-timeline mode). **Sidebar timeline mode** adds a compact update control on the expanded chrome and a red dot badge on the collapsed sidebar toggle when an update is pending.
> 
> The **`updater2`** plugin gains `is_downloaded` (cache probe) and serializes concurrent downloads with a mutex; the frontend uses it so “already downloaded” surfaces **Restart** instead of **Download**.
> 
> **Devtools** can preview OTA states via a Zustand store and new panel/Swift actions without hitting the real updater. Coverage includes `update-banner` integration tests and layout tests in `body.test.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bab2f73c754bf2504aaf625fd69fcda72643dc99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->