### PR TITLE
fix(editor): restore autolink parsing

### DIFF
--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -46,6 +46,7 @@ import {
 } from "../node-views";
 import {
   appLinkPastePlugin,
+  autolinkPlugin,
   type FileHandlerConfig,
   type PlaceholderFunction,
   SearchQuery,
@@ -540,6 +541,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         clearMarksOnEnterPlugin(),
         clipPastePlugin(),
         appLinkPastePlugin(),
+        autolinkPlugin(),
         linkBoundaryGuardPlugin(),
         ...(mentionConfig ? [mentionSkipPlugin()] : []),
         ...(sessionMentionDropConfig

--- a/packages/editor/src/plugins/autolink.test.ts
+++ b/packages/editor/src/plugins/autolink.test.ts
@@ -1,0 +1,240 @@
+import type { Node as ProseMirrorNode } from "prosemirror-model";
+import { EditorState } from "prosemirror-state";
+import { describe, expect, it } from "vitest";
+
+import { schema } from "../note/schema";
+import { autolinkPlugin } from "./autolink";
+import { linkBoundaryGuardPlugin } from "./link-boundary-guard";
+
+describe("autolinkPlugin", () => {
+  it("links bare domains with an https href", () => {
+    const state = insertText("x.com");
+
+    expect(state.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "x.com",
+              marks: [
+                {
+                  type: "link",
+                  attrs: { href: "https://x.com", target: null },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("links paths without swallowing trailing sentence punctuation", () => {
+    const state = insertText(
+      "See linear.app/fastrepl-inc/initiative/product-45dff51a8672/overview.",
+    );
+
+    expect(state.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "See " },
+            {
+              type: "text",
+              text: "linear.app/fastrepl-inc/initiative/product-45dff51a8672/overview",
+              marks: [
+                {
+                  type: "link",
+                  attrs: {
+                    href: "https://linear.app/fastrepl-inc/initiative/product-45dff51a8672/overview",
+                    target: null,
+                  },
+                },
+              ],
+            },
+            { type: "text", text: "." },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("does not link email domains", () => {
+    const state = insertText("email support@x.com");
+
+    expect(state.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "email support@x.com" }],
+        },
+      ],
+    });
+  });
+
+  it("extends a bare-domain link when adjacent path text is typed", () => {
+    let state = insertText("x.com");
+    const insertPos = state.doc.content.size - 1;
+    state = state.applyTransaction(
+      state.tr.insertText("/getcharnotes", insertPos),
+    ).state;
+
+    expect(state.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "x.com/getcharnotes",
+              marks: [
+                {
+                  type: "link",
+                  attrs: {
+                    href: "https://x.com/getcharnotes",
+                    target: null,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("updates the link href when linked URL text changes", () => {
+    let state = insertText("x.com");
+    state = state.applyTransaction(state.tr.insertText("y.com", 1, 6)).state;
+
+    expect(state.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "y.com",
+              marks: [
+                {
+                  type: "link",
+                  attrs: {
+                    href: "https://y.com",
+                    target: null,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("keeps a custom href when unrelated text changes", () => {
+    const link = schema.marks.link.create({
+      href: "https://x.com/docs?ref=note",
+      target: null,
+    });
+    let state = createState(
+      schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("x.com", [link]),
+          schema.text(" note"),
+        ]),
+      ]),
+    );
+
+    state = state.applyTransaction(
+      state.tr.insertText("!", state.doc.content.size - 1),
+    ).state;
+
+    expect(state.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "x.com",
+              marks: [
+                {
+                  type: "link",
+                  attrs: {
+                    href: "https://x.com/docs?ref=note",
+                    target: null,
+                  },
+                },
+              ],
+            },
+            { type: "text", text: " note!" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("preserves link attrs when adjacent path text is typed", () => {
+    const link = schema.marks.link.create({
+      href: "https://x.com",
+      target: "_blank",
+    });
+    let state = createState(
+      schema.node("doc", null, [
+        schema.node("paragraph", null, [schema.text("x.com", [link])]),
+      ]),
+    );
+
+    state = state.applyTransaction(
+      state.tr.insertText("/docs", state.doc.content.size - 1),
+    ).state;
+
+    expect(state.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "x.com/docs",
+              marks: [
+                {
+                  type: "link",
+                  attrs: {
+                    href: "https://x.com/docs",
+                    target: "_blank",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+});
+
+function insertText(text: string) {
+  const doc = schema.node("doc", null, [schema.node("paragraph")]);
+  const state = createState(doc);
+
+  return state.applyTransaction(state.tr.insertText(text, 1)).state;
+}
+
+function createState(doc: ProseMirrorNode) {
+  return EditorState.create({
+    schema,
+    doc,
+    plugins: [autolinkPlugin(), linkBoundaryGuardPlugin()],
+  });
+}

--- a/packages/editor/src/plugins/autolink.ts
+++ b/packages/editor/src/plugins/autolink.ts
@@ -1,0 +1,103 @@
+import { Plugin, PluginKey, type Transaction } from "prosemirror-state";
+
+import { isValidUrl, normalizeUrlHref } from "./url";
+
+const URL_CANDIDATE_REGEX =
+  /(^|[^\p{L}\p{N}_@.-])((?:https?:\/\/|www\.)[^\s<>"'`]+|(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}(?::\d{1,5})?(?:[/?#][^\s<>"'`]*)?)/giu;
+const TRAILING_PUNCTUATION = new Set([".", ",", "!", "?", ";", ":"]);
+const CLOSING_TO_OPENING: Record<string, string> = {
+  ")": "(",
+  "]": "[",
+  "}": "{",
+};
+
+function countChar(text: string, char: string) {
+  return [...text].filter((c) => c === char).length;
+}
+
+function trimTrailingPunctuation(text: string) {
+  let end = text.length;
+
+  while (end > 0) {
+    const char = text[end - 1];
+    if (TRAILING_PUNCTUATION.has(char)) {
+      end -= 1;
+      continue;
+    }
+
+    const opener = CLOSING_TO_OPENING[char];
+    if (
+      opener &&
+      countChar(text.slice(0, end), char) >
+        countChar(text.slice(0, end), opener)
+    ) {
+      end -= 1;
+      continue;
+    }
+
+    break;
+  }
+
+  return text.slice(0, end);
+}
+
+export function findAutolinkMatches(text: string) {
+  const matches: Array<{ start: number; end: number; href: string }> = [];
+  let match: RegExpExecArray | null;
+
+  URL_CANDIDATE_REGEX.lastIndex = 0;
+
+  while ((match = URL_CANDIDATE_REGEX.exec(text)) !== null) {
+    const boundary = match[1] ?? "";
+    const candidate = trimTrailingPunctuation(match[2] ?? "");
+    if (!candidate || !isValidUrl(candidate)) {
+      continue;
+    }
+
+    const start = match.index + boundary.length;
+    matches.push({
+      start,
+      end: start + candidate.length,
+      href: normalizeUrlHref(candidate),
+    });
+  }
+
+  return matches;
+}
+
+export function autolinkPlugin() {
+  return new Plugin({
+    key: new PluginKey("autolink"),
+    appendTransaction(transactions, _oldState, newState) {
+      if (!transactions.some((tr) => tr.docChanged)) return null;
+
+      const linkType = newState.schema.marks.link;
+      if (!linkType) return null;
+
+      let tr: Transaction | null = null;
+
+      newState.doc.descendants((node, pos, parent) => {
+        if (!node.isText || !node.text || parent?.type.spec.code) {
+          return;
+        }
+
+        for (const match of findAutolinkMatches(node.text)) {
+          const from = pos + match.start;
+          const to = pos + match.end;
+          if (newState.doc.rangeHasMark(from, to, linkType)) {
+            continue;
+          }
+
+          if (!tr) tr = newState.tr;
+          tr.addMark(
+            from,
+            to,
+            linkType.create({ href: match.href, target: null }),
+          );
+        }
+      });
+
+      return tr;
+    },
+  });
+}

--- a/packages/editor/src/plugins/index.ts
+++ b/packages/editor/src/plugins/index.ts
@@ -1,4 +1,5 @@
 export { appLinkPastePlugin } from "./app-link-paste";
+export { autolinkPlugin } from "./autolink";
 export { clipboardPlugin, serializeClipboardText } from "./clipboard";
 export { clearMarksOnEnterPlugin } from "./clear-marks-on-enter";
 export {

--- a/packages/editor/src/plugins/link-boundary-guard.ts
+++ b/packages/editor/src/plugins/link-boundary-guard.ts
@@ -1,22 +1,14 @@
-import { type Mark } from "prosemirror-model";
+import type { Attrs } from "prosemirror-model";
 import { Plugin, PluginKey, type Transaction } from "prosemirror-state";
-import tldList from "tlds";
 
-const VALID_TLDS = new Set(tldList.map((t: string) => t.toLowerCase()));
+import {
+  isLinkTextForHref,
+  isValidUrl,
+  looksLikeUrlText,
+  normalizeUrlHref,
+} from "./url";
 
-function isValidUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return false;
-    }
-    const parts = parsed.hostname.split(".");
-    if (parts.length < 2) return false;
-    return VALID_TLDS.has(parts[parts.length - 1].toLowerCase());
-  } catch {
-    return false;
-  }
-}
+const STANDALONE_TRAILING_PUNCTUATION_REGEX = /^[.,!?;:)\]}]+$/;
 
 export function linkBoundaryGuardPlugin() {
   return new Plugin({
@@ -30,8 +22,10 @@ export function linkBoundaryGuardPlugin() {
       let prevLink: {
         startPos: number;
         endPos: number;
-        mark: Mark;
+        attrs: Attrs;
+        href: string;
       } | null = null;
+      const changedRanges = getChangedRanges(transactions);
 
       newState.doc.descendants((node, pos) => {
         if (!node.isText || !node.text) {
@@ -42,31 +36,51 @@ export function linkBoundaryGuardPlugin() {
         const linkMark = node.marks.find((m) => m.type === linkType);
 
         if (linkMark) {
-          const textLooksLikeUrl =
-            node.text.startsWith("https://") || node.text.startsWith("http://");
+          const textLooksLikeUrl = looksLikeUrlText(node.text);
+          const href = linkMark.attrs.href;
+          const nodeTextChanged = hasChangedRange(
+            changedRanges,
+            pos,
+            pos + node.text.length,
+          );
 
-          if (textLooksLikeUrl && !isValidUrl(node.text)) {
+          if (typeof href !== "string") {
+            prevLink = null;
+            return;
+          }
+
+          if (textLooksLikeUrl && !isValidUrl(node.text) && nodeTextChanged) {
             if (!tr) tr = newState.tr;
             tr.removeMark(pos, pos + node.text.length, linkType);
             prevLink = null;
-          } else if (node.text === linkMark.attrs.href) {
+          } else if (isLinkTextForHref(node.text, href)) {
             prevLink = {
               startPos: pos,
               endPos: pos + node.text.length,
-              mark: linkMark,
+              attrs: linkMark.attrs,
+              href,
             };
-          } else if (textLooksLikeUrl) {
-            const updatedMark = linkType.create({
-              ...linkMark.attrs,
-              href: node.text,
-            });
+          } else if (textLooksLikeUrl && nodeTextChanged) {
+            const nextHref = normalizeUrlHref(node.text);
             if (!tr) tr = newState.tr;
             tr.removeMark(pos, pos + node.text.length, linkType);
-            tr.addMark(pos, pos + node.text.length, updatedMark);
+            tr.addMark(
+              pos,
+              pos + node.text.length,
+              linkType.create({ ...linkMark.attrs, href: nextHref }),
+            );
             prevLink = {
               startPos: pos,
               endPos: pos + node.text.length,
-              mark: updatedMark,
+              attrs: { ...linkMark.attrs, href: nextHref },
+              href: nextHref,
+            };
+          } else if (textLooksLikeUrl) {
+            prevLink = {
+              startPos: pos,
+              endPos: pos + node.text.length,
+              attrs: linkMark.attrs,
+              href,
             };
           } else {
             prevLink = null;
@@ -75,15 +89,21 @@ export function linkBoundaryGuardPlugin() {
           if (!/^\s/.test(node.text[0])) {
             const wsIdx = node.text.search(/\s/);
             const extendLen = wsIdx >= 0 ? wsIdx : node.text.length;
-            const newHref =
-              prevLink.mark.attrs.href + node.text.slice(0, extendLen);
-            if (isValidUrl(newHref)) {
+            const extension = node.text.slice(0, extendLen);
+            const newHref = prevLink.href + extension;
+            if (
+              !STANDALONE_TRAILING_PUNCTUATION_REGEX.test(extension) &&
+              isValidUrl(newHref)
+            ) {
               if (!tr) tr = newState.tr;
               tr.removeMark(prevLink.startPos, prevLink.endPos, linkType);
               tr.addMark(
                 prevLink.startPos,
                 pos + extendLen,
-                linkType.create({ ...prevLink.mark.attrs, href: newHref }),
+                linkType.create({
+                  ...prevLink.attrs,
+                  href: newHref,
+                }),
               );
             }
           }
@@ -96,4 +116,27 @@ export function linkBoundaryGuardPlugin() {
       return tr;
     },
   });
+}
+
+function getChangedRanges(transactions: readonly Transaction[]) {
+  const ranges: Array<{ from: number; to: number }> = [];
+
+  for (const transaction of transactions) {
+    if (!transaction.docChanged) continue;
+    transaction.mapping.maps.forEach((stepMap) => {
+      stepMap.forEach((_oldStart, _oldEnd, newStart, newEnd) => {
+        ranges.push({ from: newStart, to: newEnd });
+      });
+    });
+  }
+
+  return ranges;
+}
+
+function hasChangedRange(
+  ranges: Array<{ from: number; to: number }>,
+  from: number,
+  to: number,
+) {
+  return ranges.some((range) => range.from < to && from < range.to);
 }

--- a/packages/editor/src/plugins/url.ts
+++ b/packages/editor/src/plugins/url.ts
@@ -1,0 +1,42 @@
+import tldList from "tlds";
+
+const VALID_TLDS = new Set(tldList.map((t: string) => t.toLowerCase()));
+const HTTP_SCHEME_REGEX = /^https?:\/\//i;
+const DOMAIN_TEXT_REGEX =
+  /^(?:www\.)?(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}(?::\d{1,5})?(?:[/?#].*)?$/i;
+
+export function normalizeUrlHref(text: string): string {
+  const trimmed = text.trim();
+  return HTTP_SCHEME_REGEX.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
+export function looksLikeUrlText(text: string): boolean {
+  const trimmed = text.trim();
+  return HTTP_SCHEME_REGEX.test(trimmed) || DOMAIN_TEXT_REGEX.test(trimmed);
+}
+
+export function isValidUrl(text: string): boolean {
+  if (!looksLikeUrlText(text)) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(normalizeUrlHref(text));
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return false;
+    }
+
+    const parts = parsed.hostname.split(".");
+    if (parts.length < 2) return false;
+    return VALID_TLDS.has(parts[parts.length - 1].toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+export function isLinkTextForHref(text: string, href: unknown): boolean {
+  return (
+    typeof href === "string" &&
+    (text === href || normalizeUrlHref(text) === href)
+  );
+}


### PR DESCRIPTION
Summary:
- Add a ProseMirror autolink plugin for bare domains and URLs.
- Share URL validation and href normalization with the link boundary guard.
- Cover bare domains, paths, email exclusions, and adjacent path extension.

Verification:
- pnpm -F @hypr/editor test -- src/plugins/autolink.test.ts
- pnpm -F @hypr/editor typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only ProseMirror plugin and link-mark logic with tests; no auth, persistence, or network surface.
> 
> **Overview**
> Restores **automatic link detection** in the note editor by adding an `autolinkPlugin` that applies link marks as users type bare domains, `www.`, and `http(s)` URLs, with trailing punctuation trimmed and email addresses excluded.
> 
> **Shared URL helpers** in `url.ts` (`normalizeUrlHref`, `isValidUrl`, `looksLikeUrlText`, `isLinkTextForHref`) replace inline validation in `linkBoundaryGuardPlugin`, which now handles bare domains, syncs `href` when URL text edits, extends links across adjacent path segments, and avoids rewriting custom `href`s unless the linked text actually changed.
> 
> The plugin is wired into `NoteEditor` immediately before `linkBoundaryGuardPlugin`; behavior is covered by `autolink.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4520a4d8c600795988049ef4cf196c22dde6f38d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->