### PR TITLE
fix(past-notes): regenerate individual notes

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -26,6 +26,7 @@ const hoisted = vi.hoisted(() => ({
     isGenerating: boolean;
   }>,
   generateMissingPastNotes: vi.fn(),
+  regeneratePastNote: vi.fn(),
 }));
 
 vi.mock("react-hotkeys-hook", () => ({
@@ -55,6 +56,7 @@ vi.mock("./past-notes", () => ({
     isGenerating: false,
     canGenerate: true,
     generateMissing: hoisted.generateMissingPastNotes,
+    regenerate: hoisted.regeneratePastNote,
   }),
 }));
 
@@ -93,6 +95,7 @@ describe("useSessionBottomAccessory", () => {
     hoisted.live.liveTranscriptionActive = true;
     hoisted.pastNotes = [];
     hoisted.generateMissingPastNotes.mockClear();
+    hoisted.regeneratePastNote.mockClear();
     useShellMock.mockReturnValue({
       chat: {
         mode: "Closed",

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -53,6 +53,9 @@ export function useSessionBottomAccessory({
   const pastNotes = usePastSessionNotes(sessionId);
   const hasPastNotes = pastNotes.hasPastNotes;
   const generateMissingPastNotes = pastNotes.generateMissing;
+  const regeneratePastNote = pastNotes.canGenerate
+    ? pastNotes.regenerate
+    : undefined;
   const activePostSessionTab: PostSessionTab = hasPastNotes
     ? (postSessionTab ??
       (!hasAudio && !hasTranscript && !isRunningBatch
@@ -173,6 +176,7 @@ export function useSessionBottomAccessory({
           isTranscriptExpanded={isExpanded}
           activeTab={activePostSessionTab}
           pastNotes={pastNotes.notes}
+          onRegeneratePastNote={regeneratePastNote}
           fillHeight={isExpanded}
         />
       ) : null,

--- a/apps/desktop/src/session/components/bottom-accessory/past-note-regenerate.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/past-note-regenerate.test.tsx
@@ -1,0 +1,256 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { buildPastSessionNotes } from "./past-notes";
+import { PostSessionAccessory } from "./post-session";
+
+vi.mock("@hypr/plugin-fs-sync", () => ({
+  commands: {
+    audioPath: vi.fn(),
+  },
+}));
+
+vi.mock("@hypr/ui/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@hypr/ui/components/ui/spinner", () => ({
+  Spinner: () => <div data-testid="spinner" />,
+}));
+
+vi.mock("@hypr/ui/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("~/audio-player", () => ({
+  Timeline: () => <div data-testid="timeline" />,
+  TimelineShell: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TimelineMeta: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  useAudioPlayer: () => ({
+    audioExists: false,
+    deleteRecording: vi.fn(),
+    isDeletingRecording: false,
+  }),
+}));
+
+vi.mock("~/session/components/note-input/transcript", () => ({
+  Transcript: () => <div data-testid="transcript" />,
+}));
+
+vi.mock("~/session/components/note-input/transcript/export-data", () => ({
+  useTranscriptExportSegments: () => ({ data: [], isLoading: false }),
+  formatTranscriptExportSegments: () => "",
+}));
+
+vi.mock("~/session/components/note-input/transcript/state", () => ({
+  useTranscriptScreen: () => ({ kind: "empty" }),
+}));
+
+vi.mock("~/sidebar/toast/transient", () => ({
+  showTransientToast: vi.fn(),
+}));
+
+vi.mock("~/stt/contexts", () => ({
+  useListener: (selector: (state: Record<string, never>) => unknown) =>
+    selector({}),
+}));
+
+vi.mock("~/stt/useRunBatch", () => ({
+  useRunBatch: () => vi.fn(),
+  isStoppedTranscriptionError: vi.fn(() => false),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("past note regeneration", () => {
+  it("regenerates a selected past note from its timeline row", () => {
+    const regenerate = vi.fn();
+
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio={false}
+        hasTranscript
+        isTranscriptExpanded
+        activeTab="past_notes"
+        pastNotes={[
+          {
+            sessionId: "session-0",
+            title: "Weekly Product Sync",
+            dateLabel: "May 28, 2026",
+            summary: "Ship the transcript panel.",
+            isGenerating: false,
+          },
+        ]}
+        onRegeneratePastNote={regenerate}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Regenerate past note summary" }),
+    );
+
+    expect(regenerate).toHaveBeenCalledWith("session-0");
+  });
+
+  it("disables the row regenerate action while that note is generating", () => {
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio={false}
+        hasTranscript
+        isTranscriptExpanded
+        activeTab="past_notes"
+        pastNotes={[
+          {
+            sessionId: "session-0",
+            title: "Weekly Product Sync",
+            dateLabel: "May 28, 2026",
+            summary: "Ship the transcript panel.",
+            isGenerating: true,
+          },
+        ]}
+        onRegeneratePastNote={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Regenerate past note summary" }),
+    ).toHaveProperty("disabled", true);
+  });
+
+  it("disables row regenerate actions while another note is generating", () => {
+    const regenerate = vi.fn();
+
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio={false}
+        hasTranscript
+        isTranscriptExpanded
+        activeTab="past_notes"
+        pastNotes={[
+          {
+            sessionId: "session-0",
+            title: "Weekly Product Sync",
+            dateLabel: "May 28, 2026",
+            summary: "Ship the transcript panel.",
+            isGenerating: false,
+            isRegenerateDisabled: true,
+          },
+          {
+            sessionId: "session-2",
+            title: "Design Review",
+            dateLabel: "May 20, 2026",
+            summary: "Review final mocks.",
+            isGenerating: true,
+            isRegenerateDisabled: true,
+          },
+        ]}
+        onRegeneratePastNote={regenerate}
+      />,
+    );
+
+    const buttons = screen.getAllByRole("button", {
+      name: "Regenerate past note summary",
+    });
+
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]).toHaveProperty("disabled", true);
+    expect(buttons[1]).toHaveProperty("disabled", true);
+    fireEvent.click(buttons[0]!);
+    expect(regenerate).not.toHaveBeenCalled();
+  });
+
+  it("keeps regeneration requests for saved past note facts", () => {
+    const store = makeStore({
+      sessions: {
+        current: {
+          title: "Weekly Product Sync",
+          created_at: "2026-06-03T10:00:00.000Z",
+          event_json: "",
+          raw_md: "",
+        },
+        previous: {
+          title: "Weekly Product Sync",
+          created_at: "2026-05-28T10:00:00.000Z",
+          event_json: "",
+          raw_md: "Alex committed to send pricing by Friday.",
+        },
+      },
+      mapping_session_participant: {
+        current_alex: {
+          session_id: "current",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+        previous_alex: {
+          session_id: "previous",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+      },
+    });
+    const first = buildPastSessionNotes(store, "current", "self");
+    const request = first.requests[0]!;
+
+    store.setRow("session_key_facts", "previous", {
+      user_id: "self",
+      session_id: "previous",
+      created_at: "2026-05-28T11:00:00.000Z",
+      updated_at: "2026-05-28T11:00:00.000Z",
+      content: "Alex committed to send pricing by Friday.",
+      source_hash: request.sourceHash,
+    });
+
+    const second = buildPastSessionNotes(store, "current", "self");
+
+    expect(second.missing).toHaveLength(0);
+    expect(second.requests.map((request) => request.sessionId)).toEqual([
+      "previous",
+    ]);
+  });
+});
+
+function makeStore(
+  tables: Record<string, Record<string, Record<string, any>>>,
+) {
+  return {
+    getRow: (tableId: string, rowId: string) => tables[tableId]?.[rowId] ?? {},
+    getCell: (tableId: string, rowId: string, cellId: string) =>
+      tables[tableId]?.[rowId]?.[cellId],
+    forEachRow: (
+      tableId: string,
+      callback: (rowId: string, forEachCell: unknown) => void,
+    ) => {
+      for (const rowId of Object.keys(tables[tableId] ?? {})) {
+        callback(rowId, () => {});
+      }
+    },
+    setRow: (tableId: string, rowId: string, row: Record<string, any>) => {
+      tables[tableId] = {
+        ...(tables[tableId] ?? {}),
+        [rowId]: row,
+      };
+    },
+  } as any;
+}

--- a/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
+++ b/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
@@ -23,6 +23,7 @@ export type PastSessionNote = {
   dateLabel: string;
   summary: string | null;
   isGenerating: boolean;
+  isRegenerateDisabled?: boolean;
 };
 
 export type PastSessionNoteRequest = {
@@ -40,6 +41,7 @@ export type PastSessionNotesResult = {
   isGenerating: boolean;
   canGenerate: boolean;
   generateMissing: () => void;
+  regenerate: (sessionId: string) => void;
 };
 
 type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
@@ -67,7 +69,7 @@ export function usePastSessionNotes(sessionId: string): PastSessionNotesResult {
 
   const built = useMemo(() => {
     if (!store) {
-      return { notes: [], missing: [] };
+      return { notes: [], missing: [], requests: [] };
     }
 
     return buildPastSessionNotes(
@@ -101,10 +103,10 @@ export function usePastSessionNotes(sessionId: string): PastSessionNotesResult {
 
   const generatingIds = useMemo(
     () =>
-      mutation.isPending
-        ? new Set(built.missing.map((request) => request.sessionId))
+      mutation.isPending && mutation.variables
+        ? new Set(mutation.variables.map((request) => request.sessionId))
         : new Set<string>(),
-    [built.missing, mutation.isPending],
+    [mutation.isPending, mutation.variables],
   );
 
   const notes = useMemo(
@@ -112,8 +114,9 @@ export function usePastSessionNotes(sessionId: string): PastSessionNotesResult {
       built.notes.map((note) => ({
         ...note,
         isGenerating: generatingIds.has(note.sessionId),
+        isRegenerateDisabled: mutation.isPending,
       })),
-    [built.notes, generatingIds],
+    [built.notes, generatingIds, mutation.isPending],
   );
 
   const generateMissing = useCallback(() => {
@@ -124,12 +127,31 @@ export function usePastSessionNotes(sessionId: string): PastSessionNotesResult {
     void mutation.mutateAsync(built.missing);
   }, [built.missing, model, mutation]);
 
+  const regenerate = useCallback(
+    (targetSessionId: string) => {
+      if (!model || mutation.isPending) {
+        return;
+      }
+
+      const request = built.requests.find(
+        (request) => request.sessionId === targetSessionId,
+      );
+      if (!request) {
+        return;
+      }
+
+      void mutation.mutateAsync([request]);
+    },
+    [built.requests, model, mutation],
+  );
+
   return {
     notes,
     hasPastNotes: notes.length > 0,
     isGenerating: mutation.isPending,
     canGenerate: Boolean(model),
     generateMissing,
+    regenerate,
   };
 }
 
@@ -140,10 +162,11 @@ export function buildPastSessionNotes(
 ): {
   notes: PastSessionNote[];
   missing: PastSessionNoteRequest[];
+  requests: PastSessionNoteRequest[];
 } {
   const currentSession = store.getRow("sessions", sessionId);
   if (!currentSession) {
-    return { notes: [], missing: [] };
+    return { notes: [], missing: [], requests: [] };
   }
 
   const currentParticipantIds = getSessionParticipantIds(
@@ -154,13 +177,14 @@ export function buildPastSessionNotes(
   const currentEvent = getSessionEvent(currentSession);
   const currentSeriesId = getRecurrenceSeriesId(currentEvent);
   if (!currentSeriesId && currentParticipantIds.size === 0) {
-    return { notes: [], missing: [] };
+    return { notes: [], missing: [], requests: [] };
   }
 
   const currentTimestamp = getSessionTimestamp(currentSession);
   const items: Array<{
     note: PastSessionNote & { dateMs: number };
-    missing: PastSessionNoteRequest | null;
+    request: PastSessionNoteRequest;
+    isMissing: boolean;
   }> = [];
 
   store.forEachRow("sessions", (candidateSessionId, _forEachCell) => {
@@ -209,6 +233,14 @@ export function buildPastSessionNotes(
     const sourceHash = createSourceHash([title, dateLabel, source].join("\n"));
     const saved = getSavedKeyFacts(store, candidateSessionId, sourceHash);
     const ownerUserId = getSessionUserId(candidateSession, userId);
+    const request = {
+      sessionId: candidateSessionId,
+      userId: ownerUserId,
+      title,
+      dateLabel,
+      sourceText: source,
+      sourceHash,
+    };
 
     items.push({
       note: {
@@ -219,16 +251,8 @@ export function buildPastSessionNotes(
         isGenerating: false,
         dateMs: candidateTimestamp,
       },
-      missing: saved
-        ? null
-        : {
-            sessionId: candidateSessionId,
-            userId: ownerUserId,
-            title,
-            dateLabel,
-            sourceText: source,
-            sourceHash,
-          },
+      request,
+      isMissing: !saved,
     });
   });
 
@@ -241,7 +265,8 @@ export function buildPastSessionNotes(
       const { dateMs: _dateMs, ...rest } = note;
       return rest;
     }),
-    missing: selected.flatMap((item) => item.missing ?? []),
+    missing: selected.flatMap((item) => (item.isMissing ? [item.request] : [])),
+    requests: selected.map((item) => item.request),
   };
 }
 

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -40,6 +40,7 @@ export function PostSessionAccessory({
   isTranscriptExpanded,
   activeTab = "transcript",
   pastNotes = [],
+  onRegeneratePastNote,
   fillHeight = false,
 }: {
   sessionId: string;
@@ -48,6 +49,7 @@ export function PostSessionAccessory({
   isTranscriptExpanded: boolean;
   activeTab?: PostSessionTab;
   pastNotes?: PastSessionNote[];
+  onRegeneratePastNote?: (sessionId: string) => void;
   fillHeight?: boolean;
 }) {
   const screen = useTranscriptScreen({ sessionId });
@@ -87,6 +89,7 @@ export function PostSessionAccessory({
           {effectiveActiveTab === "past_notes" ? (
             <PastNotesPanel
               notes={pastNotes}
+              onRegenerateNote={onRegeneratePastNote}
               fillHeight={shouldFillExpandedPanel}
             />
           ) : (
@@ -129,9 +132,11 @@ function TimelineSlot({
 
 function PastNotesPanel({
   notes,
+  onRegenerateNote,
   fillHeight,
 }: {
   notes: PastSessionNote[];
+  onRegenerateNote?: (sessionId: string) => void;
   fillHeight: boolean;
 }) {
   return (
@@ -155,13 +160,24 @@ function PastNotesPanel({
             >
               <div className="absolute top-1.5 left-0 h-2 w-2 rounded-full border border-neutral-300 bg-white" />
               <div className="flex min-w-0 flex-col gap-1 overflow-hidden">
-                <div className="flex min-w-0 items-baseline gap-2">
-                  <span className="shrink-0 text-[11px] text-neutral-400">
-                    {note.dateLabel}
-                  </span>
-                  <span className="min-w-0 truncate text-xs font-medium text-neutral-700">
-                    {note.title}
-                  </span>
+                <div className="flex min-w-0 items-center justify-between gap-2">
+                  <div className="flex min-w-0 items-baseline gap-2">
+                    <span className="shrink-0 text-[11px] text-neutral-400">
+                      {note.dateLabel}
+                    </span>
+                    <span className="min-w-0 truncate text-xs font-medium text-neutral-700">
+                      {note.title}
+                    </span>
+                  </div>
+                  {onRegenerateNote ? (
+                    <RegeneratePastNoteButton
+                      isDisabled={
+                        note.isGenerating || note.isRegenerateDisabled === true
+                      }
+                      isGenerating={note.isGenerating}
+                      onClick={() => onRegenerateNote(note.sessionId)}
+                    />
+                  ) : null}
                 </div>
                 {note.summary ? (
                   <ul className="min-w-0 list-inside list-disc space-y-1 overflow-hidden pr-1 pl-1 text-xs leading-5 text-neutral-500">
@@ -201,6 +217,49 @@ function splitKeyFacts(content: string): string[] {
     )
     .filter(Boolean)
     .slice(0, 3);
+}
+
+function RegeneratePastNoteButton({
+  isDisabled,
+  isGenerating,
+  onClick,
+}: {
+  isDisabled: boolean;
+  isGenerating: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Regenerate past note summary"
+          disabled={isDisabled}
+          onClick={onClick}
+          className={cn([
+            "h-5 w-5 shrink-0 text-neutral-400",
+            "hover:bg-neutral-200/60 hover:text-neutral-700",
+            "disabled:cursor-not-allowed disabled:text-neutral-300",
+          ])}
+        >
+          {isGenerating ? (
+            <Loader2Icon size={10} className="animate-spin" />
+          ) : (
+            <RefreshCw size={10} />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        <p>
+          {isGenerating
+            ? "Regenerating past note summary"
+            : "Regenerate past note summary"}
+        </p>
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
 function TranscriptPanel({


### PR DESCRIPTION
Summary:
- Add a per-note regenerate action in the Past notes timeline.
- Keep regeneration requests for saved past-note summaries.
- Cover row actions and generating state with focused tests.

Verification:
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop test -- src/session/components/bottom-accessory/past-note-regenerate.test.tsx src/session/components/bottom-accessory/index.test.tsx
- pnpm -F @hypr/desktop typecheck

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5491 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5490
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop session UI and local key-facts regeneration only; no auth or shared API surface changes.
> 
> **Overview**
> Adds **per-row regenerate** controls on the Past notes timeline so users can refresh a single related session’s key-facts summary without re-running bulk “missing” generation.
> 
> **`usePastSessionNotes`** now exposes **`regenerate(sessionId)`**, tracks **`requests`** for every displayed past note (not only unsaved ones), and drives loading/disabled UI from the **active mutation’s session IDs** so only the targeted row spins while **all** regenerate buttons lock during any in-flight job. **`buildPastSessionNotes`** still treats **`missing`** as notes without saved facts, but keeps regeneration payloads available even after **`session_key_facts`** is stored.
> 
> The bottom accessory wires **`onRegeneratePastNote`** into **`PostSessionAccessory`** when a language model is available; new tests cover the button behavior and that saved notes remain regenerable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66ce9da17b212b45cb649b3a3731a95062a865e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->