### PR TITLE
chore(changelog): add 1.0.35 release notes

### DIFF
--- a/packages/changelog/content/1.0.35.md
+++ b/packages/changelog/content/1.0.35.md
@@ -1,0 +1,16 @@
+---
+date: "2026-06-01"
+summary: "Update prompts are easier to spot in timeline and left sidebar modes, and settings controls now feel more consistent."
+---
+
+## Updates
+
+- Timeline mode now shows a slim update prompt between the timeline and note area when a new version is available
+- Left sidebar mode now shows update availability in the sidebar chrome, with a badge when the sidebar is collapsed and progress or restart states when it is expanded
+- Update prompts now correctly switch to restart when an update has already finished downloading in the background
+- Update downloads now avoid starting twice when the app is already downloading a new version in the background
+
+## Settings
+
+- Intelligence model settings now use a cleaner layout that matches Transcription more closely
+- Select, dropdown, combobox, and provider controls now use consistent pill-shaped styling across settings


### PR DESCRIPTION
## Summary
- Add desktop changelog notes for 1.0.35 covering update prompts and settings polish.

## Verification
- Not run; changelog-only markdown change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only markdown with no runtime or build impact.
> 
> **Overview**
> Adds **`packages/changelog/content/1.0.35.md`** for the **1.0.35** desktop release, documenting user-facing changes only (no app code).
> 
> **Updates** covers clearer in-app update prompts in timeline and left-sidebar layouts, correct restart UI when a background download has already finished, and preventing duplicate download starts.
> 
> **Settings** notes a cleaner Intelligence models layout aligned with Transcription and shared pill-shaped styling for selects, dropdowns, comboboxes, and provider controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 687834c6dc59fb0e87f3795b97d4c0619e616015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->