### PR TITLE
fix(past-notes): require meeting relevance

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
+++ b/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
@@ -47,6 +47,7 @@ type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
 const MAX_PAST_NOTES = 8;
 const MAX_SOURCE_LENGTH = 6000;
 const SPACE_REGEX = /\s+/g;
+const GENERIC_TITLE_KEYS = new Set(["new note", "untitled"]);
 
 const keyFactsSchema = z.object({
   facts: z.array(z.string()).min(1).max(6),
@@ -152,7 +153,8 @@ export function buildPastSessionNotes(
   );
   const currentEvent = getSessionEvent(currentSession);
   const currentSeriesId = getRecurrenceSeriesId(currentEvent);
-  if (!currentSeriesId && currentParticipantIds.size === 0) {
+  const currentTitleKey = getSessionTitleKey(currentSession);
+  if (!currentSeriesId && !currentTitleKey) {
     return { notes: [], missing: [] };
   }
 
@@ -191,8 +193,10 @@ export function buildPastSessionNotes(
       !isRelatedPastSession({
         currentParticipantIds,
         currentSeriesId,
+        currentTitleKey,
         candidateParticipantIds,
         candidateSeriesId: getRecurrenceSeriesId(candidateEvent),
+        candidateTitleKey: getSessionTitleKey(candidateSession),
       })
     ) {
       return;
@@ -455,33 +459,46 @@ function getSessionParticipantIds(
 function isRelatedPastSession({
   currentParticipantIds,
   currentSeriesId,
+  currentTitleKey,
   candidateParticipantIds,
   candidateSeriesId,
+  candidateTitleKey,
 }: {
   currentParticipantIds: Set<string>;
   currentSeriesId: string | null;
+  currentTitleKey: string;
   candidateParticipantIds: Set<string>;
   candidateSeriesId: string | null;
+  candidateTitleKey: string;
 }) {
   if (currentSeriesId && candidateSeriesId === currentSeriesId) {
     return true;
   }
 
-  if (currentParticipantIds.size === 0) {
+  if (!currentTitleKey || currentTitleKey !== candidateTitleKey) {
     return false;
   }
 
-  for (const participantId of currentParticipantIds) {
-    if (!candidateParticipantIds.has(participantId)) {
-      return false;
+  if (currentParticipantIds.size === 0 || candidateParticipantIds.size === 0) {
+    return true;
+  }
+
+  for (const participantId of candidateParticipantIds) {
+    if (currentParticipantIds.has(participantId)) {
+      return true;
     }
   }
 
-  return true;
+  return false;
 }
 
 function getSessionTitle(session: { title?: string }): string {
   return session.title?.trim() || "Untitled";
+}
+
+function getSessionTitleKey(session: { title?: string }): string {
+  const key = getSessionTitle(session).toLowerCase().replace(SPACE_REGEX, " ");
+  return GENERIC_TITLE_KEYS.has(key) ? "" : key;
 }
 
 function getSessionUserId(

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -360,7 +360,7 @@ describe("PostSessionAccessory", () => {
     expect(screen.queryByTestId("transcript")).toBeNull();
   });
 
-  it("builds descending past notes from previous sessions with the same participants", () => {
+  it("builds descending past notes from recurring and same-title sessions", () => {
     const store = makeStore({
       sessions: {
         current: {
@@ -380,6 +380,12 @@ describe("PostSessionAccessory", () => {
             recurrence_series_id: "series-1",
           }),
           raw_md: "",
+        },
+        same_title: {
+          title: "Weekly Product Sync",
+          created_at: "2026-05-27T10:00:00.000Z",
+          event_json: "",
+          raw_md: "Confirmed notification copy and reviewed follow-ups.",
         },
         older: {
           title: "Older Product Sync",
@@ -427,6 +433,18 @@ describe("PostSessionAccessory", () => {
         },
         previous_jamie: {
           session_id: "previous",
+          human_id: "jamie",
+          user_id: "self",
+          source: "auto",
+        },
+        same_title_alex: {
+          session_id: "same_title",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+        same_title_jamie: {
+          session_id: "same_title",
           human_id: "jamie",
           user_id: "self",
           source: "auto",
@@ -483,17 +501,67 @@ describe("PostSessionAccessory", () => {
         isGenerating: false,
       },
       {
-        sessionId: "older",
-        title: "Older Product Sync",
-        dateLabel: "May 21, 2026",
+        sessionId: "same_title",
+        title: "Weekly Product Sync",
+        dateLabel: "May 27, 2026",
         summary: null,
         isGenerating: false,
       },
     ]);
     expect(result.missing.map((request) => request.sessionId)).toEqual([
       "previous",
-      "older",
+      "same_title",
     ]);
+  });
+
+  it("does not treat matching participants alone as related past notes", () => {
+    const store = makeStore({
+      sessions: {
+        current: {
+          title: "Design sync",
+          created_at: "2026-06-03T10:00:00.000Z",
+          event_json: "",
+          raw_md: "",
+        },
+        different_topic: {
+          title: "Dev sync",
+          created_at: "2026-06-01T10:00:00.000Z",
+          event_json: "",
+          raw_md: "Discussed release branch status.",
+        },
+      },
+      mapping_session_participant: {
+        current_alex: {
+          session_id: "current",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+        current_jamie: {
+          session_id: "current",
+          human_id: "jamie",
+          user_id: "self",
+          source: "auto",
+        },
+        different_topic_alex: {
+          session_id: "different_topic",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+        different_topic_jamie: {
+          session_id: "different_topic",
+          human_id: "jamie",
+          user_id: "self",
+          source: "auto",
+        },
+      },
+    });
+
+    const result = buildPastSessionNotes(store, "current", "self");
+
+    expect(result.notes).toEqual([]);
+    expect(result.missing).toEqual([]);
   });
 
   it("reuses saved key facts when the source hash still matches", () => {


### PR DESCRIPTION
Match past notes by recurrence series or same normalized title instead of participant overlap alone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible selection logic for past notes changed; some sessions may stop appearing while same-title non-recurring meetings may start appearing.
> 
> **Overview**
> **Past notes** no longer treat “same attendees” as enough to link sessions. Related history is now **recurrence series** or **same normalized meeting title** (generic titles like `Untitled` / `New note` are ignored).
> 
> For same-title matches, participant overlap is optional: if either side has no mapped participants, the session still counts; otherwise at least one shared participant is required. Sessions with different titles but overlapping attendees (e.g. Design sync vs Dev sync) are excluded.
> 
> Tests cover same-title inclusion, recurring series behavior, and the participant-only exclusion case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb84325408cf4ddedc80accc1c6ff4d821da88e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->