### PR TITLE
fix(desktop): insert dragged notes as chips

### DIFF
--- a/apps/desktop/src/chat/context/session-drag.test.ts
+++ b/apps/desktop/src/chat/context/session-drag.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   hasSessionContextDragData,
   readSessionContextDragData,
+  readSessionMentionDragData,
   writeSessionContextDragData,
 } from "./session-drag";
 
@@ -31,11 +32,30 @@ describe("session drag context", () => {
 
     expect(dataTransfer.effectAllowed).toBe("copy");
     expect(hasSessionContextDragData(dataTransfer)).toBe(true);
+    expect(dataTransfer.getData("text/plain")).toBe("Meeting notes");
+    expect(readSessionMentionDragData(dataTransfer)).toEqual({
+      id: "session-1",
+      label: "Meeting notes",
+    });
     expect(readSessionContextDragData(dataTransfer)).toEqual({
       kind: "session",
       key: "session:manual:session-1",
       source: "manual",
       sessionId: "session-1",
+    });
+  });
+
+  it("uses an untitled chip label for legacy session drag payloads", () => {
+    const dataTransfer = new FakeDataTransfer() as unknown as DataTransfer;
+
+    dataTransfer.setData(
+      "application/x-anarlog-session-context",
+      JSON.stringify({ sessionId: "session-1" }),
+    );
+
+    expect(readSessionMentionDragData(dataTransfer)).toEqual({
+      id: "session-1",
+      label: "Untitled",
     });
   });
 

