### PR TITLE
fix(chat): anchor modal to floating button

### DIFF
--- a/apps/desktop/src/chat/components/body/empty.tsx
+++ b/apps/desktop/src/chat/components/body/empty.tsx
@@ -1,7 +1,6 @@
 import {
   ListChecksIcon,
   MailIcon,
-  MessageCircleIcon,
   SearchIcon,
   SparklesIcon,
 } from "lucide-react";
@@ -64,12 +63,6 @@ export function ChatBodyEmpty({
       <div className="flex justify-start py-2 pb-1">
         <div className="flex w-full flex-col">
           <div className="mb-2 flex items-center gap-2">
-            <MessageCircleIcon
-              className={cn([
-                "size-4",
-                isFloating ? "text-stone-300" : "text-neutral-500",
-              ])}
-            />
             <span
               className={cn([
                 "text-sm font-medium",
@@ -108,12 +101,6 @@ export function ChatBodyEmpty({
     <div className="flex justify-start pb-1">
       <div className="flex w-full flex-col">
         <div className="mb-2 flex items-center gap-2">
-          <MessageCircleIcon
-            className={cn([
-              "size-4",
-              isFloating ? "text-stone-300" : "text-neutral-500",
-            ])}
-          />
           <span
             className={cn([
               "text-sm font-medium",

--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -1,0 +1,318 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useRef } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  chatMode: { current: "FloatingOpen" },
+  sendEvent: vi.fn(),
+}));
+
+vi.mock("react-hotkeys-hook", () => ({
+  useHotkeys: vi.fn(),
+}));
+
+vi.mock("~/contexts/shell", () => ({
+  useShell: () => ({
+    chat: {
+      mode: mocks.chatMode.current,
+      sendEvent: mocks.sendEvent,
+    },
+  }),
+}));
+
+vi.mock("./chat-panel", () => ({
+  ChatView: ({ onToggleExpanded }: { onToggleExpanded?: () => void }) => (
+    <>
+      <button
+        data-testid="toggle-expanded"
+        type="button"
+        onClick={onToggleExpanded}
+      >
+        Toggle expanded
+      </button>
+      <div data-testid="chat-view" />
+    </>
+  ),
+}));
+
+import { PersistentChatPanel } from "./persistent-chat";
+
+function TestHost() {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div ref={containerRef} data-testid="full-panel-container">
+      <div data-chat-floating-anchor />
+      <PersistentChatPanel floatingContainerRef={containerRef} />
+    </div>
+  );
+}
+
+describe("PersistentChatPanel", () => {
+  beforeEach(() => {
+    cleanup();
+    mocks.chatMode.current = "FloatingOpen";
+    mocks.sendEvent.mockClear();
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof ResizeObserver;
+  });
+
+  it("anchors the floating panel to the bottom FAB line", async () => {
+    render(<TestHost />);
+
+    await screen.findByTestId("chat-view");
+
+    const resizeFrame = document.querySelector("[data-chat-resize-frame]");
+    const panel = document.querySelector<HTMLElement>("[data-chat-panel]");
+
+    await waitFor(() => {
+      expect(resizeFrame?.className).toContain("items-end");
+      expect(resizeFrame?.className).toContain("justify-center");
+      expect(panel?.style.transformOrigin).toBe("bottom center");
+    });
+  });
+
+  it("resizes bottom handles by the pointer movement when bottom anchored", async () => {
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        if (this.matches("[data-chat-panel]")) {
+          return {
+            bottom: 600,
+            height: 360,
+            left: 240,
+            right: 660,
+            top: 240,
+            width: 420,
+            x: 240,
+            y: 240,
+            toJSON: () => ({}),
+          };
+        }
+
+        return {
+          bottom: 720,
+          height: 720,
+          left: 0,
+          right: 900,
+          top: 0,
+          width: 900,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        };
+      },
+    );
+
+    render(<TestHost />);
+
+    await screen.findByTestId("chat-view");
+
+    const resizeFrame = document.querySelector<HTMLElement>(
+      "[data-chat-resize-frame]",
+    );
+    const panel = document.querySelector<HTMLElement>("[data-chat-panel]");
+    const bottomHandle = document.querySelector<HTMLElement>(
+      '[data-chat-resize-handle="bottom"]',
+    );
+
+    expect(resizeFrame).toBeTruthy();
+    expect(panel).toBeTruthy();
+    expect(bottomHandle).toBeTruthy();
+
+    fireEvent.pointerDown(bottomHandle!, {
+      clientX: 450,
+      clientY: 600,
+      pointerId: 1,
+    });
+    fireEvent.pointerMove(bottomHandle!, {
+      clientX: 450,
+      clientY: 640,
+      pointerId: 1,
+    });
+
+    expect(panel?.style.height).toBe("400px");
+  });
+
+  it("resizes from side, top, and top corner handles", async () => {
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        if (this.matches("[data-chat-panel]")) {
+          return {
+            bottom: 600,
+            height: 360,
+            left: 240,
+            right: 660,
+            top: 240,
+            width: 420,
+            x: 240,
+            y: 240,
+            toJSON: () => ({}),
+          };
+        }
+
+        return {
+          bottom: 720,
+          height: 720,
+          left: 0,
+          right: 900,
+          top: 0,
+          width: 900,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        };
+      },
+    );
+
+    render(<TestHost />);
+
+    await screen.findByTestId("chat-view");
+
+    const panel = document.querySelector<HTMLElement>("[data-chat-panel]");
+    expect(panel).toBeTruthy();
+
+    const dragHandle = (
+      handle: string,
+      start: { x: number; y: number },
+      end: { x: number; y: number },
+    ) => {
+      const resizeHandle = document.querySelector<HTMLElement>(
+        `[data-chat-resize-handle="${handle}"]`,
+      );
+
+      expect(resizeHandle).toBeTruthy();
+
+      fireEvent.pointerDown(resizeHandle!, {
+        clientX: start.x,
+        clientY: start.y,
+        pointerId: 1,
+      });
+      fireEvent.pointerMove(resizeHandle!, {
+        clientX: end.x,
+        clientY: end.y,
+        pointerId: 1,
+      });
+      fireEvent.pointerUp(resizeHandle!, {
+        clientX: end.x,
+        clientY: end.y,
+        pointerId: 1,
+      });
+    };
+
+    dragHandle("right", { x: 660, y: 420 }, { x: 700, y: 420 });
+    expect(panel?.style.width).toBe("500px");
+    expect(panel?.style.height).toBe("360px");
+
+    dragHandle("left", { x: 240, y: 420 }, { x: 200, y: 420 });
+    expect(panel?.style.width).toBe("500px");
+    expect(panel?.style.height).toBe("360px");
+
+    dragHandle("top", { x: 450, y: 240 }, { x: 450, y: 200 });
+    expect(panel?.style.width).toBe("420px");
+    expect(panel?.style.height).toBe("400px");
+
+    dragHandle("top-left", { x: 240, y: 240 }, { x: 200, y: 200 });
+    expect(panel?.style.width).toBe("500px");
+    expect(panel?.style.height).toBe("400px");
+
+    dragHandle("top-right", { x: 660, y: 240 }, { x: 700, y: 200 });
+    expect(panel?.style.width).toBe("500px");
+    expect(panel?.style.height).toBe("400px");
+  });
+
+  it("keeps the expanded panel aligned to the anchor while extending to the container bottom", async () => {
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        if (this.hasAttribute("data-chat-floating-anchor")) {
+          return {
+            bottom: 600,
+            height: 600,
+            left: 200,
+            right: 900,
+            top: 0,
+            width: 700,
+            x: 200,
+            y: 0,
+            toJSON: () => ({}),
+          };
+        }
+
+        return {
+          bottom: 720,
+          height: 720,
+          left: 0,
+          right: 900,
+          top: 0,
+          width: 900,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        };
+      },
+    );
+
+    render(<TestHost />);
+
+    await screen.findByTestId("chat-view");
+
+    const resizeFrame = document.querySelector<HTMLElement>(
+      "[data-chat-resize-frame]",
+    );
+    const frame = resizeFrame?.parentElement as HTMLElement | null;
+
+    await waitFor(() => {
+      expect(frame?.style.left).toBe("200px");
+      expect(frame?.style.width).toBe("700px");
+      expect(frame?.style.height).toBe("600px");
+    });
+
+    fireEvent.click(screen.getByTestId("toggle-expanded"));
+
+    await waitFor(() => {
+      expect(frame?.style.left).toBe("200px");
+      expect(frame?.style.width).toBe("700px");
+      expect(frame?.style.height).toBe("720px");
+      expect(
+        document.querySelector<HTMLElement>("[data-chat-panel]")?.dataset
+          .chatSize,
+      ).toBe("expanded");
+    });
+  });
+
+  it("resets expanded state when the floating chat closes", async () => {
+    const { rerender } = render(<TestHost />);
+
+    await screen.findByTestId("chat-view");
+
+    fireEvent.click(screen.getByTestId("toggle-expanded"));
+
+    await waitFor(() => {
+      expect(
+        document.querySelector<HTMLElement>("[data-chat-panel]")?.dataset
+          .chatSize,
+      ).toBe("expanded");
+    });
+
+    mocks.chatMode.current = "FloatingClosed";
+    rerender(<TestHost />);
+
+    mocks.chatMode.current = "FloatingOpen";
+    rerender(<TestHost />);
+
+    await waitFor(() => {
+      expect(
+        document.querySelector<HTMLElement>("[data-chat-panel]")?.dataset
+          .chatSize,
+      ).toBe("floating");
+    });
+  });
+});

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -24,18 +24,37 @@ type FloatingPanelSize = {
   height: number;
 };
 
