### PR TITLE
Show floating listener error status

### DIFF
--- a/apps/desktop/src/meeting-float/host.test.ts
+++ b/apps/desktop/src/meeting-float/host.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { getFloatingRouteState } from "./host";
+
+import { createListenerStore } from "~/store/zustand/listener";
+
+type ListenerLiveState = ReturnType<
+  ReturnType<typeof createListenerStore>["getState"]
+>["live"];
+
+function createListenerState(live: Partial<ListenerLiveState>) {
+  const store = createListenerStore();
+  store.setState({
+    live: {
+      ...store.getState().live,
+      ...live,
+    },
+  });
+  return store.getState();
+}
+
+describe("getFloatingRouteState", () => {
+  it("returns recording status for healthy live sessions", () => {
+    expect(
+      getFloatingRouteState(
+        createListenerState({
+          status: "active",
+          sessionId: "session-1",
+          amplitude: { mic: 0.6, speaker: 0.8 },
+        }),
+      ),
+    ).toEqual({
+      sessionId: "session-1",
+      amplitude: 1,
+      status: "recording",
+    });
+  });
+
+  it("returns error status when live transcription degrades", () => {
+    expect(
+      getFloatingRouteState(
+        createListenerState({
+          status: "active",
+          sessionId: "session-1",
+          degraded: { type: "connection_timeout" },
+        }),
+      )?.status,
+    ).toBe("error");
+  });
+
+  it("returns error status when the active listener reports an error", () => {
+    expect(
+      getFloatingRouteState(
+        createListenerState({
+          status: "active",
+          sessionId: "session-1",
+          lastError: "microphone unavailable",
+        }),
+      )?.status,
+    ).toBe("error");
+  });
+});

--- a/apps/desktop/src/meeting-float/host.tsx
+++ b/apps/desktop/src/meeting-float/host.tsx
@@ -8,10 +8,11 @@ import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { listenerStore } from "~/store/zustand/listener/instance";
 
 type ListenerState = ReturnType<typeof listenerStore.getState>;