--- a/apps/desktop/src/chat/context/session-drag.ts
+++ b/apps/desktop/src/chat/context/session-drag.ts
@@ -4,6 +4,12 @@ const SESSION_CONTEXT_DRAG_TYPE = "application/x-anarlog-session-context";
 
 type SessionDragPayload = {
   sessionId: string;
+  title?: string;
+};
+
+type SessionMentionDragData = {
+  id: string;
+  label: string;
 };
 
 const createSessionContextRef = (sessionId: string): ContextRef => ({
@@ -28,17 +34,19 @@ export const writeSessionContextDragData = (
   sessionId: string,
   fallbackText: string,
 ) => {
+  const title = fallbackText.trim() || "Untitled";
+
   dataTransfer.effectAllowed = "copy";
   dataTransfer.setData(
     SESSION_CONTEXT_DRAG_TYPE,
-    JSON.stringify({ sessionId }),
+    JSON.stringify({ sessionId, title }),
   );
-  dataTransfer.setData("text/plain", fallbackText);
+  dataTransfer.setData("text/plain", title);
 };
 
-export const readSessionContextDragData = (
+const readSessionContextDragPayload = (
   dataTransfer: Pick<DataTransfer, "getData" | "types"> | null | undefined,
-): ContextRef | null => {
+): SessionDragPayload | null => {
   if (!dataTransfer || !hasSessionContextDragData(dataTransfer)) {
     return null;
   }
@@ -55,8 +63,35 @@ export const readSessionContextDragData = (
       return null;
     }
 
-    return createSessionContextRef(payload.sessionId);
+    return {
+      sessionId: payload.sessionId,
+      title:
+        typeof payload.title === "string" && payload.title.trim().length > 0
+          ? payload.title.trim()
+          : undefined,
+    };
   } catch {
     return null;
   }
+};
+
+export const readSessionContextDragData = (
+  dataTransfer: Pick<DataTransfer, "getData" | "types"> | null | undefined,
+): ContextRef | null => {
+  const payload = readSessionContextDragPayload(dataTransfer);
+  return payload ? createSessionContextRef(payload.sessionId) : null;
+};
+
+export const readSessionMentionDragData = (
+  dataTransfer: Pick<DataTransfer, "getData" | "types"> | null | undefined,
+): SessionMentionDragData | null => {
+  const payload = readSessionContextDragPayload(dataTransfer);
+  if (!payload) {
+    return null;
+  }
+
+  return {
+    id: payload.sessionId,
+    label: payload.title ?? "Untitled",
+  };
 };

--- a/apps/desktop/src/editor-bridge/session-mention-drop.ts
+++ b/apps/desktop/src/editor-bridge/session-mention-drop.ts
@@ -1,7 +1,11 @@
 import type { SessionMentionDropConfig } from "@hypr/editor/note";
 
-import { readSessionMentionDragData } from "~/chat/context/session-drag";
+import {
+  hasSessionContextDragData,
+  readSessionMentionDragData,
+} from "~/chat/context/session-drag";
 
 export const sessionMentionDropConfig = {
+  has: hasSessionContextDragData,
   read: readSessionMentionDragData,
 } satisfies SessionMentionDropConfig;

--- a/apps/desktop/src/editor-bridge/session-mention-drop.ts
+++ b/apps/desktop/src/editor-bridge/session-mention-drop.ts
@@ -1,0 +1,7 @@
+import type { SessionMentionDropConfig } from "@hypr/editor/note";
+
+import { readSessionMentionDragData } from "~/chat/context/session-drag";
+
+export const sessionMentionDropConfig = {
+  read: readSessionMentionDragData,
+} satisfies SessionMentionDropConfig;

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -9,6 +9,7 @@ import {
 
 import { AppLinkView } from "~/editor-bridge/app-link-view";
 import { useMentionConfig } from "~/editor-bridge/mention-config";
+import { sessionMentionDropConfig } from "~/editor-bridge/session-mention-drop";
 import { SessionNodeView } from "~/editor-bridge/session-view";
 import { useFileUpload } from "~/shared/hooks/useFileUpload";
 import * as main from "~/store/tinybase/store/main";
@@ -56,6 +57,7 @@ export const EnhancedEditor = forwardRef<
         initialContent={initialContent}
         handleChange={handleChange}
         mentionConfig={mentionConfig}
+        sessionMentionDropConfig={sessionMentionDropConfig}
         onNavigateToTitle={onNavigateToTitle}
         fileHandlerConfig={fileHandlerConfig}
         taskSource={{ type: "enhanced_note", id: enhancedNoteId }}

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -11,6 +11,7 @@ import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 
 import { AppLinkView } from "~/editor-bridge/app-link-view";
 import { useMentionConfig } from "~/editor-bridge/mention-config";
+import { sessionMentionDropConfig } from "~/editor-bridge/session-mention-drop";
 import { SessionNodeView } from "~/editor-bridge/session-view";
 import { emitRawEditorSync } from "~/session/raw-editor-sync";
 import { useFileUpload } from "~/shared/hooks/useFileUpload";
@@ -108,6 +109,7 @@ export const RawEditor = forwardRef<
         initialContent={initialContent}
         handleChange={handleChange}
         mentionConfig={mentionConfig}
+        sessionMentionDropConfig={sessionMentionDropConfig}
         placeholderComponent={Placeholder}
         onNavigateToTitle={onNavigateToTitle}
         fileHandlerConfig={fileHandlerConfig}

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -131,6 +131,9 @@ export type SessionMentionDropData = {
 };
 
 export type SessionMentionDropConfig = {
+  has?: (
+    dataTransfer: Pick<DataTransfer, "types"> | null | undefined,
+  ) => boolean;
   read: (
     dataTransfer: Pick<DataTransfer, "getData" | "types"> | null | undefined,
   ) => SessionMentionDropData | null;
@@ -195,6 +198,8 @@ function wrapNodeViewComponents(nodeViews?: NodeViewComponents) {
 }
 
 function createSessionMentionDropPlugin(config: SessionMentionDropConfig) {
+  const hasSession = (dataTransfer: DataTransfer | null) =>
+    config.has ? config.has(dataTransfer) : Boolean(config.read(dataTransfer));
   const readSession = (dataTransfer: DataTransfer | null) =>
     config.read(dataTransfer);
 
@@ -204,7 +209,7 @@ function createSessionMentionDropPlugin(config: SessionMentionDropConfig) {
       handleDOMEvents: {
         dragover(_view, event) {
           const dataTransfer = (event as DragEvent).dataTransfer;
-          if (!readSession(dataTransfer)) {
+          if (!hasSession(dataTransfer)) {
             return false;
           }
 

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -14,6 +14,8 @@ import { history } from "prosemirror-history";
 import { Node as PMNode } from "prosemirror-model";
 import {
   EditorState,
+  Plugin,
+  PluginKey,
   Selection,
   TextSelection,
   type Transaction,
@@ -123,6 +125,17 @@ export interface NoteEditorRef {
   commands: EditorCommands;
 }
 
+export type SessionMentionDropData = {
+  id: string;
+  label: string;
+};
+
+export type SessionMentionDropConfig = {
+  read: (
+    dataTransfer: Pick<DataTransfer, "getData" | "types"> | null | undefined,
+  ) => SessionMentionDropData | null;
+};
+
 type NodeViewComponents = NonNullable<
   ComponentProps<typeof ProseMirror>["nodeViewComponents"]
 >;
@@ -138,6 +151,7 @@ export interface NoteEditorProps {
   linkedItemOpenBehavior?: LinkedItemOpenBehavior;
   taskSource?: TaskSource;
   extraNodeViews?: NodeViewComponents;
+  sessionMentionDropConfig?: SessionMentionDropConfig;
   showFormatToolbar?: boolean;
 }
 
@@ -178,6 +192,72 @@ function wrapNodeViewComponents(nodeViews?: NodeViewComponents) {
       }),
     ]),
   ) as NodeViewComponents;
+}
+
+function createSessionMentionDropPlugin(config: SessionMentionDropConfig) {
+  const readSession = (dataTransfer: DataTransfer | null) =>
+    config.read(dataTransfer);
+
+  return new Plugin({
+    key: new PluginKey("sessionMentionDrop"),
+    props: {
+      handleDOMEvents: {
+        dragover(_view, event) {
+          const dataTransfer = (event as DragEvent).dataTransfer;
+          if (!readSession(dataTransfer)) {
+            return false;
+          }
+
+          event.preventDefault();
+          if (dataTransfer) {
+            dataTransfer.dropEffect = "copy";
+          }
+          return true;
+        },
+      },
+      handleDrop(view, event) {
+        const session = readSession(event.dataTransfer);
+        const mentionType = view.state.schema.nodes["mention-@"];
+        if (!session || !mentionType) {
+          return false;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        const mentionNode = mentionType.create({
+          id: session.id,
+          type: "session",
+          label: session.label,
+        });
+        const space = view.state.schema.text(" ");
+        const pos =
+          view.posAtCoords({
+            left: event.clientX,
+            top: event.clientY,
+          })?.pos ?? view.state.selection.from;
+
+        try {
+          const tr = view.state.tr.insert(pos, [mentionNode, space]);
+          tr.setSelection(
+            TextSelection.create(
+              tr.doc,
+              pos + mentionNode.nodeSize + space.nodeSize,
+            ),
+          );
+          view.dispatch(tr.scrollIntoView());
+        } catch {
+          const tr = view.state.tr
+            .replaceSelectionWith(mentionNode)
+            .insertText(" ");
+          view.dispatch(tr.scrollIntoView());
+        }
+
+        view.focus();
+        return true;
+      },
+    },
+  });
 }
 
 function ViewCapture({
@@ -362,6 +442,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       linkedItemOpenBehavior = "current",
       taskSource,
       extraNodeViews,
+      sessionMentionDropConfig,
       showFormatToolbar = true,
     } = props;
 
@@ -456,12 +537,16 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         appLinkPastePlugin(),
         linkBoundaryGuardPlugin(),
         ...(mentionConfig ? [mentionSkipPlugin()] : []),
+        ...(sessionMentionDropConfig
+          ? [createSessionMentionDropPlugin(sessionMentionDropConfig)]
+          : []),
         ...(fileHandlerConfig ? [fileHandlerPlugin(fileHandlerConfig)] : []),
       ],
       [
         placeholderComponent,
         fileHandlerConfig,
         mentionConfig,
+        sessionMentionDropConfig,
         onNavigateToTitle,
       ],
     );


### PR DESCRIPTION
Add editor drop handling for timeline session drags and include note titles in drag payloads.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized editor drag/drop and drag payload parsing with tests; no auth, persistence schema, or security-sensitive paths changed.
> 
> **Overview**
> Dragging a meeting/session from the timeline into a note editor now inserts a **session mention chip** at the drop position instead of only supporting chat context drops.
> 
> Session drag payloads now include the note **title** in the custom MIME JSON and `text/plain`, with **`readSessionMentionDragData`** for chip id/label and **"Untitled"** for older payloads that only had `sessionId`. **`NoteEditor`** accepts optional **`sessionMentionDropConfig`** and registers a ProseMirror plugin for copy drag-over and drop-to-mention. Desktop **raw** and **enhanced** note editors pass the shared bridge config from session-drag helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52ea71cc0b02b7f83348a7382b138caa12146727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->