### PR TITLE
fix(desktop): restore Soniqo on Sonoma

### DIFF
--- a/crates/transcribe-soniqo/build.rs
+++ b/crates/transcribe-soniqo/build.rs
@@ -8,6 +8,11 @@ use std::{
 };
 
 #[cfg(target_os = "macos")]
+const SONIQO_SWIFT_MACOS_DEPLOYMENT_TARGET: &str = "14.0";
+#[cfg(target_os = "macos")]
+const SONIQO_METALLIB_MACOS_DEPLOYMENT_TARGET: &str = "15.0";
+
+#[cfg(target_os = "macos")]
 fn swift_runtime_rpaths() -> Vec<String> {
     let mut paths = BTreeSet::from([PathBuf::from("/usr/lib/swift")]);
 
@@ -143,6 +148,78 @@ fn run_command(mut command: Command, context: &str) {
 }
 
 #[cfg(target_os = "macos")]
+fn prepare_swift_package(swift_build_dir: &Path) {
+    let manifest_dir = PathBuf::from(
+        env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set by Cargo"),
+    );
+    let swift_package_dir = manifest_dir.join("swift-lib");
+
+    let mut command = Command::new("swift");
+    command
+        .arg("package")
+        .arg("--package-path")
+        .arg(&swift_package_dir)
+        .arg("--scratch-path")
+        .arg(swift_build_dir)
+        .arg("resolve");
+    run_command(command, "resolving Soniqo Swift dependencies");
+
+    patch_speech_swift_manifest(swift_build_dir);
+}
+
+#[cfg(target_os = "macos")]
+fn patch_speech_swift_manifest(swift_build_dir: &Path) {
+    let manifest = swift_build_dir
+        .join("checkouts")
+        .join("speech-swift")
+        .join("Package.swift");
+    let target = format!(".macOS(\"{SONIQO_SWIFT_MACOS_DEPLOYMENT_TARGET}\")");
+    let contents = fs::read_to_string(&manifest).unwrap_or_else(|error| {
+        panic!(
+            "failed to read Soniqo speech-swift manifest {}: {error}",
+            manifest.display()
+        )
+    });
+
+    if contents.contains(&target) {
+        return;
+    }
+
+    let patched = contents.replace(".macOS(\"15.0\")", &target);
+    if patched == contents {
+        panic!(
+            "failed to patch Soniqo speech-swift manifest {}; expected macOS 15.0 platform declaration",
+            manifest.display()
+        );
+    }
+
+    let mut permissions = fs::metadata(&manifest)
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to read permissions for Soniqo speech-swift manifest {}: {error}",
+                manifest.display()
+            )
+        })
+        .permissions();
+    if permissions.readonly() {
+        permissions.set_readonly(false);
+        fs::set_permissions(&manifest, permissions).unwrap_or_else(|error| {
+            panic!(
+                "failed to make Soniqo speech-swift manifest writable {}: {error}",
+                manifest.display()
+            )
+        });
+    }
+
+    fs::write(&manifest, patched).unwrap_or_else(|error| {
+        panic!(
+            "failed to patch Soniqo speech-swift manifest {}: {error}",
+            manifest.display()
+        )
+    });
+}
+
+#[cfg(target_os = "macos")]
 fn compile_mlx_metallib(swift_build_dir: &Path, profile: &str) -> PathBuf {
     let mlx_swift_dir = swift_build_dir.join("checkouts").join("mlx-swift");
     let kernels_dir = mlx_swift_dir
@@ -237,7 +314,6 @@ fn compile_mlx_metallib(swift_build_dir: &Path, profile: &str) -> PathBuf {
                 "-x",
                 "metal",
                 "-std=metal3.2",
-                "-mmacosx-version-min=15.0",
                 "-Wall",
                 "-Wextra",
                 "-fno-fast-math",
@@ -245,6 +321,9 @@ fn compile_mlx_metallib(swift_build_dir: &Path, profile: &str) -> PathBuf {
                 "-Wno-c++20-extensions",
                 "-c",
             ])
+            .arg(format!(
+                "-mmacosx-version-min={SONIQO_METALLIB_MACOS_DEPLOYMENT_TARGET}"
+            ))
             .arg(source)
             .arg(format!("-I{}", kernels_dir.display()))
             .arg(format!("-I{}", include_root.display()))
@@ -334,7 +413,11 @@ fn main() {
             return;
         }
 
-        swift_rs::SwiftLinker::new("15.0")
+        let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set by Cargo"));
+        let swift_build_dir = out_dir.join("swift-rs").join("soniqo-swift");
+        prepare_swift_package(&swift_build_dir);
+
+        swift_rs::SwiftLinker::new(SONIQO_SWIFT_MACOS_DEPLOYMENT_TARGET)
             .with_package("soniqo-swift", "./swift-lib/")
             .link();
 

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -71,6 +71,12 @@ impl SoniqoModel {
         Self::ParakeetStreaming,
         Self::ParakeetBatch,
         Self::Omnilingual,
+    ];
+
+    const KNOWN: &'static [Self] = &[
+        Self::ParakeetStreaming,
+        Self::ParakeetBatch,
+        Self::Omnilingual,
         Self::Qwen3Small,
         Self::Qwen3Large,
     ];
