### PR TITLE
fix(desktop): scroll sidebar timeline to opened notes

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -6,9 +6,11 @@ import {
 } from "lucide-react";
 import {
   type ReactNode,
+  type RefCallback,
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
@@ -170,6 +172,27 @@ export function TimelineView({
     registerAnchor: setCurrentTimeIndicatorRef,
     anchorNode: todayAnchorNode,
   } = useAnchor();
+  const selectedSessionScrollFrameRef = useRef<number | null>(null);
+  const scrollSelectedSessionIntoView = useCallback<
+    RefCallback<HTMLDivElement>
+  >(
+    (node) => {
+      if (selectedSessionScrollFrameRef.current !== null) {
+        cancelAnimationFrame(selectedSessionScrollFrameRef.current);
+        selectedSessionScrollFrameRef.current = null;
+      }
+
+      if (!node || currentTab?.type !== "sessions") {
+        return;
+      }
+
+      selectedSessionScrollFrameRef.current = requestAnimationFrame(() => {
+        selectedSessionScrollFrameRef.current = null;
+        scrollTimelineItemIntoView(containerRef.current, node);
+      });
+    },
+    [containerRef, currentTab],
+  );
 
   useEffect(() => {
     const container = containerRef.current;
@@ -372,6 +395,7 @@ export function TimelineView({
                   precision={bucket.precision}
                   registerIndicator={setCurrentTimeIndicatorRef}
                   selectedSessionId={selectedSessionId}
+                  selectedNodeRef={scrollSelectedSessionIntoView}
                   timezone={timezone}
                   selectedIds={selectedIds}
                   flatItemKeys={flatItemKeys}
@@ -390,6 +414,9 @@ export function TimelineView({
                       timezone={timezone}
                       multiSelected={selectedIds.includes(itemKey)}
                       flatItemKeys={flatItemKeys}
+                      selectedNodeRef={
+                        selected ? scrollSelectedSessionIntoView : undefined
+                      }
                     />
                   );
                 })
@@ -498,6 +525,7 @@ function TodayBucket({
   precision,
   registerIndicator,
   selectedSessionId,
+  selectedNodeRef,
   timezone,
   selectedIds,
   flatItemKeys,
@@ -506,6 +534,7 @@ function TodayBucket({
   precision: TimelinePrecision;
   registerIndicator: (node: HTMLDivElement | null) => void;
   selectedSessionId: string | undefined;
+  selectedNodeRef: RefCallback<HTMLDivElement>;
   timezone?: string;
   selectedIds: string[];
   flatItemKeys: string[];
@@ -569,6 +598,7 @@ function TodayBucket({
           timezone={timezone}
           multiSelected={selectedIds.includes(itemKey)}
           flatItemKeys={flatItemKeys}
+          selectedNodeRef={selected ? selectedNodeRef : undefined}
         />
       );
 
@@ -611,12 +641,47 @@ function TodayBucket({
     precision,
     registerIndicator,
     selectedSessionId,
+    selectedNodeRef,
     timezone,
     selectedIds,
     flatItemKeys,
   ]);
 
   return renderedEntries;
+}
+
+function scrollTimelineItemIntoView(
+  container: HTMLDivElement | null,
+  item: HTMLDivElement,
+) {
+  if (!container) {
+    return;
+  }
+
+  const containerRect = container.getBoundingClientRect();
+  const itemRect = item.getBoundingClientRect();
+  const margin = 12;
+  const aboveViewport = itemRect.top < containerRect.top + margin;
+  const belowViewport = itemRect.bottom > containerRect.bottom - margin;
+
+  if (!aboveViewport && !belowViewport) {
+    return;
+  }
+
+  const itemCenter =
+    itemRect.top -
+    containerRect.top +
+    container.scrollTop +
+    itemRect.height / 2;
+  const targetScrollTop = Math.max(
+    itemCenter - container.clientHeight * 0.45,
+    0,
+  );
+
+  container.scrollTo({
+    top: targetScrollTop,
+    behavior: "smooth",
+  });
 }
 
 function useTimelineTables(): {

--- a/apps/desktop/src/sidebar/timeline/item.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.test.tsx
@@ -189,4 +189,38 @@ describe("TimelineItemComponent", () => {
     expect(mocks.stop).toHaveBeenCalledOnce();
     expect(mocks.openCurrent).not.toHaveBeenCalled();
   });
+
+  it("exposes the selected session row for sidebar scroll anchoring", () => {
+    const selectedNodeRef = vi.fn();
+
+    render(
+      <TimelineItemComponent
+        item={{
+          type: "session",
+          id: "session-live",
+          data: {
+            title: "Live Note",
+            created_at: "2024-01-15T10:30:00.000Z",
+          },
+        }}
+        precision="time"
+        selected
+        selectedNodeRef={selectedNodeRef}
+        timezone="UTC"
+        multiSelected={false}
+        flatItemKeys={["session-session-live"]}
+      />,
+    );
+
+    const row = screen
+      .getByText("Live Note")
+      .closest("[data-sidebar-timeline-session-id]");
+
+    expect(row?.getAttribute("data-sidebar-timeline-session-id")).toBe(
+      "session-live",
+    );
+    expect(selectedNodeRef.mock.calls.some(([node]) => node === row)).toBe(
+      true,
+    );
+  });
 });

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -1,5 +1,11 @@
 import { SquareIcon } from "lucide-react";
-import { memo, type DragEvent, useCallback, useMemo } from "react";
+import {
+  memo,
+  type DragEvent,
+  type RefCallback,
+  useCallback,
+  useMemo,
+} from "react";
 
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
@@ -48,6 +54,7 @@ export const TimelineItemComponent = memo(
     timezone,
     multiSelected,
     flatItemKeys,
+    selectedNodeRef,
   }: {
     item: TimelineItem;
     precision: TimelinePrecision;
@@ -55,6 +62,7 @@ export const TimelineItemComponent = memo(
     timezone?: string;
     multiSelected: boolean;
     flatItemKeys: string[];
+    selectedNodeRef?: RefCallback<HTMLDivElement>;
   }) => {
     if (item.type === "event") {
       return (
@@ -65,6 +73,7 @@ export const TimelineItemComponent = memo(
           timezone={timezone}
           multiSelected={multiSelected}
           flatItemKeys={flatItemKeys}
+          selectedNodeRef={selectedNodeRef}
         />
       );
     }
@@ -76,6 +85,7 @@ export const TimelineItemComponent = memo(
         timezone={timezone}
         multiSelected={multiSelected}
         flatItemKeys={flatItemKeys}
+        selectedNodeRef={selectedNodeRef}
       />
     );
   },
@@ -99,6 +109,8 @@ function ItemBase({
   onDragStart,
   contextMenu,
   draggable,
+  selectedNodeRef,
+  timelineSessionId,
 }: {
   title: string;
   displayTime: string;
@@ -117,12 +129,18 @@ function ItemBase({
   onDragStart?: (event: DragEvent<HTMLElement>) => void;
   contextMenu: MenuItemDef[];
   draggable?: boolean;
+  selectedNodeRef?: RefCallback<HTMLDivElement>;
+  timelineSessionId?: string;
 }) {
   const hasSelection = useTimelineSelection((s) => s.selectedIds.length > 0);
   const showLiveStop = isLive && onStop;
 
   return (
-    <div className="group/sidebar-live-item relative">
+    <div
+      ref={selectedNodeRef}
+      data-sidebar-timeline-session-id={timelineSessionId}
+      className="group/sidebar-live-item relative"
+    >
       <InteractiveButton
         onClick={ignored ? undefined : onClick}
         onCmdClick={ignored ? undefined : onCmdClick}
@@ -222,6 +240,7 @@ const EventItem = memo(
     timezone,
     multiSelected,
     flatItemKeys,
+    selectedNodeRef,
   }: {
     item: EventTimelineItem;
     precision: TimelinePrecision;
@@ -229,6 +248,7 @@ const EventItem = memo(
     timezone?: string;
     multiSelected: boolean;
     flatItemKeys: string[];
+    selectedNodeRef?: RefCallback<HTMLDivElement>;
   }) => {
     const store = main.UI.useStore(main.STORE_ID);
     const openCurrent = useTabs((state) => state.openCurrent);
@@ -369,6 +389,7 @@ const EventItem = memo(
         onCmdClick={handleCmdClick}
         onShiftClick={handleShiftClick}
         contextMenu={contextMenu}
+        selectedNodeRef={selected ? selectedNodeRef : undefined}
       />
     );
   },
@@ -382,6 +403,7 @@ const SessionItem = memo(
     timezone,
     multiSelected,
     flatItemKeys,
+    selectedNodeRef,
   }: {
     item: SessionTimelineItem;
     precision: TimelinePrecision;
@@ -389,6 +411,7 @@ const SessionItem = memo(
     timezone?: string;
     multiSelected: boolean;
     flatItemKeys: string[];
+    selectedNodeRef?: RefCallback<HTMLDivElement>;
   }) => {
     const store = main.UI.useStore(main.STORE_ID);
     const indexes = main.UI.useIndexes(main.STORE_ID);
@@ -552,6 +575,8 @@ const SessionItem = memo(
           onStop={stop}
           onDragStart={handleDragStart}
           contextMenu={contextMenu}
+          selectedNodeRef={selected ? selectedNodeRef : undefined}
+          timelineSessionId={sessionId}
           draggable
         />
       </SessionPreviewCard>


### PR DESCRIPTION
## Summary
- Scroll the selected sidebar timeline row into view when the active session changes
- Cover notes opened from search by anchoring to the active session row
- Add focused coverage for the selected sidebar timeline row anchor

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop test src/sidebar/timeline/item.test.tsx
- pnpm -F @hypr/desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized sidebar scroll and ref wiring for session selection; no auth, data, or API changes.
> 
> **Overview**
> When the active tab is a **session**, the sidebar timeline now **smooth-scrolls** so the highlighted session row stays visible if it was above or below the scroll viewport (e.g. after opening a note from search).
> 
> Selected session rows expose a **ref callback** and `data-sidebar-timeline-session-id` on the row wrapper; `TimelineView` schedules scroll via `requestAnimationFrame` and only scrolls when needed, centering roughly in the list. A unit test asserts the ref and data attribute for the selected session row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cd7e391b7943016b603e6a2206436acb038f8a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->