### PR TITLE
fix(desktop): show live transcript across tabs

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -10,6 +10,7 @@ import { type MouseEvent, type PointerEvent, useCallback, useRef } from "react";
 
 import { cn } from "@hypr/utils";
 
+import { resolveMainSurfaceChrome } from "./main-surface-chrome";
 import { ClassicMainSidebar } from "./shell-sidebar";
 import { ClassicMainTabContent } from "./tab-content";
 import { TopMeetingTimeline } from "./top-meeting-timeline";
@@ -22,6 +23,7 @@ import {
 import { useClassicMainTabsShortcuts } from "./useTabsShortcuts";
 
 import { useShell } from "~/contexts/shell";
+import { GlobalLiveTranscriptAccessory } from "~/session/components/bottom-accessory/global-live";
 import { useConfigValue } from "~/shared/config";
 import {
   hasCustomSidebarTab,
@@ -66,6 +68,14 @@ export function ClassicMainBody() {
   const showLeftSurfaceChromeBack = hasLeftSurfaceCustomSidebar;
   const enableMainAreaTopDrag =
     showSidebarTimelineChrome || hasLeftSurfaceCustomSidebar;
+  const mainSurfaceChrome = resolveMainSurfaceChrome({
+    hasLeftSurfaceCustomSidebar,
+    isChangelog,
+    leftSidebarExpanded: leftsidebar.expanded,
+    showSidebarTimeline,
+    showSidebarTimelineChrome,
+    showTopTimeline,
+  });
   const mainAreaTopDrag = useMainAreaTopWindowDrag(enableMainAreaTopDrag);
   const update = useDesktopUpdateControl();
 
@@ -148,12 +158,17 @@ export function ClassicMainBody() {
           onPointerMove={mainAreaTopDrag.onPointerMove}
           onPointerUp={mainAreaTopDrag.onPointerEnd}
         >
-          {currentTab ? (
-            <ClassicMainTabContent
-              key={uniqueIdfromTab(currentTab)}
-              tab={currentTab as Tab}
-            />
-          ) : null}
+          <GlobalLiveTranscriptAccessory
+            currentTab={currentTab}
+            surfaceChrome={mainSurfaceChrome}
+          >
+            {currentTab ? (
+              <ClassicMainTabContent
+                key={uniqueIdfromTab(currentTab)}
+                tab={currentTab as Tab}
+              />
+            ) : null}
+          </GlobalLiveTranscriptAccessory>
         </div>
       </div>
     </div>

--- a/apps/desktop/src/main/main-surface-chrome.ts
+++ b/apps/desktop/src/main/main-surface-chrome.ts
@@ -1,0 +1,35 @@
+import { type MainSurfaceChrome } from "~/shared/main";
+
+export function resolveMainSurfaceChrome({
+  hasLeftSurfaceCustomSidebar,
+  isChangelog,
+  leftSidebarExpanded,
+  showSidebarTimeline,
+  showSidebarTimelineChrome,
+  showTopTimeline,
+}: {
+  hasLeftSurfaceCustomSidebar: boolean;
+  isChangelog: boolean;
+  leftSidebarExpanded: boolean;
+  showSidebarTimeline: boolean;
+  showSidebarTimelineChrome: boolean;
+  showTopTimeline: boolean;
+}): MainSurfaceChrome {
+  if (showSidebarTimelineChrome && !leftSidebarExpanded) {
+    return "top-borderless";
+  }
+
+  if (isChangelog && !showSidebarTimeline) {
+    return "top";
+  }
+
+  if (showSidebarTimeline || hasLeftSurfaceCustomSidebar) {
+    return "left";
+  }
+
+  if (showTopTimeline) {
+    return "top";
+  }
+
+  return "default";
+}

--- a/apps/desktop/src/main/shell-frame.tsx
+++ b/apps/desktop/src/main/shell-frame.tsx
@@ -1,12 +1,9 @@
 import { ClassicMainBody } from "./body";
+import { resolveMainSurfaceChrome } from "./main-surface-chrome";
 
 import { useShell } from "~/contexts/shell";
 import { useConfigValue } from "~/shared/config";
-import {
-  type MainSurfaceChrome,
-  MainShellBodyFrame,
-  MainShellScaffold,
-} from "~/shared/main";
+import { MainShellBodyFrame, MainShellScaffold } from "~/shared/main";
 import { ToastArea } from "~/sidebar/toast";
 import {
   hasCustomSidebarTab,
@@ -27,23 +24,19 @@ export function ClassicMainShellFrame() {
   const showSidebarTimelineChrome =
     sidebarTimelineEnabled && !hasCustomSidebar && !isOnboarding;
   const showSidebarTimeline = showSidebarTimelineChrome && leftsidebar.expanded;
-  const showCollapsedSidebarTimelineChrome =
-    showSidebarTimelineChrome && !leftsidebar.expanded;
   const showTopTimeline =
     leftsidebar.expanded &&
     !showSidebarTimeline &&
     !hasCustomSidebar &&
     !isOnboarding;
-  const mainSurfaceChrome: MainSurfaceChrome =
-    showCollapsedSidebarTimelineChrome
-      ? "top-borderless"
-      : isChangelog && !showSidebarTimeline
-        ? "top"
-        : showSidebarTimeline || hasLeftSurfaceCustomSidebar
-          ? "left"
-          : showTopTimeline
-            ? "top"
-            : "default";
+  const mainSurfaceChrome = resolveMainSurfaceChrome({
+    hasLeftSurfaceCustomSidebar,
+    isChangelog,
+    leftSidebarExpanded: leftsidebar.expanded,
+    showSidebarTimeline,
+    showSidebarTimelineChrome,
+    showTopTimeline,
+  });
 
   return (
     <MainShellScaffold

--- a/apps/desktop/src/session/components/bottom-accessory/global-live.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/global-live.test.tsx
@@ -1,0 +1,333 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  live: {
+    status: "active" as "inactive" | "active" | "finalizing",
+    sessionId: "live-session" as string | null,
+    requestedLiveTranscription: true as boolean | null,
+    liveTranscriptionActive: true as boolean | null,
+  },
+  resize: vi.fn(),
+}));
+
+vi.mock("@hypr/ui/components/ui/resizable", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    ResizablePanelGroup: ({
+      children,
+      direction,
+    }: {
+      children: React.ReactNode;
+      direction: string;
+    }) => (
+      <div data-direction={direction} data-testid="panel-group">
+        {children}
+      </div>
+    ),
+    ResizablePanel: React.forwardRef<
+      { resize: (size: number) => void },
+      {
+        children: React.ReactNode;
+        className?: string;
+        defaultSize?: number;
+        maxSize?: number;
+        minSize?: number;
+      }
+    >(function ResizablePanel(
+      { children, className, defaultSize, maxSize, minSize },
+      ref,
+    ) {
+      React.useImperativeHandle(ref, () => ({
+        resize: mocks.resize,
+      }));
+
+      return (
+        <div
+          data-class-name={className}
+          data-default-size={defaultSize}
+          data-max-size={maxSize}
+          data-min-size={minSize}
+          data-testid="panel"
+        >
+          {children}
+        </div>
+      );
+    }),
+    ResizableHandle: ({ className }: { className?: string }) => (
+      <div data-class-name={className} data-testid="resize-handle" />
+    ),
+  };
+});
+
+vi.mock("./during-session", () => ({
+  DuringSessionAccessory: ({
+    fillHeight,
+    isExpanded,
+    isFinalizing,
+    sessionId,
+  }: {
+    fillHeight?: boolean;
+    isExpanded?: boolean;
+    isFinalizing?: boolean;
+    sessionId: string;
+  }) => (
+    <div
+      data-fill-height={String(fillHeight)}
+      data-finalizing={String(isFinalizing)}
+      data-is-expanded={String(isExpanded)}
+      data-session-id={sessionId}
+      data-testid="during-session-accessory"
+    />
+  ),
+}));
+
+vi.mock("~/stt/contexts", () => ({
+  useListener: (
+    selector: (state: {
+      live: {
+        status: "inactive" | "active" | "finalizing";
+        sessionId: string | null;
+        requestedLiveTranscription: boolean | null;
+        liveTranscriptionActive: boolean | null;
+      };
+    }) => unknown,
+  ) =>
+    selector({
+      live: mocks.live,
+    }),
+}));
+
+import { GlobalLiveTranscriptAccessory } from "./global-live";
+
+describe("GlobalLiveTranscriptAccessory", () => {
+  beforeEach(() => {
+    cleanup();
+    mocks.live.status = "active";
+    mocks.live.sessionId = "live-session";
+    mocks.live.requestedLiveTranscription = true;
+    mocks.live.liveTranscriptionActive = true;
+    mocks.resize.mockClear();
+  });
+
+  it("does not duplicate the live transcript on the active session tab", () => {
+    render(
+      <GlobalLiveTranscriptAccessory
+        currentTab={{ type: "sessions", id: "live-session" } as any}
+      >
+        <div data-testid="tab-content" />
+      </GlobalLiveTranscriptAccessory>,
+    );
+
+    expect(screen.getByTestId("tab-content")).toBeTruthy();
+    expect(screen.queryByTestId("during-session-accessory")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Expand Live" })).toBeNull();
+  });
+
+  it("keeps tab content mounted when the global live transcript appears", () => {
+    mocks.live.sessionId = null;
+    const mountMock = vi.fn();
+
+    class TabContent extends React.Component {
+      componentDidMount() {
+        mountMock();
+      }
+
+      render() {
+        return <div data-testid="tab-content" />;
+      }
+    }
+
+    const view = render(
+      <GlobalLiveTranscriptAccessory currentTab={{ type: "settings" } as any}>
+        <TabContent />
+      </GlobalLiveTranscriptAccessory>,
+    );
+
+    mocks.live.sessionId = "live-session";
+    view.rerender(
+      <GlobalLiveTranscriptAccessory currentTab={{ type: "settings" } as any}>
+        <TabContent />
+      </GlobalLiveTranscriptAccessory>,
+    );
+
+    expect(screen.getByTestId("tab-content")).toBeTruthy();
+    expect(screen.getByTestId("during-session-accessory")).toBeTruthy();
+    expect(mountMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows and expands the live transcript for other tabs", () => {
+    render(
+      <GlobalLiveTranscriptAccessory
+        currentTab={{ type: "sessions", id: "other-session" } as any}
+      >
+        <div data-testid="tab-content" />
+      </GlobalLiveTranscriptAccessory>,
+    );
+
+    expect(
+      screen.getByTestId("during-session-accessory").dataset,
+    ).toMatchObject({
+      sessionId: "live-session",
+      isExpanded: "false",
+      fillHeight: "false",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand Live" }));
+
+    expect(
+      screen.getByTestId("during-session-accessory").dataset,
+    ).toMatchObject({
+      sessionId: "live-session",
+      isExpanded: "true",
+      fillHeight: "true",
+    });
+    expect(screen.getByTestId("resize-handle")).toBeTruthy();
+    expect(mocks.resize).toHaveBeenCalledWith(22);
+  });
+
+  it("resets expanded state when the live session changes", () => {
+    const view = render(
+      <GlobalLiveTranscriptAccessory
+        currentTab={{ type: "sessions", id: "other-session" } as any}
+      >
+        <div data-testid="tab-content" />
+      </GlobalLiveTranscriptAccessory>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand Live" }));
+
+    expect(
+      screen.getByTestId("during-session-accessory").dataset,
+    ).toMatchObject({
+      sessionId: "live-session",
+      isExpanded: "true",
+      fillHeight: "true",
+    });
+
+    mocks.live.sessionId = "next-live-session";
+    view.rerender(
+      <GlobalLiveTranscriptAccessory
+        currentTab={{ type: "sessions", id: "other-session" } as any}
+      >
+        <div data-testid="tab-content" />
+      </GlobalLiveTranscriptAccessory>,
+    );
+
+    expect(
+      screen.getByTestId("during-session-accessory").dataset,
+    ).toMatchObject({
+      sessionId: "next-live-session",
+      isExpanded: "false",
+      fillHeight: "false",
+    });
+    expect(screen.queryByTestId("resize-handle")).toBeNull();
+  });
+
+  it("keeps the live panel flush against the bottom divider", () => {
+    render(
+      <GlobalLiveTranscriptAccessory currentTab={{ type: "settings" } as any}>
+        <div data-testid="tab-content" />
+      </GlobalLiveTranscriptAccessory>,
+    );
+
+    const panel = screen.getByTestId("during-session-accessory");
+    const afterBorderContent = panel.parentElement;
+
+    expect(afterBorderContent?.className).not.toContain("pt-1.5");
+    expect(afterBorderContent?.className).not.toContain("mt-1");
+  });
+
+  it("uses the active live footer frame outside the active session tab", () => {
+    render(
+      <GlobalLiveTranscriptAccessory currentTab={{ type: "settings" } as any}>
+        <div data-testid="tab-content" />
+      </GlobalLiveTranscriptAccessory>,
+    );
+
+    const transcriptCard = screen.getByTestId(
+      "during-session-accessory",
+    ).parentElement;
+
+    expect(
+      transcriptCard?.hasAttribute("data-global-live-transcript-card"),
+    ).toBe(true);
+    expect(transcriptCard?.className).not.toContain("border-x");
+    expect(transcriptCard?.className).not.toContain("border-b");
+    expect(transcriptCard?.className).not.toContain("rounded-b-xl");
+  });
+
+  it("keeps the current surface divider in top timeline mode", () => {
+    render(
+      <GlobalLiveTranscriptAccessory
+        currentTab={{ type: "sessions", id: "other-session" } as any}
+        surfaceChrome="top"
+      >
+        <div data-chat-floating-anchor data-testid="tab-content" />
+      </GlobalLiveTranscriptAccessory>,
+    );
+
+    const shell = document.querySelector("[data-global-live-transcript-shell]");
+
+    expect(shell?.className).toContain(
+      "[&_[data-chat-floating-anchor]]:!border-b",
+    );
+    expect(shell?.className).not.toContain("!rounded-bl-none");
+  });
+
+  it("keeps the current surface divider and left edge in sidebar timeline mode", () => {
+    render(
+      <GlobalLiveTranscriptAccessory
+        currentTab={{ type: "sessions", id: "other-session" } as any}
+        surfaceChrome="left"
+      >
+        <div data-chat-floating-anchor data-testid="tab-content" />
+      </GlobalLiveTranscriptAccessory>,
+    );
+
+    const shell = document.querySelector("[data-global-live-transcript-shell]");
+
+    expect(shell?.className).toContain(
+      "[&_[data-chat-floating-anchor]]:!border-b",
+    );
+    expect(shell?.className).toContain(
+      "[&_[data-chat-floating-anchor]]:!rounded-bl-none",
+    );
+  });
+
+  it("does not show a global live transcript while recording without live transcription", () => {
+    mocks.live.requestedLiveTranscription = false;
+    mocks.live.liveTranscriptionActive = false;
+
+    render(
+      <GlobalLiveTranscriptAccessory currentTab={{ type: "settings" } as any}>
+        <div data-testid="tab-content" />
+      </GlobalLiveTranscriptAccessory>,
+    );
+
+    expect(screen.getByTestId("tab-content")).toBeTruthy();
+    expect(screen.queryByTestId("during-session-accessory")).toBeNull();
+  });
+
+  it("keeps finalizing visible outside the active session tab", () => {
+    mocks.live.status = "finalizing";
+    mocks.live.requestedLiveTranscription = false;
+    mocks.live.liveTranscriptionActive = false;
+
+    render(
+      <GlobalLiveTranscriptAccessory currentTab={{ type: "settings" } as any}>
+        <div data-testid="tab-content" />
+      </GlobalLiveTranscriptAccessory>,
+    );
+
+    expect(
+      screen.getByTestId("during-session-accessory").dataset,
+    ).toMatchObject({
+      sessionId: "live-session",
+      finalizing: "true",
+    });
+    expect(screen.queryByRole("button", { name: "Expand Live" })).toBeNull();
+  });
+});

--- a/apps/desktop/src/session/components/bottom-accessory/global-live.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/global-live.tsx
@@ -1,0 +1,189 @@
+import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
+
+import {
+  type ImperativePanelHandle,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@hypr/ui/components/ui/resizable";
+import { cn } from "@hypr/utils";
+
+import { DuringSessionAccessory } from "./during-session";
+import { ExpandToggle } from "./expand-toggle";
+import { shouldShowLiveTranscriptAccessory } from "./live-visibility";
+
+import { type MainSurfaceChrome } from "~/shared/main";
+import { type Tab } from "~/store/zustand/tabs";
+import { useListener } from "~/stt/contexts";
+
+const GLOBAL_LIVE_AFTER_BORDER_EXPANDED_SIZE = 22;
+
+export function GlobalLiveTranscriptAccessory({
+  children,
+  currentTab,
+  surfaceChrome = "default",
+}: {
+  children: ReactNode;
+  currentTab: Tab | null;
+  surfaceChrome?: MainSurfaceChrome;
+}) {
+  const live = useListener((state) => ({
+    status: state.live.status,
+    sessionId: state.live.sessionId,
+    requestedLiveTranscription: state.live.requestedLiveTranscription,
+    liveTranscriptionActive: state.live.liveTranscriptionActive,
+  }));
+  const sessionId = live.sessionId;
+  const currentTabOwnsLiveAccessory =
+    currentTab?.type === "sessions" && currentTab.id === sessionId;
+  const accessorySessionId =
+    sessionId &&
+    !currentTabOwnsLiveAccessory &&
+    shouldShowLiveTranscriptAccessory(live)
+      ? sessionId
+      : null;
+
+  return (
+    <GlobalLiveTranscriptAccessoryContent
+      sessionId={accessorySessionId}
+      isFinalizing={live.status === "finalizing"}
+      surfaceChrome={surfaceChrome}
+    >
+      {children}
+    </GlobalLiveTranscriptAccessoryContent>
+  );
+}
+
+function GlobalLiveTranscriptAccessoryContent({
+  children,
+  sessionId,
+  isFinalizing,
+  surfaceChrome,
+}: {
+  children: ReactNode;
+  sessionId: string | null;
+  isFinalizing: boolean;
+  surfaceChrome: MainSurfaceChrome;
+}) {
+  const [expandedLiveSession, setExpandedLiveSession] = useState<{
+    sessionId: string | null;
+    isExpanded: boolean;
+  }>({ sessionId: null, isExpanded: false });
+  const afterBorderPanelRef = useRef<ImperativePanelHandle>(null);
+  const afterBorderSize = GLOBAL_LIVE_AFTER_BORDER_EXPANDED_SIZE;
+  const hasLiveAccessory = Boolean(sessionId);
+  const canExpand = hasLiveAccessory && !isFinalizing;
+  const isExpanded =
+    canExpand &&
+    expandedLiveSession.sessionId === sessionId &&
+    expandedLiveSession.isExpanded;
+  const useResizableAfterBorder = canExpand && isExpanded;
+
+  useLayoutEffect(() => {
+    if (useResizableAfterBorder) {
+      afterBorderPanelRef.current?.resize(afterBorderSize);
+    }
+  }, [afterBorderSize, useResizableAfterBorder]);
+
+  const bottomBorderHandle = canExpand ? (
+    <ExpandToggle
+      isExpanded={isExpanded}
+      onToggle={() =>
+        setExpandedLiveSession((value) => ({
+          sessionId,
+          isExpanded: value.sessionId === sessionId ? !value.isExpanded : true,
+        }))
+      }
+      label="Live"
+      collapsedClassName="bg-neutral-50"
+      expandedClassName="bg-neutral-50"
+    />
+  ) : null;
+
+  const afterBorder = sessionId ? (
+    <DuringSessionAccessory
+      sessionId={sessionId}
+      isFinalizing={isFinalizing}
+      isExpanded={isExpanded}
+      fillHeight={useResizableAfterBorder}
+    />
+  ) : null;
+
+  return (
+    <div
+      data-global-live-transcript-shell
+      className={cn([
+        "flex h-full flex-col",
+        hasLiveAccessory && "[&_[data-chat-floating-anchor]]:!border-b",
+        hasLiveAccessory &&
+          surfaceChrome === "left" &&
+          "[&_[data-chat-floating-anchor]]:!rounded-bl-none",
+      ])}
+    >
+      <ResizablePanelGroup direction="vertical" className="min-h-0 flex-1">
+        <ResizablePanel
+          defaultSize={useResizableAfterBorder ? 100 - afterBorderSize : 100}
+          minSize={35}
+          className="min-h-0"
+        >
+          <div className="relative h-full min-h-0">
+            {children}
+            {bottomBorderHandle ? (
+              <div className="pointer-events-none absolute right-0 bottom-0 left-0 z-20">
+                <div className="pointer-events-auto relative">
+                  {bottomBorderHandle}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </ResizablePanel>
+        {useResizableAfterBorder ? (
+          <>
+            <ResizableHandle className="z-10 !bg-transparent data-[panel-group-direction=vertical]:-mb-px" />
+            <ResizablePanel
+              ref={afterBorderPanelRef}
+              defaultSize={afterBorderSize}
+              minSize={10}
+              maxSize={60}
+              className="min-h-[96px] overflow-hidden"
+            >
+              <GlobalLiveAfterBorderContent
+                bottomBorderHandle={bottomBorderHandle}
+                fill
+              >
+                {afterBorder}
+              </GlobalLiveAfterBorderContent>
+            </ResizablePanel>
+          </>
+        ) : null}
+      </ResizablePanelGroup>
+      {afterBorder && !useResizableAfterBorder ? (
+        <GlobalLiveAfterBorderContent bottomBorderHandle={bottomBorderHandle}>
+          {afterBorder}
+        </GlobalLiveAfterBorderContent>
+      ) : null}
+    </div>
+  );
+}
+
+function GlobalLiveAfterBorderContent({
+  children,
+  bottomBorderHandle,
+  fill = false,
+}: {
+  children: ReactNode;
+  bottomBorderHandle: ReactNode;
+  fill?: boolean;
+}) {
+  return (
+    <div
+      data-global-live-transcript-card
+      className={cn([
+        !bottomBorderHandle && "mt-1",
+        fill && "flex h-full min-h-0 flex-col overflow-hidden",
+      ])}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -13,6 +13,8 @@ const hoisted = vi.hoisted(() => ({
     }
   >(),
   live: {
+    status: "inactive" as "inactive" | "active" | "finalizing",
+    sessionId: null as string | null,
     requestedLiveTranscription: true as boolean | null,
     liveTranscriptionActive: true as boolean | null,
   },
@@ -42,6 +44,8 @@ vi.mock("~/stt/contexts", () => ({
   useListener: (
     selector: (state: {
       live: {
+        status: "inactive" | "active" | "finalizing";
+        sessionId: string | null;
         requestedLiveTranscription: boolean | null;
         liveTranscriptionActive: boolean | null;
       };
@@ -65,6 +69,8 @@ import { useSessionBottomAccessory } from "./index";
 describe("useSessionBottomAccessory", () => {
   beforeEach(() => {
     hoisted.hotkeys.clear();
+    hoisted.live.status = "inactive";
+    hoisted.live.sessionId = null;
     hoisted.live.requestedLiveTranscription = true;
     hoisted.live.liveTranscriptionActive = true;
     useShellMock.mockReturnValue({
@@ -212,6 +218,45 @@ describe("useSessionBottomAccessory", () => {
     expect(result.current.bottomAccessoryState).toBeNull();
     expect(result.current.bottomAccessory).toBeNull();
     expect(result.current.bottomBorderHandle).toBeNull();
+  });
+
+  it("defers local transcript controls to the global live panel for another active session", () => {
+    hoisted.live.status = "active";
+    hoisted.live.sessionId = "live-session";
+
+    const { result } = renderHook(() =>
+      useSessionBottomAccessory({
+        sessionId: "session-1",
+        sessionMode: "inactive",
+        audioUrl: "file:///session.wav",
+        hasTranscript: true,
+      }),
+    );
+
+    expect(result.current.bottomAccessoryState).toBeNull();
+    expect(result.current.bottomAccessory).toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
+  });
+
+  it("keeps batch progress visible while another session is live", () => {
+    hoisted.live.status = "active";
+    hoisted.live.sessionId = "live-session";
+
+    const { result } = renderHook(() =>
+      useSessionBottomAccessory({
+        sessionId: "session-1",
+        sessionMode: "running_batch",
+        audioUrl: "file:///session.wav",
+        hasTranscript: true,
+      }),
+    );
+
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "playback",
+      expanded: false,
+    });
+    expect(result.current.bottomAccessory).not.toBeNull();
+    expect(result.current.bottomBorderHandle).not.toBeNull();
   });
 
   it("keeps batch progress visible while batch transcription is running", () => {

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -3,6 +3,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 
 import { DuringSessionAccessory } from "./during-session";
 import { ExpandToggle } from "./expand-toggle";
+import { shouldShowLiveTranscriptAccessory } from "./live-visibility";
 import { PostSessionAccessory } from "./post-session";
 
 import { useShell } from "~/contexts/shell";
@@ -38,7 +39,12 @@ export function useSessionBottomAccessory({
   const live = useListener((state) => state.live);
   const { chat } = useShell();
   const liveCaptureMode = getLiveCaptureUiMode(live);
-  const showLiveAccessory = isLive && liveCaptureMode === "live";
+  const shouldDeferToGlobalLiveAccessory =
+    live.sessionId !== null &&
+    live.sessionId !== sessionId &&
+    shouldShowLiveTranscriptAccessory(live);
+  const showLiveAccessory =
+    !shouldDeferToGlobalLiveAccessory && isLive && liveCaptureMode === "live";
   const canExpandLiveTranscript = showLiveAccessory;
   const effectiveExpanded =
     isLive && !canExpandLiveTranscript ? false : isExpanded;
@@ -60,7 +66,10 @@ export function useSessionBottomAccessory({
   }, [isLive, canExpandLiveTranscript, isExpanded]);
 
   const showPostSession =
-    (isInactive && (hasAudio || hasTranscript)) || isRunningBatch;
+    isRunningBatch ||
+    (!shouldDeferToGlobalLiveAccessory &&
+      isInactive &&
+      (hasAudio || hasTranscript));
 
   useHotkeys(
     "esc",

--- a/apps/desktop/src/session/components/bottom-accessory/live-visibility.ts
+++ b/apps/desktop/src/session/components/bottom-accessory/live-visibility.ts
@@ -1,0 +1,29 @@
+import {
+  getLiveCaptureUiMode,
+  type LiveSessionStatus,
+} from "~/store/zustand/listener/general-shared";
+
+type LiveTranscriptAccessoryState = {
+  status: LiveSessionStatus;
+  sessionId: string | null;
+  requestedLiveTranscription: boolean | null;
+  liveTranscriptionActive: boolean | null;
+};
+
+export function shouldShowLiveTranscriptAccessory(
+  live: LiveTranscriptAccessoryState,
+) {
+  if (!live.sessionId) {
+    return false;
+  }
+
+  if (live.status === "finalizing") {
+    return true;
+  }
+
+  if (live.status !== "active") {
+    return false;
+  }
+
+  return getLiveCaptureUiMode(live) === "live";
+}

--- a/apps/desktop/src/session/components/session-surface.tsx
+++ b/apps/desktop/src/session/components/session-surface.tsx
@@ -5,6 +5,7 @@ export function SessionSurface({
   children,
   afterBorder,
   afterBorderExpanded,
+  afterBorderFlush,
   afterBorderResizable,
   bottomBorderHandle,
   floatingButton,
@@ -14,6 +15,7 @@ export function SessionSurface({
   children: React.ReactNode;
   afterBorder?: React.ReactNode;
   afterBorderExpanded?: boolean;
+  afterBorderFlush?: boolean;
   afterBorderResizable?: boolean;
   bottomBorderHandle?: React.ReactNode;
   floatingButton?: React.ReactNode;
@@ -23,6 +25,7 @@ export function SessionSurface({
     <StandardTabWrapper
       afterBorder={afterBorder}
       afterBorderExpanded={afterBorderExpanded}
+      afterBorderFlush={afterBorderFlush}
       afterBorderResizable={afterBorderResizable}
       bottomBorderHandle={bottomBorderHandle}
       floatingButton={floatingButton}

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -234,6 +234,7 @@ function TabContentNoteInner({
       }
       afterBorder={bottomAccessory}
       afterBorderExpanded={resizeTranscriptSurface}
+      afterBorderFlush={bottomAccessoryState?.mode === "live"}
       afterBorderResizable={canResizeTranscriptSurface}
       bottomBorderHandle={bottomBorderHandle}
       mergeAfterBorder={mergeTranscriptSurface}

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -89,6 +89,23 @@ vi.mock("~/contexts/shell", () => ({
   }),
 }));
 
+vi.mock("~/session/components/bottom-accessory/global-live", () => ({
+  GlobalLiveTranscriptAccessory: ({
+    children,
+    currentTab,
+  }: {
+    children: React.ReactNode;
+    currentTab: { type: string } | null;
+  }) => (
+    <div
+      data-current-tab-type={currentTab?.type ?? ""}
+      data-testid="global-live-transcript-accessory"
+    >
+      {children}
+    </div>
+  ),
+}));
+
 vi.mock("~/shared/config", () => ({
   useConfigValue: () => mocks.sidebarTimelineEnabled,
 }));

--- a/apps/desktop/src/shared/main/index.test.tsx
+++ b/apps/desktop/src/shared/main/index.test.tsx
@@ -163,6 +163,24 @@ describe("StandardTabWrapper", () => {
     expect(resizeMock).not.toHaveBeenCalled();
   });
 
+  it("can render bottom content flush against the divider", () => {
+    render(
+      <StandardTabWrapper
+        afterBorder={<div data-testid="bottom-area" />}
+        afterBorderFlush
+        bottomBorderHandle={<button>Live</button>}
+      >
+        <div data-testid="main-area" />
+      </StandardTabWrapper>,
+    );
+
+    const bottomArea = screen.getByTestId("bottom-area");
+    const afterBorderContent = bottomArea.parentElement;
+
+    expect(afterBorderContent?.className).not.toContain("pt-1.5");
+    expect(afterBorderContent?.className).not.toContain("mt-1");
+  });
+
   it("keeps main content mounted when expandable bottom content toggles", () => {
     const mountMock = vi.fn();
 

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -27,6 +27,7 @@ export function StandardTabWrapper({
   bottomBorderHandle,
   afterBorderResizable = false,
   afterBorderExpanded = false,
+  afterBorderFlush = false,
   floatingButton,
   mergeAfterBorder = false,
   noBorder = false,
@@ -34,6 +35,7 @@ export function StandardTabWrapper({
   children: React.ReactNode;
   afterBorder?: React.ReactNode;
   bottomBorderHandle?: React.ReactNode;
+  afterBorderFlush?: boolean;
   afterBorderResizable?: boolean;
   afterBorderExpanded?: boolean;
   floatingButton?: React.ReactNode;
@@ -98,6 +100,7 @@ export function StandardTabWrapper({
               ])}
             >
               <AfterBorderContent
+                flush={afterBorderFlush}
                 bottomBorderHandle={bottomBorderHandle}
                 fill={afterBorderExpanded}
                 mergeAfterBorder={mergeAfterBorder}
@@ -110,6 +113,7 @@ export function StandardTabWrapper({
       </ResizablePanelGroup>
       {afterBorder && !useResizableAfterBorder ? (
         <AfterBorderContent
+          flush={afterBorderFlush}
           bottomBorderHandle={bottomBorderHandle}
           mergeAfterBorder={mergeAfterBorder}
         >
@@ -177,11 +181,13 @@ function AfterBorderContent({
   children,
   bottomBorderHandle,
   fill = false,
+  flush = false,
   mergeAfterBorder,
 }: {
   children: React.ReactNode;
   bottomBorderHandle?: React.ReactNode;
   fill?: boolean;
+  flush?: boolean;
   mergeAfterBorder: boolean;
 }) {
   return (
@@ -189,7 +195,7 @@ function AfterBorderContent({
       data-main-after-border-content
       data-main-after-border-merged={mergeAfterBorder ? "" : undefined}
       className={cn([
-        !mergeAfterBorder && (bottomBorderHandle ? "pt-1.5" : "mt-1"),
+        !flush && !mergeAfterBorder && (bottomBorderHandle ? "pt-1.5" : "mt-1"),
         fill && "flex h-full min-h-0 flex-col overflow-hidden",
       ])}
     >


### PR DESCRIPTION
Mount the active meeting live transcript in the main shell for non-active tabs and suppress competing per-session transcript controls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live-session UI coordination across the main shell and per-tab accessories; behavior is heavily tested but wrong deferral could hide transcripts or batch UI on the wrong tab.
> 
> **Overview**
> The desktop main area now wraps tab content in **`GlobalLiveTranscriptAccessory`**, so an active meeting’s live (or finalizing) transcript can appear at the bottom while you’re on **other** tabs—without unmounting the current tab. On the **live session tab**, the global layer stays off so the existing per-session live UI is not duplicated.
> 
> Per-session **`useSessionBottomAccessory`** defers live/post-session transcript chrome when another session owns the global live panel (batch progress on the open tab is unchanged). Shared **`shouldShowLiveTranscriptAccessory`** centralizes when live UI should show (active live mode vs finalizing, not record-only).
> 
> **`resolveMainSurfaceChrome`** replaces duplicated shell/body logic; the global footer adjusts borders for top vs sidebar timeline modes. **`StandardTabWrapper`** / session surfaces gain **`afterBorderFlush`** so live panels sit flush on the active session tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfbc6535ed72053330e873b23ff3f52bd313d47e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->