### PR TITLE
Fix transcript speaker assignment

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
@@ -30,7 +30,7 @@ export function SegmentHeader({
   ]);
 
   return (
-    <p className={headerClassName}>
+    <div className={headerClassName}>
       <SpeakerAssignPopover
         segment={segment}
         transcriptId={transcriptId}
@@ -38,7 +38,7 @@ export function SegmentHeader({
         label={label}
       />
       <span className="font-mono text-neutral-500">{timestamp}</span>
-    </p>
+    </div>
   );
 }
 

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCreateSpeakerParticipantOption,
+  buildSpeakerParticipantGroups,
+  getAssignmentAnchorWordId,
+  type SpeakerParticipantOption,
+} from "./speaker-assign";
+
+import type { Segment } from "~/stt/live-segment";
+
+function option(
+  id: string,
+  name: string,
+  overrides: Partial<SpeakerParticipantOption> = {},
+): SpeakerParticipantOption {
+  return {
+    id,
+    name,
+    isSessionParticipant: false,
+    ...overrides,
+  };
+}
+
+describe("buildSpeakerParticipantGroups", () => {
+  it("falls back to contacts when a transcript has no session participants", () => {
+    const groups = buildSpeakerParticipantGroups({
+      sessionParticipants: [],
+      contacts: [option("human-1", "Alice")],
+      query: "",
+    });
+
+    expect(groups).toEqual([
+      {
+        title: "Contacts",
+        options: [option("human-1", "Alice")],
+      },
+    ]);
+  });
+
+  it("keeps session participants first and excludes duplicate contacts", () => {
+    const participant = option("human-1", "Alice", {
+      isSessionParticipant: true,
+    });
+    const groups = buildSpeakerParticipantGroups({
+      sessionParticipants: [participant],
+      contacts: [option("human-1", "Alice"), option("human-2", "Bob")],
+      query: "",
+    });
+
+    expect(groups).toEqual([
+      {
+        title: "Session participants",
+        options: [participant],
+      },
+      {
+        title: "Contacts",
+        options: [option("human-2", "Bob")],
+      },
+    ]);
+  });
+});
+
+describe("buildCreateSpeakerParticipantOption", () => {
+  it("creates an add option for a new typed contact name", () => {
+    expect(
+      buildCreateSpeakerParticipantOption({
+        query: "  Charlie  ",
+        existingOptions: [option("human-1", "Alice")],
+      }),
+    ).toEqual({
+      id: "new",
+      name: "Charlie",
+      isSessionParticipant: false,
+      isNew: true,
+    });
+  });
+
+  it("does not create a duplicate add option", () => {
+    expect(
+      buildCreateSpeakerParticipantOption({
+        query: "alice@example.com",
+        existingOptions: [
+          option("human-1", "Alice", { email: "alice@example.com" }),
+        ],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("getAssignmentAnchorWordId", () => {
+  it("uses the first available word id in the segment", () => {
+    const segment = {
+      id: "segment-1",
+      key: {
+        channel: "RemoteParty",
+        speaker_index: 1,
+        speaker_human_id: null,
+      },
+      speaker_label: "Speaker 1",
+      start_ms: 0,
+      end_ms: 200,
+      text: "hello there",
+      words: [
+        {
+          text: "hello",
+          start_ms: 0,
+          end_ms: 100,
+          channel: "RemoteParty",
+          is_final: true,
+        },
+        {
+          id: "word-2",
+          text: "there",
+          start_ms: 100,
+          end_ms: 200,
+          channel: "RemoteParty",
+          is_final: true,
+        },
+      ],
+    } as Segment;
+
+    expect(getAssignmentAnchorWordId(segment)).toBe("word-2");
+  });
+});

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -37,7 +37,7 @@ export function SpeakerAssignPopover({
   const handleAssign = useCallback(
     (humanId: string) => {
       if (!store || segment.words.length === 0) return;
-      const anchorWordId = segment.words[0].id;
+      const anchorWordId = getAssignmentAnchorWordId(segment);
       if (!anchorWordId) return;
       upsertSpeakerAssignment(
         store,
@@ -69,16 +69,106 @@ export function SpeakerAssignPopover({
           {label}
         </button>
       </PopoverTrigger>
-      <PopoverContent
-        variant="app"
-        align="start"
-        className="w-56"
-        onOpenAutoFocus={(e) => e.preventDefault()}
-      >
+      <PopoverContent variant="app" align="start" className="w-64">
         <ParticipantList sessionId={sessionId} onSelect={handleAssign} />
       </PopoverContent>
     </Popover>
   );
+}
+
+export function getAssignmentAnchorWordId(
+  segment: Segment,
+): string | undefined {
+  const word = segment.words.find(
+    (word) => typeof word.id === "string" && word.id.length > 0,
+  );
+  return typeof word?.id === "string" ? word.id : undefined;
+}
+
+export type SpeakerParticipantOption = {
+  id: string;
+  name: string;
+  email?: string;
+  isSessionParticipant: boolean;
+  isNew?: boolean;
+};
+
+export function buildSpeakerParticipantGroups({
+  sessionParticipants,
+  contacts,
+  query,
+}: {
+  sessionParticipants: SpeakerParticipantOption[];
+  contacts: SpeakerParticipantOption[];
+  query: string;
+}) {
+  const normalizedQuery = query.trim().toLowerCase();
+  const matches = (option: SpeakerParticipantOption) => {
+    if (!normalizedQuery) {
+      return true;
+    }
+
+    return [option.name, option.email ?? ""].some((value) =>
+      value.toLowerCase().includes(normalizedQuery),
+    );
+  };
+
+  const sessionParticipantIds = new Set(
+    sessionParticipants.map((option) => option.id),
+  );
+  const matchingSessionParticipants = sessionParticipants.filter(matches);
+  const matchingContacts = contacts
+    .filter((option) => !sessionParticipantIds.has(option.id))
+    .filter(matches);
+
+  return [
+    ...(matchingSessionParticipants.length > 0
+      ? [
+          {
+            title: "Session participants",
+            options: matchingSessionParticipants,
+          },
+        ]
+      : []),
+    ...(matchingContacts.length > 0
+      ? [
+          {
+            title: "Contacts",
+            options: matchingContacts,
+          },
+        ]
+      : []),
+  ];
+}
+
+export function buildCreateSpeakerParticipantOption({
+  query,
+  existingOptions,
+}: {
+  query: string;
+  existingOptions: SpeakerParticipantOption[];
+}): SpeakerParticipantOption | null {
+  const name = query.trim();
+  if (!name) {
+    return null;
+  }
+
+  const normalizedName = name.toLowerCase();
+  const alreadyExists = existingOptions.some((option) =>
+    [option.name, option.email ?? ""].some(
+      (value) => value.toLowerCase() === normalizedName,
+    ),
+  );
+  if (alreadyExists) {
+    return null;
+  }
+
+  return {
+    id: "new",
+    name,
+    isSessionParticipant: false,
+    isNew: true,
+  };
 }
 
 function ParticipantList({
@@ -89,6 +179,11 @@ function ParticipantList({
   onSelect: (humanId: string) => void;
 }) {
   const queries = main.UI.useQueries(main.STORE_ID);
+  const store = main.UI.useStore(main.STORE_ID);
+  const userId = main.UI.useValue("user_id", main.STORE_ID) as
+    | string
+    | undefined;
+  const allHumanIds = main.UI.useRowIds("humans", main.STORE_ID) as string[];
 
   const mappingIds = main.UI.useSliceRowIds(
     main.INDEXES.sessionParticipantsBySession,
@@ -96,44 +191,205 @@ function ParticipantList({
     main.STORE_ID,
   ) as string[];
 
+  const [query, setQuery] = useState("");
+
   const participants = useMemo(() => {
     if (!queries) return [];
     return mappingIds
-      .map((mappingId) => {
+      .map((mappingId): SpeakerParticipantOption | null => {
         const result = queries.getResultRow(
           main.QUERIES.sessionParticipantsWithDetails,
           mappingId,
         );
         if (!result?.human_id) return null;
-        const name = (result.human_name as string) || "";
-        return { id: result.human_id as string, name };
+        const name = ((result.human_name as string | undefined) || "").trim();
+        const email = ((result.human_email as string | undefined) || "").trim();
+        return {
+          id: result.human_id as string,
+          name: name || email || "Unknown",
+          email: email || undefined,
+          isSessionParticipant: true,
+        };
       })
-      .filter((p): p is { id: string; name: string } => p !== null);
+      .filter((p): p is SpeakerParticipantOption => p !== null);
   }, [mappingIds, queries]);
 
-  if (participants.length === 0) {
-    return (
-      <AppFloatingPanel>
-        <p className="px-3 py-2 text-xs text-neutral-400">No participants</p>
-      </AppFloatingPanel>
-    );
-  }
+  const participantIds = useMemo(
+    () => new Set(participants.map((participant) => participant.id)),
+    [participants],
+  );
+
+  const contacts = useMemo(() => {
+    if (!store) return [];
+
+    return allHumanIds
+      .map((humanId): SpeakerParticipantOption | null => {
+        const human = store.getRow("humans", humanId);
+        if (!human) {
+          return null;
+        }
+
+        const name = ((human.name as string | undefined) || "").trim();
+        const email = ((human.email as string | undefined) || "").trim();
+        if (!name && !email) {
+          return null;
+        }
+
+        return {
+          id: humanId,
+          name: name || email,
+          email: email || undefined,
+          isSessionParticipant: false,
+        };
+      })
+      .filter((p): p is SpeakerParticipantOption => p !== null);
+  }, [allHumanIds, store]);
+
+  const groups = useMemo(
+    () =>
+      buildSpeakerParticipantGroups({
+        sessionParticipants: participants,
+        contacts,
+        query,
+      }),
+    [contacts, participants, query],
+  );
+
+  const createOption = useMemo(
+    () =>
+      buildCreateSpeakerParticipantOption({
+        query,
+        existingOptions: [...participants, ...contacts],
+      }),
+    [contacts, participants, query],
+  );
+
+  const linkHumanToSession = useCallback(
+    (humanId: string) => {
+      if (!store || !sessionId || !userId || participantIds.has(humanId)) {
+        return;
+      }
+
+      store.setRow("mapping_session_participant", crypto.randomUUID(), {
+        user_id: userId,
+        session_id: sessionId,
+        human_id: humanId,
+        source: "manual",
+      });
+    },
+    [participantIds, sessionId, store, userId],
+  );
+
+  const createHuman = useCallback(
+    (name: string) => {
+      if (!store || !userId) {
+        return null;
+      }
+
+      const humanId = crypto.randomUUID();
+      store.setRow("humans", humanId, {
+        user_id: userId,
+        created_at: new Date().toISOString(),
+        name,
+        email: "",
+        phone: "",
+        org_id: "",
+        job_title: "",
+        linkedin_username: "",
+        memo: "",
+        pinned: false,
+        pin_order: 0,
+      });
+      return humanId;
+    },
+    [store, userId],
+  );
+
+  const handleSelect = useCallback(
+    (option: SpeakerParticipantOption) => {
+      const humanId = option.isNew ? createHuman(option.name) : option.id;
+      if (!humanId) {
+        return;
+      }
+
+      linkHumanToSession(humanId);
+      onSelect(humanId);
+    },
+    [createHuman, linkHumanToSession, onSelect],
+  );
 
   return (
-    <AppFloatingPanel className="max-h-48 overflow-auto py-1">
-      {participants.map((p) => (
-        <button
-          key={p.id}
-          type="button"
+    <AppFloatingPanel className="overflow-hidden">
+      <div className="border-b border-neutral-100 p-2">
+        <input
+          autoFocus
+          type="search"
           className={cn([
-            "w-full px-3 py-1.5 text-left text-sm",
-            "hover:bg-neutral-100",
+            "h-8 w-full rounded-md border border-neutral-200 bg-white px-2 text-sm outline-hidden",
+            "placeholder:text-neutral-400 focus:border-neutral-300",
           ])}
-          onClick={() => onSelect(p.id)}
-        >
-          {p.name}
-        </button>
-      ))}
+          placeholder="Search contacts"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+      </div>
+      <div className="max-h-56 overflow-auto py-1">
+        {createOption && (
+          <ParticipantOptionButton
+            option={createOption}
+            onSelect={handleSelect}
+          />
+        )}
+
+        {groups.map((group) => (
+          <div key={group.title}>
+            <div className="px-3 pt-2 pb-1 text-[11px] font-medium text-neutral-400 uppercase">
+              {group.title}
+            </div>
+            {group.options.map((option) => (
+              <ParticipantOptionButton
+                key={option.id}
+                option={option}
+                onSelect={handleSelect}
+              />
+            ))}
+          </div>
+        ))}
+
+        {!createOption && groups.length === 0 && (
+          <p className="px-3 py-2 text-xs text-neutral-400">
+            {query.trim() ? "No matching contacts" : "No contacts"}
+          </p>
+        )}
+      </div>
     </AppFloatingPanel>
+  );
+}
+
+function ParticipantOptionButton({
+  option,
+  onSelect,
+}: {
+  option: SpeakerParticipantOption;
+  onSelect: (option: SpeakerParticipantOption) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn([
+        "w-full px-3 py-1.5 text-left text-sm",
+        "hover:bg-neutral-100",
+      ])}
+      onClick={() => onSelect(option)}
+    >
+      <span className="block truncate">
+        {option.isNew ? `Add "${option.name}"` : option.name}
+      </span>
+      {!option.isNew && option.email && (
+        <span className="block truncate text-xs text-neutral-400">
+          {option.email}
+        </span>
+      )}
+    </button>
   );
 }

--- a/apps/desktop/src/stt/render-transcript.test.ts
+++ b/apps/desktop/src/stt/render-transcript.test.ts
@@ -62,6 +62,31 @@ function createStore(participantIds = ["self", "remote"]): FakeStore {
       ]),
       speaker_hints: JSON.stringify([]),
     },
+    unordered: {
+      session_id: "session-1",
+      started_at: 2_000,
+      words: JSON.stringify([
+        {
+          id: "unordered-word",
+          text: " hello",
+          start_ms: 0,
+          end_ms: 100,
+          channel: 1,
+        },
+      ]),
+      speaker_hints: JSON.stringify([
+        {
+          word_id: "unordered-word",
+          type: "user_speaker_assignment",
+          value: JSON.stringify({ human_id: "remote" }),
+        },
+        {
+          word_id: "unordered-word",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 1, speaker_index: 2 }),
+        },
+      ]),
+    },
   } as const;
 
   const humans = {
@@ -154,6 +179,25 @@ describe("buildRenderTranscriptRequestFromStore", () => {
     );
 
     expect(request?.participant_human_ids).toEqual(["self", "remote", "third"]);
+  });
+
+  it("applies provider speaker hints before user assignments regardless of storage order", () => {
+    const request = buildRenderTranscriptRequestFromStore(
+      createStore() as never,
+      ["unordered"],
+    );
+
+    expect(request?.transcripts[0]?.words[0]?.speaker_index).toBe(2);
+    expect(request?.transcripts[0]?.assignments).toEqual([
+      {
+        human_id: "remote",
+        scope: {
+          kind: "channel_speaker",
+          channel: "RemoteParty",
+          speaker_index: 2,
+        },
+      },
+    ]);
   });
 
   it("rounds fractional millisecond timings before invoking Rust", async () => {

--- a/apps/desktop/src/stt/render-transcript.ts
+++ b/apps/desktop/src/stt/render-transcript.ts
@@ -214,6 +214,18 @@ function buildRenderTranscriptRequest(
     }
 
     for (const hint of transcript.speaker_hints ?? []) {
+      if (hint.type !== "provider_speaker_index") {
+        continue;
+      }
+
+      normalizeSpeakerHint(hint, words, wordIndexById);
+    }
+
+    for (const hint of transcript.speaker_hints ?? []) {
+      if (hint.type === "provider_speaker_index") {
+        continue;
+      }
+
       const normalized = normalizeSpeakerHint(hint, words, wordIndexById);
       if (normalized) {
         assignments.push(normalized);


### PR DESCRIPTION
## Summary
- Replace the dead no-participant transcript speaker panel with a searchable picker for session participants, existing contacts, and newly created contacts.
- Link selected contacts to the session before saving the speaker assignment.
- Render saved user assignments after provider speaker hints so assignment scope is stable regardless of hint storage order.
- Avoid invalid button-in-paragraph markup in transcript segment headers.

## Tests
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop exec vitest run src/stt/render-transcript.test.ts src/stt/utils.test.ts src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
- pnpm -F @hypr/desktop typecheck

Fixes #4860
Fixes #4960

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes local-store writes for humans/session participants and transcript hint normalization, which affects how speakers render but stays within desktop STT UI—not auth or billing.
> 
> **Overview**
> **Transcript speaker assignment** is reworked so the segment header popover is a searchable picker instead of a session-participants-only list that could show nothing useful.
> 
> Users can pick **session participants** or **contacts**, filter by name/email, and **add a new contact** from the search string. Selecting someone **links them to the session** (`mapping_session_participant`, manual) when needed, then saves the speaker assignment. Assignments anchor on the **first word in the segment that has an id**, not blindly `words[0]`.
> 
> **Rendering** applies `provider_speaker_index` hints on words **before** building user assignment scopes, so assignment channel/speaker scope stays correct even when hints are stored in the wrong order.
> 
> Segment headers use a **`div`** instead of **`p`** so the assign control is not a button inside a paragraph.
> 
> Unit tests cover grouping, create-option deduping, anchor word id, and hint ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84c4567f5014f49ae1e0da447fc42cf540f9d650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->