### PR TITLE
chore(changelog): add desktop 1.0.39 release notes

### DIFF
--- a/packages/changelog/content/1.0.39.md
+++ b/packages/changelog/content/1.0.39.md
@@ -1,0 +1,30 @@
+---
+date: "2026-06-04"
+summary: "Timeline actions, recurring notes, calendar sync, contacts, and editor links are more useful and reliable."
+---
+
+## Timeline
+
+- The sidebar timeline now has quick actions for creating a note, searching, and opening the calendar
+- The Now chip and current-time marker now stay better placed as you scroll through the sidebar timeline
+- Timeline rows are cleaner, with less visual noise around event dots and loading indicators
+
+## Meetings
+
+- Recurring meetings can now surface useful context from past notes when preparing the next note
+- Live transcript speaker labels now stay visible while you scroll through an active transcript
+- Meeting summaries now keep relevant hashtags from generated summaries, memos, and templates
+- The stop button remains available when the meeting sidebar is collapsed
+
+## Notes
+
+- Bare links like `example.com` now automatically become clickable links
+- Editing linked URL text now keeps the link destination in sync without overwriting custom links
+- Dragged notes now appear as note chips in the editor and chat instead of plain text
+- The slash command menu is more compact
+
+## Calendar & Contacts
+
+- Calendar sync now keeps the visible calendar range fresh and avoids stale range updates
+- Participant matching can now use contact hints from calendar events
+- Participant chips now show clearer contact details and actions


### PR DESCRIPTION
Summary:
- Add the desktop 1.0.39 changelog entry.
- Summarize user-facing timeline, meeting, notes, calendar, and contacts updates.

Verification:
- pnpm exec dprint fmt
- pnpm -F @hypr/changelog typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no application or infrastructure code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.0.39.md`**, the desktop **1.0.39** release notes entry with front matter (`date`, `summary`) and user-facing bullets grouped under **Timeline**, **Meetings**, **Notes**, and **Calendar & Contacts** (timeline quick actions/scrolling polish, recurring meeting context, link/chip editor behavior, calendar sync and participant matching, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ab738f56006ee20bfd5360e7c4d24d8ea790472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->