### PR TITLE
fix(desktop): reveal long titles on hover

### DIFF
--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -111,4 +111,32 @@ describe("TitleInput", () => {
       screen.queryByRole("button", { name: "Regenerate title" }),
     ).toBeNull();
   });
+
+  it("reveals overflowing titles with a hover scroll overlay", () => {
+    const title =
+      "Product Discovery Pace and Headless Agent Usage Strategy Review";
+
+    renderTitleInput();
+
+    const input = screen.getByPlaceholderText("Untitled");
+    Object.defineProperty(input, "clientWidth", {
+      configurable: true,
+      value: 160,
+    });
+    Object.defineProperty(input, "scrollWidth", {
+      configurable: true,
+      value: 420,
+    });
+
+    fireEvent.change(input, { target: { value: title } });
+
+    const hoverTitle = screen.getByText(title);
+    expect(input.className).toContain("text-transparent");
+    expect(hoverTitle.className).toContain(
+      "group-hover/title-input:animate-title-hover-scroll",
+    );
+    expect(
+      hoverTitle.style.getPropertyValue("--title-hover-scroll-distance"),
+    ).toBe("-260px");
+  });
 });

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -1,6 +1,7 @@
 import { usePrevious } from "@uidotdev/usehooks";
 import { SparklesIcon } from "lucide-react";
 import {
+  type CSSProperties,
   forwardRef,
   memo,
   useCallback,
@@ -145,6 +146,7 @@ const TitleInputInner = memo(
     ) => {
       const [localTitle, setLocalTitle] = useState(() => getInitialTitle());
       const [isOverflowing, setIsOverflowing] = useState(false);
+      const [overflowDistance, setOverflowDistance] = useState(0);
       const [isTitleFocused, setIsTitleFocused] = useState(false);
       const isFocused = useRef(false);
       const internalRef = useRef<HTMLInputElement>(null);
@@ -158,9 +160,12 @@ const TitleInputInner = memo(
           const input = node ?? internalRef.current;
           if (!input) {
             setIsOverflowing(false);
+            setOverflowDistance(0);
             return;
           }
-          setIsOverflowing(input.scrollWidth > input.clientWidth + 1);
+          const distance = Math.max(input.scrollWidth - input.clientWidth, 0);
+          setIsOverflowing(distance > 1);
+          setOverflowDistance(distance);
         },
         [],
       );
@@ -172,6 +177,7 @@ const TitleInputInner = memo(
             requestAnimationFrame(() => updateOverflowState(node));
           } else {
             setIsOverflowing(false);
+            setOverflowDistance(0);
           }
         },
         [updateOverflowState],
@@ -195,6 +201,19 @@ const TitleInputInner = memo(
               maskSize: "100% 100%",
             }
           : undefined;
+      const showHoverReveal =
+        isOverflowing && !isTitleFocused && localTitle.length > 0;
+      const titleHoverScrollStyle = showHoverReveal
+        ? ({
+            "--title-hover-scroll-distance": `-${Math.ceil(
+              overflowDistance,
+            )}px`,
+            "--title-hover-scroll-duration": `${Math.min(
+              Math.max(overflowDistance / 48, 2.5),
+              8,
+            ).toFixed(2)}s`,
+          } as CSSProperties)
+        : undefined;
 
       useImperativeHandle(
         ref,
@@ -332,7 +351,7 @@ const TitleInputInner = memo(
         localTitle.length === 0 ? onGenerateTitle : undefined;
 
       return (
-        <div className="relative flex h-8 w-full items-center">
+        <div className="group/title-input relative flex h-8 w-full items-center overflow-hidden">
           <input
             ref={setInputRef}
             id={`title-input-${sessionId}-${editorId}`}
@@ -342,7 +361,7 @@ const TitleInputInner = memo(
               const value = e.target.value;
               setLocalTitle(value);
               setLiveTitle(sessionId, value);
-              setIsOverflowing(e.target.scrollWidth > e.target.clientWidth + 1);
+              updateOverflowState(e.target);
             }}
             onKeyDown={handleKeyDown}
             onFocus={() => {
@@ -354,16 +373,30 @@ const TitleInputInner = memo(
               setIsTitleFocused(false);
               setStoreTitle(localTitle);
               clearLiveTitle(sessionId);
-              setIsOverflowing(e.target.scrollWidth > e.target.clientWidth + 1);
+              updateOverflowState(e.target);
             }}
             value={localTitle}
-            style={overflowFadeStyle}
+            style={showHoverReveal ? undefined : overflowFadeStyle}
             className={cn([
               "w-full min-w-0 transition-opacity duration-200",
               "border-none bg-transparent focus:outline-hidden",
               "placeholder:text-muted-foreground text-xl font-semibold",
+              showHoverReveal && "text-transparent caret-transparent",
             ])}
           />
+          {showHoverReveal ? (
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0 flex items-center overflow-hidden"
+            >
+              <span
+                style={titleHoverScrollStyle}
+                className="group-hover/title-input:animate-title-hover-scroll text-xl font-semibold whitespace-nowrap group-hover/title-input:will-change-transform"
+              >
+                {localTitle}
+              </span>
+            </div>
+          ) : null}
           {generateTitleHandler && (
             <GenerateButton
               className="absolute top-1/2 left-[84px] -translate-y-1/2"

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -14,6 +14,10 @@
 
   --animate-shimmer: shimmer 2s infinite;
   --animate-reveal-left: reveal-left 0.5s ease-out forwards;
+  --animate-title-hover-scroll: title-hover-scroll var(
+    --title-hover-scroll-duration,
+    4s
+  ) ease-in-out forwards;
   --animate-kbd-press: kbd-press 0.4s ease-out forwards;
 
   --animate-wiggle: wiggle 1s ease-in-out infinite;
@@ -55,6 +59,14 @@
     }
     100% {
       clip-path: inset(0 0 0 0);
+    }
+  }
+  @keyframes title-hover-scroll {
+    0%, 16% {
+      transform: translateX(0);
+    }
+    84%, 100% {
+      transform: translateX(var(--title-hover-scroll-distance, 0px));
     }
   }
   @keyframes kbd-press {


### PR DESCRIPTION
## Summary
- Add a hover-scroll overlay for overflowing session titles
- Keep title editing behavior intact while revealing the full title on hover
- Cover overflow behavior with a focused title input test

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop test src/session/components/title-input.test.tsx
- pnpm -F @hypr/desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only title display and animation; editing, store sync, and keyboard behavior are unchanged aside from overflow measurement.
> 
> **Overview**
> When a session title is wider than the field and the input is **not** focused, hovering now plays a horizontal scroll animation so the full text is readable instead of staying clipped behind the fade mask.
> 
> `TitleInput` tracks overflow distance, hides the real input text (transparent + no caret) in that state, and shows an `aria-hidden` overlay that animates on `group-hover/title-input`. Scroll distance and duration are CSS variables derived from measured overflow; focused editing still uses the normal input and right-edge fade. Global styles add the `title-hover-scroll` keyframes and Tailwind animation hook.
> 
> A unit test asserts the overlay, animation class, and `--title-hover-scroll-distance` for an overflowing title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f6bc3117b4456a38e6611e43dd4cda7fab3a246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->