### PR TITLE
fix(desktop): append meeting tags to summaries

### DIFF
--- a/apps/desktop/plugins/changelog.ts
+++ b/apps/desktop/plugins/changelog.ts
@@ -48,6 +48,10 @@ export function changelog(): Plugin {
       if (id === RESOLVED_ID) return buildModule();
     },
     configureServer(server: ViteDevServer) {
+      if (process.env.NODE_ENV === "test" || process.env.VITEST) {
+        return;
+      }
+
       try {
         watch(changelogDir, { recursive: true }, () => {
           const mod = server.moduleGraph.getModuleById(RESOLVED_ID);

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
@@ -1,6 +1,8 @@
 import type { LanguageModel } from "ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { json2md } from "@hypr/editor/markdown";
+
 import type { TaskConfig } from ".";
 import { enhanceSuccess } from "./enhance-success";
 
@@ -10,12 +12,32 @@ type EnhanceSuccessParams = Parameters<
   NonNullable<TaskConfig<"enhance">["onSuccess"]>
 >[0];
 
+function createTransformedArgs(): EnhanceSuccessParams["transformedArgs"] {
+  return {
+    language: "en",
+    session: {
+      title: "Weekly Review",
+      startedAt: null,
+      endedAt: null,
+      event: null,
+    },
+    participants: [],
+    template: null,
+    preMeetingMemo: "",
+    postMeetingMemo: "",
+    transcripts: [],
+    imageContext: [],
+  };
+}
+
 function createParams(
   overrides: Partial<EnhanceSuccessParams> = {},
 ): EnhanceSuccessParams {
   const store = {
     setPartialRow: vi.fn(),
     getCell: vi.fn().mockReturnValue(""),
+    getValue: vi.fn().mockReturnValue("user-1"),
+    setRow: vi.fn(),
   } as unknown as EnhanceSuccessParams["store"];
 
   return {
@@ -27,7 +49,7 @@ function createParams(
       enhancedNoteId: "note-1",
       templateId: undefined,
     },
-    transformedArgs: {} as EnhanceSuccessParams["transformedArgs"],
+    transformedArgs: createTransformedArgs(),
     store,
     settingsStore: {} as EnhanceSuccessParams["settingsStore"],
     startTask: vi.fn().mockResolvedValue(undefined),
@@ -59,10 +81,63 @@ describe("enhanceSuccess.onSuccess", () => {
     expect(() => JSON.parse(persisted)).not.toThrow();
   });
 
+  it("appends extracted meeting tags and stores session tag mappings", async () => {
+    const store = {
+      setPartialRow: vi.fn(),
+      getCell: vi.fn().mockReturnValue("Existing title"),
+      getValue: vi.fn().mockReturnValue("user-1"),
+      setRow: vi.fn(),
+    } as unknown as EnhanceSuccessParams["store"];
+    const params = createParams({
+      store,
+      text: "# Summary\n\nDiscussed launch plan #Launch.",
+      transformedArgs: {
+        ...createTransformedArgs(),
+        preMeetingMemo: "Prep notes #prep #Launch",
+        postMeetingMemo: "Follow up with #next_steps",
+        template: {
+          title: "Launch #template",
+          description: null,
+          sections: [
+            {
+              title: "Actions",
+              description: "Track #owners",
+            },
+          ],
+        },
+      },
+    });
+
+    await enhanceSuccess.onSuccess?.(params);
+
+    const persisted = (store.setPartialRow as ReturnType<typeof vi.fn>).mock
+      .calls[0][2].content;
+    const markdown = json2md(JSON.parse(persisted)).trim();
+
+    expect(markdown).toBe(
+      "# Summary\n\nDiscussed launch plan #Launch.\n\n#launch #prep #next_steps #template #owners",
+    );
+    expect(store.setRow).toHaveBeenCalledWith("tags", "launch", {
+      user_id: "user-1",
+      name: "launch",
+    });
+    expect(store.setRow).toHaveBeenCalledWith(
+      "mapping_tag_session",
+      "session-1:next_steps",
+      {
+        user_id: "user-1",
+        tag_id: "next_steps",
+        session_id: "session-1",
+      },
+    );
+  });
+
   it("starts title generation when session title is empty", async () => {
     const store = {
       setPartialRow: vi.fn(),
       getCell: vi.fn().mockReturnValue(""),
+      getValue: vi.fn().mockReturnValue("user-1"),
+      setRow: vi.fn(),
     } as unknown as EnhanceSuccessParams["store"];
     const startTask = vi.fn().mockResolvedValue(undefined);
     const params = createParams({ store, startTask });
@@ -80,6 +155,8 @@ describe("enhanceSuccess.onSuccess", () => {
     const store = {
       setPartialRow: vi.fn(),
       getCell: vi.fn().mockReturnValue("Existing title"),
+      getValue: vi.fn().mockReturnValue("user-1"),
+      setRow: vi.fn(),
     } as unknown as EnhanceSuccessParams["store"];
     const startTask = vi.fn().mockResolvedValue(undefined);
     const params = createParams({ store, startTask });

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
@@ -1,12 +1,18 @@
 import { md2json } from "@hypr/editor/markdown";
 
 import { createTaskId, type TaskConfig } from ".";
+import {
+  appendTagLineToMarkdown,
+  extractEnhanceTagNames,
+  upsertSessionTags,
+} from "./summary-tags";
 
 import { hasLiveSessionTitleDraft } from "~/store/zustand/live-title";
 
 const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = ({
   text,
   args,
+  transformedArgs,
   model,
   store,
   startTask,
@@ -16,11 +22,15 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = ({
     return;
   }
 
+  const tagNames = extractEnhanceTagNames(text, transformedArgs);
+  const textWithTags = appendTagLineToMarkdown(text, tagNames);
+
   try {
-    const jsonContent = md2json(text);
+    const jsonContent = md2json(textWithTags);
     store.setPartialRow("enhanced_notes", args.enhancedNoteId, {
       content: JSON.stringify(jsonContent),
     });
+    upsertSessionTags(store, args.sessionId, tagNames);
   } catch (error) {
     console.error("Failed to convert markdown to JSON:", error);
     return;

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/summary-tags.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/summary-tags.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  appendTagLineToMarkdown,
+  extractEnhanceTagNames,
+  upsertSessionTags,
+} from "./summary-tags";
+
+function createEnhanceArgs(
+  overrides: Partial<Parameters<typeof extractEnhanceTagNames>[1]> = {},
+): Parameters<typeof extractEnhanceTagNames>[1] {
+  return {
+    language: "en",
+    session: {
+      title: "Weekly Review",
+      startedAt: null,
+      endedAt: null,
+      event: null,
+    },
+    participants: [],
+    template: null,
+    preMeetingMemo: "",
+    postMeetingMemo: "",
+    transcripts: [],
+    imageContext: [],
+    ...overrides,
+  };
+}
+
+describe("summary tags", () => {
+  it("extracts unique hashtags from summary, memos, and template content", () => {
+    const tags = extractEnhanceTagNames(
+      "# Summary\n\nDiscussed #Launch and issue #123.",
+      createEnhanceArgs({
+        preMeetingMemo: "Prep #prep #launch",
+        postMeetingMemo: "Next #follow-up",
+        template: {
+          title: "Template #customer",
+          description: null,
+          sections: [
+            {
+              title: "Actions",
+              description: "Use #owners",
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(tags).toEqual(["launch", "prep", "follow-up", "customer", "owners"]);
+  });
+
+  it("appends tags at the bottom without duplicating existing trailing tags", () => {
+    expect(
+      appendTagLineToMarkdown("Body\n\n#old #tags", ["old", "tags", "new"]),
+    ).toBe("Body\n\n#old #tags #new");
+  });
+
+  it("upserts tag rows and session mappings", () => {
+    const store = {
+      getValue: vi.fn().mockReturnValue("user-1"),
+      setRow: vi.fn(),
+    } as any;
+
+    upsertSessionTags(store, "session-1", ["#Launch", "launch", "prep"]);
+
+    expect(store.setRow).toHaveBeenCalledWith("tags", "launch", {
+      user_id: "user-1",
+      name: "launch",
+    });
+    expect(store.setRow).toHaveBeenCalledWith(
+      "mapping_tag_session",
+      "session-1:prep",
+      {
+        user_id: "user-1",
+        tag_id: "prep",
+        session_id: "session-1",
+      },
+    );
+  });
+});

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/summary-tags.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/summary-tags.ts
@@ -1,0 +1,134 @@
+import type { TaskArgsMapTransformed } from ".";
+
+import { DEFAULT_USER_ID } from "~/shared/utils";
+import type { Store } from "~/store/tinybase/store/main";
+
+type EnhanceArgs = TaskArgsMapTransformed["enhance"];
+
+const TAG_NAME_RE = /^[\p{L}_][\p{L}\p{N}_-]*$/u;
+const HASHTAG_RE = /(^|[^\p{L}\p{N}_/#])#([\p{L}_][\p{L}\p{N}_-]*)/gu;
+
+export function extractEnhanceTagNames(
+  summaryMarkdown: string,
+  transformedArgs: EnhanceArgs,
+): string[] {
+  const sources = [
+    summaryMarkdown,
+    transformedArgs.preMeetingMemo,
+    transformedArgs.postMeetingMemo,
+    transformedArgs.template?.title,
+    transformedArgs.template?.description,
+    ...(transformedArgs.template?.sections ?? []).flatMap((section) => [
+      section.title,
+      section.description,
+    ]),
+  ];
+
+  return extractHashtagNames(sources);
+}
+
+export function appendTagLineToMarkdown(
+  markdown: string,
+  tagNames: string[],
+): string {
+  const normalizedTagNames = normalizeTagNames(tagNames);
+  if (normalizedTagNames.length === 0) {
+    return markdown;
+  }
+
+  const body = stripTrailingTagLines(markdown).trimEnd();
+  const tagLine = normalizedTagNames.map((tagName) => `#${tagName}`).join(" ");
+
+  return body ? `${body}\n\n${tagLine}` : tagLine;
+}
+
+export function upsertSessionTags(
+  store: Store,
+  sessionId: string,
+  tagNames: string[],
+): void {
+  const normalizedTagNames = normalizeTagNames(tagNames);
+  if (normalizedTagNames.length === 0) {
+    return;
+  }
+
+  const userIdValue = store.getValue("user_id");
+  const userId =
+    typeof userIdValue === "string" && userIdValue.trim()
+      ? userIdValue
+      : DEFAULT_USER_ID;
+
+  for (const tagName of normalizedTagNames) {
+    store.setRow("tags", tagName, {
+      user_id: userId,
+      name: tagName,
+    });
+    store.setRow("mapping_tag_session", `${sessionId}:${tagName}`, {
+      user_id: userId,
+      tag_id: tagName,
+      session_id: sessionId,
+    });
+  }
+}
+
+function extractHashtagNames(sources: Array<string | null | undefined>) {
+  const tagNames: string[] = [];
+
+  for (const source of sources) {
+    if (!source) {
+      continue;
+    }
+
+    for (const match of source.matchAll(HASHTAG_RE)) {
+      const tagName = match[2];
+      if (tagName) {
+        tagNames.push(tagName);
+      }
+    }
+  }
+
+  return normalizeTagNames(tagNames);
+}
+
+function normalizeTagNames(tagNames: string[]) {
+  const result = new Map<string, string>();
+
+  for (const rawTagName of tagNames) {
+    const tagName = rawTagName.replace(/^#/, "").trim().toLowerCase();
+    if (!TAG_NAME_RE.test(tagName)) {
+      continue;
+    }
+
+    result.set(tagName, tagName);
+  }
+
+  return [...result.values()];
+}
+
+function stripTrailingTagLines(markdown: string) {
+  const lines = markdown.split(/\r?\n/);
+  let end = lines.length;
+
+  while (end > 0 && lines[end - 1]?.trim() === "") {
+    end -= 1;
+  }
+
+  while (end > 0 && isTagOnlyLine(lines[end - 1] ?? "")) {
+    end -= 1;
+    while (end > 0 && lines[end - 1]?.trim() === "") {
+      end -= 1;
+    }
+  }
+
+  return lines.slice(0, end).join("\n");
+}
+
+function isTagOnlyLine(line: string) {
+  const tokens = line.trim().split(/\s+/);
+  return (
+    tokens.length > 0 &&
+    tokens.every(
+      (token) => token.startsWith("#") && TAG_NAME_RE.test(token.slice(1)),
+    )
+  );
+}


### PR DESCRIPTION
Extract hashtags from generated summaries, memos, and templates, append them to the saved summary, and persist session tag mappings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what gets persisted on enhanced notes and upserts tag/session mapping rows; behavior is scoped to the enhance success path and covered by tests.
> 
> **Overview**
> After **enhance** completes, meeting **hashtags** are collected from the generated summary plus pre/post memos and template text, **deduped and normalized**, then **appended** as a trailing tag line on the saved enhanced note (replacing any existing tag-only footer without duplicating tags).
> 
> The same tag set is **written to the local store** via `tags` rows and `mapping_tag_session` links for the session. Logic lives in new `summary-tags` helpers wired from `enhance-success.onSuccess`, with unit tests for extraction, append behavior, and persistence.
> 
> The changelog Vite plugin **skips filesystem watching** when `NODE_ENV=test` or `VITEST` is set so tests do not trigger dev reloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1c356d6304779f310980fd4459971ceb3de487b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->