### PR TITLE
fix(desktop): separate past notes tabs

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -212,14 +212,14 @@ function PostSessionTabHandle({
   onSelect: (tab: PostSessionTab) => void;
 }) {
   return (
-    <div className="relative left-3 z-10 flex h-5 items-center">
+    <div className="relative left-3 z-10 flex h-5 items-center gap-1">
       <PostSessionTabButton
         label="Transcript"
         tab="transcript"
         activeTab={activeTab}
         isExpanded={isExpanded}
         onSelect={onSelect}
-        className="rounded-tl-[10px] border-l"
+        className="rounded-t-[10px] border-x"
       />
       <PostSessionTabButton
         label="Past notes"
@@ -227,7 +227,7 @@ function PostSessionTabHandle({
         activeTab={activeTab}
         isExpanded={isExpanded}
         onSelect={onSelect}
-        className="-ml-px rounded-tr-[10px] border-r"
+        className="rounded-t-[10px] border-x"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Add visible spacing between the Transcript and Past notes bottom tabs
- Give each tab its own side borders so they read as separate tabs

## Verification
- `pnpm -F @hypr/desktop test -- src/session/components/bottom-accessory/index.test.tsx`
- `pnpm -F @hypr/desktop typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes to post-session tab chrome; no behavior, data, or auth impact.
> 
> **Overview**
> Updates the **Transcript** and **Past notes** bottom-tab chrome in `PostSessionTabHandle` so they read as two distinct tabs instead of one merged control.
> 
> The tab row now uses `gap-1` for visible separation. Each `PostSessionTabButton` gets matching `rounded-t-[10px] border-x` styling, replacing the previous left-only / right-only corners and the negative margin that visually joined the buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b96d74e2f8b6347190cc63e581ef2968419e8d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->