### PR TITLE
Fix scroll fade bottom edge

### DIFF
--- a/packages/ui/src/styles/scroll-fade.css
+++ b/packages/ui/src/styles/scroll-fade.css
@@ -61,7 +61,7 @@
 @keyframes scroll-fade-y-bottom {
   from {
     --scroll-fade-bottom-start: 94%;
-    --scroll-fade-bottom-end: 99%;
+    --scroll-fade-bottom-end: 100%;
   }
 
   to {


### PR DESCRIPTION
Set the bottom fade mask to end at the container edge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS variable tweak for scroll-fade masking; no logic, auth, or data impact.
> 
> **Overview**
> Fixes the **vertical scroll fade** at the bottom of scrollable areas by changing the `scroll-fade-y-bottom` keyframe so `--scroll-fade-bottom-end` runs from **100%** instead of **99%** in its starting state. The bottom mask gradient now aligns with the **container edge**, avoiding a thin unfaded strip when content is scrolled to the end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d1e38b183d7d8690a6e211142b7e1d957deacd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->