### PR TITLE
fix(desktop): align live transcript padding

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
@@ -78,13 +78,12 @@ describe("DuringSessionAccessory", () => {
     expect(view.container.firstChild).toBeNull();
   });
 
-  it("balances collapsed live transcript bottom padding with the top handle spacing", () => {
+  it("uses matching collapsed live transcript vertical padding", () => {
     render(<DuringSessionAccessory sessionId="session-1" />);
 
     const message = screen.getByText("All right, let's see.");
     const row = message.parentElement?.parentElement;
-    expect(row?.className).toContain("pt-0.5");
-    expect(row?.className).toContain("pb-2");
+    expect(row?.className).toContain("py-2");
   });
 
   it("lets manual scrolling override expanded live transcript bottom pinning", () => {

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -186,7 +186,7 @@ function LiveTranscriptContent({
         shouldPinToBottomRef.current = isLiveTranscriptPinnedToBottom(element);
       }}
       className={cn([
-        "flex flex-col gap-1 overflow-y-auto px-3 pt-2 pb-2.5",
+        "flex flex-col gap-1 overflow-y-auto px-3 py-2.5",
         fillHeight ? "h-full min-h-0" : "max-h-[180px]",
       ])}
     >
@@ -235,7 +235,7 @@ function CollapsedFooterMessage({ message }: { message: string }) {
   return (
     <div
       className={cn([
-        "flex min-h-7 items-center gap-2 px-2 pt-0.5 pb-2",
+        "flex min-h-7 items-center gap-2 px-2 py-2",
         "w-full max-w-full",
       ])}
     >


### PR DESCRIPTION
Make live transcript panel top padding match the bottom padding in collapsed and expanded states.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind class-only layout tweak in the live transcript footer with no logic or data changes.
> 
> **Overview**
> Aligns **live transcript** vertical spacing in the desktop during-session bottom accessory so top and bottom padding match in both collapsed and expanded layouts.
> 
> **Expanded** scroll area: replaces asymmetric `pt-2 pb-2.5` with uniform `py-2.5`. **Collapsed** footer preview row: replaces `pt-0.5 pb-2` with `py-2`. The unit test is renamed and updated to assert `py-2` on the collapsed row instead of separate top/bottom classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 574fe133505766b49307fb8c59641ad640e9c040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->