### PR TITLE
chore(web): clarify testimonial name history

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -145,6 +145,8 @@ const desktopTestimonialSidePositions: TestimonialCardPosition[] = [
 ];
 
 const testimonialDeckStateVersion = 3;
+const testimonialNameContext =
+  "Name context: Hyprnote became Char, then Anarlog.";
 
 function formatTestimonialOffset(offset: TestimonialCardPosition["x"]) {
   return typeof offset === "number" ? `${offset}px` : offset;
@@ -231,11 +233,15 @@ function TestimonialTweetCard({
           </a>
         </figcaption>
 
-        <blockquote className="flex flex-1 items-center py-6">
-          <p className="text-xl leading-[1.25] font-semibold text-balance text-[#181613]">
+        <blockquote className="flex flex-1 items-center py-3">
+          <p className="text-lg leading-[1.25] font-semibold text-balance text-[#181613]">
             {renderPullQuote(testimonial.quote)}
           </p>
         </blockquote>
+
+        <p className="border-t border-[#ede7dc] pt-3 text-xs leading-5 text-[#756b5d]">
+          {testimonialNameContext}
+        </p>
       </figure>
     </article>
   );


### PR DESCRIPTION
Summary:
- Add a per-card footer explaining that Hyprnote became Char, then Anarlog.
- Tighten testimonial quote spacing so the footer fits in the fixed-height cards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Landing-page copy and testimonial card layout only; no auth, data, or backend behavior changes.
> 
> **Overview**
> Each homepage testimonial card now includes a small **name-history footer** explaining that **Hyprnote → Char → Anarlog**, so quotes that say “Anarlog” are easier to read in context.
> 
> Quote typography is tightened (`py-3`, `text-lg` instead of `py-6`, `text-xl`) so the new footer still fits inside the existing fixed-height testimonial cards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8327d045d74cff2306b72ca1971e635978c6dfdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->