### PR TITLE
fix(desktop): highlight update button

### DIFF
--- a/apps/desktop/src/main/update-banner.tsx
+++ b/apps/desktop/src/main/update-banner.tsx
@@ -348,9 +348,9 @@ export function SidebarTimelineUpdateButton({
       disabled={isDownloading || update.downloadStarting || update.installing}
       className={cn([
         "relative flex size-7 shrink-0 items-center justify-center rounded-full",
-        "text-neutral-700 transition-colors hover:bg-neutral-100 hover:text-neutral-900",
-        "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
-        "disabled:cursor-default disabled:text-neutral-500 disabled:hover:bg-transparent disabled:hover:text-neutral-500",
+        "bg-blue-600 text-white shadow-sm transition-colors hover:bg-blue-700",
+        "focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:outline-hidden",
+        "disabled:cursor-default disabled:bg-blue-600 disabled:text-white disabled:opacity-70 disabled:hover:bg-blue-600",
       ])}
       onClick={isReady ? update.installUpdate : update.downloadUpdate}
     >
@@ -483,8 +483,8 @@ function BannerAction({
       disabled={installing}
       className={cn([
         "inline-flex h-7 shrink-0 items-center justify-center gap-1.5 overflow-hidden rounded-full px-3 font-medium",
-        "bg-neutral-950 text-white transition-colors hover:bg-neutral-800",
-        "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+        "bg-blue-600 text-white transition-colors hover:bg-blue-700",
+        "focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:outline-hidden",
         "disabled:cursor-not-allowed disabled:opacity-60",
       ])}
     >


### PR DESCRIPTION
Make the sidebar update control use a blue background with white foreground styling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes to two update buttons; no updater logic, APIs, or behavior changes.
> 
> **Overview**
> The desktop update UI now uses a **blue primary treatment** instead of neutral gray/black on two controls in `update-banner.tsx`.
> 
> The **sidebar** circular update button (`SidebarTimelineUpdateButton`) gets `bg-blue-600` / white text, a light shadow, blue hover/focus rings (with ring offset), and disabled styles that keep the blue fill with reduced opacity.
> 
> The **timeline banner** **Restart** control (when an update is ready) matches the same blue palette and focus styling; download/retry actions in that banner are unchanged and still use the dark neutral button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6efebfed9a5f053e0c3d30de0689b8e5b6460d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->