### PR TITLE
fix(desktop): keep new notes before create button

### DIFF
--- a/apps/desktop/src/main/top-meeting-timeline.test.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.test.tsx
@@ -483,6 +483,33 @@ describe("TopMeetingTimeline", () => {
     expect(timelineCards[2]?.textContent).toContain("Future note");
   });
 
+  it("places a newly created note before the create note card before the clock ticks", () => {
+    const now = new Date("2026-05-29T15:41:00.000Z");
+    const createdAt = new Date("2026-05-29T15:41:30.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    const { rerender } = render(<TopMeetingTimeline currentTab={null} />);
+
+    vi.setSystemTime(createdAt);
+    mocks.timelineSessionsTable = {
+      "session-1": {
+        created_at: createdAt.toISOString(),
+        event_json: "",
+        title: "Untitled",
+      },
+    };
+
+    rerender(<TopMeetingTimeline currentTab={null} />);
+
+    const timelineCards = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-timeline-start-ms]"),
+    );
+
+    expect(timelineCards[0]?.textContent).toContain("Untitled");
+    expect(timelineCards[1]?.textContent).toContain("Create new note");
+  });
+
   it("keeps manual scroll when the trailing create note clock ticks", () => {
     const now = new Date("2026-05-29T15:41:00.000Z");
     vi.useFakeTimers();

--- a/apps/desktop/src/main/top-meeting-timeline.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.tsx
@@ -196,7 +196,7 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
         endExclusive: timelineEnd,
         hasHiddenPastItems,
         hasHiddenFutureItems,
-        currentTime: new Date(currentTimeMs),
+        currentTime: new Date(Math.max(currentTimeMs, Date.now())),
         includeCreateNote: true,
       }),
     [


### PR DESCRIPTION
Use fresh timeline time when rebuilding carousel items and cover freshly created notes before the clock tick.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI ordering fix in timeline carousel construction with a focused regression test; no auth, data, or API changes.
> 
> **Overview**
> Fixes desktop top meeting timeline ordering when a note is created between periodic **now** ticks.
> 
> Carousel rebuilds now pass **`Math.max(currentTimeMs, Date.now())`** into `buildTimelineCarouselItems` as `currentTime`, so the dashed **Create new note** slot is anchored to real wall clock instead of a stale tick. That keeps a freshly added session (with a newer `created_at`) **before** the create card until the next scheduled time update.
> 
> Adds a Vitest case that advances fake time, injects a new **Untitled** session, and asserts **Untitled** then **Create new note** order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e74a4a4b4a2c4ea89e8e6ed6d33419608d3bcfde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->