### PR TITLE
fix(chat): keep escape on current note

### DIFF
--- a/apps/desktop/src/main/useTabsShortcuts.test.tsx
+++ b/apps/desktop/src/main/useTabsShortcuts.test.tsx
@@ -489,6 +489,25 @@ describe("useClassicMainTabsShortcuts", () => {
     expect(hoisted.openCurrent).not.toHaveBeenCalled();
   });
 
+  it("does not go home when chat closes before deferred escape handling runs", () => {
+    hoisted.chatMode = "FloatingOpen";
+    hoisted.currentTab = {
+      active: true,
+      slotId: "slot-session",
+      type: "sessions",
+    };
+
+    const { rerender } = renderHook(() => useClassicMainTabsShortcuts());
+
+    dispatchEscape();
+    hoisted.chatMode = "FloatingClosed";
+    rerender();
+    vi.runOnlyPendingTimers();
+
+    expect(hoisted.sendEvent).toHaveBeenCalledWith({ type: "CLOSE" });
+    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+  });
+
   it("closes the right panel chat before going home on escape", () => {
     hoisted.chatMode = "RightPanelOpen";
     hoisted.currentTab = {

--- a/apps/desktop/src/shared/useTabsShortcuts.tsx
+++ b/apps/desktop/src/shared/useTabsShortcuts.tsx
@@ -45,6 +45,8 @@ export function useMainTabsShortcuts({ onModT }: { onModT: () => void }) {
 
   const escapeShortcutRef = useRef(runEscapeShortcut);
   escapeShortcutRef.current = runEscapeShortcut;
+  const chatRef = useRef(chat);
+  chatRef.current = chat;
 
   useMountEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -56,6 +58,7 @@ export function useMainTabsShortcuts({ onModT }: { onModT: () => void }) {
       const hadEditorEscapeConsumer =
         fromProseMirrorEditor &&
         document.querySelector("[data-editor-escape-consumer]") !== null;
+      const hadOpenChat = chatRef.current.mode !== "FloatingClosed";
 
       window.setTimeout(() => {
         if (
@@ -64,6 +67,11 @@ export function useMainTabsShortcuts({ onModT }: { onModT: () => void }) {
             hadEditorEscapeConsumer,
           })
         ) {
+          return;
+        }
+
+        if (hadOpenChat) {
+          chatRef.current.sendEvent({ type: "CLOSE" });
           return;
         }
 


### PR DESCRIPTION
Snapshot open chat state before deferred Escape handling so closing chat cannot fall through to home navigation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small keyboard-shortcut behavior change with a focused regression test; no auth, data, or API surface changes.
> 
> **Overview**
> **Escape** on the main tabs shortcuts now records whether chat was open at keydown time, before the deferred handler runs. If it was, the timeout only sends **CLOSE** to chat and does not run the usual escape action (home / tab back navigation).
> 
> This fixes a race where chat could already be **FloatingClosed** when the deferred callback ran, so a second Escape effect would send the user to the home empty tab while they were still on a note/session tab.
> 
> A regression test covers chat closing between keydown and the timer firing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa2bfd3ac28c662f39640cd922e0f1fd1f4930d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->