### PR TITLE
fix(desktop): seed recurring notes from devtools

### DIFF
--- a/apps/desktop/src/devtools-panel/host.tsx
+++ b/apps/desktop/src/devtools-panel/host.tsx
@@ -13,6 +13,7 @@ import { TrialEndedDialog } from "~/billing/trial-ended-dialog";
 import { TrialStartedDialog } from "~/billing/trial-started-dialog";
 import { getLatestVersion } from "~/changelog";
 import { useDevtoolsStore, useDevtoolsUserId } from "~/devtools-panel/hooks";
+import { populateRecurringMeetingNotes } from "~/devtools-panel/recurring-notes";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import {
   type DevtoolsOtaPreviewStatus,
@@ -54,6 +55,7 @@ type DevtoolsPanelAction =
   | "notifications:clear"
   | "billing:trial-started"
   | "billing:trial-ended"
+  | "notes:populate-recurring"
   | "countdown:note-20"
   | "countdown:note-60"
   | "countdown:note-290"
@@ -197,6 +199,16 @@ function useDevtoolsPanelActions() {
     },
     [showMainWindow, showOtaPreview],
   );
+
+  const populateRecurringNotes = useCallback(async () => {
+    if (!store) {
+      return;
+    }
+
+    const sessionId = populateRecurringMeetingNotes({ store, userId: user_id });
+    await showMainWindow();
+    openNew({ type: "sessions", id: sessionId });
+  }, [openNew, showMainWindow, store, user_id]);
 
   const showCalendarNotification = useCallback(async () => {
     const eventId = `devtool-event-${crypto.randomUUID()}`;
@@ -438,6 +450,9 @@ function useDevtoolsPanelActions() {
         case "billing:trial-ended":
           setTrialEndedOpen(true);
           return;
+        case "notes:populate-recurring":
+          void populateRecurringNotes();
+          return;
         case "countdown:note-20":
           createWithCountdown(20);
           return;
@@ -470,9 +485,10 @@ function useDevtoolsPanelActions() {
       showMicDetectedNotification,
       showMicOptionsNotification,
       showOnboarding,
+      populateRecurringNotes,
       showToastPreviewInMainWindow,
+      showOtaPreviewInMainWindow,
       clearToastPreview,
-      showOtaPreview,
       clearOtaPreview,
     ],
   );

--- a/apps/desktop/src/devtools-panel/recurring-notes.test.ts
+++ b/apps/desktop/src/devtools-panel/recurring-notes.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+
+import { populateRecurringMeetingNotes } from "./recurring-notes";
+
+import { buildPastSessionNotes } from "~/session/components/bottom-accessory/past-notes";
+import { createTestMainStore } from "~/store/tinybase/persister/testing/mocks";
+import type { Store } from "~/store/tinybase/store/main";
+
+describe("populateRecurringMeetingNotes", () => {
+  test("seeds a recurring session with cached past note facts", () => {
+    const store = createTestMainStore() as Store;
+    const sessionId = populateRecurringMeetingNotes({
+      store,
+      userId: "user-1",
+      now: new Date("2026-06-03T10:00:00.000Z"),
+    });
+
+    const result = buildPastSessionNotes(store, sessionId, "user-1");
+
+    expect(sessionId).toBe("devtools-recurring-notes-current");
+    expect(result.missing).toHaveLength(0);
+    expect(result.notes.map((note) => note.sessionId)).toEqual([
+      "devtools-recurring-notes-week-1",
+      "devtools-recurring-notes-week-2",
+      "devtools-recurring-notes-week-3",
+    ]);
+    expect(result.notes[0]?.summary).toContain(
+      "Transcript controls shipped with a condensed panel layout.",
+    );
+    expect(
+      store
+        .getRowIds("mapping_session_participant")
+        .filter((rowId) => rowId.startsWith(`${sessionId}:`)),
+    ).toHaveLength(3);
+  });
+});

--- a/apps/desktop/src/devtools-panel/recurring-notes.ts
+++ b/apps/desktop/src/devtools-panel/recurring-notes.ts
@@ -1,0 +1,223 @@
+import type {
+  HumanStorage,
+  MappingSessionParticipantStorage,
+  SessionEvent,
+  SessionKeyFactsStorage,
+  SessionStorage,
+} from "@hypr/store";
+
+import { buildPastSessionNotes } from "~/session/components/bottom-accessory/past-notes";
+import { DEFAULT_USER_ID } from "~/shared/utils";
+import type * as main from "~/store/tinybase/store/main";
+
+type Store = main.Store;
+
+const CURRENT_SESSION_ID = "devtools-recurring-notes-current";
+const SERIES_ID = "devtools-recurring-product-sync";
+const CALENDAR_ID = "devtools-calendar";
+const MEETING_TITLE = "Devtools Weekly Product Sync";
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const PARTICIPANTS = [
+  {
+    humanId: "devtools-human-alex-rivera",
+    name: "Alex Rivera",
+    email: "alex.rivera@example.com",
+    jobTitle: "Product Lead",
+  },
+  {
+    humanId: "devtools-human-maya-chen",
+    name: "Maya Chen",
+    email: "maya.chen@example.com",
+    jobTitle: "Design Lead",
+  },
+  {
+    humanId: "devtools-human-jordan-lee",
+    name: "Jordan Lee",
+    email: "jordan.lee@example.com",
+    jobTitle: "Engineering Lead",
+  },
+] as const;
+
+const PAST_NOTES = [
+  {
+    sessionId: "devtools-recurring-notes-week-1",
+    daysAgo: 7,
+    rawMd: [
+      "# Product sync",
+      "- Shipped the condensed transcript panel and agreed to keep Past Notes below three visible lines per fact.",
+      "- Alex owns the launch checklist and will confirm analytics events before the next review.",
+      "- Maya wants another pass on empty states after the first beta feedback lands.",
+    ].join("\n"),
+    facts: [
+      "Transcript controls shipped with a condensed panel layout.",
+      "Alex owns the launch checklist and analytics confirmation.",
+      "Maya wants another empty-state pass after beta feedback.",
+    ],
+  },
+  {
+    sessionId: "devtools-recurring-notes-week-2",
+    daysAgo: 14,
+    rawMd: [
+      "# Product sync",
+      "- The team decided Past Notes should match by recurring calendar series before falling back to participants.",
+      "- Jordan called out that cached key facts should avoid requiring a model just to inspect the UI.",
+      "- Follow-up: compare date labels against the meeting start time instead of the note creation time.",
+    ].join("\n"),
+    facts: [
+      "Past Notes should prefer recurring series matches before participant fallback.",
+      "Cached key facts should make the UI inspectable without a model.",
+      "Date labels should come from meeting start time.",
+    ],
+  },
+  {
+    sessionId: "devtools-recurring-notes-week-3",
+    daysAgo: 21,
+    rawMd: [
+      "# Product sync",
+      "- We agreed the bottom accessory should stay hidden until there is useful post-session content.",
+      "- The first version of Past Notes will stay read-only and focus on short reusable facts.",
+      "- Alex and Jordan will validate that future sessions are excluded from the timeline.",
+    ].join("\n"),
+    facts: [
+      "The bottom accessory should stay hidden without useful post-session content.",
+      "Past Notes will start as a read-only timeline of reusable facts.",
+      "Future sessions should be excluded from the Past Notes timeline.",
+    ],
+  },
+] as const;
+
+export function populateRecurringMeetingNotes({
+  store,
+  userId,
+  now = new Date(),
+}: {
+  store: Store;
+  userId: string | null | undefined;
+  now?: Date;
+}): string {
+  const ownerUserId = normalizeUserId(userId);
+  const createdAt = now.toISOString();
+
+  store.transaction(() => {
+    for (const participant of PARTICIPANTS) {
+      store.setRow("humans", participant.humanId, {
+        user_id: ownerUserId,
+        created_at: createdAt,
+        name: participant.name,
+        email: participant.email,
+        phone: "",
+        org_id: "",
+        job_title: participant.jobTitle,
+        linkedin_username: "",
+        memo: "",
+        pinned: false,
+      } satisfies HumanStorage);
+    }
+
+    upsertSession({
+      store,
+      ownerUserId,
+      sessionId: CURRENT_SESSION_ID,
+      startedAt: now,
+      rawMd:
+        "Use the Past notes tab to inspect the cached timeline from previous occurrences.",
+    });
+
+    for (const note of PAST_NOTES) {
+      upsertSession({
+        store,
+        ownerUserId,
+        sessionId: note.sessionId,
+        startedAt: new Date(now.getTime() - note.daysAgo * DAY_MS),
+        rawMd: note.rawMd,
+      });
+    }
+  });
+
+  const factsBySessionId = new Map<string, string>(
+    PAST_NOTES.map((note) => [note.sessionId, note.facts.join("\n")]),
+  );
+  const { missing } = buildPastSessionNotes(
+    store,
+    CURRENT_SESSION_ID,
+    ownerUserId,
+  );
+
+  store.transaction(() => {
+    for (const request of missing) {
+      const facts = factsBySessionId.get(request.sessionId);
+      if (!facts) {
+        continue;
+      }
+
+      store.setRow("session_key_facts", request.sessionId, {
+        user_id: ownerUserId,
+        session_id: request.sessionId,
+        created_at: createdAt,
+        updated_at: createdAt,
+        content: facts,
+        source_hash: request.sourceHash,
+      } satisfies SessionKeyFactsStorage);
+    }
+  });
+
+  return CURRENT_SESSION_ID;
+}
+
+function upsertSession({
+  store,
+  ownerUserId,
+  sessionId,
+  startedAt,
+  rawMd,
+}: {
+  store: Store;
+  ownerUserId: string;
+  sessionId: string;
+  startedAt: Date;
+  rawMd: string;
+}) {
+  const endedAt = new Date(startedAt.getTime() + 45 * 60 * 1000);
+  const event: SessionEvent = {
+    tracking_id: `${SERIES_ID}:${toDateId(startedAt)}`,
+    calendar_id: CALENDAR_ID,
+    title: MEETING_TITLE,
+    started_at: startedAt.toISOString(),
+    ended_at: endedAt.toISOString(),
+    is_all_day: false,
+    has_recurrence_rules: true,
+    meeting_link: "https://zoom.us/j/1234567890",
+    description: "Seeded from devtools to exercise the Past Notes tab.",
+    recurrence_series_id: SERIES_ID,
+  };
+
+  store.setRow("sessions", sessionId, {
+    user_id: ownerUserId,
+    created_at: startedAt.toISOString(),
+    event_json: JSON.stringify(event),
+    title: MEETING_TITLE,
+    raw_md: rawMd,
+  } satisfies SessionStorage);
+
+  for (const participant of PARTICIPANTS) {
+    store.setRow(
+      "mapping_session_participant",
+      `${sessionId}:${participant.humanId}`,
+      {
+        user_id: ownerUserId,
+        session_id: sessionId,
+        human_id: participant.humanId,
+        source: "auto",
+      } satisfies MappingSessionParticipantStorage,
+    );
+  }
+}
+
+function normalizeUserId(userId: string | null | undefined): string {
+  return userId?.trim() || DEFAULT_USER_ID;
+}
+
+function toDateId(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}

--- a/plugins/windows/swift-lib/src/DevtoolsPanelView.swift
+++ b/plugins/windows/swift-lib/src/DevtoolsPanelView.swift
@@ -25,6 +25,7 @@ struct DevtoolsPanelView: View {
         ScrollView(showsIndicators: false) {
           VStack(spacing: 10) {
             navigationSection
+            meetingNotesSection
             toastsSection
             otaSection
             notificationsSection
@@ -149,6 +150,14 @@ struct DevtoolsPanelView: View {
 
       DevtoolsActionButton("Reset Dismissed") {
         RustBridge.devtoolsPanelAction("toasts:reset-dismissed")
+      }
+    }
+  }
+
+  private var meetingNotesSection: some View {
+    DevtoolsSection(title: "NOTES") {
+      DevtoolsActionButton("Populate Recurring") {
+        RustBridge.devtoolsPanelAction("notes:populate-recurring")
       }
     }
   }


### PR DESCRIPTION
Add a devtools action that creates recurring meeting sessions with cached Past Notes facts and exposes it in the native devtools panel.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5463 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5461 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only seeding and panel wiring; no production user flows or auth/data paths change.
> 
> **Overview**
> Adds a **devtools-only** workflow to seed a recurring meeting series and open the current session so **Past Notes** can be exercised with **cached key facts** (no model run).
> 
> **Populate Recurring** in the native devtools panel fires `notes:populate-recurring`, which writes humans, four linked sessions (current + three prior weeks) with shared `recurrence_series_id`, participant mappings, and `session_key_facts` rows derived from `buildPastSessionNotes`’s missing list, then focuses the main window on `devtools-recurring-notes-current`. A Vitest covers that the timeline resolves with no missing facts.
> 
> Also tightens the devtools action handler dependency list for OTA preview (uses `showOtaPreviewInMainWindow` instead of `showOtaPreview`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b458c85fb46a001a0f30380539a64aa7766d9bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->