### PR TITLE
fix(desktop): polish sidebar search controls

### DIFF
--- a/apps/desktop/src/shared/open-note-dialog.tsx
+++ b/apps/desktop/src/shared/open-note-dialog.tsx
@@ -13,6 +13,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { Kbd } from "@hypr/ui/components/ui/kbd";
 import { cn } from "@hypr/utils";
 
+import { useMainContentCenterOffset } from "~/shared/main/content-offset";
 import * as main from "~/store/tinybase/store/main";
 import { useTabs } from "~/store/zustand/tabs";
 
@@ -21,6 +22,7 @@ const MAX_RECENT_DISPLAY = 5;
 interface OpenNoteDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  mainContentCenterOffset?: number;
 }
 
 type OpenNoteDialogContextValue = {
@@ -43,6 +45,7 @@ export function OpenNoteDialogProvider({
   children: React.ReactNode;
 }) {
   const [open, setOpen] = useState(false);
+  const mainContentCenterOffset = useMainContentCenterOffset();
 
   const openDialog = useCallback(() => {
     setOpen(true);
@@ -59,7 +62,11 @@ export function OpenNoteDialogProvider({
   return (
     <OpenNoteDialogContext.Provider value={value}>
       {children}
-      <OpenNoteDialog open={open} onOpenChange={setOpen} />
+      <OpenNoteDialog
+        open={open}
+        onOpenChange={setOpen}
+        mainContentCenterOffset={mainContentCenterOffset}
+      />
     </OpenNoteDialogContext.Provider>
   );
 }
@@ -74,7 +81,11 @@ export function useOpenNoteDialog() {
   return context;
 }
 
-export function OpenNoteDialog({ open, onOpenChange }: OpenNoteDialogProps) {
+export function OpenNoteDialog({
+  open,
+  onOpenChange,
+  mainContentCenterOffset = 0,
+}: OpenNoteDialogProps) {
   const [query, setQuery] = useState("");
   const openCurrent = useTabs((state) => state.openCurrent);
   const recentlyOpenedSessionIds = useTabs(
@@ -173,7 +184,10 @@ export function OpenNoteDialog({ open, onOpenChange }: OpenNoteDialogProps) {
         className="absolute top-0 right-0 left-0 h-[15%]"
         onClick={(e) => e.stopPropagation()}
       />
-      <div className="absolute top-[15%] left-1/2 w-full max-w-lg -translate-x-1/2 px-4">
+      <div
+        className="absolute top-[15%] left-1/2 w-full max-w-lg -translate-x-1/2 px-4"
+        style={{ marginLeft: mainContentCenterOffset }}
+      >
         <div
           className={cn([
             "rounded-xl border border-neutral-200/80 bg-[#faf8f5]",

--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -154,6 +154,27 @@ describe("TimelineView", () => {
     expect(mocks.openSearch).toHaveBeenCalledTimes(1);
   });
 
+  it("places the open calendar chip below visible sidebar actions", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.smartCurrentTimeMs = Date.now();
+    mocks.timelineSessionsTable = {
+      later: {
+        title: "Quarterly planning",
+        created_at: "2024-01-17T12:00:00.000Z",
+      },
+    };
+
+    render(<TimelineView topChromeInset />);
+
+    expect(getSidebarActions().className).not.toContain("opacity-0");
+    expect(
+      screen.getByRole("button", { name: "Open calendar" }).parentElement
+        ?.className,
+    ).toContain("top-36");
+  });
+
   it("hides sidebar actions briefly after scrolling down", () => {
     vi.useFakeTimers();
 
@@ -176,12 +197,14 @@ describe("TimelineView", () => {
     fireEvent.scroll(scroller!);
 
     expect(actions.className).toContain("opacity-0");
+    expect(getTopFade(container).className).toContain("h-20");
 
     act(() => {
       vi.advanceTimersByTime(900);
     });
 
     expect(actions.className).not.toContain("opacity-0");
+    expect(getTopFade(container).className).toContain("h-36");
   });
 
   it("keeps sidebar actions hidden during timeline data refreshes", () => {
@@ -328,6 +351,14 @@ function getSidebarActions() {
   expect(actions).toBeInstanceOf(HTMLDivElement);
 
   return actions as HTMLDivElement;
+}
+
+function getTopFade(container: HTMLElement) {
+  const topFade = container.querySelector("[data-sidebar-timeline-top-fade]");
+
+  expect(topFade).toBeInstanceOf(HTMLDivElement);
+
+  return topFade as HTMLDivElement;
 }
 
 function isBefore(first: Element, second: Element) {

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -417,7 +417,7 @@ export function TimelineView({
             className={cn([
               topChromeInset
                 ? reserveOpenCalendarChipSpace
-                  ? "h-44"
+                  ? "h-52"
                   : "h-32"
                 : "h-10",
               "shrink-0",
@@ -495,11 +495,14 @@ export function TimelineView({
       {topChromeInset && (
         <div
           aria-hidden
+          data-sidebar-timeline-top-fade
           className={cn([
             "pointer-events-none absolute inset-x-0 top-0 z-[15]",
-            isScrolledToTop
-              ? "h-32 bg-neutral-50"
-              : "h-36 bg-linear-to-b from-neutral-50 via-neutral-50/95 via-55% to-neutral-50/0",
+            areSidebarActionsHidden
+              ? "h-20 bg-linear-to-b from-neutral-50 via-neutral-50/95 via-60% to-neutral-50/0"
+              : isScrolledToTop
+                ? "h-32 bg-neutral-50"
+                : "h-36 bg-linear-to-b from-neutral-50 via-neutral-50/95 via-55% to-neutral-50/0",
           ])}
         />
       )}
@@ -519,7 +522,7 @@ export function TimelineView({
             topChromeInset
               ? areSidebarActionsHidden
                 ? "top-12"
-                : "top-32"
+                : "top-36"
               : "top-2",
           ])}
         >
@@ -573,7 +576,7 @@ function SidebarTimelineActions({
     <div
       data-sidebar-timeline-actions
       className={cn([
-        "absolute inset-x-0 top-12 z-30 px-2 pt-1 pb-2",
+        "absolute inset-x-0 top-12 z-30 pt-1 pb-2",
         "bg-neutral-50",
         "transition-[opacity,transform] duration-150 ease-out",
         hidden
@@ -610,7 +613,7 @@ function SidebarTimelineActionButton({
     <button
       type="button"
       className={cn([
-        "flex h-8 w-full items-center gap-2 rounded-lg px-2.5 text-left",
+        "flex h-8 w-full items-center gap-2 rounded-full px-3 text-left",
         "text-sm font-medium text-neutral-700",
         "transition-colors hover:bg-neutral-200/70 hover:text-neutral-950",
         "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",


### PR DESCRIPTION
## Summary
- make New note and Search span the sidebar like timeline rows and render as pills
- keep the Open calendar chip below visible sidebar actions and reduce the hidden-actions top fade
- center the note search palette in the main content pane when the left sidebar is visible

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop typecheck
- pnpm -F @hypr/desktop exec vitest run src/sidebar/timeline/index.test.tsx
- pnpm -F @hypr/desktop exec vitest run src/shared/main/body.test.tsx src/sidebar/timeline/index.test.tsx src/shared/main/shell-sidebar.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout and styling only in sidebar and open-note dialog; no auth, data, or business-logic changes.
> 
> **Overview**
> Polishes **desktop sidebar** chrome and **note search** positioning so controls align with the timeline and the main pane.
> 
> The **timeline** top area now ties the **Open calendar** chip and top fade to whether **New note** / **Search** are visible or auto-hidden on scroll: chip sits at `top-36`, reserved spacer grows when needed, and the top fade shrinks to a shorter gradient while actions are hidden. **New note** and **Search** are full-width **pill** controls (rounded, less horizontal padding on the action bar).
> 
> The **mod+k** note picker applies `useMainContentCenterOffset` so the palette’s horizontal center matches the **main content** panel when the left sidebar is open, not the full window.
> 
> Tests cover calendar chip placement and top-fade height when sidebar actions hide during scroll.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d72333da7ce7d530bb8c3568c86c9ae51dad6d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->