### PR TITLE
Improve transcript copy and chat placement

### DIFF
--- a/apps/desktop/src/changelog/index.tsx
+++ b/apps/desktop/src/changelog/index.tsx
@@ -23,7 +23,7 @@ export function TabContentChangelog({
   const close = useTabs((state) => state.close);
 
   useMountEffect(() => {
-    if (chat.mode === "FloatingOpen") {
+    if (chat.mode !== "FloatingClosed") {
       chat.sendEvent({ type: "CLOSE" });
     }
   });

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -14,15 +14,17 @@ import { useShell } from "~/contexts/shell";
 import * as main from "~/store/tinybase/store/main";
 
 export function ChatView({
-  isExpanded = false,
-  onToggleExpanded,
+  layout = "floating",
+  onOpenFloating,
+  onOpenRightPanel,
 }: {
-  isExpanded?: boolean;
-  onToggleExpanded?: () => void;
+  layout?: "floating" | "right-panel";
+  onOpenFloating?: () => void;
+  onOpenRightPanel?: () => void;
 }) {
   const { chat } = useShell();
   const { groupId, sessionId, setGroupId } = chat;
-  const isFloating = chat.mode === "FloatingOpen";
+  const isFloating = layout === "floating";
 
   const { currentSessionId } = useSessionTab();
 
@@ -58,10 +60,11 @@ export function ChatView({
       >
         <ChatToolbarControls
           currentChatGroupId={groupId}
-          isExpanded={isExpanded}
+          layout={layout}
           onNewChat={chat.startNewChat}
+          onOpenFloating={onOpenFloating}
+          onOpenRightPanel={onOpenRightPanel}
           onSelectChat={chat.selectChat}
-          onToggleExpanded={onToggleExpanded}
           surface={isFloating ? "dark" : "light"}
         />
       </div>

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -1,4 +1,10 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { clearContentMock, editorState } = vi.hoisted(() => ({
@@ -16,10 +22,11 @@ vi.mock("@hypr/editor/chat", async () => {
     ChatEditor: React.forwardRef<
       { clearContent: () => void; focus: () => void; getJSON: () => unknown },
       {
+        className: string;
         onSubmit: () => void;
         onUpdate: (json: unknown) => void;
       }
-    >(function ChatEditor({ onUpdate }, ref) {
+    >(function ChatEditor({ className, onUpdate }, ref) {
       editorState.onUpdate = onUpdate;
 
       React.useImperativeHandle(ref, () => ({
@@ -28,7 +35,7 @@ vi.mock("@hypr/editor/chat", async () => {
         getJSON: () => editorState.json,
       }));
 
-      return <div data-testid="chat-editor" />;
+      return <div className={className} data-testid="chat-editor" />;
     }),
   };
 });
@@ -55,6 +62,7 @@ import { ChatMessageInput } from "./index";
 
 describe("ChatMessageInput", () => {
   beforeEach(() => {
+    cleanup();
     clearContentMock.mockClear();
     editorState.json = { type: "doc", content: [] };
     editorState.onUpdate = undefined;
@@ -97,5 +105,15 @@ describe("ChatMessageInput", () => {
       [],
     );
     expect(clearContentMock).toHaveBeenCalled();
+  });
+
+  it("keeps typed text visible on the white input surface", () => {
+    render(
+      <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
+    );
+
+    expect(screen.getByTestId("chat-editor").className).toContain(
+      "text-neutral-900",
+    );
   });
 });

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -37,7 +37,7 @@ export function ChatMessageInput({
   const editorRef = useRef<ChatEditorHandle>(null);
   const disabled =
     typeof disabledProp === "object" ? disabledProp.disabled : disabledProp;
-  const shouldFocus = chat.mode === "FloatingOpen";
+  const shouldFocus = chat.mode !== "FloatingClosed";
 
   const { hasContent, initialContent, handleEditorUpdate } = useDraftState({
     draftKey,
@@ -61,7 +61,7 @@ export function ChatMessageInput({
         <div className="mb-1 min-h-0 flex-1">
           <ChatEditor
             ref={editorRef}
-            className="max-h-[40vh] overflow-y-auto overscroll-contain text-sm"
+            className="max-h-[40vh] overflow-y-auto overscroll-contain text-sm text-neutral-900"
             initialContent={initialContent}
             mentionConfig={mentionConfig}
             placeholder={chatPlaceholder}

--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -9,7 +9,12 @@ import { useRef } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  chatMode: { current: "FloatingOpen" },
+  chatMode: {
+    current: "FloatingOpen" as
+      | "FloatingClosed"
+      | "FloatingOpen"
+      | "RightPanelOpen",
+  },
   sendEvent: vi.fn(),
 }));
 
@@ -27,14 +32,21 @@ vi.mock("~/contexts/shell", () => ({
 }));
 
 vi.mock("./chat-panel", () => ({
-  ChatView: ({ onToggleExpanded }: { onToggleExpanded?: () => void }) => (
+  ChatView: ({
+    layout,
+    onOpenRightPanel,
+  }: {
+    layout?: "floating" | "right-panel";
+    onOpenRightPanel?: () => void;
+  }) => (
     <>
       <button
-        data-testid="toggle-expanded"
+        data-layout={layout}
+        data-testid="open-right-panel"
         type="button"
-        onClick={onToggleExpanded}
+        onClick={onOpenRightPanel}
       >
-        Toggle expanded
+        Open right panel
       </button>
       <div data-testid="chat-view" />
     </>
@@ -66,7 +78,7 @@ describe("PersistentChatPanel", () => {
     } as typeof ResizeObserver;
   });
 
-  it("anchors the floating panel to the bottom FAB line", async () => {
+  it("anchors the floating panel to the bottom-right of the note surface", async () => {
     render(<TestHost />);
 
     await screen.findByTestId("chat-view");
@@ -76,8 +88,20 @@ describe("PersistentChatPanel", () => {
 
     await waitFor(() => {
       expect(resizeFrame?.className).toContain("items-end");
-      expect(resizeFrame?.className).toContain("justify-center");
-      expect(panel?.style.transformOrigin).toBe("bottom center");
+      expect(resizeFrame?.className).toContain("justify-end");
+      expect(panel?.style.transformOrigin).toBe("bottom right");
+    });
+  });
+
+  it("opens the docked right panel from the toolbar action", async () => {
+    render(<TestHost />);
+
+    await screen.findByTestId("chat-view");
+
+    fireEvent.click(screen.getByTestId("open-right-panel"));
+
+    expect(mocks.sendEvent).toHaveBeenCalledWith({
+      type: "OPEN_RIGHT_PANEL",
     });
   });
 
@@ -209,11 +233,11 @@ describe("PersistentChatPanel", () => {
     };
 
     dragHandle("right", { x: 660, y: 420 }, { x: 700, y: 420 });
-    expect(panel?.style.width).toBe("500px");
+    expect(panel?.style.width).toBe("460px");
     expect(panel?.style.height).toBe("360px");
 
     dragHandle("left", { x: 240, y: 420 }, { x: 200, y: 420 });
-    expect(panel?.style.width).toBe("500px");
+    expect(panel?.style.width).toBe("460px");
     expect(panel?.style.height).toBe("360px");
 
     dragHandle("top", { x: 450, y: 240 }, { x: 450, y: 200 });
@@ -221,98 +245,26 @@ describe("PersistentChatPanel", () => {
     expect(panel?.style.height).toBe("400px");
 
     dragHandle("top-left", { x: 240, y: 240 }, { x: 200, y: 200 });
-    expect(panel?.style.width).toBe("500px");
+    expect(panel?.style.width).toBe("460px");
     expect(panel?.style.height).toBe("400px");
 
     dragHandle("top-right", { x: 660, y: 240 }, { x: 700, y: 200 });
-    expect(panel?.style.width).toBe("500px");
+    expect(panel?.style.width).toBe("460px");
     expect(panel?.style.height).toBe("400px");
   });
 
-  it("keeps the expanded panel aligned to the anchor while extending to the container bottom", async () => {
-    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
-      function (this: HTMLElement) {
-        if (this.hasAttribute("data-chat-floating-anchor")) {
-          return {
-            bottom: 600,
-            height: 600,
-            left: 200,
-            right: 900,
-            top: 0,
-            width: 700,
-            x: 200,
-            y: 0,
-            toJSON: () => ({}),
-          };
-        }
-
-        return {
-          bottom: 720,
-          height: 720,
-          left: 0,
-          right: 900,
-          top: 0,
-          width: 900,
-          x: 0,
-          y: 0,
-          toJSON: () => ({}),
-        };
-      },
-    );
-
-    render(<TestHost />);
-
-    await screen.findByTestId("chat-view");
-
-    const resizeFrame = document.querySelector<HTMLElement>(
-      "[data-chat-resize-frame]",
-    );
-    const frame = resizeFrame?.parentElement as HTMLElement | null;
-
-    await waitFor(() => {
-      expect(frame?.style.left).toBe("200px");
-      expect(frame?.style.width).toBe("700px");
-      expect(frame?.style.height).toBe("600px");
-    });
-
-    fireEvent.click(screen.getByTestId("toggle-expanded"));
-
-    await waitFor(() => {
-      expect(frame?.style.left).toBe("200px");
-      expect(frame?.style.width).toBe("700px");
-      expect(frame?.style.height).toBe("720px");
-      expect(
-        document.querySelector<HTMLElement>("[data-chat-panel]")?.dataset
-          .chatSize,
-      ).toBe("expanded");
-    });
-  });
-
-  it("resets expanded state when the floating chat closes", async () => {
+  it("hides the floating panel when the chat moves to the right panel", async () => {
     const { rerender } = render(<TestHost />);
 
     await screen.findByTestId("chat-view");
 
-    fireEvent.click(screen.getByTestId("toggle-expanded"));
-
-    await waitFor(() => {
-      expect(
-        document.querySelector<HTMLElement>("[data-chat-panel]")?.dataset
-          .chatSize,
-      ).toBe("expanded");
-    });
-
-    mocks.chatMode.current = "FloatingClosed";
-    rerender(<TestHost />);
-
-    mocks.chatMode.current = "FloatingOpen";
+    mocks.chatMode.current = "RightPanelOpen";
     rerender(<TestHost />);
 
     await waitFor(() => {
       expect(
-        document.querySelector<HTMLElement>("[data-chat-panel]")?.dataset
-          .chatSize,
-      ).toBe("floating");
+        document.querySelector<HTMLElement>("[data-chat-panel]"),
+      ).toBeNull();
     });
   });
 });

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -89,7 +89,6 @@ export function PersistentChatPanel({
   const [hasBeenOpened, setHasBeenOpened] = useState(false);
   const [containerRect, setContainerRect] =
     useState<FloatingContainerRect | null>(null);
-  const [isExpanded, setIsExpanded] = useState(false);
   const [floatingSize, setFloatingSize] = useState<FloatingPanelSize | null>(
     null,
   );
@@ -107,28 +106,13 @@ export function PersistentChatPanel({
   };
 
   const getContainerRect = () => {
-    const root = floatingContainerRef.current;
     const anchor = getActiveContainer();
 
-    if (!root || !anchor) {
+    if (!anchor) {
       return null;
     }
 
-    const anchorRect = anchor.getBoundingClientRect();
-
-    if (!isExpanded) {
-      return toFloatingContainerRect(anchorRect);
-    }
-
-    const rootRect = root.getBoundingClientRect();
-    const bottom = Math.max(rootRect.bottom, anchorRect.bottom);
-
-    return {
-      top: anchorRect.top,
-      left: anchorRect.left,
-      width: anchorRect.width,
-      height: bottom - anchorRect.top,
-    };
+    return toFloatingContainerRect(anchor.getBoundingClientRect());
   };
 
   useEffect(() => {
@@ -137,7 +121,6 @@ export function PersistentChatPanel({
     }
 
     if (!isVisible) {
-      setIsExpanded(false);
       resizeStateRef.current = null;
     }
   }, [isVisible, hasBeenOpened]);
@@ -162,7 +145,7 @@ export function PersistentChatPanel({
       return;
     }
     setContainerRect(nextRect);
-  }, [isVisible, isExpanded, hasBeenOpened, floatingContainerRef]);
+  }, [isVisible, hasBeenOpened, floatingContainerRef]);
 
   useEffect(() => {
     const root = floatingContainerRef.current;
@@ -194,32 +177,25 @@ export function PersistentChatPanel({
       window.removeEventListener("resize", updateRect);
       window.removeEventListener("scroll", updateRect, true);
     };
-  }, [isVisible, isExpanded, hasBeenOpened, floatingContainerRef]);
+  }, [isVisible, hasBeenOpened, floatingContainerRef]);
 
   if (!hasBeenOpened) {
     return null;
   }
 
-  const panelMotion = isExpanded
-    ? {
-        initial: { opacity: 0, scale: 0.985, filter: "blur(4px)" },
-        animate: { opacity: 1, scale: 1, filter: "blur(0px)" },
-        exit: { opacity: 0, scale: 0.99, filter: "blur(3px)" },
-      }
-    : {
-        initial: { y: 24, opacity: 0, scale: 0.96, filter: "blur(6px)" },
-        animate: { y: 0, opacity: 1, scale: 1, filter: "blur(0px)" },
-        exit: { y: 18, opacity: 0, scale: 0.97, filter: "blur(4px)" },
-      };
+  const panelMotion = {
+    initial: { y: 24, opacity: 0, scale: 0.96, filter: "blur(6px)" },
+    animate: { y: 0, opacity: 1, scale: 1, filter: "blur(0px)" },
+    exit: { y: 18, opacity: 0, scale: 0.97, filter: "blur(4px)" },
+  };
   const panelTransition = {
     opacity: { duration: 0.18, ease: [0.22, 1, 0.36, 1] },
     scale: { duration: 0.24, ease: [0.22, 1, 0.36, 1] },
     y: { duration: 0.28, ease: [0.22, 1, 0.36, 1] },
     filter: { duration: 0.16, ease: "easeOut" },
   };
-  const panelStyle = isExpanded
-    ? { transformOrigin: "center" }
-    : floatingSize && containerRect
+  const panelStyle =
+    floatingSize && containerRect
       ? getFloatingPanelStyle(floatingSize, containerRect)
       : {
           width: "min(640px, calc(100% - 2rem))",
@@ -228,7 +204,7 @@ export function PersistentChatPanel({
           minHeight: "min(320px, calc(100% - 1rem))",
           maxWidth: "calc(100% - 2rem)",
           maxHeight: "calc(100% - 1rem)",
-          transformOrigin: "bottom center",
+          transformOrigin: "bottom right",
         };
 
   const handleResizeStart = (
@@ -324,12 +300,10 @@ export function PersistentChatPanel({
             data-chat-resize-frame
             className={cn([
               "pointer-events-auto relative flex h-full min-h-0",
-              isExpanded
-                ? "items-stretch justify-center p-0"
-                : "items-end justify-center p-4",
+              "items-end justify-end p-4",
             ])}
             onClick={(event) => {
-              if (!isExpanded && event.target === event.currentTarget) {
+              if (event.target === event.currentTarget) {
                 chat.sendEvent({ type: "CLOSE" });
               }
             }}
@@ -337,16 +311,12 @@ export function PersistentChatPanel({
             <motion.div
               ref={panelRef}
               data-chat-panel
-              data-chat-size={isExpanded ? "expanded" : "floating"}
+              data-chat-size="floating"
               className={cn([
                 "relative flex min-h-0 flex-col overflow-hidden",
                 "bg-stone-800 text-white",
-                isExpanded
-                  ? "h-full w-full rounded-none border-0"
-                  : [
-                      "rounded-2xl border-2 border-stone-600",
-                      "shadow-[0_4px_28px_rgba(87,83,78,0.45)]",
-                    ],
+                "rounded-2xl border-2 border-stone-600",
+                "shadow-[0_4px_28px_rgba(87,83,78,0.45)]",
               ])}
               style={panelStyle}
               initial={panelMotion.initial}
@@ -355,28 +325,27 @@ export function PersistentChatPanel({
               transition={panelTransition}
             >
               <ChatView
-                isExpanded={isExpanded}
-                onToggleExpanded={() => setIsExpanded((value) => !value)}
+                layout="floating"
+                onOpenRightPanel={() =>
+                  chat.sendEvent({ type: "OPEN_RIGHT_PANEL" })
+                }
               />
-              {!isExpanded &&
-                RESIZE_HANDLES.map((handle) => (
-                  <div
-                    key={handle.id}
-                    data-chat-resize-handle={handle.id}
-                    className={cn([
-                      "absolute z-20 touch-none select-none",
-                      handle.className,
-                    ])}
-                    onPointerDown={(event) =>
-                      handleResizeStart(handle.id, event)
-                    }
-                    onPointerMove={handleResizeMove}
-                    onPointerUp={handleResizeEnd}
-                    onPointerCancel={handleResizeEnd}
-                  >
-                    <ResizeHandleIndicator handle={handle.id} />
-                  </div>
-                ))}
+              {RESIZE_HANDLES.map((handle) => (
+                <div
+                  key={handle.id}
+                  data-chat-resize-handle={handle.id}
+                  className={cn([
+                    "absolute z-20 touch-none select-none",
+                    handle.className,
+                  ])}
+                  onPointerDown={(event) => handleResizeStart(handle.id, event)}
+                  onPointerMove={handleResizeMove}
+                  onPointerUp={handleResizeEnd}
+                  onPointerCancel={handleResizeEnd}
+                >
+                  <ResizeHandleIndicator handle={handle.id} />
+                </div>
+              ))}
             </motion.div>
           </div>
         </motion.div>
@@ -430,7 +399,7 @@ function getFloatingPanelStyle(
   return {
     width: `${clampedSize.width}px`,
     height: `${clampedSize.height}px`,
-    transformOrigin: "bottom center",
+    transformOrigin: "bottom right",
   };
 }
 
@@ -451,11 +420,11 @@ function getResizedSize(
   const nextSize = { ...resizeState.startSize };
 
   if (resizeState.handle.includes("left")) {
-    nextSize.width -= deltaX * 2;
+    nextSize.width -= deltaX;
   }
 
   if (resizeState.handle.includes("right")) {
-    nextSize.width += deltaX * 2;
+    nextSize.width += deltaX;
   }
 
   if (resizeState.handle.includes("top")) {

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -1,8 +1,8 @@
 import {
   ChevronDown,
-  Maximize2,
   MessageCircle,
-  Minimize2,
+  PanelRightClose,
+  PanelRightOpen,
   Plus,
 } from "lucide-react";
 import { useState } from "react";
@@ -25,20 +25,23 @@ import * as main from "~/store/tinybase/store/main";
 
 export function ChatToolbarControls({
   currentChatGroupId,
-  isExpanded = false,
+  layout = "floating",
   onNewChat,
+  onOpenFloating,
+  onOpenRightPanel,
   onSelectChat,
-  onToggleExpanded,
   surface = "light",
 }: {
   currentChatGroupId: string | undefined;
-  isExpanded?: boolean;
+  layout?: "floating" | "right-panel";
   onNewChat: () => void;
+  onOpenFloating?: () => void;
+  onOpenRightPanel?: () => void;
   onSelectChat: (chatGroupId: string) => void;
-  onToggleExpanded?: () => void;
   surface?: "light" | "dark";
 }) {
   const isDark = surface === "dark";
+  const isRightPanel = layout === "right-panel";
 
   return (
     <div
@@ -62,16 +65,23 @@ export function ChatToolbarControls({
           className={isDark ? darkToolbarButtonClassName : undefined}
         />
         <ChatActionButton
-          icon={isExpanded ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
-          onClick={onToggleExpanded ?? (() => {})}
-          title={isExpanded ? "Collapse chat" : "Expand chat"}
+          icon={
+            isRightPanel ? (
+              <PanelRightClose size={16} />
+            ) : (
+              <PanelRightOpen size={16} />
+            )
+          }
+          onClick={
+            isRightPanel
+              ? (onOpenFloating ?? (() => {}))
+              : (onOpenRightPanel ?? (() => {}))
+          }
+          title={isRightPanel ? "Float chat" : "Open in right panel"}
           className={cn([
             isDark
-              ? [
-                  darkToolbarButtonClassName,
-                  isExpanded && "bg-white/7 text-white hover:bg-white/10",
-                ]
-              : isExpanded &&
+              ? darkToolbarButtonClassName
+              : isRightPanel &&
                 "bg-neutral-100 text-neutral-900 hover:bg-neutral-100",
           ])}
         />

--- a/apps/desktop/src/main/useTabsShortcuts.test.tsx
+++ b/apps/desktop/src/main/useTabsShortcuts.test.tsx
@@ -2,7 +2,10 @@ import { cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
-  chatMode: "FloatingClosed" as "FloatingClosed" | "FloatingOpen",
+  chatMode: "FloatingClosed" as
+    | "FloatingClosed"
+    | "FloatingOpen"
+    | "RightPanelOpen",
   currentTab: null as null | {
     active: boolean;
     id?: string;
@@ -471,6 +474,23 @@ describe("useClassicMainTabsShortcuts", () => {
 
   it("closes the floating chat before going home on escape", () => {
     hoisted.chatMode = "FloatingOpen";
+    hoisted.currentTab = {
+      active: true,
+      slotId: "slot-session",
+      type: "sessions",
+    };
+
+    renderHook(() => useClassicMainTabsShortcuts());
+
+    dispatchEscape();
+    vi.runOnlyPendingTimers();
+
+    expect(hoisted.sendEvent).toHaveBeenCalledWith({ type: "CLOSE" });
+    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+  });
+
+  it("closes the right panel chat before going home on escape", () => {
+    hoisted.chatMode = "RightPanelOpen";
     hoisted.currentTab = {
       active: true,
       slotId: "slot-session",

--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -150,6 +150,35 @@ describe("useSessionBottomAccessory", () => {
     expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
   });
 
+  it("defers transcript escape handling while right panel chat is open", () => {
+    useShellMock.mockReturnValue({
+      chat: {
+        mode: "RightPanelOpen",
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useSessionBottomAccessory({
+        sessionId: "session-1",
+        sessionMode: "inactive",
+        audioUrl: "file:///session.wav",
+        hasTranscript: true,
+      }),
+    );
+
+    const toggle = result.current.bottomBorderHandle;
+    expect(isValidElement<{ onToggle: () => void }>(toggle)).toBe(true);
+    if (!isValidElement<{ onToggle: () => void }>(toggle)) {
+      return;
+    }
+
+    act(() => {
+      toggle.props.onToggle();
+    });
+
+    expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
+  });
+
   it("keeps the playback accessory mounted while the transcript panel is collapsed", () => {
     const { result } = renderHook(() =>
       useSessionBottomAccessory({

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -42,7 +42,8 @@ export function useSessionBottomAccessory({
   const canExpandLiveTranscript = showLiveAccessory;
   const effectiveExpanded =
     isLive && !canExpandLiveTranscript ? false : isExpanded;
-  const isChatVisible = chat.mode === "FloatingOpen";
+  const isChatVisible =
+    chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
 
   const prevLive = useRef(isLive);
   useEffect(() => {

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -14,15 +14,21 @@ const {
   useTranscriptScreenMock,
   useRunBatchMock,
   useListenerMock,
+  useTranscriptExportSegmentsMock,
   runBatchMock,
   handleBatchFailedMock,
+  writeTextMock,
+  showTransientToastMock,
 } = vi.hoisted(() => ({
   audioPathMock: vi.fn(),
   useTranscriptScreenMock: vi.fn(),
   useRunBatchMock: vi.fn(),
   useListenerMock: vi.fn(),
+  useTranscriptExportSegmentsMock: vi.fn(),
   runBatchMock: vi.fn(),
   handleBatchFailedMock: vi.fn(),
+  writeTextMock: vi.fn(),
+  showTransientToastMock: vi.fn(),
 }));
 
 vi.mock("@hypr/plugin-fs-sync", () => ({
@@ -73,6 +79,20 @@ vi.mock("~/session/components/note-input/transcript", () => ({
   Transcript: () => <div data-testid="transcript" />,
 }));
 
+vi.mock("~/sidebar/toast/transient", () => ({
+  showTransientToast: showTransientToastMock,
+}));
+
+vi.mock("~/session/components/note-input/transcript/export-data", () => ({
+  useTranscriptExportSegments: useTranscriptExportSegmentsMock,
+  formatTranscriptExportSegments: (
+    segments: Array<{ speaker: string | null; text: string }>,
+  ) =>
+    segments
+      .map((segment) => `${segment.speaker ?? "Speaker"}: ${segment.text}`)
+      .join("\n\n"),
+}));
+
 vi.mock("~/session/components/note-input/transcript/state", () => ({
   useTranscriptScreen: useTranscriptScreenMock,
 }));
@@ -97,6 +117,12 @@ describe("PostSessionAccessory", () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: writeTextMock,
+      },
+    });
 
     audioPathMock.mockResolvedValue({
       status: "ok",
@@ -109,7 +135,15 @@ describe("PostSessionAccessory", () => {
       liveSegments: [],
       currentActive: false,
     });
+    useTranscriptExportSegmentsMock.mockReturnValue({
+      data: [
+        { speaker: "Alex", text: "We should ship this." },
+        { speaker: null, text: "Agreed." },
+      ],
+      isLoading: false,
+    });
 
+    writeTextMock.mockResolvedValue(undefined);
     runBatchMock.mockResolvedValue(undefined);
     useRunBatchMock.mockReturnValue(runBatchMock);
 
@@ -139,6 +173,29 @@ describe("PostSessionAccessory", () => {
     });
 
     expect(handleBatchFailedMock).not.toHaveBeenCalled();
+  });
+
+  it("copies transcript text from the expanded transcript panel", async () => {
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio
+        hasTranscript
+        isTranscriptExpanded
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy transcript" }));
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(
+        "Alex: We should ship this.\n\nSpeaker: Agreed.",
+      );
+    });
+    expect(showTransientToastMock).toHaveBeenCalledWith({
+      id: "transcript-copy-success",
+      description: "Transcript copied to clipboard",
+    });
   });
 
   it("shows Regenerate button without upload or reserved height in empty panel", async () => {

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -1,4 +1,5 @@
 import {
+  CopyIcon,
   Loader2Icon,
   Pencil,
   RefreshCw,
@@ -20,7 +21,12 @@ import { cn } from "@hypr/utils";
 import * as AudioPlayer from "~/audio-player";
 import { getEnhancerService } from "~/services/enhancer";
 import { Transcript } from "~/session/components/note-input/transcript";
+import {
+  formatTranscriptExportSegments,
+  useTranscriptExportSegments,
+} from "~/session/components/note-input/transcript/export-data";
 import { useTranscriptScreen } from "~/session/components/note-input/transcript/state";
+import { showTransientToast } from "~/sidebar/toast/transient";
 import { useListener } from "~/stt/contexts";
 import { isStoppedTranscriptionError, useRunBatch } from "~/stt/useRunBatch";
 
@@ -395,8 +401,19 @@ function TranscriptReadyPanel({
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const regenerate = useRegenerateTranscript(sessionId);
+  const { data: transcriptSegments, isLoading: isTranscriptLoading } =
+    useTranscriptExportSegments(sessionId);
   const { audioExists, deleteRecording, isDeletingRecording } =
     AudioPlayer.useAudioPlayer();
+  const transcriptText = formatTranscriptExportSegments(transcriptSegments);
+  const canCopyTranscript = transcriptText.length > 0 && !isTranscriptLoading;
+  const handleCopyTranscript = useCallback(() => {
+    if (!canCopyTranscript) {
+      return;
+    }
+
+    void copyTranscriptToClipboard(transcriptText);
+  }, [canCopyTranscript, transcriptText]);
 
   if (!isExpanded) {
     return null;
@@ -425,6 +442,22 @@ function TranscriptReadyPanel({
               <p>Coming soon</p>
             </TooltipContent>
           </Tooltip>
+          <button
+            type="button"
+            onClick={handleCopyTranscript}
+            disabled={!canCopyTranscript}
+            aria-label="Copy transcript"
+            className={cn([
+              "flex items-center gap-1 rounded-full px-1.5 py-0.5",
+              "text-[11px] font-medium text-neutral-500",
+              "transition-colors hover:bg-neutral-200/60 hover:text-neutral-700",
+              "disabled:cursor-not-allowed disabled:text-neutral-300",
+              "disabled:hover:bg-transparent disabled:hover:text-neutral-300",
+            ])}
+          >
+            <CopyIcon size={10} />
+            {isTranscriptLoading ? "Loading..." : "Copy"}
+          </button>
           <button
             type="button"
             onClick={regenerate}
@@ -465,6 +498,23 @@ function TranscriptReadyPanel({
       </TranscriptScrollArea>
     </TranscriptCard>
   );
+}
+
+async function copyTranscriptToClipboard(text: string) {
+  try {
+    await navigator.clipboard.writeText(text);
+    showTransientToast({
+      id: "transcript-copy-success",
+      description: "Transcript copied to clipboard",
+    });
+  } catch (error) {
+    console.error("Failed to copy transcript", error);
+    showTransientToast({
+      id: "transcript-copy-error",
+      description: "Failed to copy transcript",
+      variant: "error",
+    });
+  }
 }
 
 function TranscriptEmptyPanel({

--- a/apps/desktop/src/shared/chat-cta.test.tsx
+++ b/apps/desktop/src/shared/chat-cta.test.tsx
@@ -2,7 +2,10 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  chatMode: "FloatingClosed" as "FloatingClosed" | "FloatingOpen",
+  chatMode: "FloatingClosed" as
+    | "FloatingClosed"
+    | "FloatingOpen"
+    | "RightPanelOpen",
   sendEvent: vi.fn(),
 }));
 
@@ -36,6 +39,16 @@ describe("ChatCTA", () => {
 
   it("hides while the floating chat is open", () => {
     mocks.chatMode = "FloatingOpen";
+
+    render(<ChatCTA />);
+
+    expect(
+      screen.queryByRole("button", { name: "Ask Anarlog anything" }),
+    ).toBeNull();
+  });
+
+  it("hides while the right panel chat is open", () => {
+    mocks.chatMode = "RightPanelOpen";
 
     render(<ChatCTA />);
 

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -10,7 +10,7 @@ export function ChatCTA({
   label?: string;
 }) {
   const { chat } = useShell();
-  const isChatOpen = chat.mode === "FloatingOpen";
+  const isChatOpen = chat.mode !== "FloatingClosed";
 
   const handleClick = () => {
     chat.sendEvent({ type: "OPEN" });

--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -2,7 +2,83 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  chatMode: "FloatingClosed" as
+    | "FloatingClosed"
+    | "FloatingOpen"
+    | "RightPanelOpen",
   persistentChatPanel: vi.fn(),
+  sendEvent: vi.fn(),
+}));
+
+vi.mock("@hypr/ui/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({
+    children,
+    direction,
+  }: {
+    children: React.ReactNode;
+    direction: string;
+  }) => (
+    <div data-direction={direction} data-testid="panel-group">
+      {children}
+    </div>
+  ),
+  ResizablePanel: ({
+    children,
+    className,
+    defaultSize,
+    maxSize,
+    minSize,
+    style,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    defaultSize?: number;
+    maxSize?: number;
+    minSize?: number;
+    style?: React.CSSProperties;
+  }) => (
+    <div
+      data-class-name={className}
+      data-default-size={defaultSize}
+      data-max-size={maxSize}
+      data-min-size={minSize}
+      data-min-width={style?.minWidth}
+      data-testid="panel"
+    >
+      {children}
+    </div>
+  ),
+  ResizableHandle: ({ className }: { className?: string }) => (
+    <div data-class-name={className} data-testid="resize-handle" />
+  ),
+}));
+
+vi.mock("~/contexts/shell", () => ({
+  useShell: () => ({
+    chat: {
+      mode: mocks.chatMode,
+      sendEvent: mocks.sendEvent,
+    },
+  }),
+}));
+
+vi.mock("~/chat/components/chat-panel", () => ({
+  ChatView: ({
+    layout,
+    onOpenFloating,
+  }: {
+    layout?: "floating" | "right-panel";
+    onOpenFloating?: () => void;
+  }) => (
+    <button
+      data-layout={layout}
+      data-testid="chat-view"
+      type="button"
+      onClick={onOpenFloating}
+    >
+      Chat
+    </button>
+  ),
 }));
 
 vi.mock("~/chat/components/persistent-chat", () => ({
@@ -21,7 +97,9 @@ import { MainChatPanels } from "./chat-panels";
 describe("MainChatPanels", () => {
   beforeEach(() => {
     cleanup();
+    mocks.chatMode = "FloatingClosed";
     mocks.persistentChatPanel.mockClear();
+    mocks.sendEvent.mockClear();
   });
 
   it("renders the main content and persistent floating chat host", () => {
@@ -37,8 +115,28 @@ describe("MainChatPanels", () => {
     expect(mocks.persistentChatPanel.mock.calls[0]?.[0].current).toBeInstanceOf(
       HTMLDivElement,
     );
+    expect(screen.getByTestId("panel-group").dataset.direction).toBe(
+      "horizontal",
+    );
     expect(screen.queryByTestId("resize-handle")).toBeNull();
-    expect(screen.queryByTestId("panel")).toBeNull();
+    expect(screen.getAllByTestId("panel")).toHaveLength(1);
     expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("renders the right chat panel when chat is docked", () => {
+    mocks.chatMode = "RightPanelOpen";
+
+    render(
+      <MainChatPanels>
+        <div data-testid="main-content" />
+      </MainChatPanels>,
+    );
+
+    expect(screen.getAllByTestId("panel")).toHaveLength(2);
+    expect(screen.getByTestId("resize-handle")).toBeTruthy();
+    expect(screen.getByTestId("chat-view").dataset.layout).toBe("right-panel");
+    expect(document.querySelector("[data-chat-right-panel]")).toBeInstanceOf(
+      HTMLDivElement,
+    );
   });
 });

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -1,20 +1,60 @@
 import { useRef } from "react";
 
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@hypr/ui/components/ui/resizable";
+
+import { ChatView } from "~/chat/components/chat-panel";
 import { PersistentChatPanel } from "~/chat/components/persistent-chat";
+import { useShell } from "~/contexts/shell";
+
+const RIGHT_CHAT_PANEL_MIN_WIDTH_PX = 320;
 
 export function MainChatPanels({ children }: { children: React.ReactNode }) {
+  const { chat } = useShell();
   const bodyPanelContainerRef = useRef<HTMLDivElement>(null);
+  const isRightPanelOpen = chat.mode === "RightPanelOpen";
 
   return (
     <>
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        <div
-          ref={bodyPanelContainerRef}
-          className="h-full min-h-0 min-w-0 flex-1 overflow-hidden"
-        >
-          {children}
-        </div>
-      </div>
+      <ResizablePanelGroup
+        autoSaveId="main-chat"
+        direction="horizontal"
+        className="flex min-h-0 flex-1 overflow-hidden"
+      >
+        <ResizablePanel className="min-h-0 flex-1 overflow-hidden">
+          <div
+            ref={bodyPanelContainerRef}
+            className="h-full min-h-0 min-w-0 flex-1 overflow-hidden"
+          >
+            {children}
+          </div>
+        </ResizablePanel>
+        {isRightPanelOpen ? (
+          <>
+            <ResizableHandle className="w-0" />
+            <ResizablePanel
+              defaultSize={30}
+              minSize={20}
+              maxSize={50}
+              className="min-h-0 overflow-hidden"
+              style={{ minWidth: RIGHT_CHAT_PANEL_MIN_WIDTH_PX }}
+            >
+              <div
+                data-chat-right-panel
+                className="mr-1 -mb-1 ml-2 h-[calc(100%+0.25rem)] min-h-0 overflow-hidden rounded-t-xl border border-b-0 border-neutral-200 bg-stone-50"
+              >
+                <ChatView
+                  layout="right-panel"
+                  onOpenFloating={() => chat.sendEvent({ type: "OPEN" })}
+                />
+              </div>
+            </ResizablePanel>
+          </>
+        ) : null}
+      </ResizablePanelGroup>
 
       <PersistentChatPanel floatingContainerRef={bodyPanelContainerRef} />
     </>

--- a/apps/desktop/src/shared/useTabsShortcuts.tsx
+++ b/apps/desktop/src/shared/useTabsShortcuts.tsx
@@ -225,7 +225,7 @@ export function useMainEscapeShortcutAction() {
   const { chat } = useShell();
 
   return useCallback(() => {
-    if (chat.mode === "FloatingOpen") {
+    if (chat.mode !== "FloatingClosed") {
       chat.sendEvent({ type: "CLOSE" });
       return;
     }
@@ -292,7 +292,7 @@ function isFromProseMirrorEditor(target: EventTarget | null) {
 function isPersistentChatInputFocused(
   mode: ReturnType<typeof useShell>["chat"]["mode"],
 ) {
-  if (mode !== "FloatingOpen") {
+  if (mode === "FloatingClosed") {
     return false;
   }
 

--- a/apps/desktop/src/sidebar/custom-sidebar-header.test.tsx
+++ b/apps/desktop/src/sidebar/custom-sidebar-header.test.tsx
@@ -88,6 +88,17 @@ describe("CustomSidebarHeader", () => {
     expect(mocks.openCurrent).not.toHaveBeenCalled();
   });
 
+  it("closes right panel chat before opening home", () => {
+    mocks.chatMode = "RightPanelOpen";
+
+    render(<CustomSidebarHeader title="Contacts" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Go home" }));
+
+    expect(mocks.sendEvent).toHaveBeenCalledWith({ type: "CLOSE" });
+    expect(mocks.openCurrent).not.toHaveBeenCalled();
+  });
+
   it("renders history controls when requested", () => {
     mocks.canGoBack = true;
     mocks.canGoNext = true;

--- a/apps/desktop/src/sidebar/custom-sidebar-header.tsx
+++ b/apps/desktop/src/sidebar/custom-sidebar-header.tsx
@@ -26,7 +26,7 @@ export function CustomSidebarHeader({
   const canGoNext = useTabs((state) => state.canGoNext);
 
   const handleBack = useCallback(() => {
-    if (chat.mode === "FloatingOpen") {
+    if (chat.mode !== "FloatingClosed") {
       chat.sendEvent({ type: "CLOSE" });
       return;
     }

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -10,6 +10,7 @@ import {
   createToastRegistry,
   getToastToShow,
 } from "./registry";
+import { useTransientToast } from "./transient";
 import { useDismissedToasts } from "./useDismissedToasts";
 
 import { useAuth } from "~/auth";
@@ -75,6 +76,8 @@ export function ToastArea({
   const clearDevtoolsPreview = useDevtoolsToastPreview(
     (state) => state.clearPreview,
   );
+  const transientToast = useTransientToast((state) => state.toast);
+  const clearTransientToast = useTransientToast((state) => state.clearToast);
   const isAiTranscriptionTabActive =
     currentTab?.type === "settings" &&
     currentTab.state?.tab === "transcription";
@@ -177,6 +180,11 @@ export function ToastArea({
   );
 
   const handleDismiss = useCallback(() => {
+    if (transientToast) {
+      clearTransientToast(transientToast.key);
+      return;
+    }
+
     if (devtoolsToast) {
       clearDevtoolsPreview();
       return;
@@ -185,13 +193,21 @@ export function ToastArea({
     if (currentToast) {
       dismissToast(currentToast.id);
     }
-  }, [clearDevtoolsPreview, currentToast, devtoolsToast, dismissToast]);
+  }, [
+    clearDevtoolsPreview,
+    clearTransientToast,
+    currentToast,
+    devtoolsToast,
+    dismissToast,
+    transientToast,
+  ]);
 
-  const displayToast = devtoolsToast ?? currentToast;
+  const displayToast = transientToast ?? devtoolsToast ?? currentToast;
   const displayToastKey =
-    devtoolsPreview && devtoolsToast
+    transientToast?.key ??
+    (devtoolsPreview && devtoolsToast
       ? `${devtoolsToast.id}:${devtoolsPreview.key}`
-      : displayToast?.id;
+      : displayToast?.id);
 
   const dismissAction = displayToast?.dismissible ? handleDismiss : undefined;
   const position =

--- a/apps/desktop/src/sidebar/toast/transient.ts
+++ b/apps/desktop/src/sidebar/toast/transient.ts
@@ -1,0 +1,72 @@
+import { create } from "zustand";
+
+import type { ToastType } from "./types";
+
+const DEFAULT_TRANSIENT_TOAST_DURATION_MS = 2400;
+
+type TransientToastInput = Omit<ToastType, "dismissible" | "id"> & {
+  dismissible?: boolean;
+  id?: string;
+};
+
+type TransientToast = ToastType & {
+  key: string;
+};
+
+type TransientToastState = {
+  toast: TransientToast | null;
+  showToast: (
+    toast: TransientToastInput,
+    options?: { durationMs?: number },
+  ) => void;
+  clearToast: (key?: string) => void;
+};
+
+let toastSequence = 0;
+let dismissTimer: ReturnType<typeof setTimeout> | null = null;
+
+export const useTransientToast = create<TransientToastState>((set, get) => ({
+  toast: null,
+  showToast: (toast, options) => {
+    if (dismissTimer) {
+      clearTimeout(dismissTimer);
+      dismissTimer = null;
+    }
+
+    const key = `${toast.id ?? "transient-toast"}:${++toastSequence}`;
+    const nextToast: TransientToast = {
+      ...toast,
+      id: toast.id ?? "transient-toast",
+      dismissible: toast.dismissible ?? false,
+      key,
+    };
+
+    set({ toast: nextToast });
+
+    dismissTimer = setTimeout(() => {
+      if (get().toast?.key === key) {
+        set({ toast: null });
+      }
+      dismissTimer = null;
+    }, options?.durationMs ?? DEFAULT_TRANSIENT_TOAST_DURATION_MS);
+  },
+  clearToast: (key) => {
+    if (key && get().toast?.key !== key) {
+      return;
+    }
+
+    if (dismissTimer) {
+      clearTimeout(dismissTimer);
+      dismissTimer = null;
+    }
+
+    set({ toast: null });
+  },
+}));
+
+export function showTransientToast(
+  toast: TransientToastInput,
+  options?: { durationMs?: number },
+) {
+  useTransientToast.getState().showToast(toast, options);
+}

--- a/apps/desktop/src/store/zustand/tabs/basic.ts
+++ b/apps/desktop/src/store/zustand/tabs/basic.ts
@@ -510,7 +510,7 @@ const shouldCloseChatForSessionNavigation = (
   targetTab: Tab | TabInput,
   chatMode: ChatModeState["chatMode"],
 ): boolean => {
-  if (chatMode !== "FloatingOpen" || targetTab.type !== "sessions") {
+  if (chatMode === "FloatingClosed" || targetTab.type !== "sessions") {
     return false;
   }
 

--- a/apps/desktop/src/store/zustand/tabs/chat-mode.test.ts
+++ b/apps/desktop/src/store/zustand/tabs/chat-mode.test.ts
@@ -28,6 +28,29 @@ describe("Chat Mode", () => {
     expect(useTabs.getState().chatMode).toBe("FloatingOpen");
   });
 
+  test("OPEN_RIGHT_PANEL from FloatingClosed to RightPanelOpen", () => {
+    useTabs.getState().transitionChatMode({ type: "OPEN_RIGHT_PANEL" });
+    expect(useTabs.getState().chatMode).toBe("RightPanelOpen");
+  });
+
+  test("OPEN_RIGHT_PANEL from FloatingOpen to RightPanelOpen", () => {
+    useTabs.getState().transitionChatMode({ type: "OPEN" });
+    useTabs.getState().transitionChatMode({ type: "OPEN_RIGHT_PANEL" });
+    expect(useTabs.getState().chatMode).toBe("RightPanelOpen");
+  });
+
+  test("OPEN from RightPanelOpen to FloatingOpen", () => {
+    useTabs.getState().transitionChatMode({ type: "OPEN_RIGHT_PANEL" });
+    useTabs.getState().transitionChatMode({ type: "OPEN" });
+    expect(useTabs.getState().chatMode).toBe("FloatingOpen");
+  });
+
+  test("TOGGLE from RightPanelOpen to FloatingClosed", () => {
+    useTabs.getState().transitionChatMode({ type: "OPEN_RIGHT_PANEL" });
+    useTabs.getState().transitionChatMode({ type: "TOGGLE" });
+    expect(useTabs.getState().chatMode).toBe("FloatingClosed");
+  });
+
   test("no-op when event is irrelevant for current state", () => {
     useTabs.getState().transitionChatMode({ type: "CLOSE" });
     expect(useTabs.getState().chatMode).toBe("FloatingClosed");
@@ -78,6 +101,22 @@ describe("Chat Mode", () => {
       .tabs.find((tab) => tab.type === "sessions" && tab.id === first.id)!;
 
     useTabs.getState().transitionChatMode({ type: "OPEN" });
+    useTabs.getState().select(firstTab);
+
+    expect(useTabs.getState().chatMode).toBe("FloatingClosed");
+  });
+
+  test("selecting a different session closes the right panel chat", () => {
+    const first = createSessionTab({ id: "first" });
+    const second = createSessionTab({ id: "second" });
+
+    useTabs.getState().openNew(first);
+    useTabs.getState().openNew(second);
+    const firstTab = useTabs
+      .getState()
+      .tabs.find((tab) => tab.type === "sessions" && tab.id === first.id)!;
+
+    useTabs.getState().transitionChatMode({ type: "OPEN_RIGHT_PANEL" });
     useTabs.getState().select(firstTab);
 
     expect(useTabs.getState().chatMode).toBe("FloatingClosed");

--- a/apps/desktop/src/store/zustand/tabs/chat-mode.ts
+++ b/apps/desktop/src/store/zustand/tabs/chat-mode.ts
@@ -1,9 +1,10 @@
 import type { StoreApi } from "zustand";
 
-export type ChatMode = "FloatingOpen" | "FloatingClosed";
+export type ChatMode = "FloatingOpen" | "FloatingClosed" | "RightPanelOpen";
 
 export type ChatEvent =
   | { type: "OPEN" }
+  | { type: "OPEN_RIGHT_PANEL" }
   | { type: "CLOSE" }
   | { type: "TOGGLE" };
 
@@ -21,10 +22,24 @@ const computeNextChatMode = (state: ChatMode, event: ChatEvent): ChatMode => {
       if (event.type === "CLOSE" || event.type === "TOGGLE") {
         return "FloatingClosed";
       }
+      if (event.type === "OPEN_RIGHT_PANEL") {
+        return "RightPanelOpen";
+      }
+      return state;
+    case "RightPanelOpen":
+      if (event.type === "CLOSE" || event.type === "TOGGLE") {
+        return "FloatingClosed";
+      }
+      if (event.type === "OPEN") {
+        return "FloatingOpen";
+      }
       return state;
     case "FloatingClosed":
       if (event.type === "OPEN" || event.type === "TOGGLE") {
         return "FloatingOpen";
+      }
+      if (event.type === "OPEN_RIGHT_PANEL") {
+        return "RightPanelOpen";
       }
       return state;
     default:


### PR DESCRIPTION
Summary:
- Add a direct copy action to the expanded transcript panel.
- Anchor the floating chat panel to the right side of the note surface.
- Cover both behaviors with focused desktop tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global chat mode, keyboard shortcuts, and main layout resizing across many surfaces; transcript copy uses the clipboard API but is localized UI behavior.
> 
> **Overview**
> Adds a **docked right-panel chat** alongside the existing floating overlay, with a new `RightPanelOpen` mode and `OPEN_RIGHT_PANEL` transitions so users can move between float and dock from the toolbar.
> 
> The floating chat **drops in-place “expand to fill anchor”** behavior: it stays **bottom-right** on the note surface, resize math is updated, and the old maximize/collapse control is replaced by **open in right panel** / **float chat** actions. **Escape**, home navigation, the session **Ask** CTA, changelog, and transcript **Esc** handling now treat **any open chat** (floating or docked) consistently; switching sessions still **collapses** chat when leaving the current note.
> 
> Also adds **Copy transcript** on the expanded post-session panel (formatted export text → clipboard) with **short-lived transient toasts**, and fixes chat input text color on the white composer surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 495e5576ff42788a9cc8c611da3778481c544fd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->