### PR TITLE
Support dragging notes into chat context

### DIFF
--- a/apps/desktop/src/chat/components/content.test.tsx
+++ b/apps/desktop/src/chat/components/content.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ChatContent } from "./content";
+
+vi.mock("./body", () => ({
+  ChatBody: () => <div data-testid="chat-body" />,
+}));
+
+vi.mock("./context-bar", () => ({
+  ContextBar: () => <div data-testid="context-bar" />,
+}));
+
+vi.mock("./input", () => ({
+  ChatMessageInput: () => <div data-testid="chat-input" />,
+}));
+
+class FakeDataTransfer {
+  dropEffect = "none";
+  private readonly values = new Map<string, string>();
+
+  get types() {
+    return Array.from(this.values.keys());
+  }
+
+  getData(type: string) {
+    return this.values.get(type) ?? "";
+  }
+
+  setData(type: string, value: string) {
+    this.values.set(type, value);
+  }
+}
+
+const renderContent = (onAddContextEntity = vi.fn()) => {
+  const { container } = render(
+    <ChatContent
+      sessionId="active-session"
+      messages={[]}
+      sendMessage={vi.fn()}
+      regenerate={vi.fn()}
+      stop={vi.fn()}
+      status="ready"
+      model={{} as never}
+      handleSendMessage={vi.fn()}
+      contextEntities={[]}
+      pendingRefs={[]}
+      onAddContextEntity={onAddContextEntity}
+      isSystemPromptReady
+    />,
+  );
+
+  return container.querySelector("[data-chat-content]");
+};
+
+describe("ChatContent", () => {
+  it("adds dropped session refs to chat context", () => {
+    const onAddContextEntity = vi.fn();
+    const container = renderContent(onAddContextEntity);
+    const dataTransfer = new FakeDataTransfer();
+
+    dataTransfer.setData(
+      "application/x-anarlog-session-context",
+      JSON.stringify({ sessionId: "session-1" }),
+    );
+
+    fireEvent.dragOver(container!, { dataTransfer });
+    fireEvent.drop(container!, { dataTransfer });
+
+    expect(dataTransfer.dropEffect).toBe("copy");
+    expect(onAddContextEntity).toHaveBeenCalledWith({
+      kind: "session",
+      key: "session:manual:session-1",
+      source: "manual",
+      sessionId: "session-1",
+    });
+  });
+
+  it("ignores non-session drops", () => {
+    const onAddContextEntity = vi.fn();
+    const container = renderContent(onAddContextEntity);
+    const dataTransfer = new FakeDataTransfer();
+
+    dataTransfer.setData("text/plain", "Meeting notes");
+
+    fireEvent.drop(container!, { dataTransfer });
+
+    expect(onAddContextEntity).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/chat/components/content.tsx
+++ b/apps/desktop/src/chat/components/content.tsx
@@ -6,6 +6,10 @@ import { ChatMessageInput } from "./input";
 
 import type { useLanguageModel } from "~/ai/hooks";
 import { dedupeByKey, type ContextRef } from "~/chat/context/entities";
+import {
+  hasSessionContextDragData,
+  readSessionContextDragData,
+} from "~/chat/context/session-drag";
 import type { DisplayEntity } from "~/chat/context/use-chat-context-pipeline";
 import type { HyprUIMessage } from "~/chat/types";
 
@@ -53,9 +57,37 @@ export function ChatContent({
   const disabled = !isSystemPromptReady;
   const mergeContextRefs = (contextRefs?: ContextRef[]) =>
     contextRefs ? dedupeByKey([pendingRefs, contextRefs]) : pendingRefs;
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!onAddContextEntity || !hasSessionContextDragData(event.dataTransfer)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  };
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!onAddContextEntity) {
+      return;
+    }
+
+    const contextRef = readSessionContextDragData(event.dataTransfer);
+
+    if (!contextRef) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    onAddContextEntity(contextRef);
+  };
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div
+      className="flex min-h-0 flex-1 flex-col overflow-hidden"
+      data-chat-content
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
       {children ?? (
         <ChatBody
           messages={messages}

--- a/apps/desktop/src/chat/context/session-drag.test.ts
+++ b/apps/desktop/src/chat/context/session-drag.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasSessionContextDragData,
+  readSessionContextDragData,
+  writeSessionContextDragData,
+} from "./session-drag";
+
+class FakeDataTransfer {
+  effectAllowed = "all";
+  private readonly values = new Map<string, string>();
+
+  get types() {
+    return Array.from(this.values.keys());
+  }
+
+  getData(type: string) {
+    return this.values.get(type) ?? "";
+  }
+
+  setData(type: string, value: string) {
+    this.values.set(type, value);
+  }
+}
+
+describe("session drag context", () => {
+  it("writes and reads manual session context refs", () => {
+    const dataTransfer = new FakeDataTransfer() as unknown as DataTransfer;
+
+    writeSessionContextDragData(dataTransfer, "session-1", "Meeting notes");
+
+    expect(dataTransfer.effectAllowed).toBe("copy");
+    expect(hasSessionContextDragData(dataTransfer)).toBe(true);
+    expect(readSessionContextDragData(dataTransfer)).toEqual({
+      kind: "session",
+      key: "session:manual:session-1",
+      source: "manual",
+      sessionId: "session-1",
+    });
+  });
+
+  it("ignores malformed session drag payloads", () => {
+    const dataTransfer = new FakeDataTransfer() as unknown as DataTransfer;
+
+    dataTransfer.setData("application/x-anarlog-session-context", "{");
+
+    expect(readSessionContextDragData(dataTransfer)).toBeNull();
+  });
+
+  it("ignores non-session drops", () => {
+    const dataTransfer = new FakeDataTransfer() as unknown as DataTransfer;
+
+    dataTransfer.setData("text/plain", "Meeting notes");
+
+    expect(hasSessionContextDragData(dataTransfer)).toBe(false);
+    expect(readSessionContextDragData(dataTransfer)).toBeNull();
+  });
+});

--- a/apps/desktop/src/chat/context/session-drag.ts
+++ b/apps/desktop/src/chat/context/session-drag.ts
@@ -1,0 +1,62 @@
+import type { ContextRef } from "./entities";
+
+const SESSION_CONTEXT_DRAG_TYPE = "application/x-anarlog-session-context";
+
+type SessionDragPayload = {
+  sessionId: string;
+};
+
+const createSessionContextRef = (sessionId: string): ContextRef => ({
+  kind: "session",
+  key: `session:manual:${sessionId}`,
+  source: "manual",
+  sessionId,
+});
+
+export const hasSessionContextDragData = (
+  dataTransfer: Pick<DataTransfer, "types"> | null | undefined,
+) => {
+  if (!dataTransfer) {
+    return false;
+  }
+
+  return Array.from(dataTransfer.types).includes(SESSION_CONTEXT_DRAG_TYPE);
+};
+
+export const writeSessionContextDragData = (
+  dataTransfer: DataTransfer,
+  sessionId: string,
+  fallbackText: string,
+) => {
+  dataTransfer.effectAllowed = "copy";
+  dataTransfer.setData(
+    SESSION_CONTEXT_DRAG_TYPE,
+    JSON.stringify({ sessionId }),
+  );
+  dataTransfer.setData("text/plain", fallbackText);
+};
+
+export const readSessionContextDragData = (
+  dataTransfer: Pick<DataTransfer, "getData" | "types"> | null | undefined,
+): ContextRef | null => {
+  if (!dataTransfer || !hasSessionContextDragData(dataTransfer)) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(
+      dataTransfer.getData(SESSION_CONTEXT_DRAG_TYPE),
+    ) as SessionDragPayload;
+
+    if (
+      typeof payload.sessionId !== "string" ||
+      payload.sessionId.trim().length === 0
+    ) {
+      return null;
+    }
+
+    return createSessionContextRef(payload.sessionId);
+  } catch {
+    return null;
+  }
+};

--- a/apps/desktop/src/main/top-meeting-timeline.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.tsx
@@ -11,6 +11,7 @@ import {
 import {
   memo,
   type CSSProperties,
+  type DragEvent,
   type MouseEvent,
   type MouseEventHandler,
   type PointerEvent,
@@ -47,6 +48,7 @@ import {
   type TimelineTranscriptsTable,
 } from "./meeting-timeline-recordings";
 
+import { writeSessionContextDragData } from "~/chat/context/session-drag";
 import { SessionPreviewCard } from "~/session/components/session-preview-card";
 import { useDeleteSession } from "~/session/hooks/useDeleteSession";
 import { useIsSessionEnhancing } from "~/session/hooks/useEnhancedNotes";
@@ -560,6 +562,17 @@ const SessionTimelineBar = memo(
       openNew({ id: item.id, type: "sessions" });
     }, [item.id, openNew]);
 
+    const handleDragStart = useCallback(
+      (event: DragEvent<HTMLButtonElement>) => {
+        writeSessionContextDragData(
+          event.dataTransfer,
+          item.id,
+          title || item.title || "Untitled",
+        );
+      },
+      [item.id, item.title, title],
+    );
+
     const handleDelete = useCallback(() => {
       deleteSession(item.id, sessionEvent?.tracking_id);
     }, [deleteSession, item.id, sessionEvent]);
@@ -607,8 +620,10 @@ const SessionTimelineBar = memo(
             )}
             showSpinner={showSpinner}
             onClick={openSession}
+            onDragStart={handleDragStart}
             onStop={stop}
             contextMenu={contextMenu}
+            draggable
           />
         </SessionPreviewCard>
       </TimelineCarouselCard>
@@ -831,8 +846,10 @@ function TimelineCardButton({
   amplitude,
   showSpinner,
   onClick,
+  onDragStart,
   onStop,
   contextMenu,
+  draggable,
 }: {
   item: MeetingTimelineEntry;
   title: string;
@@ -841,8 +858,10 @@ function TimelineCardButton({
   amplitude?: number;
   showSpinner?: boolean;
   onClick: (event: MouseEvent<HTMLButtonElement>) => void;
+  onDragStart?: (event: DragEvent<HTMLButtonElement>) => void;
   onStop?: () => void;
   contextMenu?: MenuItemDef[];
+  draggable?: boolean;
 }) {
   const showContextMenu = useNativeContextMenu(contextMenu ?? []);
   const handleContextMenu = useCallback<MouseEventHandler<HTMLButtonElement>>(
@@ -865,6 +884,16 @@ function TimelineCardButton({
     },
     [onStop],
   );
+  const handlePointerDown = useCallback(
+    (event: PointerEvent<HTMLButtonElement>) => {
+      if (!draggable) {
+        return;
+      }
+
+      event.stopPropagation();
+    },
+    [draggable],
+  );
   const startLabel = formatTimelineStartLabel(item.start, timezone);
   const showLiveStop = item.type === "session" && isLive && onStop;
   const showSuffixSpinner =
@@ -876,7 +905,10 @@ function TimelineCardButton({
       <button
         type="button"
         onClick={onClick}
+        onDragStart={onDragStart}
         onContextMenu={handleContextMenu}
+        onPointerDown={handlePointerDown}
+        draggable={draggable}
         className={cn([
           "flex h-10 w-full flex-col justify-center rounded-md border py-0 pl-2 text-left shadow-xs",
           showSuffix ? "pr-8" : "pr-2",

--- a/apps/desktop/src/shared/ui/interactive-button.tsx
+++ b/apps/desktop/src/shared/ui/interactive-button.tsx
@@ -1,4 +1,9 @@
-import { type MouseEvent, type ReactNode, useCallback } from "react";
+import {
+  type DragEvent,
+  type MouseEvent,
+  type ReactNode,
+  useCallback,
+} from "react";
 
 import {
   type MenuItemDef,
@@ -11,9 +16,11 @@ interface InteractiveButtonProps {
   onCmdClick?: () => void;
   onShiftClick?: () => void;
   onMouseDown?: (e: MouseEvent<HTMLElement>) => void;
+  onDragStart?: (e: DragEvent<HTMLElement>) => void;
   contextMenu?: MenuItemDef[];
   className?: string;
   disabled?: boolean;
+  draggable?: boolean;
   asChild?: boolean;
 }
 
@@ -23,9 +30,11 @@ export function InteractiveButton({
   onCmdClick,
   onShiftClick,
   onMouseDown,
+  onDragStart,
   contextMenu,
   className,
   disabled,
+  draggable,
   asChild = false,
 }: InteractiveButtonProps) {
   const showMenu = useNativeContextMenu(contextMenu ?? []);
@@ -54,10 +63,12 @@ export function InteractiveButton({
   return (
     <Element
       onClick={handleClick}
+      onDragStart={onDragStart}
       onMouseDown={onMouseDown}
       onContextMenu={contextMenu ? showMenu : undefined}
       className={className}
       disabled={!asChild ? disabled : undefined}
+      draggable={draggable}
     >
       {children}
     </Element>

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -1,5 +1,5 @@
 import { SquareIcon } from "lucide-react";
-import { memo, useCallback, useMemo } from "react";
+import { memo, type DragEvent, useCallback, useMemo } from "react";
 
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
@@ -20,6 +20,7 @@ import {
   TimelinePrecision,
 } from "./utils";
 
+import { writeSessionContextDragData } from "~/chat/context/session-drag";
 import { SessionPreviewCard } from "~/session/components/session-preview-card";
 import { useIsSessionEnhancing } from "~/session/hooks/useEnhancedNotes";
 import { getSessionEvent } from "~/session/utils";
@@ -95,7 +96,9 @@ function ItemBase({
   onCmdClick,
   onShiftClick,
   onStop,
+  onDragStart,
   contextMenu,
+  draggable,
 }: {
   title: string;
   displayTime: string;
@@ -111,7 +114,9 @@ function ItemBase({
   onCmdClick: () => void;
   onShiftClick: () => void;
   onStop?: () => void;
+  onDragStart?: (event: DragEvent<HTMLElement>) => void;
   contextMenu: MenuItemDef[];
+  draggable?: boolean;
 }) {
   const hasSelection = useTimelineSelection((s) => s.selectedIds.length > 0);
   const showLiveStop = isLive && onStop;
@@ -122,6 +127,7 @@ function ItemBase({
         onClick={ignored ? undefined : onClick}
         onCmdClick={ignored ? undefined : onCmdClick}
         onShiftClick={ignored ? undefined : onShiftClick}
+        onDragStart={onDragStart}
         contextMenu={hasSelection ? undefined : contextMenu}
         className={cn([
           "w-full rounded-lg px-3 py-2 text-left",
@@ -137,6 +143,7 @@ function ItemBase({
           ignored && "opacity-40",
           !ignored && muted && !isLive && "opacity-65",
         ])}
+        draggable={draggable}
       >
         <div className="flex items-center gap-2">
           {showSpinner && (
@@ -445,6 +452,17 @@ const SessionItem = memo(
       useTimelineSelection.getState().selectRange(flatItemKeys, itemKey);
     }, [flatItemKeys, itemKey]);
 
+    const handleDragStart = useCallback(
+      (event: DragEvent<HTMLElement>) => {
+        writeSessionContextDragData(
+          event.dataTransfer,
+          sessionId,
+          title || "Untitled",
+        );
+      },
+      [sessionId, title],
+    );
+
     const handleOpenNewTab = useCallback(() => {
       openNew({ id: sessionId, type: "sessions" });
     }, [sessionId, openNew]);
@@ -532,7 +550,9 @@ const SessionItem = memo(
           onCmdClick={handleCmdClick}
           onShiftClick={handleShiftClick}
           onStop={stop}
+          onDragStart={handleDragStart}
           contextMenu={contextMenu}
+          draggable
         />
       </SessionPreviewCard>
     );


### PR DESCRIPTION
## Summary
- add a session drag payload for note/session cards
- let chat accept dropped session payloads as manual context
- cover drag payload parsing and chat drop behavior

## Verification
- pnpm exec dprint fmt apps/desktop/src/chat/components/content.tsx apps/desktop/src/chat/components/content.test.tsx apps/desktop/src/chat/context/session-drag.ts apps/desktop/src/chat/context/session-drag.test.ts apps/desktop/src/main/top-meeting-timeline.tsx apps/desktop/src/shared/ui/interactive-button.tsx apps/desktop/src/sidebar/timeline/item.tsx
- pnpm -F @hypr/desktop exec vitest run src/chat/context/session-drag.test.ts src/chat/components/content.test.tsx
- pnpm -F desktop typecheck

Fixes #5060

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only drag-and-drop wiring to existing chat context callbacks; no auth, persistence, or network changes beyond current context flow.
> 
> **Overview**
> Users can **drag note/session cards** from the sidebar timeline and top meeting timeline into the chat area to attach them as **manual session context**.
> 
> A shared `session-drag` helper writes a custom drag payload (`application/x-anarlog-session-context`) plus plain-text fallback; **ChatContent** accepts drops, sets copy drop effect, and calls `onAddContextEntity` with a parsed manual `ContextRef`. Malformed or non-session drags are ignored. Timeline session buttons are **draggable** with `pointerdown` propagation stopped so they don’t fight the window drag region.
> 
> Unit tests cover payload read/write and chat drop behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99e8408300b97ccd5f0e6b17bb5dfb15131a30d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->