### PR TITLE
fix(desktop): fetch visible calendar range

### DIFF
--- a/apps/desktop/src/calendar/components/calendar-view.tsx
+++ b/apps/desktop/src/calendar/components/calendar-view.tsx
@@ -1,3 +1,4 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   addDays,
   addMonths,
@@ -30,7 +31,13 @@ import { cn } from "@hypr/utils";
 import { useSync } from "./context";
 import { DayCell } from "./day-cell";
 
-import { useCalendarData, useNow, useWeekStartsOn } from "~/calendar/hooks";
+import {
+  useCalendarData,
+  useEnabledCalendars,
+  useNow,
+  useWeekStartsOn,
+} from "~/calendar/hooks";
+import type { CalendarSyncRange } from "~/services/calendar";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
 const WEEKDAY_HEADERS_SUN = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -45,6 +52,8 @@ const VIEW_BREAKPOINTS = [
 
 const COMPACT_SCROLL_PAST_DAYS = 42;
 const COMPACT_SCROLL_FUTURE_DAYS = 42;
+const VISIBLE_RANGE_SYNC_QUERY_KEY = "calendar-visible-range-sync";
+const VISIBLE_RANGE_SYNC_STALE_MS = 60 * 1000;
 
 function useVisibleCols(ref: React.RefObject<HTMLDivElement | null>) {
   const [cols, setCols] = useState(7);
@@ -82,6 +91,7 @@ export function CalendarView() {
   const compactBaseRef = useRef(startOfDay(now));
   const cols = useVisibleCols(containerRef);
   const calendarData = useCalendarData();
+  const enabledCalendars = useEnabledCalendars();
 
   useMountEffect(() => {
     scheduleSync();
@@ -136,6 +146,28 @@ export function CalendarView() {
       end: addDays(visibleStart, COMPACT_SCROLL_FUTURE_DAYS - 1),
     });
   }, [currentMonth, isMonthView, visibleStart, weekOpts]);
+
+  const visibleRange = useMemo<CalendarSyncRange | null>(() => {
+    const firstDay = days[0];
+    const lastDay = days[days.length - 1];
+    if (!firstDay || !lastDay) return null;
+
+    return {
+      from: startOfDay(firstDay),
+      to: startOfDay(addDays(lastDay, 1)),
+    };
+  }, [days]);
+
+  const enabledCalendarKey = useMemo(
+    () =>
+      enabledCalendars
+        .map((calendar) => calendar.id)
+        .sort()
+        .join(","),
+    [enabledCalendars],
+  );
+
+  useVisibleRangeSync(visibleRange, enabledCalendarKey);
 
   const visibleHeaders =
     weekStartsOn === 1 ? WEEKDAY_HEADERS_MON : WEEKDAY_HEADERS_SUN;
@@ -325,7 +357,30 @@ export function CalendarView() {
   );
 }
 
+function useVisibleRangeSync(
+  range: CalendarSyncRange | null,
+  enabledCalendarKey: string,
+) {
+  const { canSync, syncRange } = useSync();
+  const from = range?.from.toISOString();
+  const to = range?.to.toISOString();
+
+  useQuery({
+    queryKey: [VISIBLE_RANGE_SYNC_QUERY_KEY, from, to, enabledCalendarKey],
+    queryFn: async ({ signal }) => {
+      if (!range) return null;
+      await syncRange(range, signal);
+      return null;
+    },
+    enabled: Boolean(range && canSync),
+    staleTime: VISIBLE_RANGE_SYNC_STALE_MS,
+    gcTime: 10 * VISIBLE_RANGE_SYNC_STALE_MS,
+    retry: false,
+  });
+}
+
 function CalendarSyncHeaderControls() {
+  const queryClient = useQueryClient();
   const { status, cancelDebouncedSync, scheduleSync } = useSync();
   const refreshFeedbackTimeoutRef = useRef<ReturnType<
     typeof setTimeout
@@ -350,9 +405,12 @@ function CalendarSyncHeaderControls() {
       refreshFeedbackTimeoutRef.current = null;
       setShowManualRefreshFeedback(false);
     }, 1500);
+    void queryClient.invalidateQueries({
+      queryKey: [VISIBLE_RANGE_SYNC_QUERY_KEY],
+    });
     cancelDebouncedSync();
     scheduleSync();
-  }, [cancelDebouncedSync, scheduleSync]);
+  }, [cancelDebouncedSync, queryClient, scheduleSync]);
 
   const showSyncIndicator = showManualRefreshFeedback || status !== "idle";
   const statusText =