+type FloatingBarStatus = "recording" | "error";
 type FloatingRouteState = {
   sessionId: string;
   amplitude: number;
-  degraded: boolean;
+  status: FloatingBarStatus;
 };
 
 export function FloatingMeetingWindowHost() {
@@ -138,7 +139,7 @@ function FloatingMeetingWindowSync() {
   return null;
 }
 
-function getFloatingRouteState(
+export function getFloatingRouteState(
   state: ListenerState,
   sessionId?: string,
 ): FloatingRouteState | null {
@@ -160,7 +161,7 @@ function getFloatingRouteState(
       Math.hypot(state.live.amplitude.mic, state.live.amplitude.speaker),
       1,
     ),
-    degraded: Boolean(state.live.degraded),
+    status: state.live.degraded || state.live.lastError ? "error" : "recording",
   };
 }
 
@@ -171,7 +172,7 @@ function isSameFloatingRouteState(
   return (
     left?.sessionId === right?.sessionId &&
     left?.amplitude === right?.amplitude &&
-    left?.degraded === right?.degraded
+    left?.status === right?.status
   );
 }
 
@@ -226,7 +227,7 @@ async function showFloatingMeetingWindow(
 
   const updateResult = await windowsCommands.floatingBarUpdate({
     amplitude: routeState.amplitude,
-    degraded: routeState.degraded,
+    status: routeState.status,
   });
   if (!shouldContinue()) {
     await hideFloatingMeetingPanel();

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -25,28 +25,12 @@ import {
 export function DuringSessionAccessory({
   sessionId,
   fillHeight = false,
-  isFinalizing = false,
   isExpanded = false,
 }: {
   sessionId: string;
   fillHeight?: boolean;
-  isFinalizing?: boolean;
   isExpanded?: boolean;
 }) {
-  if (isFinalizing) {
-    return (
-      <div className="relative w-full pt-1 select-none">
-        <div className="rounded-xl bg-neutral-50">
-          <div className="flex min-h-9 items-center gap-2 px-2 py-1">
-            <div className="min-w-0 flex-1">
-              <span className="text-xs text-neutral-400">Finalizing...</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <LiveTranscriptFooter
       sessionId={sessionId}

--- a/apps/desktop/src/session/components/bottom-accessory/global-live.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/global-live.test.tsx
@@ -66,17 +66,14 @@ vi.mock("./during-session", () => ({
   DuringSessionAccessory: ({
     fillHeight,
     isExpanded,
-    isFinalizing,
     sessionId,
   }: {
     fillHeight?: boolean;
     isExpanded?: boolean;
-    isFinalizing?: boolean;
     sessionId: string;
   }) => (
     <div
       data-fill-height={String(fillHeight)}
-      data-finalizing={String(isFinalizing)}
       data-is-expanded={String(isExpanded)}
       data-session-id={sessionId}
       data-testid="during-session-accessory"
@@ -311,7 +308,7 @@ describe("GlobalLiveTranscriptAccessory", () => {
     expect(screen.queryByTestId("during-session-accessory")).toBeNull();
   });
 
-  it("keeps finalizing visible outside the active session tab", () => {
+  it("hides the global live transcript while finalizing", () => {
     mocks.live.status = "finalizing";
     mocks.live.requestedLiveTranscription = false;
     mocks.live.liveTranscriptionActive = false;
@@ -322,12 +319,8 @@ describe("GlobalLiveTranscriptAccessory", () => {
       </GlobalLiveTranscriptAccessory>,
     );
 
-    expect(
-      screen.getByTestId("during-session-accessory").dataset,
-    ).toMatchObject({
-      sessionId: "live-session",
-      finalizing: "true",
-    });
+    expect(screen.getByTestId("tab-content")).toBeTruthy();
+    expect(screen.queryByTestId("during-session-accessory")).toBeNull();
     expect(screen.queryByRole("button", { name: "Expand Live" })).toBeNull();
   });
 });

--- a/apps/desktop/src/session/components/bottom-accessory/global-live.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/global-live.tsx
@@ -46,7 +46,6 @@ export function GlobalLiveTranscriptAccessory({
   return (
     <GlobalLiveTranscriptAccessoryContent
       sessionId={accessorySessionId}
-      isFinalizing={live.status === "finalizing"}
       surfaceChrome={surfaceChrome}
     >
       {children}
@@ -57,12 +56,10 @@ export function GlobalLiveTranscriptAccessory({
 function GlobalLiveTranscriptAccessoryContent({
   children,
   sessionId,
-  isFinalizing,
   surfaceChrome,
 }: {
   children: ReactNode;
   sessionId: string | null;
-  isFinalizing: boolean;
   surfaceChrome: MainSurfaceChrome;
 }) {
   const [expandedLiveSession, setExpandedLiveSession] = useState<{
@@ -72,7 +69,7 @@ function GlobalLiveTranscriptAccessoryContent({
   const afterBorderPanelRef = useRef<ImperativePanelHandle>(null);
   const afterBorderSize = GLOBAL_LIVE_AFTER_BORDER_EXPANDED_SIZE;
   const hasLiveAccessory = Boolean(sessionId);
-  const canExpand = hasLiveAccessory && !isFinalizing;
+  const canExpand = hasLiveAccessory;
   const isExpanded =
     canExpand &&
     expandedLiveSession.sessionId === sessionId &&
@@ -103,7 +100,6 @@ function GlobalLiveTranscriptAccessoryContent({
   const afterBorder = sessionId ? (
     <DuringSessionAccessory
       sessionId={sessionId}
-      isFinalizing={isFinalizing}
       isExpanded={isExpanded}
       fillHeight={useResizableAfterBorder}
     />

--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -282,6 +282,21 @@ describe("useSessionBottomAccessory", () => {
     expect(result.current.bottomBorderHandle).toBeNull();
   });
 
+  it("hides the bottom accessory while finalizing", () => {
+    const { result } = renderHook(() =>
+      useSessionBottomAccessory({
+        sessionId: "session-1",
+        sessionMode: "finalizing",
+        audioUrl: null,
+        hasTranscript: false,
+      }),
+    );
+
+    expect(result.current.bottomAccessoryState).toBeNull();
+    expect(result.current.bottomAccessory).toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
+  });
+
   it("defers local transcript controls to the global live panel for another active session", () => {
     hoisted.live.status = "active";
     hoisted.live.sessionId = "live-session";

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -22,7 +22,7 @@ import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
 import { useListener } from "~/stt/contexts";
 
 export type BottomAccessoryState = {
-  mode: "live" | "playback" | "transcript_only" | "finalizing";
+  mode: "live" | "playback" | "transcript_only";
   expanded: boolean;
 } | null;
 
@@ -46,7 +46,6 @@ export function useSessionBottomAccessory({
     null,
   );
   const isLive = sessionMode === "active";
-  const isFinalizing = sessionMode === "finalizing";
   const isInactive = sessionMode === "inactive";
   const isRunningBatch = sessionMode === "running_batch";
   const hasAudio = Boolean(audioUrl) && (isInactive || isRunningBatch);
@@ -128,39 +127,35 @@ export function useSessionBottomAccessory({
   const mode: NonNullable<BottomAccessoryState>["mode"] | null =
     showLiveAccessory
       ? "live"
-      : isFinalizing
-        ? "finalizing"
-        : showPostSession
-          ? hasAudio || isRunningBatch
-            ? "playback"
-            : "transcript_only"
-          : null;
+      : showPostSession
+        ? hasAudio || isRunningBatch
+          ? "playback"
+          : "transcript_only"
+        : null;
 
   const bottomAccessoryState: BottomAccessoryState = useMemo(
     () => (mode ? { mode, expanded: effectiveExpanded } : null),
     [effectiveExpanded, mode],
   );
 
-  if (showLiveAccessory || isFinalizing) {
+  if (showLiveAccessory) {
     return {
       bottomAccessory: (
         <DuringSessionAccessory
           sessionId={sessionId}
-          isFinalizing={isFinalizing}
           isExpanded={effectiveExpanded}
-          fillHeight={effectiveExpanded && !isFinalizing}
+          fillHeight={effectiveExpanded}
         />
       ),
-      bottomBorderHandle:
-        canExpandLiveTranscript && !isFinalizing ? (
-          <ExpandToggle
-            isExpanded={effectiveExpanded}
-            onToggle={() => setIsExpanded((v) => !v)}
-            label="Live"
-            collapsedClassName="bg-neutral-50"
-            expandedClassName="bg-neutral-50"
-          />
-        ) : null,
+      bottomBorderHandle: canExpandLiveTranscript ? (
+        <ExpandToggle
+          isExpanded={effectiveExpanded}
+          onToggle={() => setIsExpanded((v) => !v)}
+          label="Live"
+          collapsedClassName="bg-neutral-50"
+          expandedClassName="bg-neutral-50"
+        />
+      ) : null,
       bottomAccessoryState,
     };
   }

--- a/apps/desktop/src/session/components/bottom-accessory/live-visibility.ts
+++ b/apps/desktop/src/session/components/bottom-accessory/live-visibility.ts
@@ -17,10 +17,6 @@ export function shouldShowLiveTranscriptAccessory(
     return false;
   }
 
-  if (live.status === "finalizing") {
-    return true;
-  }
-
   if (live.status !== "active") {
     return false;
   }

--- a/apps/desktop/src/store/zustand/listener/general-shared.ts
+++ b/apps/desktop/src/store/zustand/listener/general-shared.ts
@@ -122,6 +122,7 @@ export const markLiveStartRequested = (live: LiveState, sessionId: string) => {
   live.loading = true;
   live.status = "inactive";
   live.sessionId = sessionId;
+  live.lastError = null;
   live.requestedLiveTranscription = null;
   live.liveTranscriptionActive = null;
 };

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -2,7 +2,11 @@ import { create as mutate } from "mutative";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { createListenerStore } from ".";
-import { getLiveCaptureUiMode } from "./general-shared";
+import {
+  getLiveCaptureUiMode,
+  markLiveActive,
+  updateLiveProgress,
+} from "./general-shared";
 
 let store: ReturnType<typeof createListenerStore>;
 
@@ -67,6 +71,33 @@ describe("General Listener Slice", () => {
           liveTranscriptionActive: false,
         }),
       ).toBe("fallback_record_only");
+    });
+
+    test("markLiveActive preserves startup progress errors", () => {
+      const intervalId = setInterval(() => {}, 1000);
+
+      store.setState((state) =>
+        mutate(state, (draft) => {
+          updateLiveProgress(draft.live, {
+            type: "connection_error",
+            session_id: "session-1",
+            error: "socket closed",
+          });
+          markLiveActive(
+            draft.live,
+            "session-1",
+            intervalId,
+            true,
+            false,
+            null,
+          );
+        }),
+      );
+
+      clearInterval(intervalId);
+
+      expect(store.getState().live.status).toBe("active");
+      expect(store.getState().live.lastError).toBe("socket closed");
     });
   });
 

--- a/plugins/windows/js/bindings.gen.ts
+++ b/plugins/windows/js/bindings.gen.ts
@@ -282,7 +282,8 @@ export type EditorView =
   | { type: "attachments" };
 export type ExtensionsState = { selectedExtension: string | null };
 export type FloatingBarOpenMain = Record<string, never>;
-export type FloatingBarState = { amplitude: number; degraded: boolean };
+export type FloatingBarState = { amplitude: number; status: FloatingBarStatus };
+export type FloatingBarStatus = "recording" | "error";
 export type FloatingBarStop = Record<string, never>;
 export type JsonValue =
   | null

--- a/plugins/windows/src/window/floating_bar.rs
+++ b/plugins/windows/src/window/floating_bar.rs
@@ -4,9 +4,16 @@ use crate::Error;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
+pub enum FloatingBarStatus {
+    Recording,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
 pub struct FloatingBarState {
     pub amplitude: f64,
-    pub degraded: bool,
+    pub status: FloatingBarStatus,
 }
 
 #[cfg(target_os = "macos")]

--- a/plugins/windows/swift-lib/src/FloatingBarManager.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarManager.swift
@@ -55,7 +55,7 @@ final class FloatingBarManager {
   func update(state: FloatingBarStatePayload) {
     DispatchQueue.main.async { [weak self] in
       guard let self else { return }
-      self.model.degraded = state.degraded
+      self.model.status = state.status
       self.model.amplitude = min(max(state.amplitude, 0), 1)
     }
   }

--- a/plugins/windows/swift-lib/src/FloatingBarModels.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarModels.swift
@@ -1,6 +1,11 @@
 import Foundation
 
+enum FloatingBarStatus: String, Codable {
+  case recording
+  case error
+}
+
 struct FloatingBarStatePayload: Codable {
   let amplitude: Double
-  let degraded: Bool
+  let status: FloatingBarStatus
 }

--- a/plugins/windows/swift-lib/src/FloatingBarView.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarView.swift
@@ -47,6 +47,8 @@ struct FloatingBarView: View {
                   width: FloatingBarLayout.stopSquareSize,
                   height: FloatingBarLayout.stopSquareSize
                 )
+            } else if model.status == .error {
+              ErrorMark(color: errorAccentColor)
             } else {
               DancingBars(color: accentColor, amplitude: model.amplitude)
             }
@@ -80,11 +82,15 @@ struct FloatingBarView: View {
   }
 
   private var accentColor: Color {
-    model.degraded ? Color(red: 0.96, green: 0.62, blue: 0.04) : normalAccentColor
+    model.status == .error ? errorAccentColor : normalAccentColor
   }
 
   private var stopColor: Color {
     normalAccentColor
+  }
+
+  private var errorAccentColor: Color {
+    Color(red: 1, green: 0.25, blue: 0.24)
   }
 
   private var normalAccentColor: Color {
@@ -147,6 +153,21 @@ private struct CircularClickArea<Content: View>: View {
         isHovered = hovered
         onHoverChange(hovered)
       }
+  }
+}
+
+private struct ErrorMark: View {
+  let color: Color
+
+  var body: some View {
+    VStack(spacing: 1.5) {
+      Capsule(style: .continuous)
+        .fill(color)
+        .frame(width: 3.2, height: 8)
+      Circle()
+        .fill(color)
+        .frame(width: 3.2, height: 3.2)
+    }
   }
 }
 

--- a/plugins/windows/swift-lib/src/FloatingBarViewModel.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarViewModel.swift
@@ -3,5 +3,5 @@ import Foundation
 
 final class FloatingBarViewModel: ObservableObject {
   @Published var amplitude: Double = 0
-  @Published var degraded = false
+  @Published var status: FloatingBarStatus = .recording
 }


### PR DESCRIPTION
## Summary
- Show an explicit floating bar error state when listener startup fails.
- Pass error status through the native floating bar payload.
- Hide the finalizing bottom accessory while listener cleanup completes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live-session UI, native floating-bar IPC/types, and listener error state across desktop and Swift; behavior changes during finalizing and error display are user-visible but covered by new/updated tests.
> 
> **Overview**
> The floating meeting bar now uses an explicit **`recording` / `error`** status instead of a **`degraded`** flag. Errors cover listener **`lastError`** and degraded live transcription, and the macOS bar shows a dedicated error glyph (red) instead of an amber “degraded” waveform.
> 
> **Live transcript bottom chrome** no longer has a **finalizing** mode: the “Finalizing…” strip is removed, global and per-session live accessories are hidden while the listener is finalizing, and expand controls stay available whenever a live accessory is shown.
> 
> Listener startup clears **`lastError`** on a new start request but **`markLiveActive`** no longer wipes connection errors set during startup progress, so the floating bar can still show error after capture becomes active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2871db3094fd4468838c9c3104b05bb0c7fbb56d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->