### PR TITLE
fix(editor): open note links via desktop opener

### DIFF
--- a/apps/desktop/src/editor-bridge/open-editor-link.ts
+++ b/apps/desktop/src/editor-bridge/open-editor-link.ts
@@ -1,0 +1,5 @@
+import { commands as openerCommands } from "@hypr/plugin-opener2";
+
+export async function openEditorLink(href: string) {
+  await openerCommands.openUrl(href, null);
+}

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -9,6 +9,7 @@ import {
 
 import { AppLinkView } from "~/editor-bridge/app-link-view";
 import { useMentionConfig } from "~/editor-bridge/mention-config";
+import { openEditorLink } from "~/editor-bridge/open-editor-link";
 import { sessionMentionDropConfig } from "~/editor-bridge/session-mention-drop";
 import { SessionNodeView } from "~/editor-bridge/session-view";
 import { useFileUpload } from "~/shared/hooks/useFileUpload";
@@ -59,6 +60,7 @@ export const EnhancedEditor = forwardRef<
         mentionConfig={mentionConfig}
         sessionMentionDropConfig={sessionMentionDropConfig}
         onNavigateToTitle={onNavigateToTitle}
+        onLinkOpen={openEditorLink}
         fileHandlerConfig={fileHandlerConfig}
         taskSource={{ type: "enhanced_note", id: enhancedNoteId }}
         extraNodeViews={extraNodeViews}

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -11,6 +11,7 @@ import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 
 import { AppLinkView } from "~/editor-bridge/app-link-view";
 import { useMentionConfig } from "~/editor-bridge/mention-config";
+import { openEditorLink } from "~/editor-bridge/open-editor-link";
 import { sessionMentionDropConfig } from "~/editor-bridge/session-mention-drop";
 import { SessionNodeView } from "~/editor-bridge/session-view";
 import { emitRawEditorSync } from "~/session/raw-editor-sync";
@@ -112,6 +113,7 @@ export const RawEditor = forwardRef<
         sessionMentionDropConfig={sessionMentionDropConfig}
         placeholderComponent={Placeholder}
         onNavigateToTitle={onNavigateToTitle}
+        onLinkOpen={openEditorLink}
         fileHandlerConfig={fileHandlerConfig}
         taskSource={
           syncTasks ? { type: "session_raw_note", id: sessionId } : undefined

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -58,7 +58,9 @@ import {
   getSearchState,
   hashtagPlugin,
   imageTrailingParagraphPlugin,
+  type LinkOpenHandler,
   linkBoundaryGuardPlugin,
+  linkOpenPlugin,
   placeholderPlugin,
   searchPlugin,
   searchReplaceAll,
@@ -152,6 +154,7 @@ export interface NoteEditorProps {
   placeholderComponent?: PlaceholderFunction;
   fileHandlerConfig?: FileHandlerConfig;
   onNavigateToTitle?: (pixelWidth?: number) => void;
+  onLinkOpen?: LinkOpenHandler;
   linkedItemOpenBehavior?: LinkedItemOpenBehavior;
   taskSource?: TaskSource;
   extraNodeViews?: NodeViewComponents;
@@ -445,6 +448,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       placeholderComponent,
       fileHandlerConfig,
       onNavigateToTitle,
+      onLinkOpen,
       linkedItemOpenBehavior = "current",
       taskSource,
       extraNodeViews,
@@ -543,6 +547,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         appLinkPastePlugin(),
         autolinkPlugin(),
         linkBoundaryGuardPlugin(),
+        ...(onLinkOpen ? [linkOpenPlugin(onLinkOpen)] : []),
         ...(mentionConfig ? [mentionSkipPlugin()] : []),
         ...(sessionMentionDropConfig
           ? [createSessionMentionDropPlugin(sessionMentionDropConfig)]
@@ -555,6 +560,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         mentionConfig,
         sessionMentionDropConfig,
         onNavigateToTitle,
+        onLinkOpen,
       ],
     );
     const nodeViews = useMemo(

--- a/packages/editor/src/plugins/index.ts
+++ b/packages/editor/src/plugins/index.ts
@@ -18,6 +18,11 @@ export {
 } from "./image-trailing-paragraph";
 export { linkBoundaryGuardPlugin } from "./link-boundary-guard";
 export {
+  getOpenableHref,
+  type LinkOpenHandler,
+  linkOpenPlugin,
+} from "./link-open";
+export {
   type PlaceholderFunction,
   placeholderPlugin,
   placeholderPluginKey,

--- a/packages/editor/src/plugins/link-open.test.ts
+++ b/packages/editor/src/plugins/link-open.test.ts
@@ -1,0 +1,108 @@
+import { EditorState } from "prosemirror-state";
+import { EditorView } from "prosemirror-view";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { schema } from "../note/schema";
+import { getOpenableHref, linkOpenPlugin } from "./link-open";
+
+const views: EditorView[] = [];
+
+afterEach(() => {
+  for (const view of views) {
+    view.destroy();
+  }
+  views.length = 0;
+  document.body.innerHTML = "";
+});
+
+function createLinkedEditor(href: string, onOpen = vi.fn()) {
+  const mark = schema.marks.link.create({ href, target: null });
+  const doc = schema.node("doc", null, [
+    schema.node("paragraph", null, [schema.text("Open link", [mark])]),
+  ]);
+  const state = EditorState.create({
+    doc,
+    plugins: [linkOpenPlugin(onOpen)],
+  });
+  const host = document.createElement("div");
+  document.body.append(host);
+  const view = new EditorView(host, { state });
+  views.push(view);
+
+  const anchor = view.dom.querySelector("a[href]");
+  if (!anchor) {
+    throw new Error("Expected editor to render a link");
+  }
+
+  return { anchor, onOpen };
+}
+
+describe("linkOpenPlugin", () => {
+  it("opens clicked http links", () => {
+    const { anchor, onOpen } = createLinkedEditor(
+      "https://linear.app/example/path",
+    );
+    const event = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    const defaultAllowed = anchor.dispatchEvent(event);
+
+    expect(defaultAllowed).toBe(false);
+    expect(onOpen).toHaveBeenCalledWith("https://linear.app/example/path");
+  });
+
+  it("blocks unsafe link schemes", () => {
+    const { anchor, onOpen } = createLinkedEditor("javascript:alert(1)");
+    const event = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    const defaultAllowed = anchor.dispatchEvent(event);
+
+    expect(defaultAllowed).toBe(false);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("allows mention anchors to handle their own clicks", () => {
+    const { onOpen } = createLinkedEditor("https://linear.app/example/path");
+    const mention = document.createElement("a");
+    const bubbleHandler = vi.fn();
+    mention.href = "javascript:void(0)";
+    mention.dataset.mention = "true";
+    mention.textContent = "Alex";
+    views[0]!.dom.append(mention);
+    document.body.addEventListener("click", bubbleHandler);
+
+    const defaultAllowed = mention.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(defaultAllowed).toBe(true);
+    expect(bubbleHandler).toHaveBeenCalledOnce();
+    expect(onOpen).not.toHaveBeenCalled();
+    document.body.removeEventListener("click", bubbleHandler);
+  });
+});
+
+describe("getOpenableHref", () => {
+  it("allows http and https URLs", () => {
+    expect(getOpenableHref("http://localhost:3000")).toBe(
+      "http://localhost:3000/",
+    );
+    expect(getOpenableHref("https://example.com/docs")).toBe(
+      "https://example.com/docs",
+    );
+  });
+
+  it("rejects non-web URLs", () => {
+    expect(getOpenableHref("mailto:hello@example.com")).toBeNull();
+    expect(getOpenableHref("file:///tmp/note.txt")).toBeNull();
+    expect(getOpenableHref("/relative/path")).toBeNull();
+  });
+});

--- a/packages/editor/src/plugins/link-open.ts
+++ b/packages/editor/src/plugins/link-open.ts
@@ -1,0 +1,69 @@
+import { Plugin, PluginKey } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+
+export type LinkOpenHandler = (href: string) => Promise<void> | void;
+
+const OPENABLE_PROTOCOLS = new Set(["http:", "https:"]);
+
+export function getOpenableHref(href: string | null): string | null {
+  if (!href) {
+    return null;
+  }
+
+  try {
+    const url = new URL(href);
+    if (!OPENABLE_PROTOCOLS.has(url.protocol)) {
+      return null;
+    }
+
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+function getClickedAnchor(view: EditorView, event: Event) {
+  const target = event.target;
+  const element =
+    target instanceof Element
+      ? target
+      : target instanceof Node
+        ? target.parentElement
+        : null;
+  const anchor = element?.closest<HTMLAnchorElement>("a[href]");
+
+  return anchor && view.dom.contains(anchor) ? anchor : null;
+}
+
+function isMentionAnchor(anchor: HTMLAnchorElement) {
+  return anchor.dataset.mention === "true";
+}
+
+export function linkOpenPlugin(onOpen: LinkOpenHandler) {
+  return new Plugin({
+    key: new PluginKey("linkOpen"),
+    props: {
+      handleDOMEvents: {
+        click(view, event) {
+          const anchor = getClickedAnchor(view, event);
+          if (!anchor) {
+            return false;
+          }
+          if (isMentionAnchor(anchor)) {
+            return false;
+          }
+
+          event.preventDefault();
+          event.stopPropagation();
+
+          const href = getOpenableHref(anchor.getAttribute("href"));
+          if (href) {
+            void onOpen(href);
+          }
+
+          return true;
+        },
+      },
+    },
+  });
+}


### PR DESCRIPTION
Route clicked editor links through the desktop URL opener and cover unsafe-scheme handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to link click handling with http/https allowlisting; desktop wiring is limited to session note editors and covered by tests.
> 
> **Overview**
> **Note links in session editors** now open through a custom handler instead of the browser’s default navigation. `NoteEditor` accepts an optional `onLinkOpen` callback and, when provided, registers a ProseMirror `linkOpenPlugin` that intercepts anchor clicks inside the editor.
> 
> The plugin **only forwards `http`/`https` URLs** (via `getOpenableHref`), **ignores mention links** (`data-mention="true"`), and still **prevents default navigation** for unsafe schemes such as `javascript:`. On desktop, raw and enhanced note inputs pass `openEditorLink`, which calls **`@hypr/plugin-opener2`** `openUrl` so links open in the system browser.
> 
> Unit tests cover allowed URLs, blocked schemes, and mention click passthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fafcb1d94e00d6ae04710bca61b04e7ef6f022b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->