### PR TITLE
Publish Changelog for 1.0.37

### DIFF
--- a/packages/changelog/content/1.0.37.md
+++ b/packages/changelog/content/1.0.37.md
@@ -1,0 +1,27 @@
+---
+date: "2026-06-02"
+summary: "Speaker assignment, local note context for chat, Sonoma transcription, and timeline note creation are more reliable."
+---
+
+## Transcripts
+
+- Transcript speaker labels can now be reassigned from session participants, existing contacts, or a new contact directly from the transcript
+- Saved speaker assignments now hold up better when transcript segments shift or speaker hints arrive in a different order
+- Live transcript panel spacing is more consistent between collapsed and expanded states
+
+## Recording
+
+- Soniqo transcription works again on macOS Sonoma systems
+- Meeting auto-stop now catches cases where the meeting app closes while microphone helper processes are still running
+
+## Notes
+
+- Timeline mode now keeps newly created notes before the Create new note card immediately after creation
+- Copying note content now preserves selected images as markdown image references
+- Contacts now include phone numbers in details, search, and participant matching
+
+## Chat
+
+- Notes can now be dragged into chat to add them as context
+- Chat can read and search local file-backed notes when it needs more context
+- Pressing Escape to close chat now keeps you on the current note


### PR DESCRIPTION
Add the 1.0.37 desktop changelog entry for the next stable release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition of a changelog file with no runtime or application code changes.
> 
> **Overview**
> Adds the **1.0.37** desktop changelog at `packages/changelog/content/1.0.37.md` (dated **2026-06-02**) for the next stable release.
> 
> The entry documents user-facing fixes and features across **Transcripts** (speaker reassignment and stability), **Recording** (Sonoma Soniqo transcription and meeting auto-stop), **Notes** (timeline placement, copy with images, contact phone numbers), and **Chat** (drag notes as context, local note search, Escape behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85549459fcfdfcb9fa86bc3cdbf9000d65b0d462. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->