--- a/apps/desktop/src/calendar/components/context.tsx
+++ b/apps/desktop/src/calendar/components/context.tsx
@@ -6,12 +6,18 @@ import {
   useRef,
   useState,
 } from "react";
+import type { Queries } from "tinybase/with-schemas";
 import {
   useScheduleTaskRunCallback,
   useTaskRunRunning,
 } from "tinytick/ui-react";
 
-import { CALENDAR_SYNC_TASK_ID } from "~/services/calendar";
+import {
+  type CalendarSyncRange,
+  CALENDAR_SYNC_TASK_ID,
+  syncCalendarEventsForRange,
+} from "~/services/calendar";
+import * as main from "~/store/tinybase/store/main";
 
 export const TOGGLE_SYNC_DEBOUNCE_MS = 5000;
 
@@ -19,14 +25,18 @@ export type SyncStatus = "idle" | "scheduled" | "syncing";
 
 interface SyncContextValue {
   status: SyncStatus;
+  canSync: boolean;
   scheduleSync: () => void;
   scheduleDebouncedSync: () => void;
   cancelDebouncedSync: () => void;
+  syncRange: (range: CalendarSyncRange, signal?: AbortSignal) => Promise<void>;
 }
 
 const SyncContext = createContext<SyncContextValue | null>(null);
 
 export function SyncProvider({ children }: { children: React.ReactNode }) {
+  const store = main.UI.useStore(main.STORE_ID);
+  const queries = main.UI.useQueries(main.STORE_ID);
   const scheduleEventSync = useScheduleTaskRunCallback(
     CALENDAR_SYNC_TASK_ID,
     undefined,
@@ -37,15 +47,19 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
   );
   const [pendingTaskRunId, setPendingTaskRunId] = useState<string | null>(null);
   const [isDebouncing, setIsDebouncing] = useState(false);
+  const [rangeSyncCount, setRangeSyncCount] = useState(0);
 
   const isTaskRunning = useTaskRunRunning(pendingTaskRunId ?? "");
   const isSyncing = pendingTaskRunId !== null && isTaskRunning === true;
+  const isRangeSyncing = rangeSyncCount > 0;
+  const canSync = Boolean(store && queries);
 
-  const status: SyncStatus = isSyncing
-    ? "syncing"
-    : isDebouncing
-      ? "scheduled"
-      : "idle";
+  const status: SyncStatus =
+    isSyncing || isRangeSyncing
+      ? "syncing"
+      : isDebouncing
+        ? "scheduled"
+        : "idle";
 
   useEffect(() => {
     if (pendingTaskRunId && isTaskRunning === false) {
@@ -89,13 +103,36 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
+  const syncRange = useCallback(
+    async (range: CalendarSyncRange, signal?: AbortSignal) => {
+      if (!store || !queries) {
+        return;
+      }
+
+      setRangeSyncCount((count) => count + 1);
+      try {
+        await syncCalendarEventsForRange(
+          store as main.Store,
+          queries as Queries<main.Schemas>,
+          range,
+          { signal },
+        );
+      } finally {
+        setRangeSyncCount((count) => Math.max(0, count - 1));
+      }
+    },
+    [store, queries],
+  );
+
   return (
     <SyncContext.Provider
       value={{
         status,
+        canSync,
         scheduleSync,
         scheduleDebouncedSync,
         cancelDebouncedSync,
+        syncRange,
       }}
     >
       {children}

--- a/apps/desktop/src/services/calendar/ctx.test.ts
+++ b/apps/desktop/src/services/calendar/ctx.test.ts
@@ -46,7 +46,7 @@ describe("syncCalendars", () => {
     vi.useRealTimers();
   });
 
-  test("limits event sync range to six days ago through tomorrow", () => {
+  test("limits default event sync range to six days ago through tomorrow", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 4, 29, 13, 30));
 
@@ -75,6 +75,38 @@ describe("syncCalendars", () => {
 
     expect(ctx?.from).toEqual(new Date(2026, 4, 23, 0, 0, 0, 0));
     expect(ctx?.to).toEqual(new Date(2026, 4, 31, 0, 0, 0, 0));
+  });
+
+  test("uses an explicit event sync range when provided", () => {
+    const store = createStore();
+    store.setRow("calendars", "cal-1", {
+      user_id: "user-1",
+      created_at: "2026-05-01T00:00:00.000Z",
+      tracking_id_calendar: "primary",
+      name: "Work",
+      enabled: true,
+      provider: "google",
+      source: "work@example.com",
+      color: "#4285f4",
+      connection_id: "conn-work",
+    });
+    const queries = createQueries(store).setQueryDefinition(
+      QUERIES.enabledCalendars,
+      "calendars",
+      ({ select, where }) => {
+        select("provider");
+        where("enabled", true);
+      },
+    );
+
+    const range = {
+      from: new Date("2026-06-01T00:00:00.000Z"),
+      to: new Date("2026-07-01T00:00:00.000Z"),
+    };
+    const ctx = createCtx(store, queries, "google", "conn-work", range);
+
+    expect(ctx?.from).toBe(range.from);
+    expect(ctx?.to).toBe(range.to);
   });
 
   test("keeps Google calendars isolated per connection when ids overlap", async () => {

--- a/apps/desktop/src/services/calendar/ctx.ts
+++ b/apps/desktop/src/services/calendar/ctx.ts
@@ -26,6 +26,11 @@ export interface Ctx {
   calendarTrackingIdToId: Map<string, string>;
 }
 
+export type CalendarSyncRange = {
+  from: Date;
+  to: Date;
+};
+
 // ---
 
 export function createCtx(
@@ -33,6 +38,7 @@ export function createCtx(
   queries: Queries<Schemas>,
   provider: CalendarProviderType,
   connectionId: string,
+  range: CalendarSyncRange = getDefaultRange(),
 ): Ctx | null {
   const resultTable = queries.getResultTable(QUERIES.enabledCalendars);
 
@@ -67,15 +73,13 @@ export function createCtx(
     return null;
   }
 
-  const { from, to } = getRange();
-
   return {
     store,
     provider,
     connectionId,
     userId: String(userId),
-    from,
-    to,
+    from: range.from,
+    to: range.to,
     calendarIds,
     calendarTrackingIdToId,
   };
@@ -194,7 +198,7 @@ export async function syncCalendars(
 
 // ---
 
-const getRange = () => {
+export const getDefaultRange = (): CalendarSyncRange => {
   const now = new Date();
   const from = new Date(now);
   from.setHours(0, 0, 0, 0);

--- a/apps/desktop/src/services/calendar/index.test.ts
+++ b/apps/desktop/src/services/calendar/index.test.ts
@@ -1,0 +1,150 @@
+import { createMergeableStore, createQueries } from "tinybase/with-schemas";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { SCHEMA } from "@hypr/store";
+
+const pluginCalendar = vi.hoisted(() => ({
+  listCalendars: vi.fn(),
+  listConnectionIds: vi.fn(),
+}));
+
+const fetchMocks = vi.hoisted(() => ({
+  fetchExistingEvents: vi.fn(),
+  fetchIncomingEvents: vi.fn(),
+}));
+
+const processMocks = vi.hoisted(() => ({
+  executeForEventsSync: vi.fn(),
+  executeForParticipantsSync: vi.fn(),
+  syncEvents: vi.fn(),
+  syncSessionEmbeddedEvents: vi.fn(),
+  syncSessionParticipants: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-calendar", () => ({
+  commands: {
+    listCalendars: pluginCalendar.listCalendars,
+    listConnectionIds: pluginCalendar.listConnectionIds,
+  },
+}));
+
+vi.mock("./fetch", () => ({
+  CalendarFetchError: class CalendarFetchError extends Error {},
+  fetchExistingEvents: fetchMocks.fetchExistingEvents,
+  fetchIncomingEvents: fetchMocks.fetchIncomingEvents,
+}));
+
+vi.mock("./process", () => ({
+  executeForEventsSync: processMocks.executeForEventsSync,
+  executeForParticipantsSync: processMocks.executeForParticipantsSync,
+  syncEvents: processMocks.syncEvents,
+  syncSessionEmbeddedEvents: processMocks.syncSessionEmbeddedEvents,
+  syncSessionParticipants: processMocks.syncSessionParticipants,
+}));
+
+import { syncCalendarEventsForRange } from ".";
+
+import { QUERIES } from "~/store/tinybase/store/main";
+
+function createStoreAndQueries() {
+  const store = createMergeableStore()
+    .setTablesSchema(SCHEMA.table)
+    .setValuesSchema(SCHEMA.value);
+
+  store.setValue("user_id", "user-1");
+  store.setRow("calendars", "cal-1", {
+    user_id: "user-1",
+    created_at: "2026-05-01T00:00:00.000Z",
+    tracking_id_calendar: "primary",
+    name: "Work",
+    enabled: true,
+    provider: "google",
+    source: "work@example.com",
+    color: "#4285f4",
+    connection_id: "conn-1",
+  });
+
+  const queries = createQueries(store).setQueryDefinition(
+    QUERIES.enabledCalendars,
+    "calendars",
+    ({ select, where }) => {
+      select("provider");
+      where("enabled", true);
+    },
+  );
+
+  return { store, queries };
+}
+
+describe("syncCalendarEventsForRange", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    pluginCalendar.listConnectionIds.mockResolvedValue({
+      status: "success",
+      data: [{ provider: "google", connection_ids: ["conn-1"] }],
+    });
+    pluginCalendar.listCalendars.mockResolvedValue({
+      status: "success",
+      data: [
+        {
+          id: "primary",
+          title: "Work",
+          source: "work@example.com",
+          color: "#4285f4",
+        },
+      ],
+    });
+    fetchMocks.fetchExistingEvents.mockReturnValue([]);
+    fetchMocks.fetchIncomingEvents.mockResolvedValue({
+      events: [],
+      participants: [],
+    });
+    processMocks.syncEvents.mockReturnValue({});
+    processMocks.syncSessionParticipants.mockReturnValue({});
+  });
+
+  test("does not start a range sync when already aborted", async () => {
+    const { store, queries } = createStoreAndQueries();
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await syncCalendarEventsForRange(
+      store,
+      queries,
+      {
+        from: new Date("2026-06-01T00:00:00.000Z"),
+        to: new Date("2026-06-08T00:00:00.000Z"),
+      },
+      { signal: abortController.signal },
+    );
+
+    expect(pluginCalendar.listConnectionIds).not.toHaveBeenCalled();
+    expect(fetchMocks.fetchIncomingEvents).not.toHaveBeenCalled();
+  });
+
+  test("does not write fetched events after aborting a range sync", async () => {
+    const { store, queries } = createStoreAndQueries();
+    const abortController = new AbortController();
+    fetchMocks.fetchIncomingEvents.mockImplementation(async () => {
+      abortController.abort();
+      return { events: [], participants: [] };
+    });
+
+    await syncCalendarEventsForRange(
+      store,
+      queries,
+      {
+        from: new Date("2026-06-01T00:00:00.000Z"),
+        to: new Date("2026-06-08T00:00:00.000Z"),
+      },
+      { signal: abortController.signal },
+    );
+
+    expect(fetchMocks.fetchIncomingEvents).toHaveBeenCalledTimes(1);
+    expect(fetchMocks.fetchExistingEvents).not.toHaveBeenCalled();
+    expect(processMocks.executeForEventsSync).not.toHaveBeenCalled();
+    expect(processMocks.syncSessionEmbeddedEvents).not.toHaveBeenCalled();
+    expect(processMocks.executeForParticipantsSync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/services/calendar/index.ts
+++ b/apps/desktop/src/services/calendar/index.ts
@@ -2,7 +2,12 @@ import type { Queries } from "tinybase/with-schemas";
 
 import type { CalendarProviderType } from "@hypr/plugin-calendar";
 
-import { createCtx, getProviderConnections, syncCalendars } from "./ctx";
+import {
+  type CalendarSyncRange,
+  createCtx,
+  getProviderConnections,
+  syncCalendars,
+} from "./ctx";
 import {
   CalendarFetchError,
   fetchExistingEvents,
@@ -19,6 +24,10 @@ import {
 import type { Schemas, Store } from "~/store/tinybase/store/main";
 
 export const CALENDAR_SYNC_TASK_ID = "calendarSync";
+export type { CalendarSyncRange };
+type CalendarSyncOptions = {
+  signal?: AbortSignal;
+};
 
 export async function syncCalendarEvents(
   store: Store,
@@ -30,13 +39,42 @@ export async function syncCalendarEvents(
   ]);
 }
 
-async function run(store: Store, queries: Queries<Schemas>) {
+export async function syncCalendarEventsForRange(
+  store: Store,
+  queries: Queries<Schemas>,
+  range: CalendarSyncRange,
+  options: CalendarSyncOptions = {},
+): Promise<void> {
+  await run(store, queries, range, options);
+}
+
+async function run(
+  store: Store,
+  queries: Queries<Schemas>,
+  range?: CalendarSyncRange,
+  options: CalendarSyncOptions = {},
+) {
+  if (isAborted(options.signal)) return;
+
   const providerConnections = await getProviderConnections();
+  if (isAborted(options.signal)) return;
+
   await syncCalendars(store, providerConnections);
+  if (isAborted(options.signal)) return;
+
   for (const { provider, connection_ids } of providerConnections) {
     for (const connectionId of connection_ids) {
+      if (isAborted(options.signal)) return;
+
       try {
-        await runForConnection(store, queries, provider, connectionId);
+        await runForConnection(
+          store,
+          queries,
+          provider,
+          connectionId,
+          range,
+          options,
+        );
       } catch (error) {
         console.error(
           `[calendar-sync] Error syncing ${provider} (${connectionId}): ${error}`,
@@ -51,9 +89,11 @@ async function runForConnection(
   queries: Queries<Schemas>,
   provider: CalendarProviderType,
   connectionId: string,
+  range?: CalendarSyncRange,
+  options: CalendarSyncOptions = {},
 ) {
-  const ctx = createCtx(store, queries, provider, connectionId);
-  if (!ctx) {
+  const ctx = createCtx(store, queries, provider, connectionId, range);
+  if (!ctx || isAborted(options.signal)) {
     return;
   }
 
@@ -74,18 +114,32 @@ async function runForConnection(
     throw error;
   }
 
+  if (isAborted(options.signal)) return;
+
   const existing = fetchExistingEvents(ctx);
+  if (isAborted(options.signal)) return;
 
   const eventsOut = syncEvents(ctx, {
     incoming,
     existing,
     incomingParticipants,
   });
+  if (isAborted(options.signal)) return;
+
   executeForEventsSync(ctx, eventsOut);
+  if (isAborted(options.signal)) return;
+
   syncSessionEmbeddedEvents(ctx, incoming);
+  if (isAborted(options.signal)) return;
 
   const participantsOut = syncSessionParticipants(ctx, {
     incomingParticipants,
   });
+  if (isAborted(options.signal)) return;
+
   executeForParticipantsSync(ctx, participantsOut);
+}
+
+function isAborted(signal: AbortSignal | undefined) {
+  return signal?.aborted === true;
 }


### PR DESCRIPTION
Keep the default calendar sync window narrow while syncing the currently visible calendar range and refreshing it on manual refresh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how calendar events are fetched and written to the local store, with abort handling to limit stale writes; scope is calendar sync only, not auth or payments.
> 
> **Overview**
> The desktop calendar now **syncs events for the dates actually on screen** (month grid or compact scroll window), not only the narrow default window, while **background/task sync still uses the default ~6 days back / 2 days forward** range.
> 
> **UI:** `CalendarView` derives a `CalendarSyncRange` from rendered days and runs a React Query job (`useVisibleRangeSync`) keyed by range and enabled calendar IDs, calling `syncRange` with the query abort signal. Manual refresh **invalidates** that query and still schedules the existing debounced full sync.
> 
> **Sync layer:** `SyncProvider` exposes `canSync`, `syncRange`, and treats in-flight range syncs as **syncing** status. **`syncCalendarEventsForRange`** passes an explicit range through `createCtx` and **bails out** at each step when `AbortSignal` is aborted so stale navigations do not write events. Tests cover explicit ranges and abort behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea2749e6c481cdda2e60973736b5cada0e5d5516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->