### PR TITLE
fix(desktop): move timeline spinner to row end

### DIFF
--- a/apps/desktop/src/sidebar/timeline/item.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.test.tsx
@@ -147,6 +147,7 @@ describe("TimelineItemComponent", () => {
     cleanup();
     mocks.amplitude = { mic: 0.4, speaker: 0.3 };
     mocks.sessionMode = "inactive";
+    mocks.storeTitle = "Live Note";
     mocks.stop.mockClear();
     mocks.openCurrent.mockClear();
     mocks.openNew.mockClear();
@@ -222,5 +223,35 @@ describe("TimelineItemComponent", () => {
     expect(selectedNodeRef.mock.calls.some(([node]) => node === row)).toBe(
       true,
     );
+  });
+
+  it("renders finalizing session spinner at the end of the row", () => {
+    mocks.sessionMode = "finalizing";
+    mocks.storeTitle = "Finalizing Note";
+
+    render(
+      <TimelineItemComponent
+        item={{
+          type: "session",
+          id: "session-finalizing",
+          data: {
+            title: "Finalizing Note",
+            created_at: "2024-01-15T10:30:00.000Z",
+          },
+        }}
+        precision="time"
+        selected={false}
+        timezone="UTC"
+        multiSelected={false}
+        flatItemKeys={["session-session-finalizing"]}
+      />,
+    );
+
+    const rowButton = screen.getByText("Finalizing Note").closest("button");
+    const spinnerSlot = screen.getByTestId("spinner").parentElement;
+
+    expect(rowButton?.className).toContain("pr-10");
+    expect(spinnerSlot?.className).toContain("absolute");
+    expect(spinnerSlot?.className).toContain("right-3");
   });
 });

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -134,6 +134,7 @@ function ItemBase({
 }) {
   const hasSelection = useTimelineSelection((s) => s.selectedIds.length > 0);
   const showLiveStop = isLive && onStop;
+  const showTrailingStatus = showLiveStop || showSpinner;
 
   return (
     <div
@@ -149,7 +150,7 @@ function ItemBase({
         contextMenu={hasSelection ? undefined : contextMenu}
         className={cn([
           "w-full rounded-lg px-3 py-2 text-left",
-          showLiveStop && "pr-10",
+          showTrailingStatus && "pr-10",
           ignored ? "cursor-default" : "cursor-pointer",
           multiSelected && "bg-neutral-200",
           !multiSelected && selected && "bg-neutral-200",
@@ -164,11 +165,6 @@ function ItemBase({
         draggable={draggable}
       >
         <div className="flex items-center gap-2">
-          {showSpinner && (
-            <div className="shrink-0">
-              <Spinner size={14} />
-            </div>
-          )}
           <div className="flex min-w-0 flex-1 flex-col gap-0.5">
             <div
               className={cn(
@@ -192,6 +188,14 @@ function ItemBase({
           {calendarId && <CalendarIndicator calendarId={calendarId} />}
         </div>
       </InteractiveButton>
+      {showSpinner ? (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute top-1/2 right-3 flex size-5 -translate-y-1/2 items-center justify-center text-neutral-400"
+        >
+          <Spinner size={14} />
+        </div>
+      ) : null}
       {showLiveStop ? (
         <button
           type="button"


### PR DESCRIPTION
Render sidebar timeline progress spinners in the trailing row status slot and cover finalizing placement in tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout change in the desktop sidebar timeline with a focused unit test; no auth, data, or API impact.
> 
> **Overview**
> Sidebar timeline session rows now show **finalizing / enhancing / batching** progress spinners in the **trailing status area** (same `right-3` slot as the live stop control), instead of inline beside the title.
> 
> `ItemBase` applies extra right padding when either a spinner or the live stop affordance is visible, and a new test asserts **finalizing** sessions get the absolute end-of-row spinner layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f08e1c8917c4323e41fe9765bafbfed7223c20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->