### PR TITLE
fix(desktop): remove timeline event dots

### DIFF
--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -11,11 +11,6 @@ import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { DancingSticks } from "@hypr/ui/components/ui/dancing-sticks";
 import { Spinner } from "@hypr/ui/components/ui/spinner";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@hypr/ui/components/ui/tooltip";
 import { cn, format, getYear, safeParseDate, TZDate } from "@hypr/utils";
 
 import {
@@ -94,7 +89,6 @@ export const TimelineItemComponent = memo(
 function ItemBase({
   title,
   displayTime,
-  calendarId,
   isLive,
   amplitude,
   showSpinner,
@@ -114,7 +108,6 @@ function ItemBase({
 }: {
   title: string;
   displayTime: string;
-  calendarId: string | null;
   isLive?: boolean;
   amplitude?: number;
   showSpinner?: boolean;
@@ -189,7 +182,6 @@ function ItemBase({
               </div>
             )}
           </div>
-          {calendarId && <CalendarIndicator calendarId={calendarId} />}
         </div>
       </InteractiveButton>
       {showLiveStop ? (
@@ -380,7 +372,6 @@ const EventItem = memo(
       <ItemBase
         title={title}
         displayTime={displayTime}
-        calendarId={null}
         selected={selected}
         ignored={ignored}
         muted={muted}
@@ -446,8 +437,6 @@ const SessionItem = memo(
       () => getSessionEvent(item.data),
       [item.data.event_json],
     );
-
-    const calendarId = sessionEvent?.calendar_id ?? null;
 
     const displayTime = useMemo(
       () =>
@@ -559,7 +548,6 @@ const SessionItem = memo(
         <ItemBase
           title={title}
           displayTime={displayTime}
-          calendarId={calendarId}
           isLive={isLive}
           amplitude={Math.max(
             0.25,
@@ -608,25 +596,4 @@ function formatDisplayTime(
     : format(date, "MMM d, yyyy");
 
   return `${dateStr}, ${time}`;
-}
-
-function CalendarIndicator({ calendarId }: { calendarId: string }) {
-  const calendar = main.UI.useRow("calendars", calendarId, main.STORE_ID);
-
-  const name = calendar?.name ? String(calendar.name) : undefined;
-  const color = calendar?.color ? String(calendar.color) : "#888";
-
-  return (
-    <Tooltip delayDuration={0}>
-      <TooltipTrigger asChild>
-        <div
-          className="size-2 shrink-0 rounded-full opacity-60"
-          style={{ backgroundColor: color }}
-        />
-      </TooltipTrigger>
-      <TooltipContent side="right" className="text-xs">
-        {name || "Calendar"}
-      </TooltipContent>
-    </Tooltip>
-  );
 }


### PR DESCRIPTION
Drop the calendar color dot from sidebar timeline rows while preserving row actions and live-state controls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only removal in the timeline sidebar with no auth, data, or API changes.
> 
> **Overview**
> Removes the **calendar color dot** from sidebar timeline rows in `item.tsx`. The `CalendarIndicator` component (colored dot + tooltip from Tinybase `calendars` data) is deleted, along with the `calendarId` prop on `ItemBase` and all wiring from **event** and **session** timeline items.
> 
> **Session** rows no longer read `calendar_id` from the linked session event for display. Row layout, selection, context menus, live stop controls, spinners, and drag behavior are unchanged—only the visual calendar affordance is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef877e7fb904dc41840e8467a499797dec4b78a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->