### PR TITLE
fix(desktop): add sidebar note actions

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -1,0 +1,181 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  newNote: vi.fn(),
+  openSearch: vi.fn(),
+  openNew: vi.fn(),
+  invalidateResource: vi.fn(),
+  clearSelection: vi.fn(),
+  addDeletion: vi.fn(),
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValue: () => undefined,
+}));
+
+vi.mock("~/shared/hooks/useNativeContextMenu", () => ({
+  useNativeContextMenu: () => vi.fn(),
+}));
+
+vi.mock("~/shared/useNewNote", () => ({
+  useNewNote: () => mocks.newNote,
+}));
+
+vi.mock("~/shared/open-note-dialog", () => ({
+  useOpenNoteDialog: () => ({
+    open: mocks.openSearch,
+  }),
+}));
+
+vi.mock("~/store/tinybase/hooks", () => ({
+  useIgnoredEvents: () => ({
+    isIgnored: () => false,
+  }),
+}));
+
+vi.mock("~/store/tinybase/store/deleteSession", () => ({
+  captureSessionData: vi.fn(),
+  deleteSessionCascade: vi.fn(),
+  finalizeSessionDeletion: vi.fn(),
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  QUERIES: {
+    timelineEvents: "timelineEvents",
+    timelineSessions: "timelineSessions",
+  },
+  STORE_ID: "main",
+  UI: {
+    useIndexes: () => null,
+    useResultTable: () => ({}),
+    useStore: () => null,
+  },
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: (selector: (state: unknown) => unknown) =>
+    selector({
+      currentTab: { type: "empty" },
+      invalidateResource: mocks.invalidateResource,
+      openNew: mocks.openNew,
+    }),
+}));
+
+vi.mock("~/store/zustand/timeline-selection", () => ({
+  useTimelineSelection: (selector: (state: unknown) => unknown) =>
+    selector({
+      clear: mocks.clearSelection,
+      selectedIds: [],
+    }),
+}));
+
+vi.mock("~/store/zustand/undo-delete", () => ({
+  useUndoDelete: (selector: (state: unknown) => unknown) =>
+    selector({
+      addDeletion: mocks.addDeletion,
+    }),
+}));
+
+vi.mock("./anchor", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    useAnchor: () => ({
+      anchorNode: null,
+      containerRef: React.useRef<HTMLDivElement>(null),
+      isAnchorVisible: true,
+      isScrolledPastAnchor: false,
+      registerAnchor: vi.fn(),
+      scrollToAnchor: vi.fn(),
+    }),
+    useAutoScrollToAnchor: vi.fn(),
+  };
+});
+
+vi.mock("./item", () => ({
+  TimelineItemComponent: () => <div data-testid="timeline-item" />,
+}));
+
+vi.mock("./realtime", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    CurrentTimeIndicator: React.forwardRef<HTMLDivElement>(
+      function CurrentTimeIndicator(_props, ref) {
+        return <div ref={ref} data-testid="current-time-indicator" />;
+      },
+    ),
+    useCurrentTimeMs: () => Date.now(),
+    useSmartCurrentTime: () => Date.now(),
+  };
+});
+
+import { TimelineView } from ".";
+
+describe("TimelineView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("shows sidebar actions for creating and searching notes", () => {
+    render(<TimelineView topChromeInset />);
+
+    fireEvent.click(screen.getByRole("button", { name: "New note" }));
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(mocks.newNote).toHaveBeenCalledTimes(1);
+    expect(mocks.openSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides sidebar actions briefly after scrolling down", () => {
+    vi.useFakeTimers();
+
+    const { container } = render(<TimelineView topChromeInset />);
+    const actions = getSidebarActions();
+    const scroller = container.querySelector("[data-sidebar-timeline-scroll]");
+
+    expect(scroller).toBeInstanceOf(HTMLDivElement);
+    expect(actions.className).not.toContain("opacity-0");
+
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 1200,
+    });
+    scroller!.scrollTop = 120;
+    fireEvent.scroll(scroller!);
+
+    expect(actions.className).toContain("opacity-0");
+
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(actions.className).not.toContain("opacity-0");
+  });
+});
+
+function getSidebarActions() {
+  const actions = screen
+    .getByRole("button", { name: "New note" })
+    .closest("[data-sidebar-timeline-actions]");
+
+  expect(actions).toBeInstanceOf(HTMLDivElement);
+
+  return actions as HTMLDivElement;
+}

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -2,6 +2,8 @@ import {
   ArrowDownIcon,
   ArrowUpIcon,
   CalendarDaysIcon,
+  SearchIcon,
+  SquarePenIcon,
   SunIcon,
 } from "lucide-react";
 import {
@@ -40,6 +42,8 @@ import {
 
 import { useConfigValue } from "~/shared/config";
 import { useNativeContextMenu } from "~/shared/hooks/useNativeContextMenu";
+import { useOpenNoteDialog } from "~/shared/open-note-dialog";
+import { useNewNote } from "~/shared/useNewNote";
 import { useIgnoredEvents } from "~/store/tinybase/hooks";
 import {
   captureSessionData,
@@ -50,6 +54,8 @@ import * as main from "~/store/tinybase/store/main";
 import { useTabs } from "~/store/zustand/tabs";
 import { useTimelineSelection } from "~/store/zustand/timeline-selection";
 import { useUndoDelete } from "~/store/zustand/undo-delete";
+
+const SIDEBAR_ACTIONS_REVEAL_DELAY_MS = 900;
 
 export function TimelineView({
   showOpenCalendarButton = true,
@@ -68,9 +74,12 @@ export function TimelineView({
   const [showIgnored, setShowIgnored] = useState(false);
   const [isScrolledToTop, setIsScrolledToTop] = useState(true);
   const [isScrolledToBottom, setIsScrolledToBottom] = useState(true);
+  const [areSidebarActionsHidden, setAreSidebarActionsHidden] = useState(false);
 
   const { isIgnored } = useIgnoredEvents();
   const openNew = useTabs((state) => state.openNew);
+  const createNewNote = useNewNote();
+  const openNoteDialog = useOpenNoteDialog();
 
   const buckets = useMemo(() => {
     if (showIgnored) {
@@ -173,6 +182,10 @@ export function TimelineView({
     anchorNode: todayAnchorNode,
   } = useAnchor();
   const selectedSessionScrollFrameRef = useRef<number | null>(null);
+  const previousScrollTopRef = useRef(0);
+  const sidebarActionsRevealTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
   const scrollSelectedSessionIntoView = useCallback<
     RefCallback<HTMLDivElement>
   >(
@@ -200,13 +213,42 @@ export function TimelineView({
       return;
     }
 
+    const clearSidebarActionsRevealTimer = () => {
+      if (sidebarActionsRevealTimerRef.current !== null) {
+        clearTimeout(sidebarActionsRevealTimerRef.current);
+        sidebarActionsRevealTimerRef.current = null;
+      }
+    };
+
+    const revealSidebarActionsSoon = () => {
+      clearSidebarActionsRevealTimer();
+      sidebarActionsRevealTimerRef.current = setTimeout(() => {
+        setAreSidebarActionsHidden(false);
+        sidebarActionsRevealTimerRef.current = null;
+      }, SIDEBAR_ACTIONS_REVEAL_DELAY_MS);
+    };
+
     const updateScrollPosition = () => {
       const maxScrollTop = Math.max(
         0,
         container.scrollHeight - container.clientHeight,
       );
-      setIsScrolledToTop(container.scrollTop <= 12);
-      setIsScrolledToBottom(maxScrollTop - container.scrollTop <= 12);
+      const nextScrollTop = container.scrollTop;
+      const scrolledToTop = nextScrollTop <= 12;
+      const scrollDelta = nextScrollTop - previousScrollTopRef.current;
+
+      setIsScrolledToTop(scrolledToTop);
+      setIsScrolledToBottom(maxScrollTop - nextScrollTop <= 12);
+
+      if (topChromeInset && scrollDelta > 2 && !scrolledToTop) {
+        setAreSidebarActionsHidden(true);
+        revealSidebarActionsSoon();
+      } else if (topChromeInset && (scrolledToTop || scrollDelta < -2)) {
+        clearSidebarActionsRevealTimer();
+        setAreSidebarActionsHidden(false);
+      }
+
+      previousScrollTopRef.current = nextScrollTop;
     };
 
     updateScrollPosition();
@@ -215,9 +257,10 @@ export function TimelineView({
     });
 
     return () => {
+      clearSidebarActionsRevealTimer();
       container.removeEventListener("scroll", updateScrollPosition);
     };
-  }, [containerRef, buckets.length, flatItemKeys.length]);
+  }, [containerRef, buckets.length, flatItemKeys.length, topChromeInset]);
 
   const scrollFadeMask = useMemo(() => {
     const topFadeEnd = isScrolledToTop ? "0px" : "28px";
@@ -263,6 +306,10 @@ export function TimelineView({
   const handleOpenCalendar = useCallback(() => {
     openNew({ type: "calendar" });
   }, [openNew]);
+
+  const handleOpenNoteDialog = useCallback(() => {
+    openNoteDialog.open();
+  }, [openNoteDialog]);
 
   const handleDeleteSelected = useCallback(() => {
     if (!store || !indexes) {
@@ -342,6 +389,7 @@ export function TimelineView({
     <div className="relative h-full">
       <div
         ref={containerRef}
+        data-sidebar-timeline-scroll
         onContextMenu={showContextMenu}
         className={cn([
           "scrollbar-hide flex h-full flex-col overflow-y-auto",
@@ -358,8 +406,8 @@ export function TimelineView({
             className={cn([
               topChromeInset
                 ? reserveOpenCalendarChipSpace
-                  ? "h-20"
-                  : "h-12"
+                  ? "h-44"
+                  : "h-32"
                 : "h-10",
               "shrink-0",
             ])}
@@ -439,9 +487,17 @@ export function TimelineView({
           className={cn([
             "pointer-events-none absolute inset-x-0 top-0 z-[15]",
             isScrolledToTop
-              ? "h-12 bg-neutral-50"
-              : "h-20 bg-linear-to-b from-neutral-50 via-neutral-50/95 via-55% to-neutral-50/0",
+              ? "h-32 bg-neutral-50"
+              : "h-36 bg-linear-to-b from-neutral-50 via-neutral-50/95 via-55% to-neutral-50/0",
           ])}
+        />
+      )}
+
+      {topChromeInset && (
+        <SidebarTimelineActions
+          hidden={areSidebarActionsHidden}
+          onNewNote={createNewNote}
+          onSearch={handleOpenNoteDialog}
         />
       )}
 
@@ -449,7 +505,11 @@ export function TimelineView({
         <div
           className={cn([
             "absolute left-1/2 z-20 flex -translate-x-1/2 transform flex-col items-center gap-2",
-            topChromeInset ? "top-12" : "top-2",
+            topChromeInset
+              ? areSidebarActionsHidden
+                ? "top-12"
+                : "top-32"
+              : "top-2",
           ])}
         >
           {showOpenCalendarChip && (
@@ -486,6 +546,71 @@ export function TimelineView({
         />
       )}
     </div>
+  );
+}
+
+function SidebarTimelineActions({
+  hidden,
+  onNewNote,
+  onSearch,
+}: {
+  hidden: boolean;
+  onNewNote: () => void;
+  onSearch: () => void;
+}) {
+  return (
+    <div
+      data-sidebar-timeline-actions
+      className={cn([
+        "absolute inset-x-0 top-12 z-30 px-2 pt-1 pb-2",
+        "bg-neutral-50",
+        "transition-[opacity,transform] duration-150 ease-out",
+        hidden
+          ? "pointer-events-none -translate-y-2 opacity-0"
+          : "translate-y-0 opacity-100",
+      ])}
+    >
+      <div className="flex flex-col gap-1">
+        <SidebarTimelineActionButton
+          icon={<SquarePenIcon size={15} />}
+          label="New note"
+          onClick={onNewNote}
+        />
+        <SidebarTimelineActionButton
+          icon={<SearchIcon size={15} />}
+          label="Search"
+          onClick={onSearch}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SidebarTimelineActionButton({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn([
+        "flex h-8 w-full items-center gap-2 rounded-lg px-2.5 text-left",
+        "text-sm font-medium text-neutral-700",
+        "transition-colors hover:bg-neutral-200/70 hover:text-neutral-950",
+        "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+      ])}
+      onClick={onClick}
+    >
+      <span className="flex size-4 shrink-0 items-center justify-center text-neutral-600">
+        {icon}
+      </span>
+      <span className="truncate">{label}</span>
+    </button>
   );
 }
 

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -183,9 +183,14 @@ export function TimelineView({
   } = useAnchor();
   const selectedSessionScrollFrameRef = useRef<number | null>(null);
   const previousScrollTopRef = useRef(0);
+  const areSidebarActionsHiddenRef = useRef(false);
   const sidebarActionsRevealTimerRef = useRef<ReturnType<
     typeof setTimeout
   > | null>(null);
+  const setSidebarActionsHidden = useCallback((hidden: boolean) => {
+    areSidebarActionsHiddenRef.current = hidden;
+    setAreSidebarActionsHidden(hidden);
+  }, []);
   const scrollSelectedSessionIntoView = useCallback<
     RefCallback<HTMLDivElement>
   >(
@@ -223,7 +228,7 @@ export function TimelineView({
     const revealSidebarActionsSoon = () => {
       clearSidebarActionsRevealTimer();
       sidebarActionsRevealTimerRef.current = setTimeout(() => {
-        setAreSidebarActionsHidden(false);
+        setSidebarActionsHidden(false);
         sidebarActionsRevealTimerRef.current = null;
       }, SIDEBAR_ACTIONS_REVEAL_DELAY_MS);
     };
@@ -241,17 +246,27 @@ export function TimelineView({
       setIsScrolledToBottom(maxScrollTop - nextScrollTop <= 12);
 
       if (topChromeInset && scrollDelta > 2 && !scrolledToTop) {
-        setAreSidebarActionsHidden(true);
+        setSidebarActionsHidden(true);
         revealSidebarActionsSoon();
       } else if (topChromeInset && (scrolledToTop || scrollDelta < -2)) {
         clearSidebarActionsRevealTimer();
-        setAreSidebarActionsHidden(false);
+        setSidebarActionsHidden(false);
       }
 
       previousScrollTopRef.current = nextScrollTop;
+
+      return { scrolledToTop };
     };
 
-    updateScrollPosition();
+    const { scrolledToTop } = updateScrollPosition();
+    if (
+      topChromeInset &&
+      !scrolledToTop &&
+      areSidebarActionsHiddenRef.current &&
+      sidebarActionsRevealTimerRef.current === null
+    ) {
+      revealSidebarActionsSoon();
+    }
     container.addEventListener("scroll", updateScrollPosition, {
       passive: true,
     });
@@ -260,7 +275,13 @@ export function TimelineView({
       clearSidebarActionsRevealTimer();
       container.removeEventListener("scroll", updateScrollPosition);
     };
-  }, [containerRef, buckets.length, flatItemKeys.length, topChromeInset]);
+  }, [
+    containerRef,
+    buckets.length,
+    flatItemKeys.length,
+    topChromeInset,
+    setSidebarActionsHidden,
+  ]);
 
   const scrollFadeMask = useMemo(() => {
     const topFadeEnd = isScrolledToTop ? "0px" : "28px";


### PR DESCRIPTION
Add New note and Search controls to the sidebar timeline and hide them briefly during downward scroll.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar timeline changes with mocked tests; no auth, data, or persistence logic touched.
> 
> **Overview**
> Adds **New note** and **Search** controls to the sidebar timeline when `topChromeInset` is enabled (timeline sidebar layout). **New note** uses `useNewNote`; **Search** opens the note dialog via `useOpenNoteDialog`.
> 
> While scrolling down, the action strip fades out and becomes non-interactive, then reappears after **900ms** or immediately when the user scrolls back toward the top. Top padding, the neutral chrome overlay, and floating chips (e.g. Open calendar / Now) are resized and repositioned so they do not overlap the new controls.
> 
> New Vitest coverage verifies button wiring and the scroll-hide / timer-reveal behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c54c068189ff0e5817daeb7758705731d4f57970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->