### PR TITLE
fix(desktop): place sidebar now indicator correctly

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   clearSelection: vi.fn(),
   addDeletion: vi.fn(),
   configValue: undefined as string | undefined,
+  currentTimeMs: undefined as number | undefined,
   timelineEventsTable: {} as Record<string, Record<string, unknown>>,
   timelineSessionsTable: {} as Record<string, Record<string, unknown>>,
 }));
@@ -120,7 +121,7 @@ vi.mock("./realtime", async () => {
         return <div ref={ref} data-testid="current-time-indicator" />;
       },
     ),
-    useCurrentTimeMs: () => Date.now(),
+    useCurrentTimeMs: () => mocks.currentTimeMs ?? Date.now(),
     useSmartCurrentTime: () => Date.now(),
   };
 });
@@ -131,6 +132,7 @@ describe("TimelineView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.configValue = undefined;
+    mocks.currentTimeMs = undefined;
     mocks.timelineEventsTable = {};
     mocks.timelineSessionsTable = {};
   });
@@ -251,6 +253,35 @@ describe("TimelineView", () => {
     expect(isBefore(tomorrowHeading, indicator)).toBe(true);
     expect(isBefore(indicator, yesterdayHeading)).toBe(true);
     expect(isBefore(indicator, twoDaysAgoHeading)).toBe(true);
+  });
+
+  it("places the fallback now indicator with fresh time after data refreshes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T23:58:00.000Z"));
+    mocks.configValue = "UTC";
+    mocks.currentTimeMs = Date.now();
+
+    const { rerender } = render(<TimelineView />);
+
+    vi.setSystemTime(new Date("2024-01-16T00:01:00.000Z"));
+    mocks.timelineSessionsTable = {
+      tomorrow: {
+        title: "Roadmap review",
+        created_at: "2024-01-17T12:00:00.000Z",
+      },
+      yesterday: {
+        title: "Late wrap",
+        created_at: "2024-01-15T23:59:00.000Z",
+      },
+    };
+    rerender(<TimelineView />);
+
+    const tomorrowHeading = screen.getByText("Tomorrow");
+    const yesterdayHeading = screen.getByText("Yesterday");
+    const indicator = screen.getByTestId("current-time-indicator");
+
+    expect(isBefore(tomorrowHeading, indicator)).toBe(true);
+    expect(isBefore(indicator, yesterdayHeading)).toBe(true);
   });
 });
 

