### PR TITLE
fix(desktop): tuck chat fab during active meetings

### DIFF
--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -200,6 +200,42 @@ describe("FloatingActionButton", () => {
     expect(wrapper?.className).toContain("group-hover:translate-y-0");
   });
 
+  it("keeps the chat FAB tucked during active meetings", () => {
+    hoisted.sessionMode = "active";
+
+    render(<FloatingActionButton tab={tab} />);
+
+    const wrapper = screen.getByText("Ask Anarlog anything").parentElement;
+    const hoverZone = wrapper?.parentElement;
+
+    expect(hoverZone?.className).toContain("group");
+    expect(hoverZone?.className).toContain("pointer-events-auto");
+    expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
+    expect(wrapper?.style.getPropertyValue("--floating-fab-tuck-offset")).toBe(
+      "calc(100% - 0.5rem + 18px)",
+    );
+    expect(wrapper?.className).toContain("pointer-events-none");
+    expect(wrapper?.className).toContain("group-hover:pointer-events-auto");
+    expect(wrapper?.className).toContain("group-hover:translate-y-0");
+  });
+
+  it("shows the tucked chat FAB during active meetings before transcript exists", () => {
+    hoisted.sessionMode = "active";
+    hoisted.hasTranscript = false;
+
+    render(<FloatingActionButton tab={tab} />);
+
+    const wrapper = screen.getByText("Ask Anarlog anything").parentElement;
+
+    expect(
+      screen.queryByRole("button", { name: "Start listening" }),
+    ).toBeNull();
+    expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
+    expect(wrapper?.style.getPropertyValue("--floating-fab-tuck-offset")).toBe(
+      "calc(100% - 0.5rem + 18px)",
+    );
+  });
+
   it("tucks the listen FAB near the editor caret instead of scroll state", () => {
     hoisted.hasTranscript = false;
     hoisted.isCaretNearBottom = true;

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -27,15 +27,17 @@ export function FloatingActionButton({
   skipReason?: string | null;
   tab: Extract<Tab, { type: "sessions" }>;
 }) {
-  const shouldShowListen = useShouldShowListeningFab(tab);
-  const shouldShowChat = useShouldShowChatFab(tab);
+  const sessionMode = useListener((state) => state.getSessionMode(tab.id));
+  const isLiveSessionActive = sessionMode === "active";
+  const shouldShowListen = useShouldShowListeningFab(tab, sessionMode);
+  const shouldShowChat = useShouldShowChatFab(tab, sessionMode);
   const isCaretNearBottom = useCaretPosition()?.isCaretNearBottom ?? false;
   const showSkipReason = !!skipReason;
   const showAction = shouldShowListen || shouldShowChat;
   const tuckAction =
     !showSkipReason &&
     showAction &&
-    (isCaretNearBottom || (shouldShowChat && hidden));
+    (isCaretNearBottom || (shouldShowChat && (hidden || isLiveSessionActive)));
 
   if (!showSkipReason && !showAction) {
     return null;
@@ -91,16 +93,23 @@ export function FloatingActionButton({
   );
 }
 
-function useShouldShowListeningFab(tab: Extract<Tab, { type: "sessions" }>) {
+function useShouldShowListeningFab(
+  tab: Extract<Tab, { type: "sessions" }>,
+  sessionMode: string,
+) {
   const currentTab = useCurrentNoteTab(tab);
   const hasTranscript = useHasTranscript(tab.id);
 
-  return currentTab.type === "raw" && !hasTranscript;
+  return (
+    sessionMode === "inactive" && currentTab.type === "raw" && !hasTranscript
+  );
 }
 
-function useShouldShowChatFab(tab: Extract<Tab, { type: "sessions" }>) {
+function useShouldShowChatFab(
+  tab: Extract<Tab, { type: "sessions" }>,
+  sessionMode: string,
+) {
   const hasTranscript = useHasTranscript(tab.id);
-  const sessionMode = useListener((state) => state.getSessionMode(tab.id));
   const currentTab = useCurrentNoteTab(tab);
   const enhancedNoteId = currentTab.type === "enhanced" ? currentTab.id : null;
   const taskId = enhancedNoteId
@@ -125,7 +134,14 @@ function useShouldShowChatFab(tab: Extract<Tab, { type: "sessions" }>) {
         !hasContent &&
         isBlockingLLMStatus(llmStatus)));
 
-  return hasTranscript && sessionMode === "inactive" && !hasVisibleIssue;
+  const canShowForSessionMode =
+    sessionMode === "inactive" || sessionMode === "active";
+
+  return (
+    canShowForSessionMode &&
+    (hasTranscript || sessionMode === "active") &&
+    !hasVisibleIssue
+  );
 }
 
 function isBlockingLLMStatus(status: LLMConnectionStatus) {


### PR DESCRIPTION
Keep the chat FAB available during active meetings in the existing tucked hover-reveal state, including before transcript rows exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop session UI visibility and tuck styling only; no auth, data, or API changes.
> 
> **Overview**
> During **active** listening sessions, the session floating action button now favors the **chat** CTA over **Start listening**, and keeps it in the same **tucked, hover-reveal** layout used when the editor hides the FAB or the caret is near the bottom—including **before any transcript rows exist**.
> 
> Visibility rules now key off `getSessionMode`: the listen FAB only appears when the session is **inactive** on the raw memo with no transcript; the chat FAB is allowed for **inactive** or **active** modes when there is a transcript **or** the meeting is live, still respecting enhanced-note error / LLM blocking states. Tests cover active-meeting tuck behavior and pre-transcript chat display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a48dcb0ed145b1b7405ac8d52db30da40e74eb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->