### PR TITLE
chore(changelog): update 1.0.35 release notes

### DIFF
--- a/packages/changelog/content/1.0.35.md
+++ b/packages/changelog/content/1.0.35.md
@@ -1,6 +1,6 @@
 ---
 date: "2026-06-01"
-summary: "Update prompts are easier to spot in timeline and left sidebar modes, and settings controls now feel more consistent."
+summary: "Update prompts are easier to spot in timeline and left sidebar modes, settings controls feel more consistent, and note summaries now understand attached images."
 ---
 
 ## Updates
@@ -9,6 +9,12 @@ summary: "Update prompts are easier to spot in timeline and left sidebar modes, 
 - Left sidebar mode now shows update availability in the sidebar chrome, with a badge when the sidebar is collapsed and progress or restart states when it is expanded
 - Update prompts now correctly switch to restart when an update has already finished downloading in the background
 - Update downloads now avoid starting twice when the app is already downloading a new version in the background
+
+## Notes
+
+- Enhance summaries can now include image context from note attachments when the selected model supports vision
+- The floating chat panel now stays aligned with the launcher, resizes more predictably, and closes cleanly when switching or closing tabs
+- Upgrade prompts in left sidebar mode now stay clear of the note timeline and update when the sidebar layout changes
 
 ## Settings
 


### PR DESCRIPTION
## Summary
- Add the latest desktop fixes to the 1.0.35 changelog
- Mention image-aware enhance summaries, floating chat fixes, and left sidebar toast placement

## Verification
- pnpm exec dprint fmt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or security impact.
> 
> **Overview**
> Expands the **1.0.35** release notes in `packages/changelog/content/1.0.35.md`: the front-matter **summary** now calls out vision-aware note summaries, and a new **Notes** section documents enhance summaries using attachment images, floating chat panel alignment/resize/close behavior, and left-sidebar upgrade prompt placement relative to the timeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74915d8fd75113fbd2c8754511afa841299d9a30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->