### PR TITLE
Move meeting join control into session header

### DIFF
--- a/apps/desktop/src/session/components/floating/listen.test.tsx
+++ b/apps/desktop/src/session/components/floating/listen.test.tsx
@@ -1,5 +1,5 @@
-import { render } from "@testing-library/react";
-import { describe, expect, test, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { ListenButton } from "./listen";
 
@@ -20,12 +20,6 @@ const {
       canStartLiveSession: () => true,
     }),
   ),
-}));
-
-vi.mock("@hypr/plugin-opener2", () => ({
-  commands: {
-    openUrl: vi.fn(),
-  },
 }));
 
 vi.mock("../listen-action", () => ({
@@ -54,10 +48,6 @@ vi.mock("~/session/hooks/useEventCountdown", () => ({
   },
 }));
 
-vi.mock("~/session/hooks/useRemoteMeeting", () => ({
-  useRemoteMeeting: () => null,
-}));
-
 vi.mock("~/shared/config", () => ({
   useConfigValue: useConfigValueMock,
 }));
@@ -72,6 +62,10 @@ vi.mock("~/stt/contexts", () => ({
 }));
 
 describe("floating ListenButton", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   test("requests auto-start when the event countdown expires", () => {
     const tab = {
       type: "sessions",
@@ -87,5 +81,20 @@ describe("floating ListenButton", () => {
       view: null,
       autoStart: true,
     });
+  });
+
+  test("keeps remote meeting join controls out of the floating slot", () => {
+    const tab = {
+      type: "sessions",
+      id: "session-1",
+      state: { view: null, autoStart: null },
+    } as Extract<Tab, { type: "sessions" }>;
+
+    render(<ListenButton tab={tab} />);
+
+    expect(
+      screen.getByRole("button", { name: "Listen session-1" }),
+    ).not.toBeNull();
+    expect(screen.queryByRole("button", { name: /Join/ })).toBeNull();
   });
 });

--- a/apps/desktop/src/session/components/floating/listen.tsx
+++ b/apps/desktop/src/session/components/floating/listen.tsx
@@ -1,17 +1,9 @@
-import { HeadsetIcon } from "lucide-react";
 import { useCallback } from "react";
 
-import { commands as openerCommands } from "@hypr/plugin-opener2";
-
 import { ListenActionButton } from "../listen-action";
-import { FloatingButton } from "./shared";
 
 import { useListenButtonState } from "~/session/components/shared";
 import { useEventCountdown } from "~/session/hooks/useEventCountdown";
-import {
-  type RemoteMeeting,
-  useRemoteMeeting,
-} from "~/session/hooks/useRemoteMeeting";
 import { useConfigValue } from "~/shared/config";
 import type { Tab } from "~/store/zustand/tabs";
 import { useTabs } from "~/store/zustand/tabs";
@@ -33,7 +25,6 @@ export function ListenButton({
     "auto_start_scheduled_meetings",
   );
   const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
-  const remote = useRemoteMeeting(tab.id);
   const handleCountdownExpire = useCallback(() => {
     if (!autoStartScheduledMeetings || !canStartLiveSession) {
       return;
@@ -54,23 +45,6 @@ export function ListenButton({
     return <ListenActionButton sessionId={tab.id} />;
   }
 
-  if (!remote) {
-    if (!shouldRender) {
-      return null;
-    }
-
-    return (
-      <div className="flex flex-col items-center gap-2">
-        {countdown.label && (
-          <div className="text-xs whitespace-nowrap text-neutral-500">
-            <span>{countdown.label}</span>
-          </div>
-        )}
-        <ListenActionButton sessionId={tab.id} />
-      </div>
-    );
-  }
-
   if (!shouldRender) {
     return null;
   }
@@ -82,59 +56,7 @@ export function ListenButton({
           <span>{countdown.label}</span>
         </div>
       )}
-      <div className="flex items-center gap-2">
-        <RemoteMeetingButton remote={remote} />
-        <ListenActionButton sessionId={tab.id} />
-      </div>
+      <ListenActionButton sessionId={tab.id} />
     </div>
   );
-}
-
-function RemoteMeetingButton({ remote }: { remote: RemoteMeeting }) {
-  const handleJoin = useCallback(() => {
-    void openerCommands.openUrl(remote.url, null);
-  }, [remote.url]);
-
-  const { icon, name } = getMeetingDisplay(remote.type);
-
-  return (
-    <FloatingButton
-      onClick={handleJoin}
-      className="h-10 justify-center gap-2 border-neutral-200 bg-white px-4 text-neutral-800 shadow-[0_4px_14px_rgba(0,0,0,0.1)] hover:bg-neutral-100"
-    >
-      <span>Join</span>
-      {icon}
-      <span>{name}</span>
-    </FloatingButton>
-  );
-}
-
-function getMeetingDisplay(type: RemoteMeeting["type"]) {
-  switch (type) {
-    case "zoom":
-      return {
-        name: "Zoom",
-        icon: <img src="/assets/zoom.png" alt="" width={20} height={20} />,
-      };
-    case "google-meet":
-      return {
-        name: "Meet",
-        icon: <img src="/assets/meet.png" alt="" width={20} height={20} />,
-      };
-    case "webex":
-      return {
-        name: "Webex",
-        icon: <img src="/assets/webex.png" alt="" width={20} height={20} />,
-      };
-    case "teams":
-      return {
-        name: "Teams",
-        icon: <img src="/assets/teams.png" alt="" width={20} height={20} />,
-      };
-    default:
-      return {
-        name: "Meeting",
-        icon: <HeadsetIcon size={20} />,
-      };
-  }
 }

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EditorView } from "~/store/zustand/tabs/schema";
@@ -13,12 +14,26 @@ const mocks = vi.hoisted(() => ({
   goBack: vi.fn(),
   goNext: vi.fn(),
   sessionModes: {} as Record<string, string>,
+  sessionEvents: {} as Record<string, any>,
   sidebarTimelineEnabled: false,
   stopListening: vi.fn(),
+  nowMs: new Date("2026-06-05T09:50:00.000Z").getTime(),
+  openUrl: vi.fn(),
 }));
 
 vi.mock("./metadata", () => ({
-  MetadataButton: () => <button type="button">Metadata</button>,
+  MetadataButton: ({
+    renderTrigger,
+  }: {
+    renderTrigger?: (props: { open: boolean; label: string }) => ReactElement;
+  }) =>
+    renderTrigger ? (
+      renderTrigger({ open: false, label: "Open event metadata" })
+    ) : (
+      <button type="button" aria-label="Open event metadata">
+        Metadata
+      </button>
+    ),
 }));
 
 vi.mock("./overflow", () => ({
@@ -29,6 +44,16 @@ vi.mock("@hypr/ui/components/ui/dancing-sticks", () => ({
   DancingSticks: () => <span data-testid="dancing-sticks" />,
 }));
 
+vi.mock("@hypr/plugin-opener2", () => ({
+  commands: {
+    openUrl: mocks.openUrl,
+  },
+}));
+
+vi.mock("~/calendar/hooks", () => ({
+  useNow: () => new Date(mocks.nowMs),
+}));
+
 vi.mock("~/contexts/shell", () => ({
   useShell: () => ({
     leftsidebar: mocks.leftsidebar,
@@ -37,6 +62,11 @@ vi.mock("~/contexts/shell", () => ({
 
 vi.mock("~/shared/config", () => ({
   useConfigValue: () => mocks.sidebarTimelineEnabled,
+}));
+
+vi.mock("~/store/tinybase/hooks", () => ({
+  useSessionEvent: (sessionId: string) =>
+    mocks.sessionEvents[sessionId] ?? null,
 }));
 
 vi.mock("~/store/zustand/tabs", () => ({
@@ -79,8 +109,11 @@ describe("OuterHeader", () => {
     mocks.goBack.mockClear();
     mocks.goNext.mockClear();
     mocks.sessionModes = {};
+    mocks.sessionEvents = {};
     mocks.sidebarTimelineEnabled = false;
     mocks.stopListening.mockClear();
+    mocks.nowMs = new Date("2026-06-05T09:50:00.000Z").getTime();
+    mocks.openUrl.mockClear();
   });
 
   afterEach(() => {
@@ -196,5 +229,90 @@ describe("OuterHeader", () => {
     );
 
     expect(screen.queryByRole("button", { name: "Stop listening" })).toBeNull();
+  });
+
+  it("shows a header join control before a remote meeting", () => {
+    mocks.sessionEvents = {
+      "session-1": {
+        title: "Design Review",
+        started_at: "2026-06-05T10:00:00.000Z",
+        ended_at: "2026-06-05T10:30:00.000Z",
+        meeting_link: "https://meet.google.com/abc-defg-hij",
+      },
+    };
+    mocks.nowMs = new Date("2026-06-05T09:55:00.000Z").getTime();
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    const joinButton = screen.getByRole("button", { name: "Join Meet" });
+
+    fireEvent.click(joinButton);
+
+    expect(joinButton.textContent).toContain("Join Meet");
+    expect(
+      screen.getByRole("button", { name: "Open event metadata" }),
+    ).not.toBeNull();
+    expect(mocks.openUrl).toHaveBeenCalledWith(
+      "https://meet.google.com/abc-defg-hij",
+      null,
+    );
+  });
+
+  it("shows metadata without the join control while the meeting is in progress", () => {
+    mocks.sessionEvents = {
+      "session-1": {
+        title: "Design Review",
+        started_at: "2026-06-05T10:00:00.000Z",
+        ended_at: "2026-06-05T10:30:00.000Z",
+        meeting_link: "https://meet.google.com/abc-defg-hij",
+      },
+    };
+    mocks.sessionModes = { "session-1": "active" };
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Join Meet" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Open event metadata" }),
+    ).not.toBeNull();
+  });
+
+  it("shows the calendar metadata button after the meeting is over", () => {
+    mocks.sessionEvents = {
+      "session-1": {
+        title: "Design Review",
+        started_at: "2026-06-05T10:00:00.000Z",
+        ended_at: "2026-06-05T10:30:00.000Z",
+        meeting_link: "https://meet.google.com/abc-defg-hij",
+      },
+    };
+    mocks.nowMs = new Date("2026-06-05T10:31:00.000Z").getTime();
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    const metadataButton = screen.getByRole("button", {
+      name: "Open event metadata",
+    });
+
+    expect(screen.queryByRole("button", { name: "Join Meet" })).toBeNull();
+    expect(metadataButton.textContent).toBe("Metadata");
   });
 });

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -1,13 +1,20 @@
-import { MicOff } from "lucide-react";
+import { ChevronDownIcon, HeadsetIcon, MicOff } from "lucide-react";
 
+import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { DancingSticks } from "@hypr/ui/components/ui/dancing-sticks";
-import { cn } from "@hypr/utils";
+import { cn, safeParseDate } from "@hypr/utils";
 
 import { MetadataButton } from "./metadata";
 import { OverflowButton } from "./overflow";
 
+import { useNow } from "~/calendar/hooks";
 import { useShell } from "~/contexts/shell";
+import {
+  getRemoteMeeting,
+  type RemoteMeeting,
+} from "~/session/hooks/useRemoteMeeting";
 import { useConfigValue } from "~/shared/config";
+import { useSessionEvent } from "~/store/tinybase/hooks";
 import type { EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
 
@@ -38,12 +45,131 @@ export function OuterHeader({
         </div>
         <div className="flex shrink-0 items-center gap-0 pr-1">
           <SidebarModeStopButton sessionId={sessionId} />
-          <MetadataButton sessionId={sessionId} />
+          <HeaderMeetingControl sessionId={sessionId} />
           <OverflowButton sessionId={sessionId} currentView={currentView} />
         </div>
       </div>
     </div>
   );
+}
+
+function HeaderMeetingControl({ sessionId }: { sessionId: string }) {
+  const sessionEvent = useSessionEvent(sessionId);
+
+  if (!sessionEvent) {
+    return <MetadataButton sessionId={sessionId} />;
+  }
+
+  return <EventMeetingControl sessionId={sessionId} event={sessionEvent} />;
+}
+
+function EventMeetingControl({
+  sessionId,
+  event,
+}: {
+  sessionId: string;
+  event: {
+    ended_at?: string;
+    meeting_link?: string;
+  };
+}) {
+  const mode = useListener((state) => state.getSessionMode(sessionId));
+  const now = useNow();
+  const remote = getRemoteMeeting(event.meeting_link);
+  const inProgress =
+    mode === "active" || mode === "finalizing" || mode === "running_batch";
+  const endedAt = event.ended_at ? safeParseDate(event.ended_at) : null;
+  const ended = !!endedAt && endedAt.getTime() <= now.getTime();
+
+  if (inProgress) {
+    return <MetadataButton sessionId={sessionId} />;
+  }
+
+  if (remote && !ended) {
+    return <HeaderMeetingJoinButton sessionId={sessionId} remote={remote} />;
+  }
+
+  return <MetadataButton sessionId={sessionId} />;
+}
+
+function HeaderMeetingJoinButton({
+  sessionId,
+  remote,
+}: {
+  sessionId: string;
+  remote: RemoteMeeting;
+}) {
+  const { icon, name } = getMeetingDisplay(remote.type);
+  const label = `Join ${name}`;
+  const handleJoin = () => {
+    void openerCommands.openUrl(remote.url, null);
+  };
+
+  return (
+    <div className="mr-1 flex h-8 max-w-56 shrink-0 items-center overflow-hidden rounded-full border border-neutral-200 bg-white shadow-[0_1px_4px_rgba(0,0,0,0.08)]">
+      <button
+        type="button"
+        aria-label={label}
+        title={label}
+        onClick={handleJoin}
+        className={cn([
+          "flex h-full min-w-0 items-center gap-1.5 px-3",
+          "text-sm font-medium text-neutral-800",
+          "transition-colors hover:bg-neutral-50",
+        ])}
+      >
+        {icon}
+        <span className="truncate">{label}</span>
+      </button>
+      <MetadataButton
+        sessionId={sessionId}
+        renderTrigger={({ open, label: metadataLabel }) => (
+          <button
+            type="button"
+            aria-label={metadataLabel}
+            title={metadataLabel}
+            className={cn([
+              "flex h-full w-7 shrink-0 items-center justify-center border-l border-neutral-200",
+              "text-neutral-500 transition-colors hover:bg-neutral-50 hover:text-neutral-900",
+              open && "bg-neutral-100 text-neutral-900",
+            ])}
+          >
+            <ChevronDownIcon size={14} />
+          </button>
+        )}
+      />
+    </div>
+  );
+}
+
+function getMeetingDisplay(type: RemoteMeeting["type"]) {
+  switch (type) {
+    case "zoom":
+      return {
+        name: "Zoom",
+        icon: <img src="/assets/zoom.png" alt="" width={18} height={18} />,
+      };
+    case "google-meet":
+      return {
+        name: "Meet",
+        icon: <img src="/assets/meet.png" alt="" width={18} height={18} />,
+      };
+    case "webex":
+      return {
+        name: "Webex",
+        icon: <img src="/assets/webex.png" alt="" width={18} height={18} />,
+      };
+    case "teams":
+      return {
+        name: "Teams",
+        icon: <img src="/assets/teams.png" alt="" width={18} height={18} />,
+      };
+    default:
+      return {
+        name: "Meeting",
+        icon: <HeadsetIcon size={18} />,
+      };
+  }
 }
 
 function SidebarModeStopButton({ sessionId }: { sessionId: string }) {

--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -1,5 +1,5 @@
 import { CalendarIcon, MapPinIcon, VideoIcon } from "lucide-react";
-import { forwardRef, useState } from "react";
+import { forwardRef, type ReactElement, useState } from "react";
 
 import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { Button } from "@hypr/ui/components/ui/button";
@@ -17,13 +17,25 @@ import { ParticipantsDisplay } from "./participants";
 import { useConfigValue } from "~/shared/config";
 import { useSessionEvent } from "~/store/tinybase/hooks";
 
-export function MetadataButton({ sessionId }: { sessionId: string }) {
+export function MetadataButton({
+  sessionId,
+  renderTrigger,
+}: {
+  sessionId: string;
+  renderTrigger?: (props: { open: boolean; label: string }) => ReactElement;
+}) {
   const [open, setOpen] = useState(false);
+  const sessionEvent = useSessionEvent(sessionId);
+  const label = sessionEvent ? "Open event metadata" : "Open note metadata";
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <TriggerInner sessionId={sessionId} open={open} />
+        {renderTrigger ? (
+          renderTrigger({ open, label })
+        ) : (
+          <TriggerInner label={label} open={open} />
+        )}
       </PopoverTrigger>
       <PopoverContent
         variant="app"
@@ -40,11 +52,8 @@ export function MetadataButton({ sessionId }: { sessionId: string }) {
 
 const TriggerInner = forwardRef<
   HTMLButtonElement,
-  { sessionId: string; open?: boolean }
->(({ sessionId, open, ...props }, ref) => {
-  const sessionEvent = useSessionEvent(sessionId);
-  const label = sessionEvent ? "Open event metadata" : "Open note metadata";
-
+  { label: string; open?: boolean }
+>(({ label, open, ...props }, ref) => {
   return (
     <Button
       ref={ref}

--- a/apps/desktop/src/session/hooks/useRemoteMeeting.ts
+++ b/apps/desktop/src/session/hooks/useRemoteMeeting.ts
@@ -30,10 +30,9 @@ export function detectMeetingType(
   }
 }
 
-export function useRemoteMeeting(sessionId: string): RemoteMeeting | null {
-  const event = useSessionEvent(sessionId);
-  const meetingLink = event?.meeting_link ?? null;
-
+export function getRemoteMeeting(
+  meetingLink: string | null | undefined,
+): RemoteMeeting | null {
   if (!meetingLink) {
     return null;
   }
@@ -44,4 +43,9 @@ export function useRemoteMeeting(sessionId: string): RemoteMeeting | null {
   }
 
   return { type, url: meetingLink };
+}
+
+export function useRemoteMeeting(sessionId: string): RemoteMeeting | null {
+  const event = useSessionEvent(sessionId);
+  return getRemoteMeeting(event?.meeting_link);
 }


### PR DESCRIPTION
## Summary
- Replace the floating meeting join FAB with a session header control.
- Add metadata trigger states for meeting join availability.
- Keep the join affordance colocated with session metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI relocation and display gating only; join still uses the same URL opener path with added tests.
> 
> **Overview**
> **Moves remote meeting “Join” from the floating listen UI into the session outer header**, next to calendar metadata.
> 
> The floating `ListenButton` no longer loads `useRemoteMeeting` or renders provider-specific join FABs; it only shows the countdown (when applicable) and listen action. **`OuterHeader`** now decides what to show via `HeaderMeetingControl`: a **Join {Zoom|Meet|…}** pill that opens the link through `openerCommands`, paired with a **chevron metadata trigger**, but only when the session has a recognized remote link, the event has not ended, and listening is not in progress (`active` / `finalizing` / `running_batch`). During or after the meeting window, users see the usual metadata control instead.
> 
> **`MetadataButton`** gains an optional `renderTrigger` so the header can embed metadata beside join without duplicating popover logic. **`getRemoteMeeting`** is extracted from `useRemoteMeeting` for reuse with raw `meeting_link` values. Tests cover header join visibility, open-url behavior, and that join stays out of the floating slot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4668893f87413a5a9c9eda66482639086ec4708b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->