+type FloatingContainerRect = {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+};
+
 const RESIZE_HANDLES = [
   {
+    id: "top-left",
+    className: "top-0 left-0 h-4 w-7 cursor-nwse-resize",
+  },
+  {
+    id: "top",
+    className: "top-0 right-7 left-7 h-3 cursor-row-resize",
+  },
+  {
+    id: "top-right",
+    className: "top-0 right-0 h-4 w-7 cursor-nesw-resize",
+  },
+  {
     id: "right",
-    className: "top-12 right-0 bottom-7 w-2 cursor-ew-resize",
+    className: "top-7 right-0 bottom-7 w-3 cursor-ew-resize",
   },
   {
     id: "bottom",
-    className: "right-7 bottom-0 left-7 h-2 cursor-row-resize",
+    className: "right-7 bottom-0 left-7 h-3 cursor-row-resize",
   },
   {
     id: "left",
-    className: "top-12 bottom-7 left-0 w-2 cursor-ew-resize",
+    className: "top-7 bottom-7 left-0 w-3 cursor-ew-resize",
   },
   {
     id: "bottom-left",
@@ -68,7 +87,8 @@ export function PersistentChatPanel({
   const isVisible = chat.mode === "FloatingOpen";
 
   const [hasBeenOpened, setHasBeenOpened] = useState(false);
-  const [containerRect, setContainerRect] = useState<DOMRect | null>(null);
+  const [containerRect, setContainerRect] =
+    useState<FloatingContainerRect | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
   const [floatingSize, setFloatingSize] = useState<FloatingPanelSize | null>(
     null,
@@ -86,9 +106,39 @@ export function PersistentChatPanel({
     );
   };
 
+  const getContainerRect = () => {
+    const root = floatingContainerRef.current;
+    const anchor = getActiveContainer();
+
+    if (!root || !anchor) {
+      return null;
+    }
+
+    const anchorRect = anchor.getBoundingClientRect();
+
+    if (!isExpanded) {
+      return toFloatingContainerRect(anchorRect);
+    }
+
+    const rootRect = root.getBoundingClientRect();
+    const bottom = Math.max(rootRect.bottom, anchorRect.bottom);
+
+    return {
+      top: anchorRect.top,
+      left: anchorRect.left,
+      width: anchorRect.width,
+      height: bottom - anchorRect.top,
+    };
+  };
+
   useEffect(() => {
     if (isVisible && !hasBeenOpened) {
       setHasBeenOpened(true);
+    }
+
+    if (!isVisible) {
+      setIsExpanded(false);
+      resizeStateRef.current = null;
     }
   }, [isVisible, hasBeenOpened]);
 
@@ -105,19 +155,20 @@ export function PersistentChatPanel({
   );
 
   useLayoutEffect(() => {
-    const container = getActiveContainer();
+    const nextRect = getContainerRect();
 
-    if (!isVisible || !container) {
+    if (!isVisible || !nextRect) {
       setContainerRect(null);
       return;
     }
-    setContainerRect(container.getBoundingClientRect());
-  }, [isVisible, hasBeenOpened, floatingContainerRef]);
+    setContainerRect(nextRect);
+  }, [isVisible, isExpanded, hasBeenOpened, floatingContainerRef]);
 
   useEffect(() => {
+    const root = floatingContainerRef.current;
     const container = getActiveContainer();
 
-    if (!isVisible || !container) {
+    if (!isVisible || !root || !container) {
       if (observerRef.current) {
         observerRef.current.disconnect();
         observerRef.current = null;
@@ -126,10 +177,13 @@ export function PersistentChatPanel({
     }
 
     const updateRect = () => {
-      setContainerRect(container.getBoundingClientRect());
+      setContainerRect(getContainerRect());
     };
 
     observerRef.current = new ResizeObserver(updateRect);
+    if (root !== container) {
+      observerRef.current.observe(root);
+    }
     observerRef.current.observe(container);
     window.addEventListener("resize", updateRect);
     window.addEventListener("scroll", updateRect, true);
@@ -140,7 +194,7 @@ export function PersistentChatPanel({
       window.removeEventListener("resize", updateRect);
       window.removeEventListener("scroll", updateRect, true);
     };
-  }, [isVisible, hasBeenOpened, floatingContainerRef]);
+  }, [isVisible, isExpanded, hasBeenOpened, floatingContainerRef]);
 
   if (!hasBeenOpened) {
     return null;
@@ -174,7 +228,7 @@ export function PersistentChatPanel({
           minHeight: "min(320px, calc(100% - 1rem))",
           maxWidth: "calc(100% - 2rem)",
           maxHeight: "calc(100% - 1rem)",
-          transformOrigin: "center",
+          transformOrigin: "bottom center",
         };
 
   const handleResizeStart = (
@@ -272,7 +326,7 @@ export function PersistentChatPanel({
               "pointer-events-auto relative flex h-full min-h-0",
               isExpanded
                 ? "items-stretch justify-center p-0"
-                : "items-center justify-center p-4",
+                : "items-end justify-center p-4",
             ])}
             onClick={(event) => {
               if (!isExpanded && event.target === event.currentTarget) {
@@ -320,9 +374,7 @@ export function PersistentChatPanel({
                     onPointerUp={handleResizeEnd}
                     onPointerCancel={handleResizeEnd}
                   >
-                    {handle.id === "bottom-right" && (
-                      <span className="pointer-events-none absolute right-1.5 bottom-1.5 h-3 w-3 rounded-br-md border-r border-b border-stone-300/45" />
-                    )}
+                    <ResizeHandleIndicator handle={handle.id} />
                   </div>
                 ))}
             </motion.div>
@@ -333,9 +385,41 @@ export function PersistentChatPanel({
   );
 }
 
+function ResizeHandleIndicator({ handle }: { handle: ResizeHandle }) {
+  const className = getResizeHandleIndicatorClassName(handle);
+
+  if (!className) {
+    return null;
+  }
+
+  return (
+    <span
+      className={cn([
+        "pointer-events-none absolute h-3 w-3 border-stone-300/45",
+        className,
+      ])}
+    />
+  );
+}
+
+function getResizeHandleIndicatorClassName(handle: ResizeHandle) {
+  switch (handle) {
+    case "top-left":
+      return "top-1.5 left-1.5 rounded-tl-md border-t border-l";
+    case "top-right":
+      return "top-1.5 right-1.5 rounded-tr-md border-t border-r";
+    case "bottom-left":
+      return "bottom-1.5 left-1.5 rounded-bl-md border-b border-l";
+    case "bottom-right":
+      return "right-1.5 bottom-1.5 rounded-br-md border-r border-b";
+    default:
+      return null;
+  }
+}
+
 function getFloatingPanelStyle(
   size: FloatingPanelSize,
-  containerRect: DOMRect,
+  containerRect: FloatingContainerRect,
 ): CSSProperties {
   const clampedSize = clampFloatingPanelSize(
     size,
@@ -346,7 +430,16 @@ function getFloatingPanelStyle(
   return {
     width: `${clampedSize.width}px`,
     height: `${clampedSize.height}px`,
-    transformOrigin: "center",
+    transformOrigin: "bottom center",
+  };
+}
+
+function toFloatingContainerRect(rect: DOMRect): FloatingContainerRect {
+  return {
+    top: rect.top,
+    left: rect.left,
+    width: rect.width,
+    height: rect.height,
   };
 }
 
@@ -366,11 +459,11 @@ function getResizedSize(
   }
 
   if (resizeState.handle.includes("top")) {
-    nextSize.height -= deltaY * 2;
+    nextSize.height -= deltaY;
   }
 
   if (resizeState.handle.includes("bottom")) {
-    nextSize.height += deltaY * 2;
+    nextSize.height += deltaY;
   }
 
   return nextSize;

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -44,7 +44,7 @@ export function ChatToolbarControls({
     <div
       className={cn([
         "flex h-full w-full min-w-0 items-center gap-2",
-        isDark ? "px-3" : "px-0",
+        isDark ? "px-2" : "px-0",
       ])}
     >
       <div className="flex min-w-0 flex-1 items-center gap-1">
@@ -69,9 +69,10 @@ export function ChatToolbarControls({
             isDark
               ? [
                   darkToolbarButtonClassName,
-                  "bg-white/7 text-white hover:bg-white/10",
+                  isExpanded && "bg-white/7 text-white hover:bg-white/10",
                 ]
-              : "bg-neutral-100 text-neutral-900 hover:bg-neutral-100",
+              : isExpanded &&
+                "bg-neutral-100 text-neutral-900 hover:bg-neutral-100",
           ])}
         />
       </div>
@@ -144,15 +145,15 @@ function ChatGroups({
         <Button
           variant="ghost"
           className={cn([
-            "group flex h-8 min-w-0 justify-start gap-2 px-2 py-0",
+            "group flex h-8 max-w-full min-w-0 justify-start gap-1.5 px-2 py-0 text-left",
             isDark
-              ? "h-9 max-w-full flex-1 rounded-lg px-2.5 text-stone-100 hover:bg-white/7 hover:text-white data-[state=open]:bg-white/7"
+              ? "w-fit rounded-lg text-stone-100 hover:bg-white/7 hover:text-white data-[state=open]:bg-white/7"
               : "text-neutral-700",
           ])}
         >
           <h3
             className={cn([
-              "min-w-0 flex-1 truncate font-medium",
+              "max-w-64 min-w-0 truncate text-left font-medium",
               isDark
                 ? "text-[15px] text-stone-100"
                 : "text-xs text-neutral-700",

--- a/apps/desktop/src/store/zustand/tabs/basic.ts
+++ b/apps/desktop/src/store/zustand/tabs/basic.ts
@@ -62,8 +62,13 @@ export const createBasicSlice = <
   tabs: [],
   currentTab: null,
   openCurrent: (tab) => {
-    const { tabs, history, addRecentlyOpened } = get();
+    const { tabs, history, addRecentlyOpened, chatMode } = get();
     const currentActiveTab = tabs.find((t) => t.active);
+    const shouldCloseChat = shouldCloseChatForSessionNavigation(
+      currentActiveTab,
+      tab,
+      chatMode,
+    );
 
     const isCurrentTabListening =
       currentActiveTab?.type === "sessions" &&
@@ -72,9 +77,19 @@ export const createBasicSlice = <
         listenerStore.getState().live.status === "finalizing");
 
     if (currentActiveTab?.pinned || isCurrentTabListening) {
-      set(openTab(tabs, tab, history, true));
+      set(
+        withChatCollapsedForSessionNavigation(
+          openTab(tabs, tab, history, true),
+          shouldCloseChat,
+        ),
+      );
     } else {
-      set(openTab(tabs, tab, history, false));
+      set(
+        withChatCollapsedForSessionNavigation(
+          openTab(tabs, tab, history, false),
+          shouldCloseChat,
+        ),
+      );
     }
 
     if (tab.type === "sessions") {
@@ -87,8 +102,20 @@ export const createBasicSlice = <
     });
   },
   openNew: (tab, options) => {
-    const { tabs, history, addRecentlyOpened } = get();
-    set(openTab(tabs, tab, history, true, options?.position));
+    const { tabs, history, addRecentlyOpened, chatMode } = get();
+    const currentActiveTab = tabs.find((t) => t.active);
+    const shouldCloseChat = shouldCloseChatForSessionNavigation(
+      currentActiveTab,
+      tab,
+      chatMode,
+    );
+
+    set(
+      withChatCollapsedForSessionNavigation(
+        openTab(tabs, tab, history, true, options?.position),
+        shouldCloseChat,
+      ),
+    );
 
     if (tab.type === "sessions") {
       addRecentlyOpened(tab.id);
@@ -100,10 +127,21 @@ export const createBasicSlice = <
     });
   },
   select: (tab) => {
-    const { tabs, addRecentlyOpened } = get();
+    const { tabs, addRecentlyOpened, chatMode } = get();
+    const currentActiveTab = tabs.find((t) => t.active);
+    const shouldCloseChat = shouldCloseChatForSessionNavigation(
+      currentActiveTab,
+      tab,
+      chatMode,
+    );
     const nextTabs = setActiveFlags(tabs, tab);
     const currentTab = nextTabs.find((t) => t.active) || null;
-    set({ tabs: nextTabs, currentTab } as Partial<T>);
+    set(
+      withChatCollapsedForSessionNavigation(
+        { tabs: nextTabs, currentTab } as Partial<T>,
+        shouldCloseChat,
+      ),
+    );
 
     if (tab.type === "sessions") {
       addRecentlyOpened(tab.id);
@@ -117,35 +155,55 @@ export const createBasicSlice = <
     } as Partial<T>);
   },
   selectNext: () => {
-    const { tabs, currentTab } = get();
+    const { tabs, currentTab, chatMode } = get();
     if (tabs.length === 0 || !currentTab) return;
 
     const currentIndex = tabs.findIndex((t) => isSameTab(t, currentTab));
     const nextIndex = (currentIndex + 1) % tabs.length;
     const nextTab = tabs[nextIndex];
+    const shouldCloseChat = shouldCloseChatForSessionNavigation(
+      currentTab,
+      nextTab,
+      chatMode,
+    );
 
     const nextTabs = setActiveFlags(tabs, nextTab);
-    set({
-      tabs: nextTabs,
-      currentTab: { ...nextTab, active: true },
-    } as Partial<T>);
+    set(
+      withChatCollapsedForSessionNavigation(
+        {
+          tabs: nextTabs,
+          currentTab: { ...nextTab, active: true },
+        } as Partial<T>,
+        shouldCloseChat,
+      ),
+    );
   },
   selectPrev: () => {
-    const { tabs, currentTab } = get();
+    const { tabs, currentTab, chatMode } = get();
     if (tabs.length === 0 || !currentTab) return;
 
     const currentIndex = tabs.findIndex((t) => isSameTab(t, currentTab));
     const prevIndex = (currentIndex - 1 + tabs.length) % tabs.length;
     const prevTab = tabs[prevIndex];
+    const shouldCloseChat = shouldCloseChatForSessionNavigation(
+      currentTab,
+      prevTab,
+      chatMode,
+    );
 
     const nextTabs = setActiveFlags(tabs, prevTab);
-    set({
-      tabs: nextTabs,
-      currentTab: { ...prevTab, active: true },
-    } as Partial<T>);
+    set(
+      withChatCollapsedForSessionNavigation(
+        {
+          tabs: nextTabs,
+          currentTab: { ...prevTab, active: true },
+        } as Partial<T>,
+        shouldCloseChat,
+      ),
+    );
   },
   close: (tab) => {
-    const { tabs, history, canClose } = get();
+    const { tabs, history, canClose, chatMode } = get();
     const tabToClose = tabs.find((t) => isSameTab(t, tab));
 
     if (!tabToClose) {
@@ -179,15 +237,23 @@ export const createBasicSlice = <
       remainingTabs[nextActiveIndex],
     );
     const nextCurrentTab = nextTabs[nextActiveIndex];
+    const shouldCloseChat =
+      tabToClose.active &&
+      shouldCloseChatForSessionNavigation(tabToClose, nextCurrentTab, chatMode);
 
     const nextHistory = new Map(history);
     nextHistory.delete(tabToClose.slotId);
 
-    set({
-      tabs: nextTabs,
-      currentTab: nextCurrentTab,
-      history: nextHistory,
-    } as Partial<T>);
+    set(
+      withChatCollapsedForSessionNavigation(
+        {
+          tabs: nextTabs,
+          currentTab: nextCurrentTab,
+          history: nextHistory,
+        } as Partial<T>,
+        shouldCloseChat,
+      ),
+    );
   },
   reorder: (tabs) => {
     const currentTab = tabs.find((t) => t.active) || null;
@@ -437,4 +503,30 @@ const clearReturnOrigin = <T extends Tab>(tab: T): T => {
   delete nextTab.returnToSlotId;
   delete nextTab.returnToTabId;
   return nextTab;
+};
+
+const shouldCloseChatForSessionNavigation = (
+  currentTab: Tab | null | undefined,
+  targetTab: Tab | TabInput,
+  chatMode: ChatModeState["chatMode"],
+): boolean => {
+  if (chatMode !== "FloatingOpen" || targetTab.type !== "sessions") {
+    return false;
+  }
+
+  return currentTab?.type !== "sessions" || currentTab.id !== targetTab.id;
+};
+
+const withChatCollapsedForSessionNavigation = <T extends ChatModeState>(
+  state: Partial<T>,
+  shouldCloseChat: boolean,
+): Partial<T> => {
+  if (!shouldCloseChat) {
+    return state;
+  }
+
+  return {
+    ...state,
+    chatMode: "FloatingClosed",
+  } as Partial<T>;
 };

--- a/apps/desktop/src/store/zustand/tabs/chat-mode.test.ts
+++ b/apps/desktop/src/store/zustand/tabs/chat-mode.test.ts
@@ -46,6 +46,92 @@ describe("Chat Mode", () => {
     expect(useTabs.getState().chatMode).toBe("FloatingOpen");
   });
 
+  test("opening a different session closes the floating chat", () => {
+    const first = createSessionTab({ id: "first" });
+    const second = createSessionTab({ id: "second" });
+
+    useTabs.getState().openNew(first);
+    useTabs.getState().transitionChatMode({ type: "OPEN" });
+    useTabs.getState().openNew(second);
+
+    expect(useTabs.getState().chatMode).toBe("FloatingClosed");
+  });
+
+  test("opening the current session keeps the floating chat open", () => {
+    const session = createSessionTab({ id: "session" });
+
+    useTabs.getState().openNew(session);
+    useTabs.getState().transitionChatMode({ type: "OPEN" });
+    useTabs.getState().openNew(createSessionTab({ id: session.id }));
+
+    expect(useTabs.getState().chatMode).toBe("FloatingOpen");
+  });
+
+  test("selecting a different session closes the floating chat", () => {
+    const first = createSessionTab({ id: "first" });
+    const second = createSessionTab({ id: "second" });
+
+    useTabs.getState().openNew(first);
+    useTabs.getState().openNew(second);
+    const firstTab = useTabs
+      .getState()
+      .tabs.find((tab) => tab.type === "sessions" && tab.id === first.id)!;
+
+    useTabs.getState().transitionChatMode({ type: "OPEN" });
+    useTabs.getState().select(firstTab);
+
+    expect(useTabs.getState().chatMode).toBe("FloatingClosed");
+  });
+
+  test("cycling to the next session closes the floating chat", () => {
+    const first = createSessionTab({ id: "first" });
+    const second = createSessionTab({ id: "second" });
+
+    useTabs.getState().openNew(first);
+    useTabs.getState().openNew(second);
+    useTabs
+      .getState()
+      .select(
+        useTabs
+          .getState()
+          .tabs.find((tab) => tab.type === "sessions" && tab.id === first.id)!,
+      );
+
+    useTabs.getState().transitionChatMode({ type: "OPEN" });
+    useTabs.getState().selectNext();
+
+    expect(useTabs.getState().chatMode).toBe("FloatingClosed");
+  });
+
+  test("cycling to the previous session closes the floating chat", () => {
+    const first = createSessionTab({ id: "first" });
+    const second = createSessionTab({ id: "second" });
+
+    useTabs.getState().openNew(first);
+    useTabs.getState().openNew(second);
+
+    useTabs.getState().transitionChatMode({ type: "OPEN" });
+    useTabs.getState().selectPrev();
+
+    expect(useTabs.getState().chatMode).toBe("FloatingClosed");
+  });
+
+  test("closing the active session closes the floating chat when another session becomes active", () => {
+    const first = createSessionTab({ id: "first" });
+    const second = createSessionTab({ id: "second" });
+
+    useTabs.getState().openNew(first);
+    useTabs.getState().openNew(second);
+    const secondTab = useTabs
+      .getState()
+      .tabs.find((tab) => tab.type === "sessions" && tab.id === second.id)!;
+
+    useTabs.getState().transitionChatMode({ type: "OPEN" });
+    useTabs.getState().close(secondTab);
+
+    expect(useTabs.getState().chatMode).toBe("FloatingClosed");
+  });
+
   test("closeAll leaves the floating chat mode unchanged", () => {
     const session = createSessionTab();
     useTabs.getState().openNew(session);


### PR DESCRIPTION
Align the floating chat panel to the bottom FAB line and cover the placement with a focused component test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches floating chat layout, resize math, and tab/chatMode coupling across navigation paths; regressions could affect panel placement or when chat stays open, but behavior is covered by new tests.
> 
> **Overview**
> The floating chat panel is **bottom-anchored** to the FAB line (`items-end`, `transformOrigin: bottom center`), with layout driven by a dedicated container rect that uses the floating anchor and, when expanded, stretches to the root container bottom while staying aligned to the anchor.
> 
> **Resize behavior** adds top and corner handles, adjusts handle hit areas, fixes vertical resize to follow pointer movement (not symmetric doubling), and shows corner grip indicators; expanded state clears when the panel hides.
> 
> **Tab store** auto-collapses floating chat when you open, select, or cycle to a **different** session (or close the active session and land on another); reopening the same session leaves chat open. Toolbar and empty-state tweaks trim icons and polish expand/chat-title controls.
> 
> New **`persistent-chat` component tests** cover anchoring, resize handles, expand alignment, and expanded reset on close; **chat-mode tests** cover session-navigation collapse rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a3def640fc2f000a8ae76f62fb5e06cd8e76414. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->