### PR TITLE
fix(desktop): keep escape from closing notes

### DIFF
--- a/apps/desktop/src/main/useTabsShortcuts.test.tsx
+++ b/apps/desktop/src/main/useTabsShortcuts.test.tsx
@@ -9,12 +9,14 @@ const hoisted = vi.hoisted(() => ({
   currentTab: null as null | {
     active: boolean;
     id?: string;
+    pinned?: boolean;
     returnToSlotId?: string;
     returnToTabId?: string;
     slotId: string;
     type: string;
   },
   canGoBack: false,
+  close: vi.fn(),
   goBack: vi.fn(),
   handlers: new Map<string, (event?: { defaultPrevented: boolean }) => void>(),
   openCurrent: vi.fn(),
@@ -29,6 +31,8 @@ const hoisted = vi.hoisted(() => ({
     slotId: string;
     type: string;
   }[],
+  unpin: vi.fn(),
+  setPendingCloseConfirmationTab: vi.fn(),
 }));
 
 vi.mock("react-hotkeys-hook", () => ({
@@ -65,7 +69,7 @@ vi.mock("~/store/zustand/tabs", () => {
     currentTab: hoisted.currentTab,
     canGoBack: hoisted.canGoBack,
     clearSelection: vi.fn(),
-    close: vi.fn(),
+    close: hoisted.close,
     goBack: hoisted.goBack,
     select: hoisted.select,
     selectNext: vi.fn(),
@@ -73,8 +77,8 @@ vi.mock("~/store/zustand/tabs", () => {
     restoreLastClosedTab: vi.fn(),
     openNew: hoisted.openNew,
     openCurrent: hoisted.openCurrent,
-    unpin: vi.fn(),
-    setPendingCloseConfirmationTab: vi.fn(),
+    unpin: hoisted.unpin,
+    setPendingCloseConfirmationTab: hoisted.setPendingCloseConfirmationTab,
   });
 
   const useTabs = ((
@@ -128,6 +132,7 @@ describe("useClassicMainTabsShortcuts", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     hoisted.chatMode = "FloatingClosed";
+    hoisted.close.mockClear();
     hoisted.currentTab = null;
     hoisted.canGoBack = false;
     hoisted.goBack.mockClear();
@@ -136,6 +141,8 @@ describe("useClassicMainTabsShortcuts", () => {
     hoisted.openNew.mockClear();
     hoisted.select.mockClear();
     hoisted.sendEvent.mockClear();
+    hoisted.unpin.mockClear();
+    hoisted.setPendingCloseConfirmationTab.mockClear();
     hoisted.tabs = [];
   });
 
@@ -155,24 +162,52 @@ describe("useClassicMainTabsShortcuts", () => {
     expect(hoisted.openNew).toHaveBeenCalledWith({ type: "empty" });
   });
 
-  it("binds escape to open the home view", () => {
+  it("binds mod+w to close the current note tab", () => {
     hoisted.currentTab = {
       active: true,
+      id: "session-1",
       slotId: "slot-session",
       type: "sessions",
     };
 
     renderHook(() => useClassicMainTabsShortcuts());
 
+    const handler = hoisted.handlers.get("mod+w");
+    expect(handler).toBeTruthy();
+
+    handler?.();
+
+    expect(hoisted.close).toHaveBeenCalledWith(hoisted.currentTab);
+    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+  });
+
+  it("does not open the home view from a note on escape", () => {
+    const homeTab = {
+      active: false,
+      slotId: "slot-home",
+      type: "empty",
+    };
+    hoisted.currentTab = {
+      active: true,
+      id: "session-1",
+      slotId: "slot-session",
+      type: "sessions",
+    };
+    hoisted.tabs = [homeTab, hoisted.currentTab];
+
+    renderHook(() => useClassicMainTabsShortcuts());
+
     dispatchEscape();
     vi.runOnlyPendingTimers();
 
-    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
+    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+    expect(hoisted.select).not.toHaveBeenCalled();
   });
 
-  it("returns the escape shortcut action", () => {
+  it("returns an escape shortcut action that does not close a note", () => {
     hoisted.currentTab = {
       active: true,
+      id: "session-1",
       slotId: "slot-session",
       type: "sessions",
     };
@@ -181,7 +216,8 @@ describe("useClassicMainTabsShortcuts", () => {
 
     result.current.runEscapeShortcut();
 
-    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
+    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+    expect(hoisted.select).not.toHaveBeenCalled();
   });
 
   it("uses the latest tab state when the returned escape action runs", () => {
@@ -195,18 +231,21 @@ describe("useClassicMainTabsShortcuts", () => {
 
     hoisted.currentTab = {
       active: true,
+      id: "session-1",
       slotId: "slot-session",
       type: "sessions",
     };
 
     result.current.runEscapeShortcut();
 
-    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
+    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+    expect(hoisted.select).not.toHaveBeenCalled();
   });
 
-  it("opens the home view even when the editor stops escape propagation", () => {
+  it("does not leave a note when the editor stops escape propagation", () => {
     hoisted.currentTab = {
       active: true,
+      id: "session-1",
       slotId: "slot-session",
       type: "sessions",
     };
@@ -221,12 +260,14 @@ describe("useClassicMainTabsShortcuts", () => {
     vi.runOnlyPendingTimers();
     editor.remove();
 
-    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
+    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+    expect(hoisted.select).not.toHaveBeenCalled();
   });
 
-  it("opens the home view when the editor prevents default escape handling", () => {
+  it("does not leave a note when the editor prevents default escape handling", () => {
     hoisted.currentTab = {
       active: true,
+      id: "session-1",
       slotId: "slot-session",
       type: "sessions",
     };
@@ -245,12 +286,14 @@ describe("useClassicMainTabsShortcuts", () => {
     vi.runOnlyPendingTimers();
     editor.remove();
 
-    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
+    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+    expect(hoisted.select).not.toHaveBeenCalled();
   });
 
-  it("does not rerun escape when a focused target handles it directly", () => {
+  it("does not leave a note when a focused target handles escape directly", () => {
     hoisted.currentTab = {
       active: true,
+      id: "session-1",
       slotId: "slot-session",
       type: "sessions",
     };
@@ -267,8 +310,8 @@ describe("useClassicMainTabsShortcuts", () => {
     vi.runOnlyPendingTimers();
     target.remove();
 
-    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
-    expect(hoisted.openCurrent).toHaveBeenCalledTimes(1);
+    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+    expect(hoisted.select).not.toHaveBeenCalled();
   });
 
   it("does not duplicate chat close when a focused target handles escape directly", () => {

--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -8,7 +8,6 @@ import { TitleInput } from "./title-input";
 
 const hoisted = vi.hoisted(() => ({
   clearLiveTitle: vi.fn(),
-  runEscapeShortcut: vi.fn(),
   setLiveTitle: vi.fn(),
   store: {
     addCellListener: vi.fn(() => "listener-id"),
@@ -23,10 +22,6 @@ vi.mock("usehooks-ts", () => ({
 
 vi.mock("~/ai/hooks", () => ({
   useTitleGenerating: () => false,
-}));
-
-vi.mock("~/shared/useTabsShortcuts", () => ({
-  useMainEscapeShortcutAction: () => hoisted.runEscapeShortcut,
 }));
 
 vi.mock("~/store/tinybase/store/main", () => ({
@@ -79,14 +74,14 @@ describe("TitleInput", () => {
     cleanup();
   });
 
-  it("runs the main escape shortcut directly from the title field", () => {
+  it("does not route escape from the title field into tab navigation", () => {
     renderTitleInput();
 
     fireEvent.keyDown(screen.getByPlaceholderText("Untitled"), {
       key: "Escape",
     });
 
-    expect(hoisted.runEscapeShortcut).toHaveBeenCalledTimes(1);
+    expect(hoisted.clearLiveTitle).not.toHaveBeenCalled();
   });
 
   it("positions the empty title generate button next to the placeholder", () => {

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -19,7 +19,6 @@ import {
 import { cn } from "@hypr/utils";
 
 import { useTitleGenerating } from "~/ai/hooks";
-import { useMainEscapeShortcutAction } from "~/shared/useTabsShortcuts";
 import * as main from "~/store/tinybase/store/main";
 import { useLiveTitle } from "~/store/zustand/live-title";
 import { type Tab } from "~/store/zustand/tabs";
@@ -151,7 +150,6 @@ const TitleInputInner = memo(
       const store = main.UI.useStore(main.STORE_ID);
       const setLiveTitle = useLiveTitle((s) => s.setTitle);
       const clearLiveTitle = useLiveTitle((s) => s.clearTitle);
-      const runEscapeShortcut = useMainEscapeShortcutAction();
 
       const updateOverflowState = useCallback(
         (node?: HTMLInputElement | null) => {
@@ -266,13 +264,6 @@ const TitleInputInner = memo(
       );
 
       const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === "Escape") {
-          e.preventDefault();
-          e.stopPropagation();
-          runEscapeShortcut();
-          return;
-        }
-
         if (e.key === "ArrowUp") {
           e.preventDefault();
           return;

--- a/apps/desktop/src/shared/useTabsShortcuts.tsx
+++ b/apps/desktop/src/shared/useTabsShortcuts.tsx
@@ -245,6 +245,10 @@ export function useMainEscapeShortcutAction() {
       return;
     }
 
+    if (currentTab?.type === "sessions") {
+      return;
+    }
+
     const returnToSlotId = currentTab?.returnToSlotId;
     const returnToTab = returnToSlotId
       ? tabs.find(


### PR DESCRIPTION
## Summary
- Make Escape a no-op for active session tabs instead of opening the empty home view
- Stop the title field from forwarding Escape into global tab navigation
- Keep Cmd+W as the note close path and cover it with shortcut tests

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop test src/main/useTabsShortcuts.test.tsx src/session/components/title-input.test.tsx
- pnpm -F @hypr/desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Keyboard shortcut behavior change only; limited to tab navigation and title input with test coverage.
> 
> **Overview**
> **Escape no longer dismisses open notes.** `useMainEscapeShortcutAction` returns immediately when the active tab is a `sessions` note, so global Escape (and the deferred window handler) no longer select home, go back, or open an empty tab from a note. Floating chat still closes first when open.
> 
> The **note title field** no longer intercepts Escape or calls the main escape action, so editing a title does not trigger tab navigation.
> 
> Tests now expect notes to stay put on Escape (including editor/propagation cases) and assert **`mod+w`** closes the current session tab via `close`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee86b4bc9e2e10c1164ad48e91d9e37d8f83c60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->