### PR TITLE
fix(sidebar): compact empty-future timeline spacing

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -204,6 +204,29 @@ describe("TimelineView", () => {
     ).toContain("h-24");
   });
 
+  it("uses compact top spacing when top chrome has no hidden future items", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.smartCurrentTimeMs = Date.now();
+    mocks.timelineSessionsTable = {
+      past: {
+        title: "Demo Session Kickoff",
+        created_at: "2024-01-01T12:00:00.000Z",
+      },
+    };
+
+    const { container } = render(<TimelineView topChromeInset />);
+
+    expect(getSidebarActions().className).not.toContain("opacity-0");
+    expect(
+      container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
+    ).toContain("h-20");
+    expect(
+      container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
+    ).not.toContain("h-24");
+  });
+
   it("shows the open calendar chip without top chrome", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -129,6 +129,11 @@ export function TimelineView({
     showOpenCalendarButton &&
     isScrolledToTop &&
     hasMoreFutureItems;
+  const topSpacerClassName = topChromeInset
+    ? hasMoreFutureItems
+      ? "h-24"
+      : "h-20"
+    : "h-10";
 
   const hasToday = useMemo(
     () => buckets.some((bucket) => bucket.label === "Today"),
@@ -401,7 +406,7 @@ export function TimelineView({
           <div
             aria-hidden
             data-sidebar-timeline-top-spacer
-            className={cn([topChromeInset ? "h-24" : "h-10", "shrink-0"])}
+            className={cn([topSpacerClassName, "shrink-0"])}
           />
         )}
         {buckets.map((bucket, index) => {


### PR DESCRIPTION
Summary:
- use a smaller timeline top spacer when top chrome has no hidden future items
- keep the larger spacer for hidden future items
- add a regression test for the compact no-future layout

Verification:
- pnpm exec dprint fmt
- pnpm -F desktop test -- apps/desktop/src/sidebar/timeline/index.test.tsx
- pnpm -F desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only spacing in the desktop sidebar timeline with a focused unit test; no auth, data, or API changes.
> 
> **Overview**
> When the sidebar timeline uses **top chrome inset**, the top spacer no longer always uses the taller **`h-24`** height. It now picks **`h-20`** when there are **no hidden future items** beyond tomorrow (`hasMoreFutureItems` is false), and keeps **`h-24`** when there are items to scroll to above. Non–top-chrome layouts still use **`h-10`**.
> 
> A regression test covers the **past-only** session case with top chrome: sidebar actions stay visible and the spacer is **`h-20`**, not **`h-24`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7916407e664e5817236423ea535b8054497e8cbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->