### PR TITLE
chore(changelog): update desktop 1.0.39 notes

### DIFF
--- a/packages/changelog/content/1.0.39.md
+++ b/packages/changelog/content/1.0.39.md
@@ -1,12 +1,13 @@
 ---
 date: "2026-06-04"
-summary: "Timeline actions, recurring notes, calendar sync, contacts, and editor links are more useful and reliable."
+summary: "Timeline actions, spacing, recurring notes, calendar sync, contacts, and editor links are more useful and reliable."
 ---
 
 ## Timeline
 
 - The sidebar timeline now has quick actions for creating a note, searching, and opening the calendar
 - The Now chip and current-time marker now stay better placed as you scroll through the sidebar timeline
+- Past notes now sit closer to the top of the sidebar timeline when there are no upcoming events
 - Timeline rows are cleaner, with less visual noise around event dots and loading indicators
 
 ## Meetings


### PR DESCRIPTION
Summary:
- mention the sidebar timeline spacing fix in the desktop 1.0.39 changelog
- update the changelog index summary to include spacing polish

Verification:
- pnpm exec dprint fmt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changelog edits with no application or runtime impact.
> 
> **Overview**
> Updates the **desktop 1.0.39** changelog in `packages/changelog/content/1.0.39.md` to document sidebar timeline spacing polish.
> 
> The frontmatter **summary** now mentions spacing alongside timeline actions. A new **Timeline** bullet explains that past notes sit closer to the top of the sidebar timeline when there are no upcoming events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a204d213d61e3817f6eb5ec02898a69a52dd4b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->