### PR TITLE
fix(desktop): surface past notes for recurring sessions

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -22,8 +22,10 @@ const hoisted = vi.hoisted(() => ({
     sessionId: string;
     title: string;
     dateLabel: string;
-    summary: string;
+    summary: string | null;
+    isGenerating: boolean;
   }>,
+  generateMissingPastNotes: vi.fn(),
 }));
 
 vi.mock("react-hotkeys-hook", () => ({
@@ -44,7 +46,16 @@ vi.mock("./during-session", () => ({
 
 vi.mock("./post-session", () => ({
   PostSessionAccessory: () => null,
-  usePastSessionNotes: () => hoisted.pastNotes,
+}));
+
+vi.mock("./past-notes", () => ({
+  usePastSessionNotes: () => ({
+    notes: hoisted.pastNotes,
+    hasPastNotes: hoisted.pastNotes.length > 0,
+    isGenerating: false,
+    canGenerate: true,
+    generateMissing: hoisted.generateMissingPastNotes,
+  }),
 }));
 
 vi.mock("~/stt/contexts", () => ({
@@ -81,6 +92,7 @@ describe("useSessionBottomAccessory", () => {
     hoisted.live.requestedLiveTranscription = true;
     hoisted.live.liveTranscriptionActive = true;
     hoisted.pastNotes = [];
+    hoisted.generateMissingPastNotes.mockClear();
     useShellMock.mockReturnValue({
       chat: {
         mode: "Closed",
@@ -208,6 +220,45 @@ describe("useSessionBottomAccessory", () => {
       expanded: false,
     });
     expect(result.current.bottomAccessory).not.toBeNull();
+  });
+
+  it("generates missing past note facts when the past notes tab opens", () => {
+    hoisted.pastNotes = [
+      {
+        sessionId: "past-session",
+        title: "Weekly sync",
+        dateLabel: "May 28, 2026",
+        summary: null,
+        isGenerating: false,
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useSessionBottomAccessory({
+        sessionId: "session-1",
+        sessionMode: "inactive",
+        audioUrl: "file:///session.wav",
+        hasTranscript: true,
+      }),
+    );
+
+    const handle = result.current.bottomBorderHandle;
+    expect(
+      isValidElement<{ onSelect: (tab: "past_notes") => void }>(handle),
+    ).toBe(true);
+    if (!isValidElement<{ onSelect: (tab: "past_notes") => void }>(handle)) {
+      return;
+    }
+
+    act(() => {
+      handle.props.onSelect("past_notes");
+    });
+
+    expect(hoisted.generateMissingPastNotes).toHaveBeenCalledTimes(1);
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "playback",
+      expanded: true,
+    });
   });
 
   it("hides the bottom accessory while recording for batch transcription", () => {

--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -18,6 +18,12 @@ const hoisted = vi.hoisted(() => ({
     requestedLiveTranscription: true as boolean | null,
     liveTranscriptionActive: true as boolean | null,
   },
+  pastNotes: [] as Array<{
+    sessionId: string;
+    title: string;
+    dateLabel: string;
+    summary: string;
+  }>,
 }));
 
 vi.mock("react-hotkeys-hook", () => ({
@@ -38,6 +44,7 @@ vi.mock("./during-session", () => ({
 
 vi.mock("./post-session", () => ({
   PostSessionAccessory: () => null,
+  usePastSessionNotes: () => hoisted.pastNotes,
 }));
 
 vi.mock("~/stt/contexts", () => ({
@@ -73,6 +80,7 @@ describe("useSessionBottomAccessory", () => {
     hoisted.live.sessionId = null;
     hoisted.live.requestedLiveTranscription = true;
     hoisted.live.liveTranscriptionActive = true;
+    hoisted.pastNotes = [];
     useShellMock.mockReturnValue({
       chat: {
         mode: "Closed",

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -14,11 +14,8 @@ import { cn } from "@hypr/utils";
 import { DuringSessionAccessory } from "./during-session";
 import { ExpandToggle } from "./expand-toggle";
 import { shouldShowLiveTranscriptAccessory } from "./live-visibility";
-import {
-  PostSessionAccessory,
-  type PostSessionTab,
-  usePastSessionNotes,
-} from "./post-session";
+import { usePastSessionNotes } from "./past-notes";
+import { PostSessionAccessory, type PostSessionTab } from "./post-session";
 
 import { useShell } from "~/contexts/shell";
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
@@ -54,7 +51,8 @@ export function useSessionBottomAccessory({
   const isRunningBatch = sessionMode === "running_batch";
   const hasAudio = Boolean(audioUrl) && (isInactive || isRunningBatch);
   const pastNotes = usePastSessionNotes(sessionId);
-  const hasPastNotes = pastNotes.length > 0;
+  const hasPastNotes = pastNotes.hasPastNotes;
+  const generateMissingPastNotes = pastNotes.generateMissing;
   const activePostSessionTab: PostSessionTab = hasPastNotes
     ? (postSessionTab ??
       (!hasAudio && !hasTranscript && !isRunningBatch
@@ -97,12 +95,17 @@ export function useSessionBottomAccessory({
       (hasAudio || hasTranscript || hasPastNotes));
   const selectPostSessionTab = useCallback(
     (tab: PostSessionTab) => {
+      const shouldExpand = activePostSessionTab !== tab || !isExpanded;
+      if (tab === "past_notes" && shouldExpand) {
+        generateMissingPastNotes();
+      }
+
       setPostSessionTab(tab);
       setIsExpanded((expanded) =>
         activePostSessionTab === tab ? !expanded : true,
       );
     },
-    [activePostSessionTab],
+    [activePostSessionTab, generateMissingPastNotes, isExpanded],
   );
 
   useHotkeys(
@@ -169,7 +172,7 @@ export function useSessionBottomAccessory({
           hasTranscript={hasTranscript}
           isTranscriptExpanded={isExpanded}
           activeTab={activePostSessionTab}
-          pastNotes={pastNotes}
+          pastNotes={pastNotes.notes}
           fillHeight={isExpanded}
         />
       ) : null,

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -1,10 +1,24 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { X } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+
+import { cn } from "@hypr/utils";
 
 import { DuringSessionAccessory } from "./during-session";
 import { ExpandToggle } from "./expand-toggle";
 import { shouldShowLiveTranscriptAccessory } from "./live-visibility";
-import { PostSessionAccessory } from "./post-session";
+import {
+  PostSessionAccessory,
+  type PostSessionTab,
+  usePastSessionNotes,
+} from "./post-session";
 
 import { useShell } from "~/contexts/shell";
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
@@ -31,11 +45,22 @@ export function useSessionBottomAccessory({
   bottomAccessoryState: BottomAccessoryState;
 } {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [postSessionTab, setPostSessionTab] = useState<PostSessionTab | null>(
+    null,
+  );
   const isLive = sessionMode === "active";
   const isFinalizing = sessionMode === "finalizing";
   const isInactive = sessionMode === "inactive";
   const isRunningBatch = sessionMode === "running_batch";
   const hasAudio = Boolean(audioUrl) && (isInactive || isRunningBatch);
+  const pastNotes = usePastSessionNotes(sessionId);
+  const hasPastNotes = pastNotes.length > 0;
+  const activePostSessionTab: PostSessionTab = hasPastNotes
+    ? (postSessionTab ??
+      (!hasAudio && !hasTranscript && !isRunningBatch
+        ? "past_notes"
+        : "transcript"))
+    : "transcript";
   const live = useListener((state) => state.live);
   const { chat } = useShell();
   const liveCaptureMode = getLiveCaptureUiMode(live);
@@ -69,7 +94,16 @@ export function useSessionBottomAccessory({
     isRunningBatch ||
     (!shouldDeferToGlobalLiveAccessory &&
       isInactive &&
-      (hasAudio || hasTranscript));
+      (hasAudio || hasTranscript || hasPastNotes));
+  const selectPostSessionTab = useCallback(
+    (tab: PostSessionTab) => {
+      setPostSessionTab(tab);
+      setIsExpanded((expanded) =>
+        activePostSessionTab === tab ? !expanded : true,
+      );
+    },
+    [activePostSessionTab],
+  );
 
   useHotkeys(
     "esc",
@@ -134,10 +168,18 @@ export function useSessionBottomAccessory({
           hasAudio={hasAudio}
           hasTranscript={hasTranscript}
           isTranscriptExpanded={isExpanded}
+          activeTab={activePostSessionTab}
+          pastNotes={pastNotes}
           fillHeight={isExpanded}
         />
       ) : null,
-      bottomBorderHandle: (
+      bottomBorderHandle: hasPastNotes ? (
+        <PostSessionTabHandle
+          isExpanded={isExpanded}
+          activeTab={activePostSessionTab}
+          onSelect={selectPostSessionTab}
+        />
+      ) : (
         <ExpandToggle
           isExpanded={isExpanded}
           onToggle={() => setIsExpanded((v) => !v)}
@@ -155,4 +197,76 @@ export function useSessionBottomAccessory({
     bottomBorderHandle: null,
     bottomAccessoryState,
   };
+}
+
+function PostSessionTabHandle({
+  isExpanded,
+  activeTab,
+  onSelect,
+}: {
+  isExpanded: boolean;
+  activeTab: PostSessionTab;
+  onSelect: (tab: PostSessionTab) => void;
+}) {
+  return (
+    <div className="relative left-3 z-10 flex h-5 items-center">
+      <PostSessionTabButton
+        label="Transcript"
+        tab="transcript"
+        activeTab={activeTab}
+        isExpanded={isExpanded}
+        onSelect={onSelect}
+        className="rounded-tl-[10px] border-l"
+      />
+      <PostSessionTabButton
+        label="Past notes"
+        tab="past_notes"
+        activeTab={activeTab}
+        isExpanded={isExpanded}
+        onSelect={onSelect}
+        className="-ml-px rounded-tr-[10px] border-r"
+      />
+    </div>
+  );
+}
+
+function PostSessionTabButton({
+  label,
+  tab,
+  activeTab,
+  isExpanded,
+  onSelect,
+  className,
+}: {
+  label: string;
+  tab: PostSessionTab;
+  activeTab: PostSessionTab;
+  isExpanded: boolean;
+  onSelect: (tab: PostSessionTab) => void;
+  className?: string;
+}) {
+  const isActive = activeTab === tab;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(tab)}
+      className={cn([
+        "relative flex h-5 items-center justify-center gap-1 border-t border-neutral-200 px-3",
+        "after:pointer-events-none after:absolute after:right-px after:-bottom-px after:left-px after:h-0.5 after:bg-inherit after:content-['']",
+        "text-[10px] font-medium transition-colors",
+        isActive && isExpanded
+          ? "bg-neutral-50 text-neutral-600"
+          : "bg-white text-neutral-400",
+        "hover:cursor-pointer hover:bg-neutral-100 hover:text-neutral-600",
+        className,
+      ])}
+      aria-label={
+        isActive && isExpanded ? `Collapse ${label}` : `Expand ${label}`
+      }
+    >
+      <span>{label}</span>
+      {isActive && isExpanded ? <X size={10} className="shrink-0" /> : null}
+    </button>
+  );
 }

--- a/apps/desktop/src/session/components/bottom-accessory/past-note-key-facts.system.md.jinja
+++ b/apps/desktop/src/session/components/bottom-accessory/past-note-key-facts.system.md.jinja
@@ -1,0 +1,11 @@
+You extract reusable key facts from prior meeting notes.
+
+Return facts that will help someone prepare for the next meeting with the same people.
+
+Rules:
+
+- Capture concrete decisions, commitments, blockers, preferences, constraints, open questions, names, dates, numbers, and follow-ups.
+- Omit generic meeting-summary language.
+- Do not mention that these are notes or that you are summarizing.
+- Keep each fact short and standalone.
+- Prefer 3-6 facts.

--- a/apps/desktop/src/session/components/bottom-accessory/past-note-key-facts.user.md.jinja
+++ b/apps/desktop/src/session/components/bottom-accessory/past-note-key-facts.user.md.jinja
@@ -1,0 +1,8 @@
+# Prior Meeting
+
+Title: {{ session.title }}
+Date: {{ session.date_label }}
+
+# Notes
+
+{{ notes }}

--- a/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
+++ b/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
@@ -1,0 +1,531 @@
+import { useMutation } from "@tanstack/react-query";
+import { generateText, type LanguageModel, Output } from "ai";
+import { useCallback, useMemo } from "react";
+import { z } from "zod";
+
+import {
+  commands as templateCommands,
+  type JsonValue,
+} from "@hypr/plugin-template";
+import { format, safeParseDate } from "@hypr/utils";
+
+import systemPromptTemplate from "./past-note-key-facts.system.md.jinja?raw";
+import userPromptTemplate from "./past-note-key-facts.user.md.jinja?raw";
+
+import { useLanguageModel } from "~/ai/hooks";
+import { extractPlainText } from "~/search/contexts/engine/utils";
+import { getSessionEvent } from "~/session/utils";
+import * as main from "~/store/tinybase/store/main";
+
+export type PastSessionNote = {
+  sessionId: string;
+  title: string;
+  dateLabel: string;
+  summary: string | null;
+  isGenerating: boolean;
+};
+
+export type PastSessionNoteRequest = {
+  sessionId: string;
+  userId: string;
+  title: string;
+  dateLabel: string;
+  sourceText: string;
+  sourceHash: string;
+};
+
+export type PastSessionNotesResult = {
+  notes: PastSessionNote[];
+  hasPastNotes: boolean;
+  isGenerating: boolean;
+  canGenerate: boolean;
+  generateMissing: () => void;
+};
+
+type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
+
+const MAX_PAST_NOTES = 8;
+const MAX_SOURCE_LENGTH = 6000;
+const SPACE_REGEX = /\s+/g;
+
+const keyFactsSchema = z.object({
+  facts: z.array(z.string()).min(1).max(6),
+});
+
+export function usePastSessionNotes(sessionId: string): PastSessionNotesResult {
+  const store = main.UI.useStore(main.STORE_ID);
+  const sessionsTable = main.UI.useTable("sessions", main.STORE_ID);
+  const participantsTable = main.UI.useTable(
+    "mapping_session_participant",
+    main.STORE_ID,
+  );
+  const enhancedNotesTable = main.UI.useTable("enhanced_notes", main.STORE_ID);
+  const keyFactsTable = main.UI.useTable("session_key_facts", main.STORE_ID);
+  const userId = main.UI.useValue("user_id", main.STORE_ID);
+  const model = useLanguageModel("enhance");
+
+  const built = useMemo(() => {
+    if (!store) {
+      return { notes: [], missing: [] };
+    }
+
+    return buildPastSessionNotes(
+      store,
+      sessionId,
+      typeof userId === "string" ? userId : null,
+    );
+  }, [
+    store,
+    sessionId,
+    userId,
+    sessionsTable,
+    participantsTable,
+    enhancedNotesTable,
+    keyFactsTable,
+  ]);
+
+  const mutation = useMutation({
+    mutationFn: async (requests: PastSessionNoteRequest[]) => {
+      if (!store || !model || requests.length === 0) {
+        return;
+      }
+
+      await generateAndSavePastSessionNotes({
+        store,
+        model,
+        requests,
+      });
+    },
+  });
+
+  const generatingIds = useMemo(
+    () =>
+      mutation.isPending
+        ? new Set(built.missing.map((request) => request.sessionId))
+        : new Set<string>(),
+    [built.missing, mutation.isPending],
+  );
+
+  const notes = useMemo(
+    () =>
+      built.notes.map((note) => ({
+        ...note,
+        isGenerating: generatingIds.has(note.sessionId),
+      })),
+    [built.notes, generatingIds],
+  );
+
+  const generateMissing = useCallback(() => {
+    if (!model || built.missing.length === 0 || mutation.isPending) {
+      return;
+    }
+
+    void mutation.mutateAsync(built.missing);
+  }, [built.missing, model, mutation]);
+
+  return {
+    notes,
+    hasPastNotes: notes.length > 0,
+    isGenerating: mutation.isPending,
+    canGenerate: Boolean(model),
+    generateMissing,
+  };
+}
+
+export function buildPastSessionNotes(
+  store: MainStore,
+  sessionId: string,
+  userId: string | null,
+): {
+  notes: PastSessionNote[];
+  missing: PastSessionNoteRequest[];
+} {
+  const currentSession = store.getRow("sessions", sessionId);
+  if (!currentSession) {
+    return { notes: [], missing: [] };
+  }
+
+  const currentParticipantIds = getSessionParticipantIds(
+    store,
+    sessionId,
+    userId,
+  );
+  const currentEvent = getSessionEvent(currentSession);
+  const currentSeriesId = getRecurrenceSeriesId(currentEvent);
+  if (!currentSeriesId && currentParticipantIds.size === 0) {
+    return { notes: [], missing: [] };
+  }
+
+  const currentTimestamp = getSessionTimestamp(currentSession);
+  const items: Array<{
+    note: PastSessionNote & { dateMs: number };
+    missing: PastSessionNoteRequest | null;
+  }> = [];
+
+  store.forEachRow("sessions", (candidateSessionId, _forEachCell) => {
+    if (candidateSessionId === sessionId) {
+      return;
+    }
+
+    const candidateSession = store.getRow("sessions", candidateSessionId);
+    if (!candidateSession) {
+      return;
+    }
+
+    const candidateTimestamp = getSessionTimestamp(candidateSession);
+    if (
+      currentTimestamp > 0 &&
+      candidateTimestamp > 0 &&
+      candidateTimestamp >= currentTimestamp
+    ) {
+      return;
+    }
+
+    const candidateEvent = getSessionEvent(candidateSession);
+    const candidateParticipantIds = getSessionParticipantIds(
+      store,
+      candidateSessionId,
+      userId,
+    );
+    if (
+      !isRelatedPastSession({
+        currentParticipantIds,
+        currentSeriesId,
+        candidateParticipantIds,
+        candidateSeriesId: getRecurrenceSeriesId(candidateEvent),
+      })
+    ) {
+      return;
+    }
+
+    const source = getSessionKeyFactsSource(store, candidateSessionId);
+    if (!source) {
+      return;
+    }
+
+    const title = getSessionTitle(candidateSession);
+    const dateLabel = formatSessionDate(candidateSession);
+    const sourceHash = createSourceHash([title, dateLabel, source].join("\n"));
+    const saved = getSavedKeyFacts(store, candidateSessionId, sourceHash);
+    const ownerUserId = getSessionUserId(candidateSession, userId);
+
+    items.push({
+      note: {
+        sessionId: candidateSessionId,
+        title,
+        dateLabel,
+        summary: saved,
+        isGenerating: false,
+        dateMs: candidateTimestamp,
+      },
+      missing: saved
+        ? null
+        : {
+            sessionId: candidateSessionId,
+            userId: ownerUserId,
+            title,
+            dateLabel,
+            sourceText: source,
+            sourceHash,
+          },
+    });
+  });
+
+  const selected = items
+    .sort((a, b) => b.note.dateMs - a.note.dateMs)
+    .slice(0, MAX_PAST_NOTES);
+
+  return {
+    notes: selected.map(({ note }) => {
+      const { dateMs: _dateMs, ...rest } = note;
+      return rest;
+    }),
+    missing: selected.flatMap((item) => item.missing ?? []),
+  };
+}
+
+async function generateAndSavePastSessionNotes({
+  store,
+  model,
+  requests,
+}: {
+  store: MainStore;
+  model: LanguageModel;
+  requests: PastSessionNoteRequest[];
+}) {
+  const rows: Array<PastSessionNoteRequest & { content: string }> = [];
+
+  for (const request of requests) {
+    const content = await generatePastSessionKeyFacts({ model, request });
+    if (content) {
+      rows.push({ ...request, content });
+    }
+  }
+
+  if (rows.length === 0) {
+    return;
+  }
+
+  const now = new Date().toISOString();
+  store.transaction(() => {
+    for (const row of rows) {
+      const existingCreatedAt = store.getCell(
+        "session_key_facts",
+        row.sessionId,
+        "created_at",
+      );
+
+      store.setRow("session_key_facts", row.sessionId, {
+        user_id: row.userId,
+        session_id: row.sessionId,
+        created_at:
+          typeof existingCreatedAt === "string" && existingCreatedAt
+            ? existingCreatedAt
+            : now,
+        updated_at: now,
+        content: row.content,
+        source_hash: row.sourceHash,
+      });
+    }
+  });
+}
+
+async function generatePastSessionKeyFacts({
+  model,
+  request,
+}: {
+  model: LanguageModel;
+  request: PastSessionNoteRequest;
+}): Promise<string> {
+  const system = await renderJinja(systemPromptTemplate, {});
+  const prompt = await renderJinja(userPromptTemplate, {
+    session: {
+      title: request.title,
+      date_label: request.dateLabel,
+    },
+    notes: request.sourceText,
+  });
+
+  const result = await generateText({
+    model,
+    temperature: 0,
+    system,
+    prompt,
+    output: Output.object({ schema: keyFactsSchema }),
+    maxRetries: 2,
+    maxOutputTokens: 700,
+  });
+
+  return normalizeFacts(result.output?.facts ?? []).join("\n");
+}
+
+type TemplateContext = Partial<{ [key: string]: JsonValue }>;
+
+async function renderJinja(templateContent: string, ctx: TemplateContext) {
+  const result = await templateCommands.renderCustom(templateContent, ctx);
+  if (result.status === "error") {
+    throw new Error(result.error);
+  }
+  return result.data;
+}
+
+function normalizeFacts(facts: string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const fact of facts) {
+    const text = fact
+      .replace(/^[-*]\s+/, "")
+      .replace(/^\d+[.)]\s+/, "")
+      .replace(SPACE_REGEX, " ")
+      .trim();
+    const key = text.toLowerCase();
+    if (!text || seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    normalized.push(text);
+  }
+
+  return normalized.slice(0, 6);
+}
+
+function getSavedKeyFacts(
+  store: MainStore,
+  sessionId: string,
+  sourceHash: string,
+): string | null {
+  const row = store.getRow("session_key_facts", sessionId);
+  if (
+    row.session_id !== sessionId ||
+    row.source_hash !== sourceHash ||
+    !row.content?.trim()
+  ) {
+    return null;
+  }
+
+  return row.content.trim();
+}
+
+function getSessionKeyFactsSource(
+  store: MainStore,
+  sessionId: string,
+): string | null {
+  const enhancedNotes: Array<{ content: string; position: number }> = [];
+
+  store.forEachRow("enhanced_notes", (noteId, _forEachCell) => {
+    const note = store.getRow("enhanced_notes", noteId);
+    if (note.session_id !== sessionId || !note.content?.trim()) {
+      return;
+    }
+
+    enhancedNotes.push({
+      content: note.content,
+      position: typeof note.position === "number" ? note.position : 0,
+    });
+  });
+
+  enhancedNotes.sort((a, b) => a.position - b.position);
+  const enhancedText = cleanSourceText(
+    enhancedNotes.map((note) => extractPlainText(note.content)).join("\n\n"),
+  );
+  if (enhancedText) {
+    return truncateAtWord(enhancedText, MAX_SOURCE_LENGTH);
+  }
+
+  const rawMd = store.getCell("sessions", sessionId, "raw_md");
+  const rawText = cleanSourceText(extractPlainText(rawMd));
+  return rawText ? truncateAtWord(rawText, MAX_SOURCE_LENGTH) : null;
+}
+
+function cleanSourceText(text: string): string {
+  return text
+    .replace(/!\[[^\]]*]\([^)]+\)/g, "")
+    .replace(/\[([^\]]+)]\([^)]+\)/g, "$1")
+    .replace(/[`*_~>#]/g, "")
+    .replace(/(^|\s)([-+]|[0-9]+[.)])\s+/g, " ")
+    .replace(SPACE_REGEX, " ")
+    .trim();
+}
+
+function truncateAtWord(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  const slice = text.slice(0, maxLength + 1);
+  const lastSpace = slice.lastIndexOf(" ");
+  const end = lastSpace > maxLength * 0.6 ? lastSpace : maxLength;
+  return `${slice.slice(0, end).trim()}...`;
+}
+
+function getSessionParticipantIds(
+  store: MainStore,
+  sessionId: string,
+  userId: string | null,
+): Set<string> {
+  const participantIds = new Set<string>();
+
+  store.forEachRow("mapping_session_participant", (mappingId, _forEachCell) => {
+    const mapping = store.getRow("mapping_session_participant", mappingId);
+    if (
+      mapping.session_id !== sessionId ||
+      mapping.source === "excluded" ||
+      !mapping.human_id
+    ) {
+      return;
+    }
+
+    const ownerUserId =
+      typeof mapping.user_id === "string" && mapping.user_id.trim()
+        ? mapping.user_id
+        : null;
+    const isCurrentUser =
+      (userId && mapping.human_id === userId) ||
+      (!userId && ownerUserId && mapping.human_id === ownerUserId);
+    if (!isCurrentUser) {
+      participantIds.add(mapping.human_id);
+    }
+  });
+
+  return participantIds;
+}
+
+function isRelatedPastSession({
+  currentParticipantIds,
+  currentSeriesId,
+  candidateParticipantIds,
+  candidateSeriesId,
+}: {
+  currentParticipantIds: Set<string>;
+  currentSeriesId: string | null;
+  candidateParticipantIds: Set<string>;
+  candidateSeriesId: string | null;
+}) {
+  if (currentSeriesId && candidateSeriesId === currentSeriesId) {
+    return true;
+  }
+
+  if (currentParticipantIds.size === 0) {
+    return false;
+  }
+
+  for (const participantId of currentParticipantIds) {
+    if (!candidateParticipantIds.has(participantId)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function getSessionTitle(session: { title?: string }): string {
+  return session.title?.trim() || "Untitled";
+}
+
+function getSessionUserId(
+  session: { user_id?: string },
+  fallbackUserId: string | null,
+): string {
+  return session.user_id?.trim() || fallbackUserId || "";
+}
+
+function getRecurrenceSeriesId(
+  event: ReturnType<typeof getSessionEvent>,
+): string | null {
+  const seriesId = event?.recurrence_series_id?.trim();
+  return seriesId || null;
+}
+
+function getSessionTimestamp(session: {
+  created_at?: string;
+  event_json?: string;
+}): number {
+  const event = getSessionEvent(session);
+  const value = event?.started_at || session.created_at;
+  if (!value) {
+    return 0;
+  }
+
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function formatSessionDate(session: {
+  created_at?: string;
+  event_json?: string;
+}): string {
+  const event = getSessionEvent(session);
+  const parsed = safeParseDate(event?.started_at || session.created_at);
+  return parsed ? format(parsed, "MMM d, yyyy") : "";
+}
+
+function createSourceHash(text: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16);
+}

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -7,7 +7,7 @@ import {
 } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { PostSessionAccessory } from "./post-session";
+import { buildPastSessionNotes, PostSessionAccessory } from "./post-session";
 
 const {
   audioPathMock,
@@ -101,6 +101,8 @@ vi.mock("~/store/tinybase/store/main", () => ({
   UI: {
     useStore: vi.fn(() => null),
     useIndexes: vi.fn(() => null),
+    useTable: vi.fn(() => ({})),
+    useValue: vi.fn(() => null),
   },
 }));
 
@@ -327,4 +329,183 @@ describe("PostSessionAccessory", () => {
     expect(screen.getByTestId("transcript-skeleton")).toBeTruthy();
     expect(screen.queryByTestId("transcript")).toBeNull();
   });
+
+  it("renders the past notes timeline when the past notes tab is active", () => {
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio={false}
+        hasTranscript
+        isTranscriptExpanded
+        activeTab="past_notes"
+        pastNotes={[
+          {
+            sessionId: "session-0",
+            title: "Weekly Product Sync",
+            dateLabel: "May 28, 2026",
+            summary: "Decided to ship the transcript panel and revisit polish.",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Past notes")).toBeTruthy();
+    expect(screen.getByText("Weekly Product Sync")).toBeTruthy();
+    expect(screen.getByText("May 28, 2026")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Decided to ship the transcript panel and revisit polish.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("transcript")).toBeNull();
+  });
+
+  it("builds descending past notes from previous sessions with the same participants", () => {
+    const store = makeStore({
+      sessions: {
+        current: {
+          title: "Weekly Product Sync",
+          created_at: "2026-06-03T10:00:00.000Z",
+          event_json: JSON.stringify({
+            started_at: "2026-06-03T10:00:00.000Z",
+            recurrence_series_id: "series-1",
+          }),
+          raw_md: "",
+        },
+        previous: {
+          title: "Weekly Product Sync",
+          created_at: "2026-05-28T10:00:00.000Z",
+          event_json: JSON.stringify({
+            started_at: "2026-05-28T10:00:00.000Z",
+            recurrence_series_id: "series-1",
+          }),
+          raw_md: "",
+        },
+        older: {
+          title: "Older Product Sync",
+          created_at: "2026-05-21T10:00:00.000Z",
+          event_json: "",
+          raw_md: "Reviewed onboarding follow-ups and assigned owners.",
+        },
+        partial: {
+          title: "Alex 1:1",
+          created_at: "2026-05-20T10:00:00.000Z",
+          event_json: "",
+          raw_md: "Should not show up.",
+        },
+        future: {
+          title: "Future Product Sync",
+          created_at: "2026-06-10T10:00:00.000Z",
+          event_json: "",
+          raw_md: "Should not show up.",
+        },
+      },
+      mapping_session_participant: {
+        current_self: {
+          session_id: "current",
+          human_id: "self",
+          user_id: "self",
+          source: "manual",
+        },
+        current_alex: {
+          session_id: "current",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+        current_jamie: {
+          session_id: "current",
+          human_id: "jamie",
+          user_id: "self",
+          source: "auto",
+        },
+        previous_alex: {
+          session_id: "previous",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+        previous_jamie: {
+          session_id: "previous",
+          human_id: "jamie",
+          user_id: "self",
+          source: "auto",
+        },
+        older_alex: {
+          session_id: "older",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+        older_jamie: {
+          session_id: "older",
+          human_id: "jamie",
+          user_id: "self",
+          source: "auto",
+        },
+        partial_alex: {
+          session_id: "partial",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+        future_alex: {
+          session_id: "future",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+        future_jamie: {
+          session_id: "future",
+          human_id: "jamie",
+          user_id: "self",
+          source: "auto",
+        },
+      },
+      enhanced_notes: {
+        previous_summary: {
+          session_id: "previous",
+          content:
+            "Aligned on transcript panel behavior. Past notes should stay short and scannable.",
+          position: 0,
+        },
+      },
+    });
+
+    const notes = buildPastSessionNotes(store, "current", "self");
+
+    expect(notes).toEqual([
+      {
+        sessionId: "previous",
+        title: "Weekly Product Sync",
+        dateLabel: "May 28, 2026",
+        summary:
+          "Aligned on transcript panel behavior. Past notes should stay short and scannable.",
+      },
+      {
+        sessionId: "older",
+        title: "Older Product Sync",
+        dateLabel: "May 21, 2026",
+        summary: "Reviewed onboarding follow-ups and assigned owners.",
+      },
+    ]);
+  });
 });
+
+function makeStore(
+  tables: Record<string, Record<string, Record<string, any>>>,
+) {
+  return {
+    getRow: (tableId: string, rowId: string) => tables[tableId]?.[rowId] ?? {},
+    getCell: (tableId: string, rowId: string, cellId: string) =>
+      tables[tableId]?.[rowId]?.[cellId],
+    forEachRow: (
+      tableId: string,
+      callback: (rowId: string, forEachCell: unknown) => void,
+    ) => {
+      for (const rowId of Object.keys(tables[tableId] ?? {})) {
+        callback(rowId, () => {});
+      }
+    },
+  } as any;
+}

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -7,7 +7,8 @@ import {
 } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { buildPastSessionNotes, PostSessionAccessory } from "./post-session";
+import { buildPastSessionNotes } from "./past-notes";
+import { PostSessionAccessory } from "./post-session";
 
 const {
   audioPathMock,
@@ -343,7 +344,9 @@ describe("PostSessionAccessory", () => {
             sessionId: "session-0",
             title: "Weekly Product Sync",
             dateLabel: "May 28, 2026",
-            summary: "Decided to ship the transcript panel and revisit polish.",
+            summary:
+              "Ship the transcript panel.\nRevisit visual polish next week.",
+            isGenerating: false,
           },
         ]}
       />,
@@ -352,11 +355,8 @@ describe("PostSessionAccessory", () => {
     expect(screen.getByText("Past notes")).toBeTruthy();
     expect(screen.getByText("Weekly Product Sync")).toBeTruthy();
     expect(screen.getByText("May 28, 2026")).toBeTruthy();
-    expect(
-      screen.getByText(
-        "Decided to ship the transcript panel and revisit polish.",
-      ),
-    ).toBeTruthy();
+    expect(screen.getByText("Ship the transcript panel.")).toBeTruthy();
+    expect(screen.getByText("Revisit visual polish next week.")).toBeTruthy();
     expect(screen.queryByTestId("transcript")).toBeNull();
   });
 
@@ -472,23 +472,87 @@ describe("PostSessionAccessory", () => {
       },
     });
 
-    const notes = buildPastSessionNotes(store, "current", "self");
+    const result = buildPastSessionNotes(store, "current", "self");
 
-    expect(notes).toEqual([
+    expect(result.notes).toEqual([
       {
         sessionId: "previous",
         title: "Weekly Product Sync",
         dateLabel: "May 28, 2026",
-        summary:
-          "Aligned on transcript panel behavior. Past notes should stay short and scannable.",
+        summary: null,
+        isGenerating: false,
       },
       {
         sessionId: "older",
         title: "Older Product Sync",
         dateLabel: "May 21, 2026",
-        summary: "Reviewed onboarding follow-ups and assigned owners.",
+        summary: null,
+        isGenerating: false,
       },
     ]);
+    expect(result.missing.map((request) => request.sessionId)).toEqual([
+      "previous",
+      "older",
+    ]);
+  });
+
+  it("reuses saved key facts when the source hash still matches", () => {
+    const store = makeStore({
+      sessions: {
+        current: {
+          title: "Weekly Product Sync",
+          created_at: "2026-06-03T10:00:00.000Z",
+          event_json: "",
+          raw_md: "",
+        },
+        previous: {
+          title: "Weekly Product Sync",
+          created_at: "2026-05-28T10:00:00.000Z",
+          event_json: "",
+          raw_md: "Alex committed to send pricing by Friday.",
+        },
+      },
+      mapping_session_participant: {
+        current_alex: {
+          session_id: "current",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+        previous_alex: {
+          session_id: "previous",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+      },
+    });
+
+    const first = buildPastSessionNotes(store, "current", "self");
+    expect(first.notes[0]?.summary).toBeNull();
+    const request = first.missing[0]!;
+
+    store.setRow("session_key_facts", "previous", {
+      user_id: "self",
+      session_id: "previous",
+      created_at: "2026-05-28T11:00:00.000Z",
+      updated_at: "2026-05-28T11:00:00.000Z",
+      content: "Alex committed to send pricing by Friday.",
+      source_hash: request.sourceHash,
+    });
+
+    const second = buildPastSessionNotes(store, "current", "self");
+
+    expect(second.notes).toEqual([
+      {
+        sessionId: "previous",
+        title: "Weekly Product Sync",
+        dateLabel: "May 28, 2026",
+        summary: "Alex committed to send pricing by Friday.",
+        isGenerating: false,
+      },
+    ]);
+    expect(second.missing).toHaveLength(0);
   });
 });
 
@@ -506,6 +570,12 @@ function makeStore(
       for (const rowId of Object.keys(tables[tableId] ?? {})) {
         callback(rowId, () => {});
       }
+    },
+    setRow: (tableId: string, rowId: string, row: Record<string, any>) => {
+      tables[tableId] = {
+        ...(tables[tableId] ?? {}),
+        [rowId]: row,
+      };
     },
   } as any;
 }

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -6,7 +6,7 @@ import {
   SquareIcon,
   TrashIcon,
 } from "lucide-react";
-import { type ReactNode, useCallback, useMemo, useRef } from "react";
+import { type ReactNode, useCallback, useRef } from "react";
 
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { Button } from "@hypr/ui/components/ui/button";
@@ -16,33 +16,22 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@hypr/ui/components/ui/tooltip";
-import { cn, format, safeParseDate } from "@hypr/utils";
+import { cn } from "@hypr/utils";
 
 import * as AudioPlayer from "~/audio-player";
-import { extractPlainText } from "~/search/contexts/engine/utils";
 import { getEnhancerService } from "~/services/enhancer";
+import type { PastSessionNote } from "~/session/components/bottom-accessory/past-notes";
 import { Transcript } from "~/session/components/note-input/transcript";
 import {
   formatTranscriptExportSegments,
   useTranscriptExportSegments,
 } from "~/session/components/note-input/transcript/export-data";
 import { useTranscriptScreen } from "~/session/components/note-input/transcript/state";
-import { getSessionEvent } from "~/session/utils";
 import { showTransientToast } from "~/sidebar/toast/transient";
-import * as main from "~/store/tinybase/store/main";
 import { useListener } from "~/stt/contexts";
 import { isStoppedTranscriptionError, useRunBatch } from "~/stt/useRunBatch";
 
 export type PostSessionTab = "transcript" | "past_notes";
-
-export type PastSessionNote = {
-  sessionId: string;
-  title: string;
-  dateLabel: string;
-  summary: string;
-};
-
-type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
 
 export function PostSessionAccessory({
   sessionId,
@@ -119,36 +108,6 @@ export function PostSessionAccessory({
   );
 }
 
-export function usePastSessionNotes(sessionId: string): PastSessionNote[] {
-  const store = main.UI.useStore(main.STORE_ID);
-  const sessionsTable = main.UI.useTable("sessions", main.STORE_ID);
-  const participantsTable = main.UI.useTable(
-    "mapping_session_participant",
-    main.STORE_ID,
-  );
-  const enhancedNotesTable = main.UI.useTable("enhanced_notes", main.STORE_ID);
-  const userId = main.UI.useValue("user_id", main.STORE_ID);
-
-  return useMemo(() => {
-    if (!store) {
-      return [];
-    }
-
-    return buildPastSessionNotes(
-      store,
-      sessionId,
-      typeof userId === "string" ? userId : null,
-    );
-  }, [
-    store,
-    sessionId,
-    userId,
-    sessionsTable,
-    participantsTable,
-    enhancedNotesTable,
-  ]);
-}
-
 function TimelineSlot({
   children,
   flushTop = false,
@@ -204,9 +163,21 @@ function PastNotesPanel({
                     {note.dateLabel}
                   </span>
                 </div>
-                <p className="line-clamp-3 text-xs leading-5 text-neutral-500">
-                  {note.summary}
-                </p>
+                {note.summary ? (
+                  <ul className="flex flex-col gap-1 text-xs leading-5 text-neutral-500">
+                    {splitKeyFacts(note.summary).map((fact) => (
+                      <li key={fact} className="line-clamp-2">
+                        {fact}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-xs leading-5 text-neutral-400">
+                    {note.isGenerating
+                      ? "Generating key facts..."
+                      : "Key facts will be generated when this tab opens."}
+                  </p>
+                )}
               </div>
             </div>
           ))}
@@ -214,6 +185,13 @@ function PastNotesPanel({
       </div>
     </TranscriptCard>
   );
+}
+
+function splitKeyFacts(content: string): string[] {
+  return content
+    .split("\n")
+    .map((fact) => fact.trim())
+    .filter(Boolean);
 }
 
 function TranscriptPanel({
@@ -714,260 +692,4 @@ function TranscriptCard({
       {children}
     </div>
   );
-}
-
-const MAX_PAST_NOTES = 8;
-const MAX_SUMMARY_LENGTH = 220;
-const SUMMARY_TARGET_LENGTH = 150;
-const SPACE_REGEX = /\s+/g;
-
-export function buildPastSessionNotes(
-  store: MainStore,
-  sessionId: string,
-  userId: string | null,
-): PastSessionNote[] {
-  const currentSession = store.getRow("sessions", sessionId);
-  if (!currentSession) {
-    return [];
-  }
-
-  const currentParticipantIds = getSessionParticipantIds(
-    store,
-    sessionId,
-    userId,
-  );
-  const currentEvent = getSessionEvent(currentSession);
-  const currentSeriesId = getRecurrenceSeriesId(currentEvent);
-  if (!currentSeriesId && currentParticipantIds.size === 0) {
-    return [];
-  }
-
-  const currentTimestamp = getSessionTimestamp(currentSession);
-  const notes: Array<PastSessionNote & { dateMs: number }> = [];
-
-  store.forEachRow("sessions", (candidateSessionId, _forEachCell) => {
-    if (candidateSessionId === sessionId) {
-      return;
-    }
-
-    const candidateSession = store.getRow("sessions", candidateSessionId);
-    if (!candidateSession) {
-      return;
-    }
-
-    const candidateTimestamp = getSessionTimestamp(candidateSession);
-    if (
-      currentTimestamp > 0 &&
-      candidateTimestamp > 0 &&
-      candidateTimestamp >= currentTimestamp
-    ) {
-      return;
-    }
-
-    const candidateEvent = getSessionEvent(candidateSession);
-    const candidateParticipantIds = getSessionParticipantIds(
-      store,
-      candidateSessionId,
-      userId,
-    );
-    if (
-      !isRelatedPastSession({
-        currentParticipantIds,
-        currentSeriesId,
-        candidateParticipantIds,
-        candidateSeriesId: getRecurrenceSeriesId(candidateEvent),
-      })
-    ) {
-      return;
-    }
-
-    const summary = getSessionNoteSummary(store, candidateSessionId);
-    if (!summary) {
-      return;
-    }
-
-    notes.push({
-      sessionId: candidateSessionId,
-      title: getSessionTitle(candidateSession),
-      dateLabel: formatSessionDate(candidateSession),
-      summary,
-      dateMs: candidateTimestamp,
-    });
-  });
-
-  return notes
-    .sort((a, b) => b.dateMs - a.dateMs)
-    .slice(0, MAX_PAST_NOTES)
-    .map(({ dateMs: _dateMs, ...note }) => note);
-}
-
-function getSessionParticipantIds(
-  store: MainStore,
-  sessionId: string,
-  userId: string | null,
-): Set<string> {
-  const participantIds = new Set<string>();
-
-  store.forEachRow("mapping_session_participant", (mappingId, _forEachCell) => {
-    const mapping = store.getRow("mapping_session_participant", mappingId);
-    if (
-      mapping.session_id !== sessionId ||
-      mapping.source === "excluded" ||
-      !mapping.human_id
-    ) {
-      return;
-    }
-
-    const ownerUserId =
-      typeof mapping.user_id === "string" && mapping.user_id.trim()
-        ? mapping.user_id
-        : null;
-    const isCurrentUser =
-      (userId && mapping.human_id === userId) ||
-      (!userId && ownerUserId && mapping.human_id === ownerUserId);
-    if (!isCurrentUser) {
-      participantIds.add(mapping.human_id);
-    }
-  });
-
-  return participantIds;
-}
-
-function isRelatedPastSession({
-  currentParticipantIds,
-  currentSeriesId,
-  candidateParticipantIds,
-  candidateSeriesId,
-}: {
-  currentParticipantIds: Set<string>;
-  currentSeriesId: string | null;
-  candidateParticipantIds: Set<string>;
-  candidateSeriesId: string | null;
-}) {
-  if (currentSeriesId && candidateSeriesId === currentSeriesId) {
-    return true;
-  }
-
-  if (currentParticipantIds.size === 0) {
-    return false;
-  }
-
-  for (const participantId of currentParticipantIds) {
-    if (!candidateParticipantIds.has(participantId)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-function getSessionNoteSummary(store: MainStore, sessionId: string): string {
-  const enhancedNotes: Array<{ content: string; position: number }> = [];
-
-  store.forEachRow("enhanced_notes", (noteId, _forEachCell) => {
-    const note = store.getRow("enhanced_notes", noteId);
-    if (note.session_id !== sessionId || !note.content?.trim()) {
-      return;
-    }
-
-    enhancedNotes.push({
-      content: note.content,
-      position: typeof note.position === "number" ? note.position : 0,
-    });
-  });
-
-  enhancedNotes.sort((a, b) => a.position - b.position);
-  for (const note of enhancedNotes) {
-    const summary = toConciseSummary(note.content);
-    if (summary) {
-      return summary;
-    }
-  }
-
-  const rawMd = store.getCell("sessions", sessionId, "raw_md");
-  return toConciseSummary(rawMd);
-}
-
-function toConciseSummary(value: unknown): string {
-  const cleaned = cleanSummaryText(extractPlainText(value));
-  if (!cleaned) {
-    return "";
-  }
-
-  const sentences = cleaned.match(/[^.!?]+(?:[.!?]+|$)/g) ?? [cleaned];
-  let summary = "";
-
-  for (const sentence of sentences) {
-    const trimmed = sentence.trim();
-    if (!trimmed) {
-      continue;
-    }
-
-    const next = summary ? `${summary} ${trimmed}` : trimmed;
-    if (summary && next.length > SUMMARY_TARGET_LENGTH) {
-      break;
-    }
-
-    summary = next;
-    if (summary.length >= SUMMARY_TARGET_LENGTH) {
-      break;
-    }
-  }
-
-  return truncateAtWord(summary || cleaned, MAX_SUMMARY_LENGTH);
-}
-
-function cleanSummaryText(text: string): string {
-  return text
-    .replace(/!\[[^\]]*]\([^)]+\)/g, "")
-    .replace(/\[([^\]]+)]\([^)]+\)/g, "$1")
-    .replace(/[`*_~>#]/g, "")
-    .replace(/(^|\s)([-+]|[0-9]+[.)])\s+/g, " ")
-    .replace(SPACE_REGEX, " ")
-    .trim();
-}
-
-function truncateAtWord(text: string, maxLength: number): string {
-  if (text.length <= maxLength) {
-    return text;
-  }
-
-  const slice = text.slice(0, maxLength + 1);
-  const lastSpace = slice.lastIndexOf(" ");
-  const end = lastSpace > maxLength * 0.6 ? lastSpace : maxLength;
-  return `${slice.slice(0, end).trim()}...`;
-}
-
-function getSessionTitle(session: { title?: string }): string {
-  return session.title?.trim() || "Untitled";
-}
-
-function getRecurrenceSeriesId(
-  event: ReturnType<typeof getSessionEvent>,
-): string | null {
-  const seriesId = event?.recurrence_series_id?.trim();
-  return seriesId || null;
-}
-
-function getSessionTimestamp(session: {
-  created_at?: string;
-  event_json?: string;
-}): number {
-  const event = getSessionEvent(session);
-  const value = event?.started_at || session.created_at;
-  if (!value) {
-    return 0;
-  }
-
-  const timestamp = Date.parse(value);
-  return Number.isNaN(timestamp) ? 0 : timestamp;
-}
-
-function formatSessionDate(session: {
-  created_at?: string;
-  event_json?: string;
-}): string {
-  const event = getSessionEvent(session);
-  const parsed = safeParseDate(event?.started_at || session.created_at);
-  return parsed ? format(parsed, "MMM d, yyyy") : "";
 }

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -6,7 +6,7 @@ import {
   SquareIcon,
   TrashIcon,
 } from "lucide-react";
-import { type ReactNode, useCallback, useRef } from "react";
+import { type ReactNode, useCallback, useMemo, useRef } from "react";
 
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { Button } from "@hypr/ui/components/ui/button";
@@ -16,9 +16,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@hypr/ui/components/ui/tooltip";
-import { cn } from "@hypr/utils";
+import { cn, format, safeParseDate } from "@hypr/utils";
 
 import * as AudioPlayer from "~/audio-player";
+import { extractPlainText } from "~/search/contexts/engine/utils";
 import { getEnhancerService } from "~/services/enhancer";
 import { Transcript } from "~/session/components/note-input/transcript";
 import {
@@ -26,26 +27,49 @@ import {
   useTranscriptExportSegments,
 } from "~/session/components/note-input/transcript/export-data";
 import { useTranscriptScreen } from "~/session/components/note-input/transcript/state";
+import { getSessionEvent } from "~/session/utils";
 import { showTransientToast } from "~/sidebar/toast/transient";
+import * as main from "~/store/tinybase/store/main";
 import { useListener } from "~/stt/contexts";
 import { isStoppedTranscriptionError, useRunBatch } from "~/stt/useRunBatch";
+
+export type PostSessionTab = "transcript" | "past_notes";
+
+export type PastSessionNote = {
+  sessionId: string;
+  title: string;
+  dateLabel: string;
+  summary: string;
+};
+
+type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
 
 export function PostSessionAccessory({
   sessionId,
   hasAudio,
   hasTranscript,
   isTranscriptExpanded,
+  activeTab = "transcript",
+  pastNotes = [],
   fillHeight = false,
 }: {
   sessionId: string;
   hasAudio: boolean;
   hasTranscript: boolean;
   isTranscriptExpanded: boolean;
+  activeTab?: PostSessionTab;
+  pastNotes?: PastSessionNote[];
   fillHeight?: boolean;
 }) {
   const screen = useTranscriptScreen({ sessionId });
   const isBatching = screen.kind === "running_batch";
-  const shouldFillTranscriptPanel = fillHeight && (hasTranscript || isBatching);
+  const effectiveActiveTab =
+    activeTab === "past_notes" && pastNotes.length > 0
+      ? "past_notes"
+      : "transcript";
+  const shouldFillExpandedPanel =
+    fillHeight &&
+    (effectiveActiveTab === "past_notes" || hasTranscript || isBatching);
   const timeline = isBatching ? (
     <BatchProgressTimeline sessionId={sessionId} screen={screen} />
   ) : hasAudio ? (
@@ -66,19 +90,26 @@ export function PostSessionAccessory({
       {isTranscriptExpanded ? (
         <div
           className={cn([
-            shouldFillTranscriptPanel
+            shouldFillExpandedPanel
               ? "min-h-[114px] flex-1 overflow-hidden"
               : "shrink-0",
           ])}
         >
-          <TranscriptPanel
-            sessionId={sessionId}
-            screen={screen}
-            hasAudio={hasAudio}
-            hasTranscript={hasTranscript}
-            isExpanded={isTranscriptExpanded}
-            fillHeight={shouldFillTranscriptPanel}
-          />
+          {effectiveActiveTab === "past_notes" ? (
+            <PastNotesPanel
+              notes={pastNotes}
+              fillHeight={shouldFillExpandedPanel}
+            />
+          ) : (
+            <TranscriptPanel
+              sessionId={sessionId}
+              screen={screen}
+              hasAudio={hasAudio}
+              hasTranscript={hasTranscript}
+              isExpanded={isTranscriptExpanded}
+              fillHeight={shouldFillExpandedPanel}
+            />
+          )}
         </div>
       ) : null}
       {timeline ? (
@@ -86,6 +117,36 @@ export function PostSessionAccessory({
       ) : null}
     </div>
   );
+}
+
+export function usePastSessionNotes(sessionId: string): PastSessionNote[] {
+  const store = main.UI.useStore(main.STORE_ID);
+  const sessionsTable = main.UI.useTable("sessions", main.STORE_ID);
+  const participantsTable = main.UI.useTable(
+    "mapping_session_participant",
+    main.STORE_ID,
+  );
+  const enhancedNotesTable = main.UI.useTable("enhanced_notes", main.STORE_ID);
+  const userId = main.UI.useValue("user_id", main.STORE_ID);
+
+  return useMemo(() => {
+    if (!store) {
+      return [];
+    }
+
+    return buildPastSessionNotes(
+      store,
+      sessionId,
+      typeof userId === "string" ? userId : null,
+    );
+  }, [
+    store,
+    sessionId,
+    userId,
+    sessionsTable,
+    participantsTable,
+    enhancedNotesTable,
+  ]);
 }
 
 function TimelineSlot({
@@ -104,6 +165,54 @@ function TimelineSlot({
     >
       {children}
     </div>
+  );
+}
+
+function PastNotesPanel({
+  notes,
+  fillHeight,
+}: {
+  notes: PastSessionNote[];
+  fillHeight: boolean;
+}) {
+  return (
+    <TranscriptCard fillHeight={fillHeight}>
+      <div className="flex shrink-0 items-center justify-between px-3 py-1.5">
+        <span className="text-xs font-medium text-neutral-500">Past notes</span>
+      </div>
+
+      <div
+        className={cn([
+          "min-h-0 overflow-y-auto px-4 pb-4",
+          fillHeight ? "flex-1" : "max-h-[300px]",
+        ])}
+      >
+        <div className="relative flex flex-col gap-4 pt-2">
+          <div className="absolute top-2 bottom-0 left-[3px] w-px bg-neutral-200" />
+          {notes.map((note) => (
+            <div
+              key={note.sessionId}
+              className="relative grid grid-cols-1 pl-5"
+            >
+              <div className="absolute top-1.5 left-0 h-2 w-2 rounded-full border border-neutral-300 bg-white" />
+              <div className="flex min-w-0 flex-col gap-1">
+                <div className="flex min-w-0 items-baseline justify-between gap-3">
+                  <span className="min-w-0 truncate text-xs font-medium text-neutral-700">
+                    {note.title}
+                  </span>
+                  <span className="shrink-0 text-[11px] text-neutral-400">
+                    {note.dateLabel}
+                  </span>
+                </div>
+                <p className="line-clamp-3 text-xs leading-5 text-neutral-500">
+                  {note.summary}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </TranscriptCard>
   );
 }
 
@@ -605,4 +714,260 @@ function TranscriptCard({
       {children}
     </div>
   );
+}
+
+const MAX_PAST_NOTES = 8;
+const MAX_SUMMARY_LENGTH = 220;
+const SUMMARY_TARGET_LENGTH = 150;
+const SPACE_REGEX = /\s+/g;
+
+export function buildPastSessionNotes(
+  store: MainStore,
+  sessionId: string,
+  userId: string | null,
+): PastSessionNote[] {
+  const currentSession = store.getRow("sessions", sessionId);
+  if (!currentSession) {
+    return [];
+  }
+
+  const currentParticipantIds = getSessionParticipantIds(
+    store,
+    sessionId,
+    userId,
+  );
+  const currentEvent = getSessionEvent(currentSession);
+  const currentSeriesId = getRecurrenceSeriesId(currentEvent);
+  if (!currentSeriesId && currentParticipantIds.size === 0) {
+    return [];
+  }
+
+  const currentTimestamp = getSessionTimestamp(currentSession);
+  const notes: Array<PastSessionNote & { dateMs: number }> = [];
+
+  store.forEachRow("sessions", (candidateSessionId, _forEachCell) => {
+    if (candidateSessionId === sessionId) {
+      return;
+    }
+
+    const candidateSession = store.getRow("sessions", candidateSessionId);
+    if (!candidateSession) {
+      return;
+    }
+
+    const candidateTimestamp = getSessionTimestamp(candidateSession);
+    if (
+      currentTimestamp > 0 &&
+      candidateTimestamp > 0 &&
+      candidateTimestamp >= currentTimestamp
+    ) {
+      return;
+    }
+
+    const candidateEvent = getSessionEvent(candidateSession);
+    const candidateParticipantIds = getSessionParticipantIds(
+      store,
+      candidateSessionId,
+      userId,
+    );
+    if (
+      !isRelatedPastSession({
+        currentParticipantIds,
+        currentSeriesId,
+        candidateParticipantIds,
+        candidateSeriesId: getRecurrenceSeriesId(candidateEvent),
+      })
+    ) {
+      return;
+    }
+
+    const summary = getSessionNoteSummary(store, candidateSessionId);
+    if (!summary) {
+      return;
+    }
+
+    notes.push({
+      sessionId: candidateSessionId,
+      title: getSessionTitle(candidateSession),
+      dateLabel: formatSessionDate(candidateSession),
+      summary,
+      dateMs: candidateTimestamp,
+    });
+  });
+
+  return notes
+    .sort((a, b) => b.dateMs - a.dateMs)
+    .slice(0, MAX_PAST_NOTES)
+    .map(({ dateMs: _dateMs, ...note }) => note);
+}
+
+function getSessionParticipantIds(
+  store: MainStore,
+  sessionId: string,
+  userId: string | null,
+): Set<string> {
+  const participantIds = new Set<string>();
+
+  store.forEachRow("mapping_session_participant", (mappingId, _forEachCell) => {
+    const mapping = store.getRow("mapping_session_participant", mappingId);
+    if (
+      mapping.session_id !== sessionId ||
+      mapping.source === "excluded" ||
+      !mapping.human_id
+    ) {
+      return;
+    }
+
+    const ownerUserId =
+      typeof mapping.user_id === "string" && mapping.user_id.trim()
+        ? mapping.user_id
+        : null;
+    const isCurrentUser =
+      (userId && mapping.human_id === userId) ||
+      (!userId && ownerUserId && mapping.human_id === ownerUserId);
+    if (!isCurrentUser) {
+      participantIds.add(mapping.human_id);
+    }
+  });
+
+  return participantIds;
+}
+
+function isRelatedPastSession({
+  currentParticipantIds,
+  currentSeriesId,
+  candidateParticipantIds,
+  candidateSeriesId,
+}: {
+  currentParticipantIds: Set<string>;
+  currentSeriesId: string | null;
+  candidateParticipantIds: Set<string>;
+  candidateSeriesId: string | null;
+}) {
+  if (currentSeriesId && candidateSeriesId === currentSeriesId) {
+    return true;
+  }
+
+  if (currentParticipantIds.size === 0) {
+    return false;
+  }
+
+  for (const participantId of currentParticipantIds) {
+    if (!candidateParticipantIds.has(participantId)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function getSessionNoteSummary(store: MainStore, sessionId: string): string {
+  const enhancedNotes: Array<{ content: string; position: number }> = [];
+
+  store.forEachRow("enhanced_notes", (noteId, _forEachCell) => {
+    const note = store.getRow("enhanced_notes", noteId);
+    if (note.session_id !== sessionId || !note.content?.trim()) {
+      return;
+    }
+
+    enhancedNotes.push({
+      content: note.content,
+      position: typeof note.position === "number" ? note.position : 0,
+    });
+  });
+
+  enhancedNotes.sort((a, b) => a.position - b.position);
+  for (const note of enhancedNotes) {
+    const summary = toConciseSummary(note.content);
+    if (summary) {
+      return summary;
+    }
+  }
+
+  const rawMd = store.getCell("sessions", sessionId, "raw_md");
+  return toConciseSummary(rawMd);
+}
+
+function toConciseSummary(value: unknown): string {
+  const cleaned = cleanSummaryText(extractPlainText(value));
+  if (!cleaned) {
+    return "";
+  }
+
+  const sentences = cleaned.match(/[^.!?]+(?:[.!?]+|$)/g) ?? [cleaned];
+  let summary = "";
+
+  for (const sentence of sentences) {
+    const trimmed = sentence.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const next = summary ? `${summary} ${trimmed}` : trimmed;
+    if (summary && next.length > SUMMARY_TARGET_LENGTH) {
+      break;
+    }
+
+    summary = next;
+    if (summary.length >= SUMMARY_TARGET_LENGTH) {
+      break;
+    }
+  }
+
+  return truncateAtWord(summary || cleaned, MAX_SUMMARY_LENGTH);
+}
+
+function cleanSummaryText(text: string): string {
+  return text
+    .replace(/!\[[^\]]*]\([^)]+\)/g, "")
+    .replace(/\[([^\]]+)]\([^)]+\)/g, "$1")
+    .replace(/[`*_~>#]/g, "")
+    .replace(/(^|\s)([-+]|[0-9]+[.)])\s+/g, " ")
+    .replace(SPACE_REGEX, " ")
+    .trim();
+}
+
+function truncateAtWord(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  const slice = text.slice(0, maxLength + 1);
+  const lastSpace = slice.lastIndexOf(" ");
+  const end = lastSpace > maxLength * 0.6 ? lastSpace : maxLength;
+  return `${slice.slice(0, end).trim()}...`;
+}
+
+function getSessionTitle(session: { title?: string }): string {
+  return session.title?.trim() || "Untitled";
+}
+
+function getRecurrenceSeriesId(
+  event: ReturnType<typeof getSessionEvent>,
+): string | null {
+  const seriesId = event?.recurrence_series_id?.trim();
+  return seriesId || null;
+}
+
+function getSessionTimestamp(session: {
+  created_at?: string;
+  event_json?: string;
+}): number {
+  const event = getSessionEvent(session);
+  const value = event?.started_at || session.created_at;
+  if (!value) {
+    return 0;
+  }
+
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function formatSessionDate(session: {
+  created_at?: string;
+  event_json?: string;
+}): string {
+  const event = getSessionEvent(session);
+  const parsed = safeParseDate(event?.started_at || session.created_at);
+  return parsed ? format(parsed, "MMM d, yyyy") : "";
 }

--- a/apps/desktop/src/store/tinybase/persister/session/changes.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/changes.test.ts
@@ -124,6 +124,20 @@ describe("getSessionSaveScope", () => {
     });
   });
 
+  test("limits saved key fact changes to session metadata output", () => {
+    expect(
+      getSessionSaveScope({
+        session_key_facts: {
+          "session-1": [{ content: ["Alex owns pricing.", "stamp"] }],
+        },
+      }),
+    ).toEqual({
+      session: true,
+      transcript: false,
+      note: false,
+    });
+  });
+
   test("saves all artifacts when the session folder changes", () => {
     expect(
       getSessionSaveScope({
@@ -259,6 +273,24 @@ describe("getChangedSessionIds", () => {
       const result = getChangedSessionIds(tables, changedTables);
 
       expect(result?.hasUnresolvedDeletions).toBe(true);
+    });
+  });
+
+  describe("key facts changes", () => {
+    test("resolves session id from saved key facts", () => {
+      const tables: TablesContent = {
+        session_key_facts: {
+          "session-1": { session_id: "session-1" },
+        },
+      };
+      const changedTables: ChangedTables = {
+        session_key_facts: { "session-1": {} },
+      };
+
+      const result = getChangedSessionIds(tables, changedTables);
+
+      expect(result?.changedSessionIds).toEqual(new Set(["session-1"]));
+      expect(result?.hasUnresolvedDeletions).toBe(false);
     });
   });
 

--- a/apps/desktop/src/store/tinybase/persister/session/changes.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/changes.ts
@@ -77,6 +77,10 @@ export function getChangedSessionIds(
       table: "enhanced_notes",
       extractId: (id, tables) => tables.enhanced_notes?.[id]?.session_id,
     },
+    {
+      table: "session_key_facts",
+      extractId: (id, tables) => tables.session_key_facts?.[id]?.session_id,
+    },
   ]);
 
   const changedSessionIds = new Set(result?.changedIds ?? []);
@@ -132,7 +136,8 @@ export function getSessionSaveScope(
       hasSessionCellChange(changedTables, SESSION_META_CELLS) ||
       hasTableChange(changedTables, "mapping_session_participant") ||
       hasTableChange(changedTables, "mapping_tag_session") ||
-      hasTableChange(changedTables, "tags"),
+      hasTableChange(changedTables, "tags") ||
+      hasTableChange(changedTables, "session_key_facts"),
     transcript:
       sessionPathChanged || hasTableChange(changedTables, "transcripts"),
     note:

--- a/apps/desktop/src/store/tinybase/persister/session/load/meta.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/load/meta.test.ts
@@ -204,6 +204,36 @@ describe("processMetaFile", () => {
     });
   });
 
+  test("restores saved key facts from meta JSON", () => {
+    const content = JSON.stringify({
+      id: "session-1",
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:00Z",
+      title: "Test Session",
+      participants: [],
+      key_facts: {
+        id: "legacy-row-id",
+        user_id: "user-1",
+        session_id: "session-1",
+        created_at: "2024-01-01T01:00:00Z",
+        updated_at: "2024-01-01T01:05:00Z",
+        content: "Alex owns pricing follow-up.",
+        source_hash: "hash-1",
+      },
+    });
+
+    processMetaFile("/data/sessions/session-1/_meta.json", content, result);
+
+    expect(result.session_key_facts["session-1"]).toEqual({
+      user_id: "user-1",
+      session_id: "session-1",
+      created_at: "2024-01-01T01:00:00Z",
+      updated_at: "2024-01-01T01:05:00Z",
+      content: "Alex owns pricing follow-up.",
+      source_hash: "hash-1",
+    });
+  });
+
   test("handles parse errors gracefully", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 

--- a/apps/desktop/src/store/tinybase/persister/session/load/meta.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/load/meta.ts
@@ -52,6 +52,17 @@ export function processMetaFile(
       };
     }
 
+    if (meta.key_facts?.content && meta.key_facts.source_hash) {
+      result.session_key_facts[sessionId] = {
+        user_id: meta.key_facts.user_id ?? meta.user_id ?? "",
+        session_id: sessionId,
+        created_at: meta.key_facts.created_at ?? "",
+        updated_at: meta.key_facts.updated_at ?? "",
+        content: meta.key_facts.content,
+        source_hash: meta.key_facts.source_hash,
+      };
+    }
+
     if (meta.tags) {
       for (const tagName of meta.tags) {
         if (!result.tags[tagName]) {

--- a/apps/desktop/src/store/tinybase/persister/session/load/types.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/load/types.ts
@@ -9,6 +9,7 @@ export const SESSION_TABLES = [
   "mapping_tag_session",
   "transcripts",
   "enhanced_notes",
+  "session_key_facts",
 ] as const satisfies readonly (keyof typeof SCHEMA.table)[];
 
 type SessionTables = (typeof SESSION_TABLES)[number];

--- a/apps/desktop/src/store/tinybase/persister/session/persister.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/persister.ts
@@ -31,6 +31,7 @@ export function createSessionPersister(store: Store) {
       { tableName: "mapping_tag_session", foreignKey: "session_id" },
       { tableName: "transcripts", foreignKey: "session_id" },
       { tableName: "enhanced_notes", foreignKey: "session_id" },
+      { tableName: "session_key_facts", foreignKey: "session_id" },
     ],
     loadAll: loadAllSessionData,
     loadSingle: loadSingleSession,

--- a/apps/desktop/src/store/tinybase/persister/session/save/session.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/save/session.test.ts
@@ -124,6 +124,38 @@ describe("tablesToSessionMetaMap", () => {
     expect(result.get("session-1")?.meta.tags).toBeUndefined();
   });
 
+  test("includes saved key facts in session metadata", () => {
+    const store = createTestMainStore();
+    store.setRow("sessions", "session-1", {
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:00Z",
+      title: "Test Session",
+      folder_id: "/sessions",
+      event_json: "",
+      raw_md: "",
+    });
+    store.setRow("session_key_facts", "session-1", {
+      user_id: "user-1",
+      session_id: "session-1",
+      created_at: "2024-01-01T01:00:00Z",
+      updated_at: "2024-01-01T01:05:00Z",
+      content: "Alex owns pricing follow-up.",
+      source_hash: "hash-1",
+    });
+
+    const result = tablesToSessionMetaMap(store);
+
+    expect(result.get("session-1")?.meta.key_facts).toEqual({
+      id: "session-1",
+      user_id: "user-1",
+      session_id: "session-1",
+      created_at: "2024-01-01T01:00:00Z",
+      updated_at: "2024-01-01T01:05:00Z",
+      content: "Alex owns pricing follow-up.",
+      source_hash: "hash-1",
+    });
+  });
+
   test("handles multiple sessions independently", () => {
     const store = createTestMainStore();
     store.setRow("sessions", "session-1", {

--- a/apps/desktop/src/store/tinybase/persister/session/save/session.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/save/session.ts
@@ -2,6 +2,7 @@ import { sep } from "@tauri-apps/api/path";
 
 import type {
   ParticipantData,
+  SessionKeyFactsData,
   SessionMetaJson,
 } from "~/store/tinybase/persister/session/types";
 import {
@@ -43,6 +44,7 @@ export function tablesToSessionMetaMap(
   const tables = store.getTables() as TablesContent;
 
   const participantsBySession = buildParticipantMap(tables);
+  const keyFactsBySession = buildKeyFactsMap(tables);
   const tagsBySession = buildTagMap(tables);
 
   const result = new Map<string, SessionMetaWithFolder>();
@@ -56,6 +58,7 @@ export function tablesToSessionMetaMap(
         title: session.title ?? "",
         event: tryParseJson(session.event_json),
         participants: participantsBySession.get(session.id) ?? [],
+        key_facts: keyFactsBySession.get(session.id),
         tags: tagsBySession.get(session.id),
       },
       folderPath: session.folder_id ?? "",
@@ -82,6 +85,7 @@ function collectSessionMetas(ctx: BuildContext): MetaItem[] {
   const { tables, dataDir, changedSessionIds } = ctx;
 
   const participantsBySession = buildParticipantMap(tables);
+  const keyFactsBySession = buildKeyFactsMap(tables);
   const tagsBySession = buildTagMap(tables);
 
   return iterateTableRows(tables, "sessions")
@@ -96,6 +100,7 @@ function collectSessionMetas(ctx: BuildContext): MetaItem[] {
         title: session.title ?? "",
         event: tryParseJson(session.event_json),
         participants: participantsBySession.get(session.id) ?? [],
+        key_facts: keyFactsBySession.get(session.id),
         tags: tagsBySession.get(session.id),
       };
 
@@ -127,6 +132,30 @@ function buildParticipantMap(
       source: p.source,
     });
     result.set(p.session_id, list);
+  }
+
+  return result;
+}
+
+function buildKeyFactsMap(
+  tables: TablesContent,
+): Map<string, SessionKeyFactsData> {
+  const result = new Map<string, SessionKeyFactsData>();
+
+  for (const row of iterateTableRows(tables, "session_key_facts")) {
+    if (!row.session_id || !row.content || !row.source_hash) {
+      continue;
+    }
+
+    result.set(row.session_id, {
+      id: row.id,
+      user_id: row.user_id,
+      session_id: row.session_id,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+      content: row.content,
+      source_hash: row.source_hash,
+    });
   }
 
   return result;

--- a/apps/desktop/src/store/tinybase/persister/session/types.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/types.ts
@@ -1,9 +1,11 @@
 import type {
   MappingSessionParticipantStorage,
+  SessionKeyFactsStorage,
   SessionStorage,
 } from "@hypr/store";
 
 export type ParticipantData = MappingSessionParticipantStorage & { id: string };
+export type SessionKeyFactsData = SessionKeyFactsStorage & { id: string };
 
 export type SessionMetaJson = Pick<
   SessionStorage,
@@ -13,6 +15,7 @@ export type SessionMetaJson = Pick<
   event?: Record<string, unknown>;
   event_id?: string;
   participants: ParticipantData[];
+  key_facts?: SessionKeyFactsData;
   tags?: string[];
 };
 

--- a/apps/desktop/src/store/tinybase/store/deleteSession.test.ts
+++ b/apps/desktop/src/store/tinybase/store/deleteSession.test.ts
@@ -49,6 +49,23 @@ describe("deleteSessionCascade", () => {
     expect(fsSyncMocks.deleteSessionFolder).not.toHaveBeenCalled();
   });
 
+  test("deletes cached key facts with the session", () => {
+    store.setRow("session_key_facts", "session-1", {
+      user_id: "user-1",
+      session_id: "session-1",
+      created_at: "2024-01-01T01:00:00Z",
+      updated_at: "2024-01-01T01:05:00Z",
+      content: "Alex owns pricing follow-up.",
+      source_hash: "hash-1",
+    });
+
+    deleteSessionCascade(store, undefined, "session-1", {
+      deferFilesystemDelete: true,
+    });
+
+    expect(store.getRow("session_key_facts", "session-1")).toEqual({});
+  });
+
   test("finalizes deletion by removing the session folder", async () => {
     await finalizeSessionDeletion("session-1");
 

--- a/apps/desktop/src/store/tinybase/store/deleteSession.ts
+++ b/apps/desktop/src/store/tinybase/store/deleteSession.ts
@@ -62,6 +62,20 @@ export function captureSessionData(
     raw_md: sessionRow.raw_md as string,
   };
 
+  const keyFactsRow = store.getRow("session_key_facts", sessionId);
+  const keyFacts =
+    keyFactsRow && Object.keys(keyFactsRow).length > 0
+      ? {
+          id: sessionId,
+          user_id: keyFactsRow.user_id as string,
+          session_id: keyFactsRow.session_id as string,
+          created_at: keyFactsRow.created_at as string,
+          updated_at: keyFactsRow.updated_at as string,
+          content: keyFactsRow.content as string,
+          source_hash: keyFactsRow.source_hash as string,
+        }
+      : null;
+
   const transcripts: DeletedSessionData["transcripts"] = [];
   const participants: DeletedSessionData["participants"] = [];
   const tagSessions: DeletedSessionData["tagSessions"] = [];
@@ -148,6 +162,7 @@ export function captureSessionData(
     participants,
     tagSessions,
     enhancedNotes,
+    keyFacts,
     deletedAt: Date.now(),
   };
 }
@@ -157,8 +172,14 @@ export function restoreSessionData(
   data: DeletedSessionData,
 ): void {
   store.transaction(() => {
-    const { session, transcripts, participants, tagSessions, enhancedNotes } =
-      data;
+    const {
+      session,
+      transcripts,
+      participants,
+      tagSessions,
+      enhancedNotes,
+      keyFacts,
+    } = data;
 
     store.setRow("sessions", session.id, {
       user_id: session.user_id,
@@ -211,6 +232,17 @@ export function restoreSessionData(
         title: enhancedNote.title,
       });
     }
+
+    if (keyFacts) {
+      store.setRow("session_key_facts", keyFacts.id, {
+        user_id: keyFacts.user_id,
+        session_id: keyFacts.session_id,
+        created_at: keyFacts.created_at,
+        updated_at: keyFacts.updated_at,
+        content: keyFacts.content,
+        source_hash: keyFacts.source_hash,
+      });
+    }
   });
 }
 
@@ -221,6 +253,7 @@ export function deleteSessionCascade(
   options?: { deferFilesystemDelete?: boolean },
 ): void {
   if (!indexes) {
+    store.delRow("session_key_facts", sessionId);
     store.delRow("sessions", sessionId);
   } else {
     store.transaction(() => {
@@ -255,6 +288,7 @@ export function deleteSessionCascade(
         "enhanced_notes",
       );
 
+      store.delRow("session_key_facts", sessionId);
       store.delRow("sessions", sessionId);
     });
   }

--- a/apps/desktop/src/store/zustand/undo-delete.ts
+++ b/apps/desktop/src/store/zustand/undo-delete.ts
@@ -47,12 +47,23 @@ type EnhancedNoteRow = {
   title: string;
 };
 
+type SessionKeyFactsRow = {
+  id: string;
+  user_id: string;
+  session_id: string;
+  created_at: string;
+  updated_at: string;
+  content: string;
+  source_hash: string;
+};
+
 export type DeletedSessionData = {
   session: SessionRow;
   transcripts: TranscriptRow[];
   participants: ParticipantRow[];
   tagSessions: TagSessionRow[];
   enhancedNotes: EnhancedNoteRow[];
+  keyFacts: SessionKeyFactsRow | null;
   deletedAt: number;
 };
 

--- a/packages/store/src/tinybase.ts
+++ b/packages/store/src/tinybase.ts
@@ -14,6 +14,7 @@ import {
   mappingSessionParticipantSchema,
   mappingTagSessionSchema,
   organizationSchema,
+  sessionKeyFactsSchema,
   sessionSchema,
   tagSchema,
   taskSchema,
@@ -135,6 +136,14 @@ export const tableSchemaForTinybase = {
     position: { type: "number" },
     title: { type: "string" },
   } as const satisfies InferTinyBaseSchema<typeof enhancedNoteSchema>,
+  session_key_facts: {
+    user_id: { type: "string" },
+    session_id: { type: "string" },
+    created_at: { type: "string" },
+    updated_at: { type: "string" },
+    content: { type: "string" },
+    source_hash: { type: "string" },
+  } as const satisfies InferTinyBaseSchema<typeof sessionKeyFactsSchema>,
   tasks: {
     user_id: { type: "string" },
     task_id: { type: "string" },

--- a/packages/store/src/zod.ts
+++ b/packages/store/src/zod.ts
@@ -221,6 +221,15 @@ export const enhancedNoteSchema = z.object({
   title: z.preprocess((val) => val ?? undefined, z.string().optional()),
 });
 
+export const sessionKeyFactsSchema = z.object({
+  user_id: z.string(),
+  session_id: z.string(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  content: z.string(),
+  source_hash: z.string(),
+});
+
 export const taskStatusSchema = z.enum(["todo", "in_progress", "done"]);
 export type TaskStatus = z.infer<typeof taskStatusSchema>;
 
@@ -337,6 +346,7 @@ export type ChatMessageStatus = z.infer<typeof chatMessageStatusSchema>;
 export type ChatMessage = z.infer<typeof chatMessageSchema>;
 export type DailyNote = z.infer<typeof dailyNoteSchema>;
 export type EnhancedNote = z.infer<typeof enhancedNoteSchema>;
+export type SessionKeyFacts = z.infer<typeof sessionKeyFactsSchema>;
 export type Task = z.infer<typeof taskSchema>;
 export type AIProvider = z.infer<typeof aiProviderSchema>;
 export type General = z.infer<typeof generalSchema>;
@@ -347,6 +357,9 @@ export type WordStorage = ToStorageType<typeof wordSchema>;
 export type SpeakerHintStorage = ToStorageType<typeof speakerHintSchema>;
 export type ChatMessageStorage = ToStorageType<typeof chatMessageSchema>;
 export type EnhancedNoteStorage = ToStorageType<typeof enhancedNoteSchema>;
+export type SessionKeyFactsStorage = ToStorageType<
+  typeof sessionKeyFactsSchema
+>;
 export type TaskStorage = ToStorageType<typeof taskSchema>;
 export type HumanStorage = ToStorageType<typeof humanSchema>;
 export type OrganizationStorage = ToStorageType<typeof organizationSchema>;


### PR DESCRIPTION
Add a Past notes tab to the bottom transcript accessory and populate it from previous sessions with matching participants.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces on-demand LLM generation and new persisted `session_key_facts` data tied to session lifecycle; scope is mostly UI and session meta, not auth or payments.
> 
> **Overview**
> Adds a **Past notes** tab alongside **Transcript** on the post-session bottom accessory when the current session has related prior meetings (same recurrence series or matching participants).
> 
> **Past notes** lists up to eight earlier sessions (newest first) and shows short **key facts** per meeting. Facts are generated on demand when the tab is opened (via the enhance LLM), cached in a new `session_key_facts` store row keyed by a **source hash** of the underlying notes, and persisted in session `_meta.json` with the rest of session metadata. Deletion and undo flows include key facts.
> 
> The post-session panel renders a timeline UI for past notes; tests cover tab selection, note selection logic, and cache reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4da8e55e5da57de0396e5360f5e47e95cd265c03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->