### PR TITLE
Add desktop 1.0.36 changelog

### DIFF
--- a/packages/changelog/content/1.0.36.md
+++ b/packages/changelog/content/1.0.36.md
@@ -1,0 +1,15 @@
+---
+date: "2026-06-01"
+summary: "Transcripts are easier to copy, and chat now has clearer floating and right-panel behavior."
+---
+
+## Transcripts
+
+- Expanded transcript panels now include a direct copy action
+- Copying a transcript now uses the same top toast style as the rest of the app
+
+## Chat
+
+- Chat can be opened in the right panel again when you want it pinned beside your note
+- Floating chat now keeps its input readable on the white editor surface
+- Floating chat controls now better match the active chat surface


### PR DESCRIPTION
Summary:
- Add the desktop 1.0.36 changelog entry for transcript copy and chat placement updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no application or infrastructure changes.
> 
> **Overview**
> Adds the **desktop 1.0.36** release notes at `packages/changelog/content/1.0.36.md` (dated 2026-06-01), using the same front matter and bullet layout as other version entries.
> 
> The entry documents **transcript** improvements (copy action on expanded panels, copy feedback via the standard top toast) and **chat** improvements (right-panel pinning, floating input readability on the white editor, control styling aligned with the active chat surface).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02dcad7e4a18eaf1ee7eb1a6b1bf74f7f57b68d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->