### PR TITLE
fix(desktop): show stop button when sidebar collapsed

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -87,8 +87,9 @@ describe("OuterHeader", () => {
     cleanup();
   });
 
-  it("shows a stop listening button for active sessions in sidebar timeline mode", () => {
+  it("shows a stop listening button for active sessions in collapsed sidebar timeline mode", () => {
     mocks.sidebarTimelineEnabled = true;
+    mocks.leftsidebar.expanded = false;
     mocks.sessionModes = { "session-1": "active" };
 
     render(
@@ -139,6 +140,7 @@ describe("OuterHeader", () => {
 
   it("keeps sidebar timeline header controls hidden while the sidebar is expanded", () => {
     mocks.sidebarTimelineEnabled = true;
+    mocks.sessionModes = { "session-1": "active" };
 
     const { container } = render(
       <OuterHeader
@@ -151,6 +153,7 @@ describe("OuterHeader", () => {
     expect(screen.queryByRole("button", { name: "Hide sidebar" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Stop listening" })).toBeNull();
     expect(container.firstElementChild?.className).not.toContain("pl-[156px]");
   });
 

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -59,7 +59,7 @@ function SidebarModeStopButton({ sessionId }: { sessionId: string }) {
   const active = mode === "active" || mode === "finalizing";
   const finalizing = mode === "finalizing";
 
-  if (!sidebarTimelineEnabled || !leftsidebar.expanded || !active) {
+  if (!sidebarTimelineEnabled || leftsidebar.expanded || !active) {
     return null;
   }
 


### PR DESCRIPTION
Render the sidebar timeline stop control only while the left sidebar is collapsed and update header coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI visibility guard change in the session header with matching unit tests; no auth, data, or listening pipeline logic changes.
> 
> **Overview**
> Fixes inverted sidebar state logic so the **Stop listening** control in `SidebarModeStopButton` appears only when sidebar timeline mode is on, the left sidebar is **collapsed**, and the session is active or finalizing—it was previously shown while the sidebar was expanded.
> 
> Tests now set `leftsidebar.expanded = false` for the collapsed stop-button case, assert **Stop listening** is absent when the sidebar is expanded (including with an active session), and rename the primary test to reflect collapsed-sidebar behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 676d3775b1c5ecaca42ed6686588a3932db3ecf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->