### PR TITLE
fix(settings): make settings controls pill shaped

### DIFF
--- a/apps/desktop/src/settings/ai/llm/configure.tsx
+++ b/apps/desktop/src/settings/ai/llm/configure.tsx
@@ -1,27 +1,9 @@
-import { useCallback } from "react";
-
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@hypr/ui/components/ui/accordion";
-import { cn } from "@hypr/utils";
+import { Accordion } from "@hypr/ui/components/ui/accordion";
 
 import { useLlmSettings } from "./context";
 import { ProviderId, PROVIDERS } from "./shared";
 
-import { useAuth } from "~/auth";
-import { useBillingAccess } from "~/auth/billing";
-import {
-  AnarlogProviderIcon,
-  HyprCloudCTAButton,
-  HyprProviderRow,
-  NonHyprProviderCard,
-  ProviderIconSlot,
-  StyledStreamdown,
-} from "~/settings/ai/shared";
-import * as settings from "~/store/tinybase/store/settings";
+import { NonHyprProviderCard, StyledStreamdown } from "~/settings/ai/shared";
 
 export function ConfigureProviders() {
   const { accordionValue, setAccordionValue } = useLlmSettings();
@@ -36,12 +18,6 @@ export function ConfigureProviders() {
         value={accordionValue}
         onValueChange={setAccordionValue}
       >
-        <HyprProviderCard
-          providerId="hyprnote"
-          providerName="Anarlog"
-          icon={<AnarlogProviderIcon />}
-          badge={PROVIDERS.find((p) => p.id === "hyprnote")?.badge}
-        />
         {PROVIDERS.filter((provider) => provider.id !== "hyprnote").map(
           (provider) => (
             <NonHyprProviderCard
@@ -58,114 +34,23 @@ export function ConfigureProviders() {
   );
 }
 
-function HyprProviderCard({
-  providerId,
-  providerName,
-  icon,
-  badge,
-}: {
-  providerId: ProviderId;
-  providerName: string;
-  icon: React.ReactNode;
-  badge?: string | null;
-}) {
-  const { hyprAccordionRef, shouldHighlight } = useLlmSettings();
-  const auth = useAuth();
-  const isConfigured = !!auth?.session;
-
-  return (
-    <AccordionItem
-      ref={hyprAccordionRef}
-      value={providerId}
-      className={cn([
-        "rounded-xl border-2 bg-neutral-50",
-        isConfigured ? "border-solid border-neutral-300" : "border-dashed",
-      ])}
-    >
-      <AccordionTrigger className="gap-2 px-4 capitalize hover:no-underline">
-        <div className="flex items-center gap-2">
-          <ProviderIconSlot>{icon}</ProviderIconSlot>
-          <span>{providerName}</span>
-          {badge && (
-            <span className="rounded-full border border-neutral-300 px-2 text-xs font-light text-neutral-500">
-              {badge}
-            </span>
-          )}
-        </div>
-      </AccordionTrigger>
-      <AccordionContent className="px-4">
-        <ProviderContext providerId={providerId} />
-        <div className="flex flex-col gap-3">
-          <HyprProviderAutoRow highlight={shouldHighlight} />
-        </div>
-      </AccordionContent>
-    </AccordionItem>
-  );
-}
-
-function HyprProviderAutoRow({ highlight }: { highlight?: boolean }) {
-  const { isPaid, canStartTrial, upgradeToPro } = useBillingAccess();
-
-  const handleSelectProvider = settings.UI.useSetValueCallback(
-    "current_llm_provider",
-    (provider: string) => provider,
-    [],
-    settings.STORE_ID,
-  );
-
-  const handleSelectModel = settings.UI.useSetValueCallback(
-    "current_llm_model",
-    (model: string) => model,
-    [],
-    settings.STORE_ID,
-  );
-
-  const handleClick = useCallback(() => {
-    if (!isPaid) {
-      upgradeToPro();
-    } else {
-      handleSelectProvider("hyprnote");
-      handleSelectModel("Auto");
-    }
-  }, [isPaid, upgradeToPro, handleSelectProvider, handleSelectModel]);
-
-  return (
-    <HyprProviderRow>
-      <div className="flex-1">
-        <span className="text-sm font-medium">Anarlog Cloud</span>
-        <p className="text-xs text-neutral-500">
-          Use the Anarlog Cloud API for AI assistance.
-        </p>
-      </div>
-      <HyprCloudCTAButton
-        isPaid={isPaid}
-        canStartTrial={canStartTrial.data}
-        highlight={highlight}
-        onClick={handleClick}
-      />
-    </HyprProviderRow>
-  );
-}
-
 function ProviderContext({ providerId }: { providerId: ProviderId }) {
   const content =
-    providerId === "hyprnote"
-      ? "A curated set of models we continuously test to provide the **best performance & reliability**."
-      : providerId === "lmstudio"
-        ? "- Ensure LM Studio server is **running.** (Default port is 1234)\n- Enable **CORS** in LM Studio config."
-        : providerId === "ollama"
-          ? "- Ensure Ollama is **running** (`ollama serve`)\n- Pull a model first (`ollama pull llama3.2`)"
-          : providerId === "custom"
-            ? "We only support **OpenAI-compatible** endpoints for now."
-            : providerId === "openrouter"
-              ? "We filter out models from the combobox based on heuristics like **input modalities** and **tool support**."
-              : providerId === "azure_openai"
-                ? "Enter your **Azure OpenAI endpoint** (e.g. `https://your-resource.openai.azure.com`) as the Base URL and your **API key**. [Report issues](https://github.com/fastrepl/char/issues/3928)"
-                : providerId === "azure_ai"
-                  ? "Enter your **Azure AI Foundry endpoint** as the Base URL and your **API key**. Supports Claude and other models deployed via Azure AI Foundry. [Report issues](https://github.com/fastrepl/char/issues/3928)"
-                  : providerId === "google_generative_ai"
-                    ? "Visit [AI Studio](https://aistudio.google.com/api-keys) to create an API key."
-                    : "";
+    providerId === "lmstudio"
+      ? "- Ensure LM Studio server is **running.** (Default port is 1234)\n- Enable **CORS** in LM Studio config."
+      : providerId === "ollama"
+        ? "- Ensure Ollama is **running** (`ollama serve`)\n- Pull a model first (`ollama pull llama3.2`)"
+        : providerId === "custom"
+          ? "We only support **OpenAI-compatible** endpoints for now."
+          : providerId === "openrouter"
+            ? "We filter out models from the combobox based on heuristics like **input modalities** and **tool support**."
+            : providerId === "azure_openai"
+              ? "Enter your **Azure OpenAI endpoint** (e.g. `https://your-resource.openai.azure.com`) as the Base URL and your **API key**. [Report issues](https://github.com/fastrepl/char/issues/3928)"
+              : providerId === "azure_ai"
+                ? "Enter your **Azure AI Foundry endpoint** as the Base URL and your **API key**. Supports Claude and other models deployed via Azure AI Foundry. [Report issues](https://github.com/fastrepl/char/issues/3928)"
+                : providerId === "google_generative_ai"
+                  ? "Visit [AI Studio](https://aistudio.google.com/api-keys) to create an API key."
+                  : "";
 
   if (!content) {
     return null;

--- a/apps/desktop/src/settings/ai/llm/context.tsx
+++ b/apps/desktop/src/settings/ai/llm/context.tsx
@@ -1,23 +1,8 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
-
-import { useBillingAccess } from "~/auth/billing";
-import { useConfigValues } from "~/shared/config";
-import { useToastAction } from "~/store/zustand/toast-action";
+import { createContext, useContext, useState } from "react";
 
 type LlmSettingsContextType = {
   accordionValue: string;
   setAccordionValue: (value: string) => void;
-  openHyprAccordion: () => void;
-  startTrial: () => void;
-  shouldHighlight: boolean;
-  hyprAccordionRef: React.RefObject<HTMLDivElement | null>;
 };
 
 const LlmSettingsContext = createContext<LlmSettingsContextType | null>(null);
@@ -27,63 +12,13 @@ export function LlmSettingsProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const { current_llm_provider, current_llm_model } = useConfigValues([
-    "current_llm_provider",
-    "current_llm_model",
-  ] as const);
-  const hasLlmConfigured = !!(current_llm_provider && current_llm_model);
-
-  const [accordionValue, setAccordionValue] = useState<string>(
-    hasLlmConfigured ? "" : "hyprnote",
-  );
-  const [shouldHighlight, setShouldHighlight] = useState(false);
-  const { upgradeToPro } = useBillingAccess();
-  const hyprAccordionRef = useRef<HTMLDivElement | null>(null);
-
-  const toastActionTarget = useToastAction((state) => state.target);
-  const clearToastActionTarget = useToastAction((state) => state.clearTarget);
-
-  useEffect(() => {
-    if (toastActionTarget === "llm") {
-      setAccordionValue("hyprnote");
-      setShouldHighlight(true);
-
-      const timer = setTimeout(() => {
-        hyprAccordionRef.current?.scrollIntoView({
-          behavior: "smooth",
-          block: "center",
-        });
-      }, 100);
-
-      clearToastActionTarget();
-      return () => clearTimeout(timer);
-    }
-  }, [toastActionTarget, clearToastActionTarget]);
-
-  useEffect(() => {
-    if (hasLlmConfigured && shouldHighlight) {
-      setShouldHighlight(false);
-    }
-  }, [hasLlmConfigured, shouldHighlight]);
-
-  const openHyprAccordion = useCallback(() => {
-    setAccordionValue("hyprnote");
-  }, []);
-
-  const startTrial = useCallback(() => {
-    openHyprAccordion();
-    upgradeToPro();
-  }, [openHyprAccordion, upgradeToPro]);
+  const [accordionValue, setAccordionValue] = useState<string>("");
 
   return (
     <LlmSettingsContext.Provider
       value={{
         accordionValue,
         setAccordionValue,
-        openHyprAccordion,
-        startTrial,
-        shouldHighlight,
-        hyprAccordionRef,
       }}
     >
       {children}

--- a/apps/desktop/src/settings/ai/llm/select.tsx
+++ b/apps/desktop/src/settings/ai/llm/select.tsx
@@ -8,7 +8,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@hypr/ui/components/ui/select";
-import { cn } from "@hypr/utils";
 
 import { useLlmSettings } from "./context";
 import { HealthStatusIndicator, useConnectionHealth } from "./health";
@@ -168,94 +167,86 @@ export function SelectProviderAndModel() {
   };
 
   return (
-    <div className="flex flex-col gap-3">
-      <h3 className="text-md font-sans font-semibold">Model being used</h3>
-      <div
-        className={cn([
-          "flex flex-col gap-4",
-          "rounded-xl border border-neutral-200 p-4",
-          !isConfigured || hasError ? "bg-red-50" : "bg-neutral-50",
-        ])}
-      >
-        <div className="flex flex-row items-center gap-4">
-          <div className="min-w-0 flex-2" data-llm-provider-selector>
-            <Select
-              value={current_llm_provider || ""}
-              onValueChange={handleProviderChange}
-            >
-              <SelectTrigger className="bg-white shadow-none focus:ring-0">
-                <SelectValue placeholder="Select a provider" />
-              </SelectTrigger>
-              <SelectContent>
-                {PROVIDERS.map((provider) => {
-                  const requiresPro = requiresEntitlement(
-                    provider.requirements,
-                    "pro",
-                  );
-                  const locked = requiresPro && !billing.isPaid;
+    <div className="flex flex-col gap-4">
+      {!isConfigured && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3">
+          <span className="text-sm text-red-600">
+            <strong className="font-medium">Language model</strong> is needed to
+            make Anarlog summarize and chat about your conversations.
+          </span>
+        </div>
+      )}
 
-                  return (
-                    <SelectItem
-                      key={provider.id}
-                      value={provider.id}
-                      disabled={locked}
-                    >
-                      <div className="flex flex-col gap-0.5">
-                        <div className="flex items-center gap-2">
-                          <ProviderIconSlot>{provider.icon}</ProviderIconSlot>
-                          <span>{provider.displayName}</span>
-                          {requiresPro ? (
-                            <span className="rounded-full border border-neutral-200 px-2 py-0.5 text-[10px] tracking-wide text-neutral-500 uppercase">
-                              Pro
-                            </span>
-                          ) : null}
-                        </div>
-                        {locked ? (
-                          <span className="text-[11px] text-neutral-500">
-                            Upgrade to Pro to use this provider.
+      {hasError && health.message && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3">
+          <span className="text-sm text-red-600">{health.message}</span>
+        </div>
+      )}
+
+      <h3 className="text-md font-sans font-semibold">Model being used</h3>
+      <div className="flex flex-row items-center gap-4">
+        <div className="min-w-0 flex-2" data-llm-provider-selector>
+          <Select
+            value={current_llm_provider || ""}
+            onValueChange={handleProviderChange}
+          >
+            <SelectTrigger className="bg-white shadow-none focus:ring-0">
+              <SelectValue placeholder="Select a provider" />
+            </SelectTrigger>
+            <SelectContent>
+              {PROVIDERS.map((provider) => {
+                const requiresPro = requiresEntitlement(
+                  provider.requirements,
+                  "pro",
+                );
+                const locked = requiresPro && !billing.isPaid;
+
+                return (
+                  <SelectItem
+                    key={provider.id}
+                    value={provider.id}
+                    disabled={locked}
+                  >
+                    <div className="flex flex-col gap-0.5">
+                      <div className="flex items-center gap-2">
+                        <ProviderIconSlot>{provider.icon}</ProviderIconSlot>
+                        <span>{provider.displayName}</span>
+                        {requiresPro ? (
+                          <span className="rounded-full border border-neutral-200 px-2 py-0.5 text-[10px] tracking-wide text-neutral-500 uppercase">
+                            Pro
                           </span>
                         ) : null}
                       </div>
-                    </SelectItem>
-                  );
-                })}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <span className="text-neutral-500">/</span>
-
-          <div className="min-w-0 flex-3">
-            <ModelCombobox
-              providerId={current_llm_provider || ""}
-              value={current_llm_model || ""}
-              onChange={handleModelChange}
-              disabled={!current_llm_provider}
-              listModels={
-                current_llm_provider
-                  ? configuredProviders[current_llm_provider]?.listModels
-                  : undefined
-              }
-              isConfigured={isConfigured}
-              suffix={isConfigured ? <HealthStatusIndicator /> : undefined}
-            />
-          </div>
+                      {locked ? (
+                        <span className="text-[11px] text-neutral-500">
+                          Upgrade to Pro to use this provider.
+                        </span>
+                      ) : null}
+                    </div>
+                  </SelectItem>
+                );
+              })}
+            </SelectContent>
+          </Select>
         </div>
 
-        {!isConfigured && (
-          <div className="flex items-center gap-2 border-t border-red-200 pt-2">
-            <span className="text-sm text-red-600">
-              <strong className="font-medium">Language model</strong> is needed
-              to make Anarlog summarize and chat about your conversations.
-            </span>
-          </div>
-        )}
+        <span className="text-neutral-500">/</span>
 
-        {hasError && health.message && (
-          <div className="flex items-center gap-2 border-t border-red-200 pt-2">
-            <span className="text-sm text-red-600">{health.message}</span>
-          </div>
-        )}
+        <div className="min-w-0 flex-3">
+          <ModelCombobox
+            providerId={current_llm_provider || ""}
+            value={current_llm_model || ""}
+            onChange={handleModelChange}
+            disabled={!current_llm_provider}
+            listModels={
+              current_llm_provider
+                ? configuredProviders[current_llm_provider]?.listModels
+                : undefined
+            }
+            isConfigured={isConfigured}
+            suffix={isConfigured ? <HealthStatusIndicator /> : undefined}
+          />
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -166,7 +166,7 @@ export function NonHyprProviderCard({
       disabled={config.disabled || locked}
       value={config.id}
       className={cn([
-        "rounded-xl border-2 bg-neutral-50",
+        "rounded-[22px] border-2 bg-neutral-50",
         isConfigured ? "border-solid border-neutral-300" : "border-dashed",
       ])}
     >

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -575,7 +575,7 @@ function ModelSelectItem({
     <div
       className={cn([
         "relative flex items-center justify-between",
-        "rounded-xs px-2 py-1.5 text-sm outline-hidden",
+        "rounded-full px-2 py-1.5 text-sm outline-hidden",
         "cursor-pointer select-none",
         "hover:bg-accent hover:text-accent-foreground",
         "group",

--- a/apps/desktop/src/settings/general/notification.tsx
+++ b/apps/desktop/src/settings/general/notification.tsx
@@ -289,7 +289,7 @@ export function NotificationSettingsView() {
                         tabIndex={0}
                         aria-expanded={searchOpen}
                         className={cn([
-                          "flex min-h-[38px] w-full cursor-text flex-wrap items-center gap-2 rounded-md border p-2",
+                          "flex min-h-[38px] w-full cursor-text flex-wrap items-center gap-2 rounded-2xl border p-2",
                           "focus-visible:ring-ring focus-visible:ring-1 focus-visible:outline-hidden",
                         ])}
                         onKeyDown={(event) => {

--- a/apps/desktop/src/settings/general/spoken-languages.tsx
+++ b/apps/desktop/src/settings/general/spoken-languages.tsx
@@ -121,7 +121,7 @@ export function SpokenLanguagesView({
       <div className="relative">
         <div
           className={cn([
-            "flex min-h-[38px] w-full flex-wrap items-center gap-1.5 rounded-lg border border-neutral-200 bg-white px-2 py-1.5 focus-within:border-neutral-300",
+            "flex min-h-[38px] w-full flex-wrap items-center gap-1.5 rounded-2xl border border-neutral-200 bg-white px-2 py-1.5 focus-within:border-neutral-300",
             languageInputFocused && "border-neutral-300",
           ])}
           onClick={() =>
@@ -184,7 +184,7 @@ export function SpokenLanguagesView({
           <div
             id="language-options"
             role="listbox"
-            className="absolute top-full right-0 left-0 z-10 mt-1 flex max-h-60 w-full flex-col overflow-hidden overflow-y-auto rounded-xs border border-neutral-200 bg-white shadow-md"
+            className="absolute top-full right-0 left-0 z-10 mt-1 flex max-h-60 w-full flex-col overflow-hidden overflow-y-auto rounded-2xl border border-neutral-200 bg-white shadow-md"
           >
             {filteredLanguages.length > 0 ? (
               filteredLanguages.map((langCode, index) => (

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -86,9 +86,8 @@ export function ToastArea() {
   );
 
   const handleOpenLLMSettings = useCallback(() => {
-    setToastActionTarget("llm");
     openAiTab("intelligence");
-  }, [openAiTab, setToastActionTarget]);
+  }, [openAiTab]);
 
   const handleOpenSTTSettings = useCallback(() => {
     setToastActionTarget("stt");

--- a/apps/desktop/src/store/zustand/toast-action.ts
+++ b/apps/desktop/src/store/zustand/toast-action.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-type ToastActionTarget = "stt" | "llm" | null;
+type ToastActionTarget = "stt" | null;
 
 interface ToastActionState {
   target: ToastActionTarget;

--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -13,7 +13,7 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn([
-      "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+      "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-2xl",
       className,
     ])}
     {...props}
@@ -42,7 +42,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn([
-        "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+        "placeholder:text-muted-foreground flex h-10 w-full rounded-full bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
         className,
       ])}
       {...props}
@@ -116,7 +116,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn([
-      "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-full px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className,
     ])}
     {...props}

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -26,7 +26,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn([
-      "focus:bg-accent data-[state=open]:bg-accent flex cursor-default items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-hidden [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "focus:bg-accent data-[state=open]:bg-accent flex cursor-default items-center gap-2 rounded-full px-2 py-1.5 text-sm outline-hidden [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className,
     ])}
@@ -51,7 +51,7 @@ const DropdownMenuSubContent = React.forwardRef<
       "text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden",
       variant === "app"
         ? appFloatingContentClassName
-        : "bg-popover rounded-lg border p-1 shadow-lg",
+        : "bg-popover rounded-2xl border p-1 shadow-lg",
       className,
     ])}
     {...props}
@@ -74,7 +74,7 @@ const DropdownMenuContent = React.forwardRef<
         "text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden",
         variant === "app"
           ? appFloatingContentClassName
-          : "bg-popover rounded-lg border p-1 shadow-md",
+          : "bg-popover rounded-2xl border p-1 shadow-md",
         className,
       ])}
       {...props}
@@ -92,7 +92,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn([
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-full px-2 py-1.5 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className,
     ])}
@@ -108,7 +108,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn([
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50",
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-full py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     ])}
     checked={checked}
@@ -132,7 +132,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn([
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50",
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-full py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     ])}
     {...props}

--- a/packages/ui/src/components/ui/floating-content.tsx
+++ b/packages/ui/src/components/ui/floating-content.tsx
@@ -12,7 +12,7 @@ export function AppFloatingPanel({
   return (
     <div
       className={cn([
-        "rounded-xl border border-neutral-200 bg-white",
+        "rounded-2xl border border-neutral-200 bg-white",
         className,
       ])}
       {...props}

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -38,7 +38,7 @@ const PopoverContent = React.forwardRef<
           "text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) outline-hidden",
           variant === "app"
             ? appFloatingContentClassName
-            : "bg-popover rounded-md border p-4 shadow-md",
+            : "bg-popover rounded-2xl border p-4 shadow-md",
           className,
         ])}
         {...props}

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -15,7 +15,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn([
-      "border-input ring-offset-background data-placeholder:text-muted-foreground focus:ring-ring flex h-9 w-full items-center justify-between rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs focus:ring-1 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "border-input ring-offset-background data-placeholder:text-muted-foreground focus:ring-ring flex h-9 w-full items-center justify-between rounded-full border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs focus:ring-1 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className,
     ])}
     {...props}
@@ -71,7 +71,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn([
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-2xl border shadow-md",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,
@@ -114,7 +114,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn([
-      "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center rounded-xs py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+      "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center rounded-full py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     ])}
     {...props}


### PR DESCRIPTION
Summary:
- Normalize settings select, dropdown, combobox, and provider row radii to pill-shaped controls.
- Align Intelligence model settings with the Transcription selector layout by removing the Anarlog provider card.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly visual class changes plus LLM settings UX simplification; hyprnote remains selectable via the provider dropdown with existing Pro gating.
> 
> **Overview**
> This PR **pill-shapes** shared settings controls and **realigns Intelligence (LLM) settings** with the Transcription layout.
> 
> **UI radii:** `Select`, `DropdownMenu`, `Command`, `Popover`, and floating panels now use **`rounded-full`** on triggers/items and **`rounded-2xl`** on menus/popovers. Desktop settings pick up the same treatment on provider accordions, language/notification comboboxes, and STT download rows.
> 
> **Intelligence settings:** The dedicated **Anarlog / `hyprnote` accordion card** and its Cloud CTA are removed from **Configure Providers**; only third-party providers remain in the accordion. The **Model being used** block drops the bordered red/green wrapper—warnings/errors sit in standalone alert boxes above a flat provider/model row, matching transcription. **`LlmSettingsProvider`** no longer auto-opens the hypr accordion, highlights, or scroll-on-toast; sidebar toasts that open LLM settings only navigate to **intelligence** (the `"llm"` toast-action target is removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb0139e2393941b07eca64cfdce933d228925bd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->