### PR TITLE
fix(desktop): use calendar icon for metadata

### DIFF
--- a/apps/desktop/src/session/components/outer-header/metadata/date.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/date.tsx
@@ -1,5 +1,5 @@
 import { useForm } from "@tanstack/react-form";
-import { CalendarIcon, CheckIcon, XIcon } from "lucide-react";
+import { CheckIcon, PencilIcon, XIcon } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@hypr/ui/components/ui/button";
@@ -36,7 +36,7 @@ export function DateEditor({ sessionId }: { sessionId: string }) {
           onClick={() => setIsEditing(true)}
           aria-label="Edit date"
         >
-          <CalendarIcon size={16} />
+          <PencilIcon size={16} />
         </Button>
       </div>
     );


### PR DESCRIPTION
Replace the session metadata chip with a calendar icon button while preserving the existing popover content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic icon-only change in the desktop session metadata UI with no logic or data path changes.
> 
> **Overview**
> Swaps the session **date** inline edit control in `DateEditor` from a **calendar** icon to a **pencil** icon (`lucide-react` import and button content in `date.tsx`). Edit behavior, labels, and the datetime form are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54b75c59743d20bcd12ced1e58e2937dc2087648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->