### PR TITLE
fix(desktop): refine chat panel chrome

### DIFF
--- a/apps/desktop/src/chat/components/body/empty.tsx
+++ b/apps/desktop/src/chat/components/body/empty.tsx
@@ -45,7 +45,8 @@ export function ChatBodyEmpty({
 }) {
   const { chat } = useShell();
   const openNew = useTabs((state) => state.openNew);
-  const isFloating = chat.mode === "FloatingOpen";
+  const isDarkSurface =
+    chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
 
   const handleGoToSettings = useCallback(() => {
     openNew({ type: "settings", state: { tab: "intelligence" } });
@@ -66,7 +67,7 @@ export function ChatBodyEmpty({
             <span
               className={cn([
                 "text-sm font-medium",
-                isFloating ? "text-white" : "text-neutral-800",
+                isDarkSurface ? "text-white" : "text-neutral-800",
               ])}
             >
               Anarlog AI
@@ -76,7 +77,7 @@ export function ChatBodyEmpty({
           <p
             className={cn([
               "mb-2 text-sm",
-              isFloating ? "text-stone-200" : "text-neutral-700",
+              isDarkSurface ? "text-stone-200" : "text-neutral-700",
             ])}
           >
             Hi, I'm Anarlog AI. Set up a language model and I'll be ready to
@@ -104,7 +105,7 @@ export function ChatBodyEmpty({
           <span
             className={cn([
               "text-sm font-medium",
-              isFloating ? "text-white" : "text-neutral-800",
+              isDarkSurface ? "text-white" : "text-neutral-800",
             ])}
           >
             Anarlog AI
@@ -114,7 +115,7 @@ export function ChatBodyEmpty({
         <p
           className={cn([
             "mb-2 text-sm",
-            isFloating ? "text-stone-200" : "text-neutral-700",
+            isDarkSurface ? "text-stone-200" : "text-neutral-700",
           ])}
         >
           Hi, I'm Anarlog AI. I can help you pull context from your notes, find
@@ -128,7 +129,7 @@ export function ChatBodyEmpty({
                 onClick={() => handleSuggestionClick(prompt)}
                 className={cn([
                   "inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[11px]",
-                  isFloating
+                  isDarkSurface
                     ? "border-stone-600 bg-stone-700 text-stone-100 hover:bg-stone-600"
                     : "border-neutral-300 bg-white text-neutral-700 hover:bg-neutral-100",
                   "transition-colors",

--- a/apps/desktop/src/chat/components/body/index.test.tsx
+++ b/apps/desktop/src/chat/components/body/index.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { shellState } = vi.hoisted(() => ({
+  shellState: {
+    mode: "FloatingOpen" as
+      | "FloatingClosed"
+      | "FloatingOpen"
+      | "RightPanelOpen",
+  },
+}));
+
+vi.mock("./empty", () => ({
+  ChatBodyEmpty: () => <div data-testid="chat-body-empty" />,
+}));
+
+vi.mock("./non-empty", () => ({
+  ChatBodyNonEmpty: () => <div data-testid="chat-body-non-empty" />,
+}));
+
+vi.mock("./use-chat-auto-scroll", () => ({
+  useChatAutoScroll: () => ({
+    contentRef: { current: null },
+    handleWheel: vi.fn(),
+    isAtBottom: true,
+    scrollRef: { current: null },
+    scrollToBottom: vi.fn(),
+    showGoToRecent: false,
+    updateAutoScrollState: vi.fn(),
+  }),
+}));
+
+vi.mock("~/contexts/shell", () => ({
+  useShell: () => ({
+    chat: {
+      mode: shellState.mode,
+    },
+  }),
+}));
+
+import { ChatBody } from "./index";
+
+describe("ChatBody", () => {
+  beforeEach(() => {
+    cleanup();
+    shellState.mode = "FloatingOpen";
+  });
+
+  it("keeps horizontal content padding", () => {
+    render(<ChatBody messages={[]} status="ready" />);
+
+    const content = screen.getByTestId("chat-body-empty").parentElement;
+
+    expect(content?.className).toContain("px-2");
+    expect(content?.className).not.toContain("pr-0");
+  });
+
+  it("uses balanced content padding in the right panel", () => {
+    shellState.mode = "RightPanelOpen";
+
+    render(<ChatBody messages={[]} status="ready" />);
+
+    const content = screen.getByTestId("chat-body-empty").parentElement;
+
+    expect(content?.className).toContain("px-3");
+    expect(content?.className).toContain("py-5");
+    expect(content?.className).not.toContain("px-5");
+    expect(content?.className).not.toContain("px-2");
+  });
+});

--- a/apps/desktop/src/chat/components/body/index.tsx
+++ b/apps/desktop/src/chat/components/body/index.tsx
@@ -2,6 +2,7 @@ import type { ChatStatus } from "ai";
 import { ChevronDownIcon } from "lucide-react";
 
 import { Button } from "@hypr/ui/components/ui/button";
+import { cn } from "@hypr/utils";
 
 import { ChatBodyEmpty } from "./empty";
 import { ChatBodyNonEmpty } from "./non-empty";
@@ -9,6 +10,7 @@ import { useChatAutoScroll } from "./use-chat-auto-scroll";
 
 import type { ContextRef } from "~/chat/context/entities";
 import type { HyprUIMessage } from "~/chat/types";
+import { useShell } from "~/contexts/shell";
 
 export function ChatBody({
   messages,
@@ -31,6 +33,8 @@ export function ChatBody({
     contextRefs?: ContextRef[],
   ) => void;
 }) {
+  const { chat } = useShell();
+  const isRightPanel = chat.mode === "RightPanelOpen";
   const {
     contentRef,
     isAtBottom,
@@ -51,7 +55,10 @@ export function ChatBody({
       >
         <div
           ref={contentRef}
-          className="flex min-h-full flex-1 flex-col px-2 py-3"
+          className={cn([
+            "flex min-h-full flex-1 flex-col",
+            isRightPanel ? "px-3 py-5" : "px-2 py-3",
+          ])}
         >
           <div className="flex-1" />
           {messages.length === 0 ? (

--- a/apps/desktop/src/chat/components/chat-panel.test.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  chat: {
+    groupId: undefined as string | undefined,
+    selectChat: vi.fn(),
+    sessionId: "chat-session-id",
+    setGroupId: vi.fn(),
+    startNewChat: vi.fn(),
+  },
+  toolbarControls: vi.fn(),
+}));
+
+vi.mock("./toolbar-controls", () => ({
+  ChatToolbarControls: (props: {
+    layout?: "floating" | "right-panel";
+    surface?: "light" | "dark";
+  }) => {
+    mocks.toolbarControls(props);
+    return <div data-surface={props.surface} data-testid="chat-toolbar" />;
+  },
+}));
+
+vi.mock("./use-session-tab", () => ({
+  useSessionTab: () => ({ currentSessionId: "current-session-id" }),
+}));
+
+vi.mock("~/ai/hooks", () => ({
+  useLanguageModel: () => undefined,
+}));
+
+vi.mock("~/chat/store/use-chat-actions", () => ({
+  useChatActions: () => ({ handleSendMessage: vi.fn() }),
+}));
+
+vi.mock("~/contexts/shell", () => ({
+  useShell: () => ({ chat: mocks.chat }),
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useValues: () => ({}),
+  },
+}));
+
+import { ChatView } from "./chat-panel";
+
+describe("ChatView", () => {
+  beforeEach(() => {
+    cleanup();
+    mocks.toolbarControls.mockClear();
+  });
+
+  it("uses the modal dark surface for the right panel layout", () => {
+    const { container } = render(<ChatView layout="right-panel" />);
+    const root = container.firstElementChild;
+
+    expect(root?.className).toContain("bg-stone-800");
+    expect(root?.className).toContain("text-white");
+    expect(root?.firstElementChild?.className).toContain("h-12");
+    expect(screen.getByTestId("chat-toolbar").dataset.surface).toBe("dark");
+    expect(mocks.toolbarControls).toHaveBeenCalledWith(
+      expect.objectContaining({
+        layout: "right-panel",
+        surface: "dark",
+      }),
+    );
+  });
+});

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -47,15 +47,14 @@ export function ChatView({
     <div
       className={cn([
         "flex h-full min-h-0 flex-col overflow-hidden",
-        isFloating ? "bg-stone-800 text-white" : "bg-stone-50",
+        "bg-stone-800 text-white",
       ])}
     >
       <div
         className={cn([
           "flex shrink-0 items-center pr-0 pl-0",
-          isFloating
-            ? "h-11 border-b border-stone-700/80"
-            : "h-10 border-b border-neutral-100",
+          isFloating ? "h-11" : "h-12",
+          "border-b border-stone-700/80",
         ])}
       >
         <ChatToolbarControls
@@ -65,7 +64,7 @@ export function ChatView({
           onOpenFloating={onOpenFloating}
           onOpenRightPanel={onOpenRightPanel}
           onSelectChat={chat.selectChat}
-          surface={isFloating ? "dark" : "light"}
+          surface="dark"
         />
       </div>
       {user_id && (

--- a/apps/desktop/src/chat/components/context-bar.test.tsx
+++ b/apps/desktop/src/chat/components/context-bar.test.tsx
@@ -9,9 +9,15 @@ import {
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { openNewMock, searchMock, storeState } = vi.hoisted(() => ({
+const { openNewMock, searchMock, shellState, storeState } = vi.hoisted(() => ({
   openNewMock: vi.fn(),
   searchMock: vi.fn(),
+  shellState: {
+    mode: "FloatingOpen" as
+      | "FloatingClosed"
+      | "FloatingOpen"
+      | "RightPanelOpen",
+  },
   storeState: {
     rows: {} as Record<string, Record<string, unknown>>,
     sessionIds: [] as string[],
@@ -40,7 +46,7 @@ vi.mock("@hypr/ui/components/ui/tooltip", () => ({
 vi.mock("~/contexts/shell", () => ({
   useShell: () => ({
     chat: {
-      mode: "FloatingOpen",
+      mode: shellState.mode,
     },
   }),
 }));
@@ -103,6 +109,7 @@ describe("ContextBar session picker", () => {
     cleanup();
     openNewMock.mockClear();
     searchMock.mockReset();
+    shellState.mode = "FloatingOpen";
     storeState.rows = {};
     storeState.sessionIds = [];
     globalThis.ResizeObserver = class {
@@ -178,5 +185,18 @@ describe("ContextBar session picker", () => {
 
     expect(await screen.findByText("Hydrated Note")).toBeTruthy();
     expect(screen.queryByText(/1970/)).toBeNull();
+  });
+
+  it("uses balanced context bar horizontal margin in the right panel", () => {
+    shellState.mode = "RightPanelOpen";
+
+    renderContextBar();
+
+    const outer = document.querySelector("[data-chat-context-bar]");
+
+    expect(outer?.className).toContain("mx-3");
+    expect(outer?.className).not.toContain("mx-5");
+    expect(outer?.className).not.toContain("mx-2");
+    expect(outer?.className).not.toContain("mr-0");
   });
 });

--- a/apps/desktop/src/chat/components/context-bar.tsx
+++ b/apps/desktop/src/chat/components/context-bar.tsx
@@ -18,6 +18,7 @@ import { cn, safeParseDate } from "@hypr/utils";
 import type { ContextRef } from "~/chat/context/entities";
 import { type ContextChipProps, renderChip } from "~/chat/context/registry";
 import type { DisplayEntity } from "~/chat/context/use-chat-context-pipeline";
+import { useShell } from "~/contexts/shell";
 import { useSearchEngine } from "~/search/contexts/engine";
 import { getSessionEvent } from "~/session/utils";
 import * as main from "~/store/tinybase/store/main";
@@ -352,6 +353,8 @@ export function ContextBar({
   onRemoveEntity?: (key: string) => void;
   onAddEntity?: (ref: ContextRef) => void;
 }) {
+  const { chat } = useShell();
+  const isRightPanel = chat.mode === "RightPanelOpen";
   const chips = useMemo(
     () =>
       entities
@@ -372,9 +375,10 @@ export function ContextBar({
 
   return (
     <div
+      data-chat-context-bar
       className={cn([
         "shrink-0 rounded-t-xl border-t border-r border-l border-neutral-200 bg-white",
-        "mx-2",
+        isRightPanel ? "mx-3" : "mx-2",
       ])}
     >
       <div className="flex items-start gap-1.5 px-2 py-2">

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -7,11 +7,17 @@ import {
 } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { clearContentMock, editorState } = vi.hoisted(() => ({
+const { clearContentMock, editorState, shellState } = vi.hoisted(() => ({
   clearContentMock: vi.fn(),
   editorState: {
     json: undefined as unknown,
     onUpdate: undefined as undefined | ((json: unknown) => void),
+  },
+  shellState: {
+    mode: "FloatingOpen" as
+      | "FloatingClosed"
+      | "FloatingOpen"
+      | "RightPanelOpen",
   },
 }));
 
@@ -49,7 +55,7 @@ vi.mock("@hypr/plugin-analytics", () => ({
 vi.mock("~/contexts/shell", () => ({
   useShell: () => ({
     chat: {
-      mode: "FloatingOpen",
+      mode: shellState.mode,
     },
   }),
 }));
@@ -66,6 +72,7 @@ describe("ChatMessageInput", () => {
     clearContentMock.mockClear();
     editorState.json = { type: "doc", content: [] };
     editorState.onUpdate = undefined;
+    shellState.mode = "FloatingOpen";
   });
 
   it("disables send until the draft has content", () => {
@@ -115,5 +122,24 @@ describe("ChatMessageInput", () => {
     expect(screen.getByTestId("chat-editor").className).toContain(
       "text-neutral-900",
     );
+  });
+
+  it("uses balanced outer padding in the right panel", () => {
+    shellState.mode = "RightPanelOpen";
+
+    render(
+      <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
+    );
+
+    const messageInput = screen
+      .getByTestId("chat-editor")
+      .closest("[data-chat-message-input]");
+    const outerContainer = messageInput?.parentElement?.parentElement;
+
+    expect(outerContainer?.className).toContain("px-3");
+    expect(outerContainer?.className).toContain("pb-5");
+    expect(outerContainer?.className).not.toContain("px-5");
+    expect(outerContainer?.className).not.toContain("px-2");
+    expect(outerContainer?.className).not.toContain("pr-0");
   });
 });

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -54,9 +54,10 @@ export function ChatMessageInput({
   useAutoFocusEditor({ editorRef, disabled, shouldFocus });
   const mentionConfig = useMentionConfig();
   const isSendDisabled = Boolean(disabled) || !hasContent;
+  const isRightPanel = chat.mode === "RightPanelOpen";
 
   return (
-    <Container hasContextBar={hasContextBar}>
+    <Container hasContextBar={hasContextBar} isRightPanel={isRightPanel}>
       <div data-chat-message-input className="flex flex-col px-2 pt-3 pb-2">
         <div className="mb-1 min-h-0 flex-1">
           <ChatEditor
@@ -117,12 +118,19 @@ export function ChatMessageInput({
 function Container({
   children,
   hasContextBar,
+  isRightPanel,
 }: {
   children: React.ReactNode;
   hasContextBar?: boolean;
+  isRightPanel: boolean;
 }) {
   return (
-    <div className="relative min-w-0 shrink-0 px-2 pb-2">
+    <div
+      className={cn([
+        "relative min-w-0 shrink-0",
+        isRightPanel ? "px-3 pb-5" : "px-2 pb-2",
+      ])}
+    >
       <div
         className={cn([
           "flex max-h-full flex-col border border-neutral-200 bg-white",

--- a/apps/desktop/src/chat/components/message/shared.tsx
+++ b/apps/desktop/src/chat/components/message/shared.tsx
@@ -34,7 +34,8 @@ export function MessageBubble({
   children: ReactNode;
 }) {
   const { chat } = useShell();
-  const isFloating = chat.mode === "FloatingOpen";
+  const isDarkSurface =
+    chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
 
   return (
     <div
@@ -43,11 +44,11 @@ export function MessageBubble({
         variant === "user" &&
           "w-fit max-w-full rounded-2xl bg-blue-100 px-3 py-1 text-neutral-800 [&_p]:[text-wrap:wrap]",
         variant === "assistant" &&
-          (isFloating
+          (isDarkSurface
             ? "rounded-2xl bg-white/95 px-3 py-1 text-neutral-800"
             : "text-neutral-800"),
         variant === "loading" &&
-          (isFloating
+          (isDarkSurface
             ? "w-fit rounded-2xl bg-white/95 px-3 py-1 text-neutral-800"
             : "text-neutral-800"),
         variant === "error" &&

--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -78,7 +78,7 @@ describe("PersistentChatPanel", () => {
     } as typeof ResizeObserver;
   });
 
-  it("anchors the floating panel to the bottom-right of the note surface", async () => {
+  it("anchors the floating panel to the bottom center of the note surface", async () => {
     render(<TestHost />);
 
     await screen.findByTestId("chat-view");
@@ -88,8 +88,8 @@ describe("PersistentChatPanel", () => {
 
     await waitFor(() => {
       expect(resizeFrame?.className).toContain("items-end");
-      expect(resizeFrame?.className).toContain("justify-end");
-      expect(panel?.style.transformOrigin).toBe("bottom right");
+      expect(resizeFrame?.className).toContain("justify-center");
+      expect(panel?.style.transformOrigin).toBe("bottom center");
     });
   });
 
@@ -105,7 +105,7 @@ describe("PersistentChatPanel", () => {
     });
   });
 
-  it("resizes bottom handles by the pointer movement when bottom anchored", async () => {
+  it("resizes the bottom handle by the pointer movement", async () => {
     vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
       function (this: HTMLElement) {
         if (this.matches("[data-chat-panel]")) {
@@ -251,6 +251,20 @@ describe("PersistentChatPanel", () => {
     dragHandle("top-right", { x: 660, y: 240 }, { x: 700, y: 200 });
     expect(panel?.style.width).toBe("460px");
     expect(panel?.style.height).toBe("400px");
+  });
+
+  it("does not render bottom corner handles or visible corner indicators", async () => {
+    render(<TestHost />);
+
+    await screen.findByTestId("chat-view");
+
+    expect(
+      document.querySelector('[data-chat-resize-handle="bottom-left"]'),
+    ).toBeNull();
+    expect(
+      document.querySelector('[data-chat-resize-handle="bottom-right"]'),
+    ).toBeNull();
+    expect(document.querySelector("[data-chat-resize-handle] span")).toBeNull();
   });
 
   it("hides the floating panel when the chat moves to the right panel", async () => {

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -56,14 +56,6 @@ const RESIZE_HANDLES = [
     id: "left",
     className: "top-7 bottom-7 left-0 w-3 cursor-ew-resize",
   },
-  {
-    id: "bottom-left",
-    className: "bottom-0 left-0 h-7 w-7 cursor-nesw-resize",
-  },
-  {
-    id: "bottom-right",
-    className: "right-0 bottom-0 h-7 w-7 cursor-nwse-resize",
-  },
 ] as const;
 
 type ResizeHandle = (typeof RESIZE_HANDLES)[number]["id"];
@@ -204,7 +196,7 @@ export function PersistentChatPanel({
           minHeight: "min(320px, calc(100% - 1rem))",
           maxWidth: "calc(100% - 2rem)",
           maxHeight: "calc(100% - 1rem)",
-          transformOrigin: "bottom right",
+          transformOrigin: "bottom center",
         };
 
   const handleResizeStart = (
@@ -300,7 +292,7 @@ export function PersistentChatPanel({
             data-chat-resize-frame
             className={cn([
               "pointer-events-auto relative flex h-full min-h-0",
-              "items-end justify-end p-4",
+              "items-end justify-center p-4",
             ])}
             onClick={(event) => {
               if (event.target === event.currentTarget) {
@@ -342,9 +334,7 @@ export function PersistentChatPanel({
                   onPointerMove={handleResizeMove}
                   onPointerUp={handleResizeEnd}
                   onPointerCancel={handleResizeEnd}
-                >
-                  <ResizeHandleIndicator handle={handle.id} />
-                </div>
+                />
               ))}
             </motion.div>
           </div>
@@ -352,38 +342,6 @@ export function PersistentChatPanel({
       )}
     </AnimatePresence>
   );
-}
-
-function ResizeHandleIndicator({ handle }: { handle: ResizeHandle }) {
-  const className = getResizeHandleIndicatorClassName(handle);
-
-  if (!className) {
-    return null;
-  }
-
-  return (
-    <span
-      className={cn([
-        "pointer-events-none absolute h-3 w-3 border-stone-300/45",
-        className,
-      ])}
-    />
-  );
-}
-
-function getResizeHandleIndicatorClassName(handle: ResizeHandle) {
-  switch (handle) {
-    case "top-left":
-      return "top-1.5 left-1.5 rounded-tl-md border-t border-l";
-    case "top-right":
-      return "top-1.5 right-1.5 rounded-tr-md border-t border-r";
-    case "bottom-left":
-      return "bottom-1.5 left-1.5 rounded-bl-md border-b border-l";
-    case "bottom-right":
-      return "right-1.5 bottom-1.5 rounded-br-md border-r border-b";
-    default:
-      return null;
-  }
 }
 
 function getFloatingPanelStyle(
@@ -399,7 +357,7 @@ function getFloatingPanelStyle(
   return {
     width: `${clampedSize.width}px`,
     height: `${clampedSize.height}px`,
-    transformOrigin: "bottom right",
+    transformOrigin: "bottom center",
   };
 }
 

--- a/apps/desktop/src/chat/components/toolbar-controls.test.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.test.tsx
@@ -1,0 +1,107 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@hypr/ui/components/ui/button", () => ({
+  Button: ({
+    children,
+    className,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button className={className} type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@hypr/ui/components/ui/dropdown-menu", () => ({
+  AppFloatingPanel: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenu: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useCell: () => undefined,
+    useRow: () => undefined,
+    useSortedRowIds: () => [],
+  },
+}));
+
+import { ChatToolbarControls } from "./toolbar-controls";
+
+describe("ChatToolbarControls", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("renders the dark chat title trigger as a pill", () => {
+    render(
+      <ChatToolbarControls
+        currentChatGroupId={undefined}
+        onNewChat={vi.fn()}
+        onOpenRightPanel={vi.fn()}
+        onSelectChat={vi.fn()}
+        surface="dark"
+      />,
+    );
+
+    const title = screen.getByText("Ask Anarlog AI anything");
+    expect(title.closest("button")?.className).toContain("rounded-full");
+  });
+
+  it("renders dark toolbar action buttons as circles without tooltips", () => {
+    render(
+      <ChatToolbarControls
+        currentChatGroupId={undefined}
+        onNewChat={vi.fn()}
+        onOpenRightPanel={vi.fn()}
+        onSelectChat={vi.fn()}
+        surface="dark"
+      />,
+    );
+
+    const newChatButton = screen.getByRole("button", { name: "New chat" });
+    const rightPanelButton = screen.getByRole("button", {
+      name: "Open in right panel",
+    });
+
+    expect(newChatButton.className).toContain("rounded-full");
+    expect(newChatButton.className).toContain("hover:!bg-white/7");
+    expect(newChatButton.getAttribute("title")).toBeNull();
+    expect(rightPanelButton.className).toContain("rounded-full");
+    expect(rightPanelButton.className).toContain("hover:!bg-white/7");
+    expect(rightPanelButton.getAttribute("title")).toBeNull();
+  });
+
+  it("uses balanced toolbar horizontal padding in the right panel", () => {
+    const { container } = render(
+      <ChatToolbarControls
+        currentChatGroupId={undefined}
+        layout="right-panel"
+        onNewChat={vi.fn()}
+        onOpenFloating={vi.fn()}
+        onSelectChat={vi.fn()}
+        surface="dark"
+      />,
+    );
+
+    expect(container.firstElementChild?.className).toContain("px-3");
+    expect(container.firstElementChild?.className).not.toContain("px-5");
+    expect(container.firstElementChild?.className).not.toContain("px-2");
+    expect(container.firstElementChild?.className).not.toContain("pr-0");
+    expect(
+      screen.getByRole("button", { name: "Float chat" }).className,
+    ).toContain("mr-1");
+  });
+});

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -14,11 +14,6 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@hypr/ui/components/ui/dropdown-menu";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@hypr/ui/components/ui/tooltip";
 import { cn, formatDistanceToNow } from "@hypr/utils";
 
 import * as main from "~/store/tinybase/store/main";
@@ -47,7 +42,7 @@ export function ChatToolbarControls({
     <div
       className={cn([
         "flex h-full w-full min-w-0 items-center gap-2",
-        isDark ? "px-2" : "px-0",
+        isRightPanel ? "px-3" : isDark ? "px-2" : "px-0",
       ])}
     >
       <div className="flex min-w-0 flex-1 items-center gap-1">
@@ -60,8 +55,8 @@ export function ChatToolbarControls({
       <div className="flex shrink-0 items-center gap-1">
         <ChatActionButton
           icon={<Plus size={16} />}
+          label="New chat"
           onClick={onNewChat}
-          title="New chat"
           className={isDark ? darkToolbarButtonClassName : undefined}
         />
         <ChatActionButton
@@ -77,12 +72,13 @@ export function ChatToolbarControls({
               ? (onOpenFloating ?? (() => {}))
               : (onOpenRightPanel ?? (() => {}))
           }
-          title={isRightPanel ? "Float chat" : "Open in right panel"}
+          label={isRightPanel ? "Float chat" : "Open in right panel"}
           className={cn([
             isDark
               ? darkToolbarButtonClassName
               : isRightPanel &&
                 "bg-neutral-100 text-neutral-900 hover:bg-neutral-100",
+            isRightPanel && "mr-1",
           ])}
         />
       </div>
@@ -91,34 +87,29 @@ export function ChatToolbarControls({
 }
 
 const darkToolbarButtonClassName =
-  "size-8 rounded-lg text-stone-300 hover:bg-white/7 hover:text-white";
+  "size-8 bg-transparent text-stone-300 hover:!bg-white/7 hover:!text-white focus-visible:!bg-white/7 focus-visible:!text-white active:!bg-white/10";
 
 function ChatActionButton({
   className,
   icon,
-  title,
+  label,
   onClick,
 }: {
   className?: string;
   icon: React.ReactNode;
-  title: string;
+  label: string;
   onClick: () => void;
 }) {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          onClick={onClick}
-          title={title}
-          size="icon"
-          variant="ghost"
-          className={cn(["text-neutral-600", className])}
-        >
-          {icon}
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">{title}</TooltipContent>
-    </Tooltip>
+    <Button
+      aria-label={label}
+      onClick={onClick}
+      size="icon"
+      variant="ghost"
+      className={cn(["rounded-full text-neutral-600", className])}
+    >
+      {icon}
+    </Button>
   );
 }
 
@@ -157,7 +148,7 @@ function ChatGroups({
           className={cn([
             "group flex h-8 max-w-full min-w-0 justify-start gap-1.5 px-2 py-0 text-left",
             isDark
-              ? "w-fit rounded-lg text-stone-100 hover:bg-white/7 hover:text-white data-[state=open]:bg-white/7"
+              ? "w-fit rounded-full text-stone-100 hover:bg-white/7 hover:text-white data-[state=open]:bg-white/7"
               : "text-neutral-700",
           ])}
         >

--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -135,8 +135,16 @@ describe("MainChatPanels", () => {
     expect(screen.getAllByTestId("panel")).toHaveLength(2);
     expect(screen.getByTestId("resize-handle")).toBeTruthy();
     expect(screen.getByTestId("chat-view").dataset.layout).toBe("right-panel");
-    expect(document.querySelector("[data-chat-right-panel]")).toBeInstanceOf(
-      HTMLDivElement,
-    );
+    const rightPanel = document.querySelector("[data-chat-right-panel]");
+
+    expect(rightPanel).toBeInstanceOf(HTMLDivElement);
+    expect(rightPanel?.className).toContain("bg-stone-800");
+    expect(rightPanel?.className).toContain("border-x");
+    expect(rightPanel?.className).toContain("border-stone-600");
+    expect(rightPanel?.className).not.toContain("border-b-0");
+    expect(rightPanel?.className).toContain("rounded-tr-xl");
+    expect(rightPanel?.className).not.toContain("rounded-t-xl");
+    expect(rightPanel?.className).not.toContain("ml-2");
+    expect(rightPanel?.className).not.toContain("mr-1");
   });
 });

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -44,7 +44,7 @@ export function MainChatPanels({ children }: { children: React.ReactNode }) {
             >
               <div
                 data-chat-right-panel
-                className="mr-1 -mb-1 ml-2 h-[calc(100%+0.25rem)] min-h-0 overflow-hidden rounded-t-xl border border-b-0 border-neutral-200 bg-stone-50"
+                className="-mb-1 h-[calc(100%+0.25rem)] min-h-0 overflow-hidden rounded-tr-xl border-x border-stone-600 bg-stone-800"
               >
                 <ChatView
                   layout="right-panel"

--- a/apps/desktop/src/store/zustand/tabs/basic.test.ts
+++ b/apps/desktop/src/store/zustand/tabs/basic.test.ts
@@ -145,6 +145,17 @@ describe("Basic Tab Actions", () => {
     });
   });
 
+  test("openNew collapses docked chat when opening settings", () => {
+    const session = createSessionTab({ id: "tab1", active: false });
+
+    useTabs.getState().openNew(session);
+    useTabs.getState().transitionChatMode({ type: "OPEN_RIGHT_PANEL" });
+    useTabs.getState().openNew({ type: "settings" });
+
+    expect(useTabs.getState()).toHaveCurrentTab({ type: "settings" });
+    expect(useTabs.getState().chatMode).toBe("FloatingClosed");
+  });
+
   test("openNew refreshes settings return target when reusing its tab", () => {
     const session1 = createSessionTab({ id: "tab1", active: false });
     const session2 = createSessionTab({ id: "tab2", active: false });

--- a/apps/desktop/src/store/zustand/tabs/basic.ts
+++ b/apps/desktop/src/store/zustand/tabs/basic.ts
@@ -64,7 +64,7 @@ export const createBasicSlice = <
   openCurrent: (tab) => {
     const { tabs, history, addRecentlyOpened, chatMode } = get();
     const currentActiveTab = tabs.find((t) => t.active);
-    const shouldCloseChat = shouldCloseChatForSessionNavigation(
+    const shouldCloseChat = shouldCloseChatForNavigation(
       currentActiveTab,
       tab,
       chatMode,
@@ -78,14 +78,14 @@ export const createBasicSlice = <
 
     if (currentActiveTab?.pinned || isCurrentTabListening) {
       set(
-        withChatCollapsedForSessionNavigation(
+        withChatCollapsedForNavigation(
           openTab(tabs, tab, history, true),
           shouldCloseChat,
         ),
       );
     } else {
       set(
-        withChatCollapsedForSessionNavigation(
+        withChatCollapsedForNavigation(
           openTab(tabs, tab, history, false),
           shouldCloseChat,
         ),
@@ -104,14 +104,14 @@ export const createBasicSlice = <
   openNew: (tab, options) => {
     const { tabs, history, addRecentlyOpened, chatMode } = get();
     const currentActiveTab = tabs.find((t) => t.active);
-    const shouldCloseChat = shouldCloseChatForSessionNavigation(
+    const shouldCloseChat = shouldCloseChatForNavigation(
       currentActiveTab,
       tab,
       chatMode,
     );
 
     set(
-      withChatCollapsedForSessionNavigation(
+      withChatCollapsedForNavigation(
         openTab(tabs, tab, history, true, options?.position),
         shouldCloseChat,
       ),
@@ -129,7 +129,7 @@ export const createBasicSlice = <
   select: (tab) => {
     const { tabs, addRecentlyOpened, chatMode } = get();
     const currentActiveTab = tabs.find((t) => t.active);
-    const shouldCloseChat = shouldCloseChatForSessionNavigation(
+    const shouldCloseChat = shouldCloseChatForNavigation(
       currentActiveTab,
       tab,
       chatMode,
@@ -137,7 +137,7 @@ export const createBasicSlice = <
     const nextTabs = setActiveFlags(tabs, tab);
     const currentTab = nextTabs.find((t) => t.active) || null;
     set(
-      withChatCollapsedForSessionNavigation(
+      withChatCollapsedForNavigation(
         { tabs: nextTabs, currentTab } as Partial<T>,
         shouldCloseChat,
       ),
@@ -161,7 +161,7 @@ export const createBasicSlice = <
     const currentIndex = tabs.findIndex((t) => isSameTab(t, currentTab));
     const nextIndex = (currentIndex + 1) % tabs.length;
     const nextTab = tabs[nextIndex];
-    const shouldCloseChat = shouldCloseChatForSessionNavigation(
+    const shouldCloseChat = shouldCloseChatForNavigation(
       currentTab,
       nextTab,
       chatMode,
@@ -169,7 +169,7 @@ export const createBasicSlice = <
 
     const nextTabs = setActiveFlags(tabs, nextTab);
     set(
-      withChatCollapsedForSessionNavigation(
+      withChatCollapsedForNavigation(
         {
           tabs: nextTabs,
           currentTab: { ...nextTab, active: true },
@@ -185,7 +185,7 @@ export const createBasicSlice = <
     const currentIndex = tabs.findIndex((t) => isSameTab(t, currentTab));
     const prevIndex = (currentIndex - 1 + tabs.length) % tabs.length;
     const prevTab = tabs[prevIndex];
-    const shouldCloseChat = shouldCloseChatForSessionNavigation(
+    const shouldCloseChat = shouldCloseChatForNavigation(
       currentTab,
       prevTab,
       chatMode,
@@ -193,7 +193,7 @@ export const createBasicSlice = <
 
     const nextTabs = setActiveFlags(tabs, prevTab);
     set(
-      withChatCollapsedForSessionNavigation(
+      withChatCollapsedForNavigation(
         {
           tabs: nextTabs,
           currentTab: { ...prevTab, active: true },
@@ -239,13 +239,13 @@ export const createBasicSlice = <
     const nextCurrentTab = nextTabs[nextActiveIndex];
     const shouldCloseChat =
       tabToClose.active &&
-      shouldCloseChatForSessionNavigation(tabToClose, nextCurrentTab, chatMode);
+      shouldCloseChatForNavigation(tabToClose, nextCurrentTab, chatMode);
 
     const nextHistory = new Map(history);
     nextHistory.delete(tabToClose.slotId);
 
     set(
-      withChatCollapsedForSessionNavigation(
+      withChatCollapsedForNavigation(
         {
           tabs: nextTabs,
           currentTab: nextCurrentTab,
@@ -505,19 +505,27 @@ const clearReturnOrigin = <T extends Tab>(tab: T): T => {
   return nextTab;
 };
 
-const shouldCloseChatForSessionNavigation = (
+const shouldCloseChatForNavigation = (
   currentTab: Tab | null | undefined,
   targetTab: Tab | TabInput,
   chatMode: ChatModeState["chatMode"],
 ): boolean => {
-  if (chatMode === "FloatingClosed" || targetTab.type !== "sessions") {
+  if (chatMode === "FloatingClosed") {
+    return false;
+  }
+
+  if (targetTab.type === "settings") {
+    return true;
+  }
+
+  if (targetTab.type !== "sessions") {
     return false;
   }
 
   return currentTab?.type !== "sessions" || currentTab.id !== targetTab.id;
 };
 
-const withChatCollapsedForSessionNavigation = <T extends ChatModeState>(
+const withChatCollapsedForNavigation = <T extends ChatModeState>(
   state: Partial<T>,
   shouldCloseChat: boolean,
 ): Partial<T> => {


### PR DESCRIPTION
Use the modal dark surface for the docked chat panel, remove its side inset and right padding, square its top-left corner, fix the docked panel icon button, and restore the floating panel toolbar and resize affordance polish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI, layout, and tab/chat-mode behavior with broad unit test coverage; no auth, data, or security-sensitive paths.
> 
> **Overview**
> Aligns **floating and docked** chat on the same **dark stone modal** chrome: the right panel shell, `ChatView`, toolbar, empty state, and assistant bubbles all treat `RightPanelOpen` like the floating dark surface instead of a light docked layout.
> 
> **Docked panel layout** drops side insets and light borders in favor of flush `border-x` / `rounded-tr-xl` styling, with **balanced `px-3` padding** on body, context bar, input, and toolbar in right-panel mode.
> 
> **Floating panel** is anchored **bottom-center** (not bottom-right), with **bottom corner resize handles and corner indicators removed**; resize behavior tests were updated accordingly.
> 
> **Toolbar** uses pill title and circular ghost actions with `aria-label` (tooltips removed on dark actions).
> 
> **Tab navigation** collapses open chat to `FloatingClosed` when navigating to **Settings**, not only when switching session tabs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6fdf389e9e8e1a95d0b3b3d98eaef6009814f88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->