@@ -140,7 +146,11 @@ impl SoniqoModel {
     }
 
     pub const fn is_available_on_current_platform(self) -> bool {
-        cfg!(all(target_os = "macos", target_arch = "aarch64"))
+        cfg!(all(target_os = "macos", target_arch = "aarch64")) && !self.requires_macos_15()
+    }
+
+    const fn requires_macos_15(self) -> bool {
+        matches!(self, Self::Qwen3Small | Self::Qwen3Large)
     }
 
     pub const fn supports_live_on_current_platform(self) -> bool {
@@ -180,7 +190,7 @@ impl FromStr for SoniqoModel {
     type Err = Error;
 
     fn from_str(value: &str) -> Result<Self> {
-        Self::ALL
+        Self::KNOWN
             .iter()
             .copied()
             .find(|model| value == model.as_str() || value == model.repo())
@@ -268,6 +278,8 @@ pub enum Error {
     UnsupportedModel(String),
     #[error("Soniqo is only available on macOS Apple Silicon")]
     UnsupportedPlatform,
+    #[error("{} requires macOS 15 or newer.", .0.display_name())]
+    RequiresMacOs15(SoniqoModel),
     #[error("Soniqo bridge failed: {0}")]
     Bridge(String),
     #[error("failed to parse Soniqo bridge response: {0}")]
@@ -279,11 +291,15 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 fn ensure_supported_platform(model: SoniqoModel) -> Result<()> {
-    if model.is_available_on_current_platform() {
-        Ok(())
-    } else {
-        Err(Error::UnsupportedPlatform)
+    if !cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        return Err(Error::UnsupportedPlatform);
     }
+
+    if model.requires_macos_15() {
+        return Err(Error::RequiresMacOs15(model));
+    }
+
+    Ok(())
 }
 
 pub fn model_cache_dir(model: SoniqoModel) -> Result<PathBuf> {
@@ -853,18 +869,24 @@ mod tests {
             "soniqo-parakeet-streaming".parse::<SoniqoModel>().unwrap(),
             SoniqoModel::ParakeetStreaming
         );
+        assert_eq!(
+            "soniqo-qwen3-small".parse::<SoniqoModel>().unwrap(),
+            SoniqoModel::Qwen3Small
+        );
+        assert_eq!(
+            "soniqo-qwen3-large".parse::<SoniqoModel>().unwrap(),
+            SoniqoModel::Qwen3Large
+        );
     }
 
     #[test]
-    fn all_includes_every_model_variant() {
+    fn all_includes_available_model_variants() {
         assert_eq!(
             SoniqoModel::all(),
             &[
                 SoniqoModel::ParakeetStreaming,
                 SoniqoModel::ParakeetBatch,
                 SoniqoModel::Omnilingual,
-                SoniqoModel::Qwen3Small,
-                SoniqoModel::Qwen3Large,
             ]
         );
     }
@@ -912,6 +934,17 @@ mod tests {
             cfg!(all(target_os = "macos", target_arch = "aarch64")),
         );
         assert!(!SoniqoModel::ParakeetBatch.supports_live_on_current_platform());
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[test]
+    fn qwen3_platform_error_mentions_macos_15() {
+        let error = ensure_supported_platform(SoniqoModel::Qwen3Small).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Soniqo Qwen3 0.6B requires macOS 15 or newer."
+        );
     }
 
     #[test]

--- a/crates/transcribe-soniqo/swift-lib/Package.swift
+++ b/crates/transcribe-soniqo/swift-lib/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
   name: "soniqo-swift",
-  platforms: [.macOS("15.0")],
+  platforms: [.macOS("14.0")],
   products: [
     .library(
       name: "soniqo-swift",
@@ -25,7 +25,6 @@ let package = Package(
         .product(name: "OmnilingualASR", package: "speech-swift"),
         .product(name: "ParakeetASR", package: "speech-swift"),
         .product(name: "ParakeetStreamingASR", package: "speech-swift"),
-        .product(name: "Qwen3ASR", package: "speech-swift"),
         .product(name: "SwiftRs", package: "swift-rs"),
       ],
       path: "src"

--- a/crates/transcribe-soniqo/swift-lib/src/lib.swift
+++ b/crates/transcribe-soniqo/swift-lib/src/lib.swift
@@ -3,7 +3,6 @@ import Foundation
 import OmnilingualASR
 import ParakeetASR
 import ParakeetStreamingASR
-import Qwen3ASR
 import SwiftRs
 
 private enum SoniqoBridgeError: LocalizedError {
@@ -157,13 +156,7 @@ private enum SpeechModelKind: String, CaseIterable {
         )
       )
     case .qwen3Small, .qwen3Large:
-      return .qwen3(
-        try await Qwen3ASRModel.fromPretrained(
-          modelId: repo,
-          offlineMode: offlineMode,
-          progressHandler: progressHandler
-        )
-      )
+      throw SoniqoBridgeError.message("\(label) requires macOS 15 or newer.")
     }
   }
 
@@ -238,7 +231,6 @@ private enum LoadedSpeechModel {
   case streaming(ParakeetStreamingASRModel)
   case parakeetBatch(ParakeetASRModel)
   case omnilingual(OmnilingualASRModel)
-  case qwen3(Qwen3ASRModel)
 
   func asStreamingModel() throws -> ParakeetStreamingASRModel {
     guard case .streaming(let model) = self else {
@@ -260,59 +252,7 @@ private enum LoadedSpeechModel {
       return try model.transcribeAudio(audio, sampleRate: sampleRate, language: languageHint)
     case .omnilingual(let model):
       return try model.transcribeAudio(audio, sampleRate: sampleRate)
-    case .qwen3(let model):
-      return transcribeQwen3Audio(
-        model: model,
-        audio: audio,
-        sampleRate: sampleRate,
-        language: languageHint
-      )
     }
-  }
-
-  private func transcribeQwen3Audio(
-    model: Qwen3ASRModel,
-    audio: [Float],
-    sampleRate: Int,
-    language: String?
-  ) -> String {
-    let minimumSamples = max(sampleRate, 1)
-    guard audio.count >= minimumSamples else {
-      return ""
-    }
-
-    let chunkSamples = max(sampleRate * 30, minimumSamples)
-    guard audio.count > chunkSamples else {
-      return model.transcribe(audio: audio, sampleRate: sampleRate, language: language)
-    }
-
-    var chunks: [String] = []
-    var offset = 0
-
-    while offset < audio.count {
-      var end = min(offset + chunkSamples, audio.count)
-      let trailingSamples = audio.count - end
-      if trailingSamples > 0 && trailingSamples < minimumSamples {
-        end = audio.count
-      }
-      defer {
-        offset = end
-      }
-
-      let text = autoreleasepool {
-        model.transcribe(
-          audio: Array(audio[offset..<end]),
-          sampleRate: sampleRate,
-          language: language
-        )
-      }
-      let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-      if !trimmed.isEmpty {
-        chunks.append(trimmed)
-      }
-    }
-
-    return chunks.joined(separator: " ")
   }
 }
 


### PR DESCRIPTION
Keep the desktop macOS floor at 14.2, build the Soniqo Swift bridge for macOS 14, and leave macOS 15-only Qwen ASR unavailable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build-time manifest patching and split deployment targets (Swift 14 vs MLX 15) affect macOS Apple Silicon builds; Qwen is intentionally removed from the advertised model list.
> 
> **Overview**
> Restores **Soniqo on macOS 14 (Sonoma)** by lowering the Swift bridge to **macOS 14.0** while keeping **MLX Metal** builds on a **15.0** minimum.
> 
> The **Cargo build** now runs `swift package resolve`, patches the checked-out **`speech-swift`** manifest from macOS 15 → 14, and links via **`SwiftLinker`** at 14.0. **`soniqo-swift`** drops **`Qwen3ASR`**; Qwen load paths in the bridge return a clear **“requires macOS 15 or newer”** error instead of linking MLX Qwen code.
> 
> On the Rust side, **`SoniqoModel::all()`** lists only Parakeet and Omnilingual (so Qwen no longer appears in the general local-model catalog), while **`KNOWN`** still parses Qwen IDs. Platform checks add **`RequiresMacOs15`** and treat Qwen as unavailable on the current platform until macOS 15.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2ec7220809ebd743ee3c1a9aace4a5b36d08566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->