### PR TITLE
fix(desktop): keep live speaker labels sticky

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
@@ -192,6 +192,29 @@ describe("DuringSessionAccessory", () => {
     expect(chip.className).toContain("min-w-0");
     expect(screen.getByText(label).className).toContain("truncate");
   });
+
+  it("keeps speaker labels sticky while expanded transcript content scrolls", () => {
+    const label = "Artem";
+
+    useStoreMock.mockReturnValue({
+      getValue: vi.fn(() => undefined),
+      getRow: vi.fn((tableId: string, rowId: string) =>
+        tableId === "humans" && rowId === "human-1" ? { name: label } : {},
+      ),
+    });
+    liveSegments = [
+      segment("This speaker label should remain visible while scrolling.", 0, {
+        channel: "RemoteParty",
+        speaker_human_id: "human-1",
+      }),
+    ];
+
+    render(<DuringSessionAccessory sessionId="session-1" isExpanded />);
+
+    const chip = screen.getByTitle(label);
+    expect(chip.className).toContain("sticky");
+    expect(chip.className).toContain("top-2.5");
+  });
 });
 
 function getLiveTranscriptScrollViewport() {

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -370,7 +370,7 @@ function TranscriptSegmentRow({
   return (
     <div className="grid min-w-0 grid-cols-[92px_minmax(0,1fr)] items-start gap-x-3">
       <span
-        className="mt-0.5 flex min-h-5 max-w-full min-w-0 items-center justify-start rounded-full px-2 text-[11px] font-medium"
+        className="sticky top-2.5 z-10 mt-0.5 flex min-h-5 max-w-full min-w-0 items-center justify-start rounded-full px-2 text-[11px] font-medium"
         title={label}
         style={{
           backgroundColor: `${color}1A`,


### PR DESCRIPTION
Keep live transcript speaker chips sticky within each long segment and add coverage for the expanded transcript panel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CSS and test-only change in the desktop live transcript UI; no auth, data, or backend impact.
> 
> **Overview**
> The expanded **live transcript** panel now keeps each row’s **speaker chip** pinned while the transcript scrolls, by adding `sticky`, `top-2.5`, and `z-10` on the label in `TranscriptSegmentRow` inside `during-session.tsx`.
> 
> A new test in `during-session.test.tsx` asserts those classes on the speaker chip when the footer is expanded with a named remote speaker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e345482108ba7f14ce55f8db925b829ec89ed53f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->