### PR TITLE
fix(desktop): collapse devtools panel

### DIFF
--- a/plugins/windows/swift-lib/src/DevtoolsPanelManager.swift
+++ b/plugins/windows/swift-lib/src/DevtoolsPanelManager.swift
@@ -8,6 +8,9 @@ final class DevtoolsPanelManager {
   private let placement = FloatingPanelPositionController()
   private var displayChangeObserver: Any?
   private var followActiveScreenTimer: Timer?
+  private var targetPanelSize = NSSize(
+    width: DevtoolsPanelLayout.containerWidth,
+    height: DevtoolsPanelLayout.containerHeight)
 
   private init() {}
 
@@ -36,6 +39,9 @@ final class DevtoolsPanelManager {
       hostingView.autoresizingMask = [.width, .height]
 
       panel.contentView = hostingView
+      self.targetPanelSize = NSSize(
+        width: DevtoolsPanelLayout.containerWidth,
+        height: DevtoolsPanelLayout.containerHeight)
       self.position(panel, force: true)
       panel.orderFrontRegardless()
       self.panel = panel
@@ -47,8 +53,16 @@ final class DevtoolsPanelManager {
     DispatchQueue.main.async { [weak self] in
       guard let self, let panel = self.panel else { return }
       self.stopFollowingActiveScreen()
+      self.placement.preparePinnedFrameForReplacement(
+        panel,
+        size: NSSize(
+          width: DevtoolsPanelLayout.containerWidth,
+          height: DevtoolsPanelLayout.containerHeight))
       panel.orderOut(nil)
       self.panel = nil
+      self.targetPanelSize = NSSize(
+        width: DevtoolsPanelLayout.containerWidth,
+        height: DevtoolsPanelLayout.containerHeight)
       self.placement.resetActiveScreen()
     }
   }
@@ -78,10 +92,10 @@ final class DevtoolsPanelManager {
   }
 
   private func position(_ panel: NSPanel, force: Bool = false) {
-    placement.position(panel, force: force) { screen in
+    placement.position(panel, force: force, size: targetPanelSize) { screen, size in
       let frame = screen.visibleFrame
-      let x = frame.maxX - panel.frame.width - DevtoolsPanelLayout.screenMargin
-      let y = frame.maxY - panel.frame.height - DevtoolsPanelLayout.screenMargin
+      let x = frame.maxX - size.width - DevtoolsPanelLayout.screenMargin
+      let y = frame.maxY - size.height - DevtoolsPanelLayout.screenMargin
       return NSPoint(x: x, y: y)
     }
   }
@@ -91,13 +105,15 @@ final class DevtoolsPanelManager {
       isCollapsed
       ? DevtoolsPanelLayout.collapsedHeight
       : DevtoolsPanelLayout.containerHeight
+    let size = NSSize(width: DevtoolsPanelLayout.containerWidth, height: height)
+    targetPanelSize = size
     guard abs(panel.frame.height - height) > 0.5 else { return }
 
     let frame = NSRect(
       x: panel.frame.minX,
       y: panel.frame.maxY - height,
-      width: DevtoolsPanelLayout.containerWidth,
-      height: height)
+      width: size.width,
+      height: size.height)
     placement.setFrame(panel, to: frame, display: true, animate: true)
   }
 

--- a/plugins/windows/swift-lib/src/DevtoolsPanelManager.swift
+++ b/plugins/windows/swift-lib/src/DevtoolsPanelManager.swift
@@ -23,7 +23,11 @@ final class DevtoolsPanelManager {
       }
 
       let panel = self.createPanel()
-      let hostingView = NSHostingView(rootView: DevtoolsPanelView())
+      let hostingView = NSHostingView(
+        rootView: DevtoolsPanelView { [weak self, weak panel] isCollapsed in
+          guard let panel else { return }
+          self?.resize(panel, isCollapsed: isCollapsed)
+        })
       hostingView.frame = NSRect(
         x: 0,
         y: 0,
@@ -76,10 +80,25 @@ final class DevtoolsPanelManager {
   private func position(_ panel: NSPanel, force: Bool = false) {
     placement.position(panel, force: force) { screen in
       let frame = screen.visibleFrame
-      let x = frame.maxX - DevtoolsPanelLayout.containerWidth - DevtoolsPanelLayout.screenMargin
-      let y = frame.maxY - DevtoolsPanelLayout.containerHeight - DevtoolsPanelLayout.screenMargin
+      let x = frame.maxX - panel.frame.width - DevtoolsPanelLayout.screenMargin
+      let y = frame.maxY - panel.frame.height - DevtoolsPanelLayout.screenMargin
       return NSPoint(x: x, y: y)
     }
+  }
+
+  private func resize(_ panel: NSPanel, isCollapsed: Bool) {
+    let height =
+      isCollapsed
+      ? DevtoolsPanelLayout.collapsedHeight
+      : DevtoolsPanelLayout.containerHeight
+    guard abs(panel.frame.height - height) > 0.5 else { return }
+
+    let frame = NSRect(
+      x: panel.frame.minX,
+      y: panel.frame.maxY - height,
+      width: DevtoolsPanelLayout.containerWidth,
+      height: height)
+    placement.setFrame(panel, to: frame, display: true, animate: true)
   }
 
   private func startFollowingActiveScreen() {

--- a/plugins/windows/swift-lib/src/DevtoolsPanelView.swift
+++ b/plugins/windows/swift-lib/src/DevtoolsPanelView.swift
@@ -3,32 +3,43 @@ import SwiftUI
 enum DevtoolsPanelLayout {
   static let containerWidth: CGFloat = 300
   static let containerHeight: CGFloat = 560
+  static let collapsedHeight: CGFloat = 44
   static let screenMargin: CGFloat = 14
 }
 
 struct DevtoolsPanelView: View {
   @State private var toastPreview = DevtoolsToastPreview.languageModel
+  @State private var isCollapsed = false
+
+  private let onCollapseChange: (Bool) -> Void
+
+  init(onCollapseChange: @escaping (Bool) -> Void = { _ in }) {
+    self.onCollapseChange = onCollapseChange
+  }
 
   var body: some View {
     VStack(spacing: 0) {
       header
-      Divider()
-      ScrollView(showsIndicators: false) {
-        VStack(spacing: 10) {
-          navigationSection
-          toastsSection
-          otaSection
-          notificationsSection
-          billingSection
-          countdownSection
-          errorSection
+      if !isCollapsed {
+        Divider()
+        ScrollView(showsIndicators: false) {
+          VStack(spacing: 10) {
+            navigationSection
+            toastsSection
+            otaSection
+            notificationsSection
+            billingSection
+            countdownSection
+            errorSection
+          }
+          .padding(10)
         }
-        .padding(10)
       }
     }
     .frame(
       width: DevtoolsPanelLayout.containerWidth,
-      height: DevtoolsPanelLayout.containerHeight
+      height: isCollapsed
+        ? DevtoolsPanelLayout.collapsedHeight : DevtoolsPanelLayout.containerHeight
     )
     .background(
       RoundedRectangle(cornerRadius: 12, style: .continuous)
@@ -47,15 +58,25 @@ struct DevtoolsPanelView: View {
         .font(.system(size: 13, weight: .semibold))
         .foregroundStyle(.primary)
       Spacer()
-      Text("DEV")
-        .font(.system(size: 10, weight: .bold))
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, 7)
-        .padding(.vertical, 3)
-        .background(
-          Capsule(style: .continuous)
-            .fill(Color.black.opacity(0.06))
-        )
+      Button {
+        let nextIsCollapsed = !isCollapsed
+        withAnimation(.easeInOut(duration: 0.16)) {
+          isCollapsed = nextIsCollapsed
+        }
+        onCollapseChange(nextIsCollapsed)
+      } label: {
+        Image(systemName: isCollapsed ? "chevron.down" : "chevron.up")
+          .font(.system(size: 11, weight: .bold))
+          .foregroundStyle(.secondary)
+          .frame(width: 24, height: 22)
+          .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+              .fill(Color.black.opacity(0.05))
+          )
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel(isCollapsed ? "Expand devtools" : "Collapse devtools")
     }
     .padding(.horizontal, 12)
     .padding(.vertical, 10)

--- a/plugins/windows/swift-lib/src/FloatingBarManager.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarManager.swift
@@ -85,10 +85,16 @@ final class FloatingBarManager {
   }
 
   private func position(_ panel: NSPanel, force: Bool = false) {
-    placement.position(panel, force: force) { screen in
+    placement.position(
+      panel,
+      force: force,
+      size: NSSize(
+        width: FloatingBarLayout.containerWidth,
+        height: FloatingBarLayout.containerHeight)
+    ) { screen, size in
       let frame = screen.visibleFrame
-      let x = frame.maxX - FloatingBarLayout.containerWidth - FloatingBarLayout.screenMargin
-      let y = frame.midY - FloatingBarLayout.containerHeight / 2
+      let x = frame.maxX - size.width - FloatingBarLayout.screenMargin
+      let y = frame.midY - size.height / 2
       return NSPoint(x: x, y: y)
     }
   }

--- a/plugins/windows/swift-lib/src/FloatingPanelPositionController.swift
+++ b/plugins/windows/swift-lib/src/FloatingPanelPositionController.swift
@@ -29,6 +29,20 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
     activeScreenId = screenId
   }
 
+  func setFrame(_ panel: NSPanel, to frame: NSRect, display: Bool, animate: Bool) {
+    let wasPinned = pinnedOrigin != nil
+
+    performProgrammaticMove(expectedOrigin: frame.origin) {
+      panel.setFrame(frame, display: display, animate: animate)
+      return panel.frame.origin
+    }
+
+    if wasPinned {
+      pinnedOrigin = panel.frame.origin
+      activeScreenId = panel.screen.flatMap { displayId(for: $0) }
+    }
+  }
+
   func resetActiveScreen() {
     activeScreenId = nil
   }
@@ -57,15 +71,21 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
   }
 
   private func move(_ panel: NSPanel, to origin: NSPoint) {
+    performProgrammaticMove(expectedOrigin: origin) {
+      panel.setFrameOrigin(origin)
+      return panel.frame.origin
+    }
+  }
+
+  private func performProgrammaticMove(expectedOrigin: NSPoint, updateFrame: () -> NSPoint) {
     programmaticMoveId += 1
     let moveId = programmaticMoveId
 
     isProgrammaticMove = true
-    programmaticOrigin = origin
-    panel.setFrameOrigin(origin)
-    programmaticOrigin = panel.frame.origin
+    programmaticOrigin = expectedOrigin
+    programmaticOrigin = updateFrame()
 
-    // AppKit can deliver move notifications shortly after setFrameOrigin returns.
+    // AppKit can deliver move notifications shortly after programmatic frame changes.
     DispatchQueue.main.asyncAfter(deadline: .now() + programmaticMoveSuppressionDelay) {
       [weak self] in
       guard let self, self.programmaticMoveId == moveId else { return }

--- a/plugins/windows/swift-lib/src/FloatingPanelPositionController.swift
+++ b/plugins/windows/swift-lib/src/FloatingPanelPositionController.swift
@@ -8,13 +8,22 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
   private var programmaticOrigin: NSPoint?
   private let programmaticMoveSuppressionDelay: TimeInterval = 0.15
 
-  func position(_ panel: NSPanel, force: Bool = false, defaultOrigin: (NSScreen) -> NSPoint) {
+  func position(
+    _ panel: NSPanel,
+    force: Bool = false,
+    size: NSSize? = nil,
+    defaultOrigin: (NSScreen, NSSize) -> NSPoint
+  ) {
+    let panelSize = size ?? panel.frame.size
+
     if let pinnedOrigin {
       if force {
-        let origin = clampedOrigin(pinnedOrigin, for: panel)
+        let origin = clampedOrigin(pinnedOrigin, size: panelSize)
         move(panel, to: origin)
         self.pinnedOrigin = origin
-        activeScreenId = panel.screen.flatMap { displayId(for: $0) }
+        let frame = NSRect(origin: origin, size: panelSize)
+        activeScreenId =
+          (screen(containing: frame) ?? panel.screen).flatMap { displayId(for: $0) }
       }
       return
     }
@@ -25,7 +34,7 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
       return
     }
 
-    move(panel, to: defaultOrigin(screen))
+    move(panel, to: defaultOrigin(screen, panelSize))
     activeScreenId = screenId
   }
 
@@ -38,13 +47,27 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
     }
 
     if wasPinned {
-      pinnedOrigin = panel.frame.origin
-      activeScreenId = panel.screen.flatMap { displayId(for: $0) }
+      pinnedOrigin = frame.origin
+      activeScreenId =
+        (screen(containing: frame) ?? panel.screen).flatMap { displayId(for: $0) }
     }
   }
 
   func resetActiveScreen() {
     activeScreenId = nil
+  }
+
+  func preparePinnedFrameForReplacement(_ panel: NSPanel, size: NSSize) {
+    guard pinnedOrigin != nil else { return }
+
+    let frame = NSRect(
+      x: panel.frame.minX,
+      y: panel.frame.maxY - size.height,
+      width: size.width,
+      height: size.height)
+    pinnedOrigin = frame.origin
+    activeScreenId =
+      (screen(containing: frame) ?? panel.screen).flatMap { displayId(for: $0) }
   }
 
   func windowDidMove(_ notification: Notification) {
@@ -83,7 +106,9 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
 
     isProgrammaticMove = true
     programmaticOrigin = expectedOrigin
-    programmaticOrigin = updateFrame()
+    let actualOrigin = updateFrame()
+    programmaticOrigin =
+      pointsAreClose(actualOrigin, expectedOrigin) ? actualOrigin : expectedOrigin
 
     // AppKit can deliver move notifications shortly after programmatic frame changes.
     DispatchQueue.main.asyncAfter(deadline: .now() + programmaticMoveSuppressionDelay) {
@@ -111,8 +136,7 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
     return nearestScreen(to: mouse) ?? NSScreen.main ?? screens.first!
   }
 
-  private func clampedOrigin(_ origin: NSPoint, for panel: NSPanel) -> NSPoint {
-    let size = panel.frame.size
+  private func clampedOrigin(_ origin: NSPoint, size: NSSize) -> NSPoint {
     let rect = NSRect(origin: origin, size: size)
     guard
       let screen = screen(containing: rect) ?? nearestScreen(to: center(of: rect)) ?? NSScreen.main


### PR DESCRIPTION
Add a header icon button that collapses the native devtools panel and resizes the floating window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only floating UI and AppKit window placement; no auth, data, or production user flows beyond desktop panel behavior.
> 
> **Overview**
> Adds a **collapsible** native macOS devtools floating panel: the header gets a chevron control that hides the scrollable sections and shrinks the SwiftUI chrome to a short **collapsed** height, with an `onCollapseChange` callback driving the host window.
> 
> **`DevtoolsPanelManager`** tracks `targetPanelSize`, resizes the `NSPanel` with a top-anchored animated frame change, and on **hide** normalizes pinned placement back to the full default size so a collapsed panel does not reopen tiny.
> 
> **`FloatingPanelPositionController`** now takes an optional **size** for default placement and clamping, adds **`setFrame`** / **`preparePinnedFrameForReplacement`**, and refactors programmatic moves to support full frame updates—not just origin. **`FloatingBarManager`** is updated to pass its fixed bar dimensions through the new `position` API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b12b073b4b53294da37f31957823e567c34ed78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5463 
- <kbd>&nbsp;1&nbsp;</kbd> #5461 👈 
<!-- GitButler Footer Boundary Bottom -->

