### PR TITLE
chore(changelog): publish 1.0.38 notes

### DIFF
--- a/packages/changelog/content/1.0.38.md
+++ b/packages/changelog/content/1.0.38.md
@@ -1,0 +1,10 @@
+---
+date: "2026-06-03"
+summary: "Long note titles, note closing shortcuts, and search-opened notes now behave more predictably."
+---
+
+## Notes
+
+- Long note titles now scroll on hover so you can read the full title in the sidebar and header
+- Pressing Escape while writing in a note no longer closes the note; use Command-W when you want to close it
+- Opening a note from search now scrolls the sidebar timeline to the selected note


### PR DESCRIPTION
## Summary
- Add the 1.0.38 desktop changelog entry for the stable release.

## Verification
- pnpm exec dprint fmt --allow-no-files packages/changelog/content/1.0.38.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no application or infrastructure changes.
> 
> **Overview**
> Adds the **1.0.38** desktop changelog entry (`packages/changelog/content/1.0.38.md`) for the stable release, documenting **Notes** UX fixes: long titles scroll on hover in the sidebar and header, **Escape** no longer closes a note while editing (use **Command-W** to close), and opening a note from search scrolls the sidebar timeline to that note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51fd9c24b52aa4ea14ca0e291503bf4379144fd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->