### PR TITLE
fix(desktop): restore meeting auto-stop fallback

### DIFF
--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -382,6 +382,52 @@ describe("ListenerProvider detect events", () => {
     expect(stopSpy).toHaveBeenCalledTimes(1);
   });
 
+  test("keeps direct trigger auto-stop confidence when a later helper stop arrives", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["us.zoom.xos"]);
+    setStoreActive(store);
+    listMicUsingApplicationsMock.mockResolvedValue({
+      status: "error",
+      error: "failed to read mic snapshot",
+    });
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+    listMicUsingApplicationsMock.mockClear();
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
+      },
+    });
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "pid:42", name: "Zoom Helper" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+
+    expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
   test("passes ignorable app ids and footer metadata through mic-detected notifications", async () => {
     const store = createListenerStore();
 

--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -273,6 +273,115 @@ describe("ListenerProvider detect events", () => {
     expect(stopSpy).not.toHaveBeenCalled();
   });
 
+  test("does not stop after non-trigger MicStopped when a trigger app is still active", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["us.zoom.xos"]);
+    setStoreActive(store);
+    listMicUsingApplicationsMock.mockResolvedValue({
+      status: "ok",
+      data: [{ id: "us.zoom.xos", name: "Zoom" }],
+    });
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+    listMicUsingApplicationsMock.mockClear();
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "/opt/homebrew/bin/ffmpeg", name: "ffmpeg" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+
+    expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  test("auto-stops when MicStopped omits the trigger app and no trigger app remains active (regression: #5436)", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["com.microsoft.teams2"]);
+    setStoreActive(store);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+    listMicUsingApplicationsMock.mockClear();
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "pid:42", name: "Microsoft Teams Helper" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+
+    expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("auto-stops Teams running in a browser when the browser no longer uses the mic (regression: #5436)", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["company.thebrowser.Browser"]);
+    setStoreActive(store);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+    listMicUsingApplicationsMock.mockClear();
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "company.thebrowser.Browser", name: "Arc" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+
+    expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
   test("passes ignorable app ids and footer metadata through mic-detected notifications", async () => {
     const store = createListenerStore();
 
@@ -466,67 +575,73 @@ describe("ListenerProvider detect events", () => {
     expect(stopSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("asks before stopping when a browser meeting stops well before the scheduled end", async () => {
-    const store = createListenerStore();
-    const stopSpy = vi.fn();
-    const now = new Date("2026-05-19T10:05:00.000Z");
+  test.each([
+    { id: "com.google.Chrome", name: "Google Chrome" },
+    { id: "at.studio.AsideBrowser", name: "Aside" },
+    { id: "net.imput.helium", name: "Helium" },
+  ])(
+    "asks before stopping when $name stops well before the scheduled end",
+    async (browser) => {
+      const store = createListenerStore();
+      const stopSpy = vi.fn();
+      const now = new Date("2026-05-19T10:05:00.000Z");
 
-    store.setState({ stop: stopSpy });
-    store.getState().setTriggerAppIds(["com.google.Chrome"]);
-    setStoreActive(store);
-    (useStoreMock as any).mockReturnValue(
-      mockSessionEventStore({
-        started_at: "2026-05-19T10:00:00.000Z",
-        ended_at: "2026-05-19T10:30:00.000Z",
-      }),
-    );
+      store.setState({ stop: stopSpy });
+      store.getState().setTriggerAppIds([browser.id]);
+      setStoreActive(store);
+      (useStoreMock as any).mockReturnValue(
+        mockSessionEventStore({
+          started_at: "2026-05-19T10:00:00.000Z",
+          ended_at: "2026-05-19T10:30:00.000Z",
+        }),
+      );
 
-    render(
-      <ListenerProvider store={store}>
-        <div>child</div>
-      </ListenerProvider>,
-    );
+      render(
+        <ListenerProvider store={store}>
+          <div>child</div>
+        </ListenerProvider>,
+      );
 
-    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
 
-    const handler = listenMock.mock.calls[0]?.[0];
-    expect(handler).toBeTypeOf("function");
+      const handler = listenMock.mock.calls[0]?.[0];
+      expect(handler).toBeTypeOf("function");
 
-    vi.useFakeTimers();
-    vi.setSystemTime(now);
-    listMicUsingApplicationsMock.mockClear();
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+      listMicUsingApplicationsMock.mockClear();
 
-    handler({
-      payload: {
-        type: "micStopped",
-        apps: [{ id: "com.google.Chrome", name: "Google Chrome" }],
-      },
-    });
+      handler({
+        payload: {
+          type: "micStopped",
+          apps: [browser],
+        },
+      });
 
-    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+      await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
 
-    expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
-    expect(stopSpy).not.toHaveBeenCalled();
-    const notification = showNotificationMock.mock.calls[0]?.[0];
-    expect(parseAutoStopEndedNotificationKey(notification.key)).toBe(
-      "session-1",
-    );
-    expect(notification).toEqual({
-      key: expect.stringContaining("auto-stop-ended:session-1"),
-      title: "Did your meeting end?",
-      message:
-        "Google Chrome stopped using the microphone before the scheduled end time.",
-      timeout: { secs: 60, nanos: 0 },
-      source: null,
-      start_time: null,
-      participants: null,
-      event_details: null,
-      action_label: "Stop recording",
-      options: null,
-      footer: null,
-      icon: { type: "bundle_id", bundle_id: "com.google.Chrome" },
-    });
-  });
+      expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
+      expect(stopSpy).not.toHaveBeenCalled();
+      const notification = showNotificationMock.mock.calls[0]?.[0];
+      expect(parseAutoStopEndedNotificationKey(notification.key)).toBe(
+        "session-1",
+      );
+      expect(notification).toEqual({
+        key: expect.stringContaining("auto-stop-ended:session-1"),
+        title: "Did your meeting end?",
+        message: `${browser.name} stopped using the microphone before the scheduled end time.`,
+        timeout: { secs: 60, nanos: 0 },
+        source: null,
+        start_time: null,
+        participants: null,
+        event_details: null,
+        action_label: "Stop recording",
+        options: null,
+        footer: null,
+        icon: { type: "bundle_id", bundle_id: browser.id },
+      });
+    },
+  );
 
   test("auto-stops browser meetings inside the scheduled end window", async () => {
     const store = createListenerStore();

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -283,7 +283,10 @@ const useHandleDetectEvents = (store: ListenerStore) => {
 
   const tinybaseStoreRef = useRef(tinybaseStore);
   const settingsStoreRef = useRef(settingsStore);
-  const pendingAutoStopRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingAutoStopRef = useRef<{
+    timeout: ReturnType<typeof setTimeout>;
+    requireMicSnapshot: boolean;
+  } | null>(null);
   useEffect(() => {
     tinybaseStoreRef.current = tinybaseStore;
     settingsStoreRef.current = settingsStore;
@@ -294,7 +297,7 @@ const useHandleDetectEvents = (store: ListenerStore) => {
     let cancelled = false;
     const clearPendingAutoStop = () => {
       if (pendingAutoStopRef.current) {
-        clearTimeout(pendingAutoStopRef.current);
+        clearTimeout(pendingAutoStopRef.current.timeout);
         pendingAutoStopRef.current = null;
       }
     };
@@ -425,16 +428,28 @@ const useHandleDetectEvents = (store: ListenerStore) => {
             payload.apps,
           );
           if (candidateAppIds.length > 0) {
+            const requireMicSnapshot = stoppedTriggerAppIds.length === 0;
+            if (
+              pendingAutoStopRef.current &&
+              !pendingAutoStopRef.current.requireMicSnapshot &&
+              requireMicSnapshot
+            ) {
+              return;
+            }
+
             clearPendingAutoStop();
 
-            pendingAutoStopRef.current = setTimeout(() => {
-              pendingAutoStopRef.current = null;
-              void confirmAutoStop(
-                candidateAppIds,
-                payload.apps,
-                stoppedTriggerAppIds.length === 0,
-              );
-            }, AUTO_STOP_CONFIRM_DELAY_MS);
+            pendingAutoStopRef.current = {
+              timeout: setTimeout(() => {
+                pendingAutoStopRef.current = null;
+                void confirmAutoStop(
+                  candidateAppIds,
+                  payload.apps,
+                  requireMicSnapshot,
+                );
+              }, AUTO_STOP_CONFIRM_DELAY_MS),
+              requireMicSnapshot,
+            };
           }
         } else if (payload.type === "sleepStateChanged") {
           if (payload.value) {

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -26,18 +26,39 @@ export const AUTO_STOP_CONFIRM_DELAY_MS = 5_000;
 export const AUTO_STOP_CALENDAR_EARLY_END_THRESHOLD_MS = 3 * 60_000;
 export const AUTO_STOP_CALENDAR_EARLY_START_BUFFER_MS = 5 * 60_000;
 
-const BROWSER_MEETING_APP_IDS = new Set([
+const BROWSER_AUTO_STOP_APP_IDS = new Set([
+  "at.studio.AsideBrowser",
   "app.zen-browser.zen",
   "com.apple.Safari",
+  "com.apple.SafariTechnologyPreview",
   "com.brave.Browser",
+  "com.brave.Browser.beta",
+  "com.brave.Browser.nightly",
+  "com.duckduckgo.macos.browser",
   "com.google.Chrome",
   "com.google.Chrome.canary",
+  "com.kagi.kagimacOS",
+  "com.kagi.kagimacOS.RC",
   "com.microsoft.edgemac",
+  "com.microsoft.edgemac.Beta",
   "com.microsoft.edgemac.Canary",
+  "com.microsoft.edgemac.Dev",
   "com.operasoftware.Opera",
+  "com.operasoftware.OperaDeveloper",
+  "com.operasoftware.OperaGX",
+  "com.operasoftware.OperaNext",
   "com.vivaldi.Vivaldi",
   "company.thebrowser.Browser",
+  "company.thebrowser.dia",
+  "net.imput.helium",
+  "net.mullvad.mullvadbrowser",
+  "net.waterfox.waterfox",
+  "org.chromium.Chromium",
   "org.mozilla.firefox",
+  "org.mozilla.firefoxdeveloperedition",
+  "org.mozilla.librewolf",
+  "org.mozilla.nightly",
+  "org.torproject.torbrowser",
 ]);
 
 type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
@@ -107,7 +128,7 @@ function shouldPromptBeforeAutoStopping({
   sessionId: string | null;
   nowMs: number;
 }) {
-  if (!appIds.some((id) => BROWSER_MEETING_APP_IDS.has(id))) {
+  if (!appIds.some((id) => BROWSER_AUTO_STOP_APP_IDS.has(id))) {
     return false;
   }
 
@@ -141,11 +162,22 @@ function getPrimaryStoppedApp(
     stoppedApps.find(
       (app) =>
         stoppedTriggerAppIds.includes(app.id) &&
-        BROWSER_MEETING_APP_IDS.has(app.id),
+        BROWSER_AUTO_STOP_APP_IDS.has(app.id),
     ) ??
     stoppedApps.find((app) => stoppedTriggerAppIds.includes(app.id)) ??
     null
   );
+}
+
+function getAutoStopCandidateAppIds(
+  triggerAppIds: string[] | null | undefined,
+  stoppedApps: { id: string }[],
+) {
+  const trigger = triggerAppIds ?? [];
+  const stoppedIds = new Set(stoppedApps.map((app) => app.id));
+  const stoppedTriggerAppIds = trigger.filter((id) => stoppedIds.has(id));
+
+  return stoppedTriggerAppIds.length > 0 ? stoppedTriggerAppIds : trigger;
 }
 
 function getStoppedAppLabel(app: { name: string } | null) {
@@ -268,8 +300,9 @@ const useHandleDetectEvents = (store: ListenerStore) => {
     };
 
     const confirmAutoStop = async (
-      stoppedTriggerAppIds: string[],
+      candidateAppIds: string[],
       stoppedApps: { id: string; name: string }[],
+      requireMicSnapshot = false,
     ) => {
       const live = store.getState().live;
       if (live.status !== "active") {
@@ -279,7 +312,7 @@ const useHandleDetectEvents = (store: ListenerStore) => {
       const currentTrigger = live.triggerAppIds;
       if (
         !currentTrigger ||
-        !stoppedTriggerAppIds.some((id) => currentTrigger.includes(id))
+        !candidateAppIds.some((id) => currentTrigger.includes(id))
       ) {
         return;
       }
@@ -287,15 +320,17 @@ const useHandleDetectEvents = (store: ListenerStore) => {
       const result = await detectCommands.listMicUsingApplications();
       if (result.status === "ok") {
         const activeAppIds = new Set(result.data.map((app) => app.id));
-        if (stoppedTriggerAppIds.some((id) => activeAppIds.has(id))) {
+        if (candidateAppIds.some((id) => activeAppIds.has(id))) {
           return;
         }
+      } else if (requireMicSnapshot) {
+        return;
       }
 
       const sessionId = store.getState().live.sessionId;
       if (
         shouldPromptBeforeAutoStopping({
-          appIds: stoppedTriggerAppIds,
+          appIds: candidateAppIds,
           tinybaseStore: tinybaseStoreRef.current,
           sessionId,
           nowMs: Date.now(),
@@ -304,7 +339,7 @@ const useHandleDetectEvents = (store: ListenerStore) => {
         if (sessionId) {
           showMeetingEndedPrompt({
             sessionId,
-            stoppedTriggerAppIds,
+            stoppedTriggerAppIds: candidateAppIds,
             stoppedApps,
           });
         }
@@ -385,12 +420,20 @@ const useHandleDetectEvents = (store: ListenerStore) => {
             trigger?.filter((id) =>
               payload.apps.some((app) => app.id === id),
             ) ?? [];
-          if (stoppedTriggerAppIds.length > 0) {
+          const candidateAppIds = getAutoStopCandidateAppIds(
+            trigger,
+            payload.apps,
+          );
+          if (candidateAppIds.length > 0) {
             clearPendingAutoStop();
 
             pendingAutoStopRef.current = setTimeout(() => {
               pendingAutoStopRef.current = null;
-              void confirmAutoStop(stoppedTriggerAppIds, payload.apps);
+              void confirmAutoStop(
+                candidateAppIds,
+                payload.apps,
+                stoppedTriggerAppIds.length === 0,
+              );
             }, AUTO_STOP_CONFIRM_DELAY_MS);
           }
         } else if (payload.type === "sleepStateChanged") {


### PR DESCRIPTION
Stop recordings when trigger apps disappear even if micStopped reports a helper process, while keeping active-trigger false positive protection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live recording stop behavior on mic events; mistakes could stop sessions early or leave them running, but logic is guarded by mic snapshots and existing calendar prompts.
> 
> **Overview**
> **Meeting auto-stop** now treats `micStopped` more reliably when the OS reports helper/PID processes instead of the real trigger app (e.g. Teams, browser-based meetings). A new `getAutoStopCandidateAppIds` path uses the full trigger list when the stopped app list doesn’t include the trigger bundle id, while still re-checking the mic snapshot so a still-active trigger isn’t stopped on unrelated stops.
> 
> Pending auto-stop timers track whether a mic snapshot is required; weaker helper-only events won’t downgrade a timer started from a direct trigger stop, and snapshot failures block stop only when that stricter path applies.
> 
> The browser bundle-id set is expanded and renamed (`BROWSER_AUTO_STOP_APP_IDS`) for calendar early-end prompts and primary stopped-app labeling. Tests cover regressions **#5436** / helper behavior and parameterize early-end prompts across multiple browsers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5209719763ff35a5bb656e556fba822e51431c8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->