### PR TITLE
fix(desktop): enhance contacts per participant chip

### DIFF
--- a/apps/desktop/src/session/components/outer-header/metadata/participants/chip.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/chip.tsx
@@ -1,14 +1,27 @@
-import { X } from "lucide-react";
+import { Loader2Icon, SparklesIcon, X } from "lucide-react";
 import { useCallback } from "react";
 
 import { Badge } from "@hypr/ui/components/ui/badge";
 import { Button } from "@hypr/ui/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@hypr/ui/components/ui/tooltip";
 
 import * as main from "~/store/tinybase/store/main";
 import { useTabs } from "~/store/zustand/tabs/index";
 import { parseTranscriptHints, updateTranscriptHints } from "~/stt/utils";
 
-export function ParticipantChip({ mappingId }: { mappingId: string }) {
+export function ParticipantChip({
+  mappingId,
+  enhancingHumanId,
+  onEnhanceContact,
+}: {
+  mappingId: string;
+  enhancingHumanId?: string;
+  onEnhanceContact?: (humanId: string) => void;
+}) {
   const details = useParticipantDetails(mappingId);
 
   const assignedHumanId = details?.humanId;
@@ -36,6 +49,8 @@ export function ParticipantChip({ mappingId }: { mappingId: string }) {
   }
 
   const { humanName } = details;
+  const isEnhancing = enhancingHumanId === assignedHumanId;
+  const canEnhance = Boolean(onEnhanceContact && assignedHumanId);
 
   return (
     <Badge
@@ -44,6 +59,18 @@ export function ParticipantChip({ mappingId }: { mappingId: string }) {
       onClick={handleClick}
     >
       {humanName || "Unknown"}
+      {canEnhance && (
+        <EnhanceContactButton
+          isEnhancing={isEnhancing}
+          isDisabled={Boolean(enhancingHumanId)}
+          label={humanName || "contact"}
+          onClick={() => {
+            if (assignedHumanId) {
+              onEnhanceContact?.(assignedHumanId);
+            }
+          }}
+        />
+      )}
       <Button
         type="button"
         variant="ghost"
@@ -57,6 +84,44 @@ export function ParticipantChip({ mappingId }: { mappingId: string }) {
         <X className="h-2.5 w-2.5" />
       </Button>
     </Badge>
+  );
+}
+
+function EnhanceContactButton({
+  isEnhancing,
+  isDisabled,
+  label,
+  onClick,
+}: {
+  isEnhancing: boolean;
+  isDisabled: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <Tooltip delayDuration={0}>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-label={`Enhance contact ${label}`}
+          className="ml-0.5 h-3.5 w-3.5 p-0 text-neutral-500 hover:bg-transparent hover:text-neutral-800"
+          disabled={isDisabled}
+          onClick={(e) => {
+            e.stopPropagation();
+            onClick();
+          }}
+        >
+          {isEnhancing ? (
+            <Loader2Icon className="h-2.5 w-2.5 animate-spin" />
+          ) : (
+            <SparklesIcon className="h-2.5 w-2.5" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">Enhance contact</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
@@ -265,6 +265,71 @@ describe("event contact extraction", () => {
     ).toHaveLength(3);
   });
 
+  test("does not enhance a selected participant from a loose first-name alias", () => {
+    const store = createStore();
+    store.setRow("humans", "human-1", {
+      user_id: "user-1",
+      created_at: "2026-04-01T00:00:00.000Z",
+      name: "Yongkyun",
+      email: "",
+      phone: "",
+      org_id: "",
+      job_title: "",
+      linkedin_username: "",
+      memo: "",
+      pinned: false,
+    });
+    store.setRow("mapping_session_participant", "mapping-1", {
+      user_id: "user-1",
+      session_id: "session-1",
+      human_id: "human-1",
+      source: "manual",
+    });
+
+    const result = applyExtractedContactToHuman(
+      store,
+      "session-1",
+      "human-1",
+      [
+        {
+          name: "Yongkyun Lee",
+          email: "yongkyun.lee@example.com",
+        },
+      ],
+      { userId: "user-1" },
+    );
+
+    expect(result).toMatchObject({
+      updated: 0,
+      matched: false,
+    });
+    expect(store.getCell("humans", "human-1", "email")).toBe("");
+  });
+
+  test("treats the current user contact as already up to date", () => {
+    const store = createStore();
+
+    const result = applyExtractedContactToHuman(
+      store,
+      "session-1",
+      "user-1",
+      [
+        {
+          name: "John Jeong",
+          email: "john@example.com",
+        },
+      ],
+      { userId: "user-1" },
+    );
+
+    expect(result).toMatchObject({
+      updated: 0,
+      skipped: 1,
+      matched: true,
+    });
+    expect(store.getCell("humans", "user-1", "email")).toBe("john@example.com");
+  });
+
   test("creates and links a new contact when no existing contact matches", () => {
     const store = createStore();
 

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  applyExtractedContactToHuman,
   applyExtractedContacts,
   buildEventContactExtractionContext,
   extractDeterministicContactHints,
@@ -188,6 +189,80 @@ describe("event contact extraction", () => {
         (mapping) => mapping.human_id === "human-1",
       ),
     ).toHaveLength(1);
+  });
+
+  test("enhances only the selected participant contact", () => {
+    const store = createStore();
+    store.setRow("humans", "human-1", {
+      user_id: "user-1",
+      created_at: "2026-04-01T00:00:00.000Z",
+      name: "yongkyun.daniel.lee@gmail.com",
+      email: "yongkyun.daniel.lee@gmail.com",
+      phone: "",
+      org_id: "",
+      job_title: "",
+      linkedin_username: "",
+      memo: "",
+      pinned: false,
+    });
+    store.setRow("humans", "human-2", {
+      user_id: "user-1",
+      created_at: "2026-04-01T00:00:00.000Z",
+      name: "other@example.com",
+      email: "other@example.com",
+      phone: "",
+      org_id: "",
+      job_title: "",
+      linkedin_username: "",
+      memo: "",
+      pinned: false,
+    });
+    store.setRow("mapping_session_participant", "mapping-1", {
+      user_id: "user-1",
+      session_id: "session-1",
+      human_id: "human-1",
+      source: "auto",
+    });
+    store.setRow("mapping_session_participant", "mapping-2", {
+      user_id: "user-1",
+      session_id: "session-1",
+      human_id: "human-2",
+      source: "auto",
+    });
+
+    const result = applyExtractedContactToHuman(
+      store,
+      "session-1",
+      "human-1",
+      [
+        {
+          name: "Yongkyun (Daniel) Lee",
+          email: "yongkyun.daniel.lee@gmail.com",
+        },
+        {
+          name: "Other Person",
+          email: "other@example.com",
+        },
+      ],
+      { userId: "user-1" },
+    );
+
+    expect(result).toMatchObject({
+      created: 0,
+      updated: 1,
+      linked: 0,
+      matched: true,
+    });
+    expect(store.getCell("humans", "human-1", "name")).toBe(
+      "Yongkyun (Daniel) Lee",
+    );
+    expect(store.getCell("humans", "human-2", "name")).toBe(
+      "other@example.com",
+    );
+    expect(Object.keys(store.getTable("humans"))).toHaveLength(3);
+    expect(
+      Object.keys(store.getTable("mapping_session_participant")),
+    ).toHaveLength(3);
   });
 
   test("creates and links a new contact when no existing contact matches", () => {

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
@@ -273,7 +273,7 @@ export function applyExtractedContactToHuman(
   store.transaction(() => {
     const sessionMappings = buildSessionMappingsByHuman(store, sessionId);
     const mapping = sessionMappings.get(humanId);
-    if (!mapping || mapping.source === "excluded" || humanId === userId) {
+    if (!mapping || mapping.source === "excluded") {
       result.skipped += 1;
       return;
     }
@@ -286,6 +286,11 @@ export function applyExtractedContactToHuman(
 
     const contact = findContactForHuman(human, normalizedContacts);
     if (!contact) {
+      if (humanId === userId) {
+        result.matched = true;
+        result.contacts.push(normalizedContacts[0]);
+        result.skipped += 1;
+      }
       return;
     }
 
@@ -293,7 +298,7 @@ export function applyExtractedContactToHuman(
     result.contacts.push(contact);
 
     const currentUser = store.getRow("humans", userId);
-    if (isCurrentUserContact(contact, currentUser)) {
+    if (humanId === userId || isCurrentUserContact(contact, currentUser)) {
       result.skipped += 1;
       return;
     }
@@ -723,7 +728,7 @@ function findContactForHuman(
   };
   const humanEmail = normalizeEmail(humanCandidate.email);
   const humanName = normalizeName(humanCandidate.name ?? "");
-  const humanAliases = getCandidateAliases(humanCandidate);
+  const humanAliases = getStrongCandidateAliases(humanCandidate);
 
   return contacts.find((contact) => {
     const contactEmail = normalizeEmail(contact.email);
@@ -736,7 +741,7 @@ function findContactForHuman(
       return true;
     }
 
-    const contactAliases = getCandidateAliases({
+    const contactAliases = getStrongCandidateAliases({
       name: contact.name,
       email: contact.email,
     });
@@ -745,13 +750,8 @@ function findContactForHuman(
 }
 
 function getCandidateAliases(candidate: EventContactCandidate): Set<string> {
-  const aliases = new Set<string>();
-  const normalizedName = normalizeName(candidate.name ?? "");
+  const aliases = getStrongCandidateAliases(candidate);
   const nameTokens = tokenizeName(candidate.name ?? "");
-
-  if (normalizedName) {
-    aliases.add(normalizedName);
-  }
 
   if (nameTokens[0]) {
     aliases.add(nameTokens[0]);
@@ -768,6 +768,29 @@ function getCandidateAliases(candidate: EventContactCandidate): Set<string> {
     }
     if (emailTokens[0]) {
       aliases.add(emailTokens[0]);
+    }
+  }
+
+  return aliases;
+}
+
+function getStrongCandidateAliases(
+  candidate: EventContactCandidate,
+): Set<string> {
+  const aliases = new Set<string>();
+  const normalizedName = normalizeName(candidate.name ?? "");
+
+  if (normalizedName) {
+    aliases.add(normalizedName);
+  }
+
+  const emailLocal = candidate.email?.split("@")[0];
+  if (emailLocal) {
+    const normalizedEmailLocal = normalizeName(
+      emailLocal.replace(/[._+-]+/g, " "),
+    );
+    if (normalizedEmailLocal) {
+      aliases.add(normalizedEmailLocal);
     }
   }
 

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
@@ -52,6 +52,10 @@ export type ApplyExtractedContactsResult = {
   contacts: ExtractedEventContact[];
 };
 
+export type ApplyContactEnhancementResult = ApplyExtractedContactsResult & {
+  matched: boolean;
+};
+
 const aiExtractionSchema = z.object({
   contacts: z
     .array(
@@ -236,6 +240,80 @@ export function applyExtractedContacts(
       } else if (existingMapping.source === "excluded") {
         result.skipped += 1;
       }
+    }
+  });
+
+  return result;
+}
+
+export function applyExtractedContactToHuman(
+  store: Store,
+  sessionId: string,
+  humanId: string,
+  contacts: ExtractedEventContact[],
+  options: {
+    userId?: string;
+  } = {},
+): ApplyContactEnhancementResult {
+  const userId = options.userId || getCurrentUserId(store);
+  const normalizedContacts = normalizeExtractedContacts(contacts, []);
+  const result: ApplyContactEnhancementResult = {
+    created: 0,
+    updated: 0,
+    linked: 0,
+    skipped: 0,
+    contacts: [],
+    matched: false,
+  };
+
+  if (normalizedContacts.length === 0) {
+    return result;
+  }
+
+  store.transaction(() => {
+    const sessionMappings = buildSessionMappingsByHuman(store, sessionId);
+    const mapping = sessionMappings.get(humanId);
+    if (!mapping || mapping.source === "excluded" || humanId === userId) {
+      result.skipped += 1;
+      return;
+    }
+
+    const human = store.getRow("humans", humanId);
+    if (!human) {
+      result.skipped += 1;
+      return;
+    }
+
+    const contact = findContactForHuman(human, normalizedContacts);
+    if (!contact) {
+      return;
+    }
+
+    result.matched = true;
+    result.contacts.push(contact);
+
+    const currentUser = store.getRow("humans", userId);
+    if (isCurrentUserContact(contact, currentUser)) {
+      result.skipped += 1;
+      return;
+    }
+
+    const existingName = stringCell(human.name);
+    const existingEmail = stringCell(human.email);
+    const shouldUpdateName = shouldUpdateHumanName(existingName, contact.email);
+    const shouldUpdateEmail = shouldUpdateHumanEmail(
+      existingEmail,
+      contact.email,
+    );
+
+    if (shouldUpdateName) {
+      store.setCell("humans", humanId, "name", contact.name);
+    }
+    if (shouldUpdateEmail) {
+      store.setCell("humans", humanId, "email", contact.email ?? "");
+    }
+    if (shouldUpdateName || shouldUpdateEmail) {
+      result.updated += 1;
     }
   });
 
@@ -633,6 +711,37 @@ function isCurrentUserContact(
   return getCandidateAliases(currentUserCandidate).has(
     normalizeName(contact.name),
   );
+}
+
+function findContactForHuman(
+  human: Record<string, unknown>,
+  contacts: ExtractedEventContact[],
+): ExtractedEventContact | undefined {
+  const humanCandidate: EventContactCandidate = {
+    name: stringCell(human.name),
+    email: stringCell(human.email),
+  };
+  const humanEmail = normalizeEmail(humanCandidate.email);
+  const humanName = normalizeName(humanCandidate.name ?? "");
+  const humanAliases = getCandidateAliases(humanCandidate);
+
+  return contacts.find((contact) => {
+    const contactEmail = normalizeEmail(contact.email);
+    if (humanEmail && contactEmail === humanEmail) {
+      return true;
+    }
+
+    const contactName = normalizeName(contact.name);
+    if (contactName && humanAliases.has(contactName)) {
+      return true;
+    }
+
+    const contactAliases = getCandidateAliases({
+      name: contact.name,
+      email: contact.email,
+    });
+    return Boolean(humanName && contactAliases.has(humanName));
+  });
 }
 
 function getCandidateAliases(candidate: EventContactCandidate): Set<string> {

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
@@ -1,18 +1,10 @@
 import { useMutation } from "@tanstack/react-query";
-import { Loader2Icon, SparklesIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
-import { Button } from "@hypr/ui/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@hypr/ui/components/ui/tooltip";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import { ParticipantChip } from "./chip";
 import { ParticipantDropdown } from "./dropdown";
 import {
-  applyExtractedContacts,
+  applyExtractedContactToHuman,
   buildEventContactExtractionContext,
   extractEventContacts,
 } from "./event-contact-extraction";
@@ -37,8 +29,8 @@ export function ParticipantInput({ sessionId }: { sessionId: string }) {
     deleteLastParticipant,
     resetInput,
   } = useParticipantInput(sessionId);
-  const { extractContacts, isExtracting, showExtractionButton } =
-    useEventContactExtraction(sessionId);
+  const { enhanceContact, enhancingHumanId, showEnhancementButtons } =
+    useEventContactEnhancement(sessionId);
   const placeholder =
     mappingIds.length > 0
       ? "Who else was in the meeting?"
@@ -84,7 +76,14 @@ export function ParticipantInput({ sessionId }: { sessionId: string }) {
         onClick={() => inputRef.current?.focus()}
       >
         {mappingIds.map((mappingId) => (
-          <ParticipantChip key={mappingId} mappingId={mappingId} />
+          <ParticipantChip
+            key={mappingId}
+            mappingId={mappingId}
+            enhancingHumanId={enhancingHumanId}
+            onEnhanceContact={
+              showEnhancementButtons ? enhanceContact : undefined
+            }
+          />
         ))}
 
         <input
@@ -97,13 +96,6 @@ export function ParticipantInput({ sessionId }: { sessionId: string }) {
           onKeyDown={handleKeyDown}
           onFocus={() => setShowDropdown(true)}
         />
-
-        {showExtractionButton && (
-          <ExtractEventContactsButton
-            isExtracting={isExtracting}
-            onClick={extractContacts}
-          />
-        )}
       </div>
 
       {showDropdown && inputValue.trim() && (
@@ -115,40 +107,6 @@ export function ParticipantInput({ sessionId }: { sessionId: string }) {
         />
       )}
     </div>
-  );
-}
-
-function ExtractEventContactsButton({
-  isExtracting,
-  onClick,
-}: {
-  isExtracting: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <Tooltip delayDuration={0}>
-      <TooltipTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label="Extract contacts from event"
-          className="size-6 shrink-0 text-neutral-400 hover:text-neutral-700"
-          disabled={isExtracting}
-          onClick={(event) => {
-            event.stopPropagation();
-            onClick();
-          }}
-        >
-          {isExtracting ? (
-            <Loader2Icon className="size-3.5 animate-spin" />
-          ) : (
-            <SparklesIcon className="size-3.5" />
-          )}
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">Extract contacts from event</TooltipContent>
-    </Tooltip>
   );
 }
 
@@ -308,14 +266,10 @@ function useParticipantInput(sessionId: string) {
     sessionId,
     mappingIds,
   );
-
-  useEffect(() => {
-    if (selectedIndex >= dropdownOptions.length && dropdownOptions.length > 0) {
-      setSelectedIndex(dropdownOptions.length - 1);
-    } else if (dropdownOptions.length === 0) {
-      setSelectedIndex(0);
-    }
-  }, [dropdownOptions.length, selectedIndex]);
+  const activeSelectedIndex =
+    dropdownOptions.length > 0
+      ? Math.min(selectedIndex, dropdownOptions.length - 1)
+      : 0;
 
   const resetInput = useCallback(() => {
     setInputValue("");
@@ -341,7 +295,7 @@ function useParticipantInput(sessionId: string) {
     inputValue,
     showDropdown,
     setShowDropdown,
-    selectedIndex,
+    selectedIndex: activeSelectedIndex,
     setSelectedIndex,
     mappingIds,
     dropdownOptions,
@@ -352,19 +306,19 @@ function useParticipantInput(sessionId: string) {
   };
 }
 
-function useEventContactExtraction(sessionId: string) {
+function useEventContactEnhancement(sessionId: string) {
   const store = main.UI.useStore(main.STORE_ID);
   const userId = main.UI.useValue("user_id", main.STORE_ID);
   const sessionEvent = useSessionEvent(sessionId);
   const model = useLanguageModel("title");
 
-  const showExtractionButton = Boolean(
+  const showEnhancementButtons = Boolean(
     sessionEvent?.title?.trim() || sessionEvent?.description?.trim(),
   );
 
-  const { mutate, isPending } = useMutation({
-    mutationKey: ["event-contact-extraction", sessionId],
-    mutationFn: async () => {
+  const { isPending, mutate, variables } = useMutation({
+    mutationKey: ["event-contact-enhancement", sessionId],
+    mutationFn: async (humanId: string) => {
       if (!store || !sessionEvent) {
         throw new Error("Event unavailable");
       }
@@ -375,87 +329,69 @@ function useEventContactExtraction(sessionId: string) {
         sessionEvent,
       );
       const extraction = await extractEventContacts({ model, context });
-      const applied = applyExtractedContacts(
+      const applied = applyExtractedContactToHuman(
         store,
         sessionId,
+        humanId,
         extraction.contacts,
         {
           userId: typeof userId === "string" ? userId : undefined,
         },
       );
 
-      return { extraction, applied };
+      return { extraction, applied, humanId };
     },
-    onSuccess: ({ extraction, applied }) => {
+    onSuccess: ({ extraction, applied, humanId }) => {
       const changed = applied.created + applied.updated + applied.linked;
-      if (extraction.contacts.length === 0) {
+      const toastId = `event-contact-enhancement-${humanId}`;
+
+      if (extraction.contacts.length === 0 || !applied.matched) {
         showTransientToast({
-          id: "event-contact-extraction",
-          description: "No contact hint found",
+          id: toastId,
+          description: "No contact detail found",
         });
         return;
       }
 
       if (changed === 0) {
         showTransientToast({
-          id: "event-contact-extraction",
-          description: "Contacts already up to date",
+          id: toastId,
+          description: "Contact already up to date",
         });
         return;
       }
 
       showTransientToast({
-        id: "event-contact-extraction",
-        description: formatExtractionToastDescription(applied),
+        id: toastId,
+        description: "Contact enhanced",
       });
     },
     onError: (error) => {
       const message =
         error instanceof Error && error.message === "Language model needed"
           ? "Language model needed"
-          : "Could not extract contacts";
+          : "Could not enhance contact";
 
       showTransientToast({
-        id: "event-contact-extraction",
+        id: "event-contact-enhancement",
         description: message,
         variant: "error",
       });
     },
   });
 
-  const extractContacts = useCallback(() => {
-    mutate();
-  }, [mutate]);
+  const enhanceContact = useCallback(
+    (humanId: string) => {
+      mutate(humanId);
+    },
+    [mutate],
+  );
 
   return {
-    extractContacts,
-    isExtracting: isPending,
-    showExtractionButton,
+    enhanceContact,
+    enhancingHumanId: isPending ? variables : undefined,
+    showEnhancementButtons,
   };
-}
-
-function formatExtractionToastDescription({
-  created,
-  updated,
-  linked,
-}: {
-  created: number;
-  updated: number;
-  linked: number;
-}) {
-  if (created > 0 && updated === 0) {
-    return created === 1 ? "Contact created" : `${created} contacts created`;
-  }
-
-  if (updated > 0 && created === 0) {
-    return updated === 1 ? "Contact updated" : `${updated} contacts updated`;
-  }
-
-  if (linked > 0 && created === 0 && updated === 0) {
-    return linked === 1 ? "Contact linked" : `${linked} contacts linked`;
-  }
-
-  return "Contacts updated";
 }
 
 function useLinkHumanToSession(


### PR DESCRIPTION
Move event contact enhancement onto participant chips and apply extracted details only to the selected contact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how local contact/human records are updated from calendar event text; wrong matching could update the wrong person’s name/email, though scope is limited to one selected participant and matching was tightened.
> 
> **Overview**
> Replaces **session-wide** event contact extraction with **per-participant** enhancement: each participant chip can show a sparkles control (when the session event has title/description) that runs the same event extraction flow but applies results only to that contact.
> 
> Backend adds `applyExtractedContactToHuman`, which matches one human to extracted hints using **stricter** aliases (full normalized name / email local), avoids weak first-name-only matches, skips the current user as “already up to date,” and does not bulk-create or link other contacts. Toasts and loading state are scoped per `humanId` (one enhancement at a time).
> 
> Tests cover selective updates, rejected loose-name enhancement, and the signed-in user case. Dropdown keyboard selection index is clamped without a `useEffect`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 336ba800ffc26f2608f71c9cd360d7db79a5dee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->