### PR TITLE
fix(web): remove landing header logo

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link, redirect } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { ArrowRight, ChevronDown } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { z } from "zod";
@@ -140,12 +140,6 @@ function Component() {
 
       <div className="mx-auto w-full max-w-[700px] px-5 py-8 md:px-8 md:py-12">
         <div className="min-w-0">
-          <header className="flex items-center justify-between gap-6">
-            <Link to="/" aria-label="Anarlog home">
-              <img src="/logo.svg" alt="Anarlog" className="h-9 w-auto" />
-            </Link>
-          </header>
-
           <section className="pt-24 pb-16 md:pt-32">
             <h1 className="font-hand max-w-3xl text-6xl leading-[0.98] font-semibold tracking-normal text-balance md:text-8xl">
               AI notepad for private meetings.


### PR DESCRIPTION
Remove the small Anarlog logo above the home page hero.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentational change on the marketing landing route with no auth, data, or API impact.
> 
> **Overview**
> Removes the **landing page header** that showed the Anarlog logo and home link above the hero on `/`.
> 
> Also drops the unused **`Link`** import from `@tanstack/react-router` now that nothing on this route uses it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 840252cf3882a5d9a5b4ff4caf890322e553aece. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->