--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -14,10 +14,13 @@ const mocks = vi.hoisted(() => ({
   invalidateResource: vi.fn(),
   clearSelection: vi.fn(),
   addDeletion: vi.fn(),
+  configValue: undefined as string | undefined,
+  timelineEventsTable: {} as Record<string, Record<string, unknown>>,
+  timelineSessionsTable: {} as Record<string, Record<string, unknown>>,
 }));
 
 vi.mock("~/shared/config", () => ({
-  useConfigValue: () => undefined,
+  useConfigValue: () => mocks.configValue,
 }));
 
 vi.mock("~/shared/hooks/useNativeContextMenu", () => ({
@@ -54,7 +57,10 @@ vi.mock("~/store/tinybase/store/main", () => ({
   STORE_ID: "main",
   UI: {
     useIndexes: () => null,
-    useResultTable: () => ({}),
+    useResultTable: (query: string) =>
+      query === "timelineEvents"
+        ? mocks.timelineEventsTable
+        : mocks.timelineSessionsTable,
     useStore: () => null,
   },
 }));
@@ -100,7 +106,9 @@ vi.mock("./anchor", async () => {
 });
 
 vi.mock("./item", () => ({
-  TimelineItemComponent: () => <div data-testid="timeline-item" />,
+  TimelineItemComponent: ({ item }: { item: { id: string } }) => (
+    <div data-testid={`timeline-item-${item.id}`} />
+  ),
 }));
 
 vi.mock("./realtime", async () => {
@@ -122,6 +130,9 @@ import { TimelineView } from ".";
 describe("TimelineView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.configValue = undefined;
+    mocks.timelineEventsTable = {};
+    mocks.timelineSessionsTable = {};
   });
 
   afterEach(() => {
@@ -168,6 +179,79 @@ describe("TimelineView", () => {
 
     expect(actions.className).not.toContain("opacity-0");
   });
+
+  it("keeps sidebar actions hidden during timeline data refreshes", () => {
+    vi.useFakeTimers();
+
+    const { container, rerender } = render(<TimelineView topChromeInset />);
+    const scroller = container.querySelector("[data-sidebar-timeline-scroll]");
+
+    expect(scroller).toBeInstanceOf(HTMLDivElement);
+
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 1200,
+    });
+    scroller!.scrollTop = 120;
+    fireEvent.scroll(scroller!);
+
+    expect(getSidebarActions().className).toContain("opacity-0");
+
+    mocks.timelineSessionsTable = {
+      "session-1": {
+        title: "Planning",
+        created_at: "2024-01-15T12:00:00.000Z",
+      },
+    };
+    rerender(<TimelineView topChromeInset />);
+
+    expect(getSidebarActions().className).toContain("opacity-0");
+
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(getSidebarActions().className).not.toContain("opacity-0");
+  });
+
+  it("places the fallback now indicator between future and past buckets", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T15:54:00.000Z"));
+
+    mocks.configValue = "Asia/Seoul";
+    mocks.timelineSessionsTable = {
+      tomorrow: {
+        title: "Sprint retro & planning",
+        created_at: "2024-01-15T00:00:00.000Z",
+        event_json: JSON.stringify({
+          started_at: "2024-01-17T08:30:00.000Z",
+        }),
+      },
+      yesterday: {
+        title: "Design sync",
+        created_at: "2024-01-15T12:00:00.000Z",
+      },
+      "two-days-ago": {
+        title: "Product Discovery Pace",
+        created_at: "2024-01-14T12:00:00.000Z",
+      },
+    };
+
+    render(<TimelineView />);
+
+    const tomorrowHeading = screen.getByText("Tomorrow");
+    const yesterdayHeading = screen.getByText("Yesterday");
+    const twoDaysAgoHeading = screen.getByText("2 days ago");
+    const indicator = screen.getByTestId("current-time-indicator");
+
+    expect(isBefore(tomorrowHeading, indicator)).toBe(true);
+    expect(isBefore(indicator, yesterdayHeading)).toBe(true);
+    expect(isBefore(indicator, twoDaysAgoHeading)).toBe(true);
+  });
 });
 
 function getSidebarActions() {
@@ -178,4 +262,10 @@ function getSidebarActions() {
   expect(actions).toBeInstanceOf(HTMLDivElement);
 
   return actions as HTMLDivElement;
+}
+
+function isBefore(first: Element, second: Element) {
+  return Boolean(
+    first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING,
+  );
 }

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -307,6 +307,7 @@ export function TimelineView({
     if (hasToday) {
       return -1;
     }
+    const nowMs = Date.now();
     return buckets.findIndex((bucket) => {
       const firstItem = bucket.items[0];
       if (!firstItem) {
@@ -314,7 +315,7 @@ export function TimelineView({
       }
 
       const itemDate = getItemTimestamp(firstItem);
-      return itemDate ? itemDate.getTime() < currentTimeMs : false;
+      return itemDate ? itemDate.getTime() < nowMs : false;
     });
   }, [buckets, hasToday, currentTimeMs]);
 

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -17,7 +17,7 @@ import {
 } from "react";
 
 import { Button } from "@hypr/ui/components/ui/button";
-import { cn, startOfDay } from "@hypr/utils";
+import { cn } from "@hypr/utils";
 
 import { useAnchor, useAutoScrollToAnchor } from "./anchor";
 import { TimelineItemComponent } from "./item";
@@ -148,6 +148,7 @@ export function TimelineView({
     () => buckets.some((bucket) => bucket.label === "Today"),
     [buckets],
   );
+  const currentTimeMs = useCurrentTimeMs();
 
   const currentTab = useTabs((state) => state.currentTab);
 
@@ -302,23 +303,20 @@ export function TimelineView({
     deps: [todayBucketLength],
   });
 
-  const todayTimestamp = useMemo(() => startOfDay(new Date()).getTime(), []);
   const indicatorIndex = useMemo(() => {
     if (hasToday) {
       return -1;
     }
-    return buckets.findIndex(
-      (bucket) =>
-        bucket.items.length > 0 &&
-        (() => {
-          const itemDate = getItemTimestamp(bucket.items[0]);
-          if (!itemDate) {
-            return false;
-          }
-          return itemDate.getTime() < todayTimestamp;
-        })(),
-    );
-  }, [buckets, hasToday, todayTimestamp]);
+    return buckets.findIndex((bucket) => {
+      const firstItem = bucket.items[0];
+      if (!firstItem) {
+        return false;
+      }
+
+      const itemDate = getItemTimestamp(firstItem);
+      return itemDate ? itemDate.getTime() < currentTimeMs : false;
+    });
+  }, [buckets, hasToday, currentTimeMs]);
 
   const toggleShowIgnored = useCallback(() => {
     setShowIgnored((prev) => !prev);


### PR DESCRIPTION
Use current time for the no-Today sidebar timeline marker and cover timezone-split buckets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only timeline indicator logic with no auth, data, or API changes; risk is limited to sidebar ordering/display.
> 
> **Overview**
> When the sidebar timeline has **no "Today" bucket**, the fallback **now** line is positioned using **live** `Date.now()` instead of a **start-of-day** timestamp frozen at first render. That keeps the marker between future and past day buckets when labels are timezone-driven (e.g. **Tomorrow** vs **Yesterday**) and lets it move after midnight or when session data refreshes via `useCurrentTimeMs()` in the placement memo.
> 
> Tests add controllable mocks for timezone, timeline tables, and current time, plus coverage for indicator DOM order and sidebar actions staying hidden through a data **rerender** while scrolled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de7a54c133c81e8dda1fa784a856ed522cf08ce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->