### PR TITLE
chore(desktop): update 1.0.36 changelog

### DIFF
--- a/packages/changelog/content/1.0.36.md
+++ b/packages/changelog/content/1.0.36.md
@@ -1,7 +1,19 @@
 ---
 date: "2026-06-01"
-summary: "Transcripts are easier to copy, and chat now has clearer floating and right-panel behavior."
+summary: "Live transcripts stay available across notes, timeline note creation is easier to reach, and chat has clearer floating and docked behavior."
 ---
+
+## Live Meetings
+
+- Live transcript panels now stay visible when you move from the active meeting note to another note
+- Live transcript panels now match the current layout border treatment in both timeline and left sidebar modes
+- Expanded live transcripts now reset when a different live session starts
+
+## Timeline
+
+- Timeline mode now keeps Create new note next to the current Now position after your latest note, instead of letting future events push it away
+- Timeline mode now leaves extra space after the Create new note card at the right edge
+- Sidebar timeline rows now highlight the active note more clearly
 
 ## Transcripts
 
@@ -13,3 +25,5 @@ summary: "Transcripts are easier to copy, and chat now has clearer floating and 
 - Chat can be opened in the right panel again when you want it pinned beside your note
 - Floating chat now keeps its input readable on the white editor surface
 - Floating chat controls now better match the active chat surface
+- Floating chat now stays out of the way while a meeting is active
+- Docked chat now fits the note surface more cleanly, with tighter panel chrome and spacing


### PR DESCRIPTION
Update the desktop 1.0.36 changelog with the latest live transcript, timeline, sidebar timeline, and chat improvements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or product code changes.
> 
> **Overview**
> Updates **`packages/changelog/content/1.0.36.md`** for the desktop **1.0.36** release so the top-line **summary** matches the full set of user-facing notes.
> 
> Adds **Live Meetings** and **Timeline** sections (live transcript persistence, layout borders, session resets; Create new note placement, right-edge spacing, sidebar active-note highlighting). Extends **Chat** with meeting-aware floating behavior and tighter docked panel chrome. Existing **Transcripts** and earlier **Chat** bullets are unchanged aside from the new summary wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 907caacee95bfafd2974aade50749c0d7f1589a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->