### PR TITLE
add darkmode and migrate to semantic tokens

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -7,6 +7,18 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
     <title>Anarlog</title>
+    <script>
+      (function () {
+        var theme = localStorage.getItem("hypr-theme");
+        var prefersDark = window.matchMedia("(prefers-color-scheme: dark)")
+          .matches;
+        var isDark =
+          theme === "dark" || ((theme === "system" || !theme) && prefersDark);
+        if (isDark) {
+          document.documentElement.classList.add("dark");
+        }
+      })();
+    </script>
     <style>
       html, body, #root {
         background: transparent !important;

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -13,10 +13,11 @@
         var prefersDark = window.matchMedia("(prefers-color-scheme: dark)")
           .matches;
         var isDark =
-          theme === "dark" || ((theme === "system" || !theme) && prefersDark);
-        if (isDark) {
-          document.documentElement.classList.add("dark");
-        }
+          theme === "dark" ||
+          (theme !== "light" &&
+            (theme === "system" || !theme) &&
+            prefersDark);
+        document.documentElement.classList.toggle("dark", isDark);
       })();
     </script>
     <style>

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -7,19 +7,7 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
     <title>Anarlog</title>
-    <script>
-      (function () {
-        var theme = localStorage.getItem("hypr-theme");
-        var prefersDark = window.matchMedia("(prefers-color-scheme: dark)")
-          .matches;
-        var isDark =
-          theme === "dark" ||
-          (theme !== "light" &&
-            (theme === "system" || !theme) &&
-            prefersDark);
-        document.documentElement.classList.toggle("dark", isDark);
-      })();
-    </script>
+    <script src="/theme-boot.js"></script>
     <style>
       html, body, #root {
         background: transparent !important;

--- a/apps/desktop/public/theme-boot.js
+++ b/apps/desktop/public/theme-boot.js
@@ -1,0 +1,11 @@
+(function () {
+  var stored = localStorage.getItem("hypr-theme");
+  var theme =
+    stored === "light" || stored === "dark" || stored === "system"
+      ? stored
+      : "system";
+  var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  var isDark =
+    theme === "dark" ? true : theme === "light" ? false : prefersDark;
+  document.documentElement.classList.toggle("dark", isDark);
+})();

--- a/apps/desktop/public/theme-boot.js
+++ b/apps/desktop/public/theme-boot.js
@@ -1,4 +1,5 @@
 (function () {
+  // Fast path before React boots. `main.tsx` re-reads settings.json and syncs this key.
   var stored = localStorage.getItem("hypr-theme");
   var theme =
     stored === "light" || stored === "dark" || stored === "system"

--- a/apps/desktop/src/audio-player/timeline-shell.tsx
+++ b/apps/desktop/src/audio-player/timeline-shell.tsx
@@ -4,7 +4,7 @@ import { cn } from "@hypr/utils";
 
 export function TimelineMeta({ children }: { children: ReactNode }) {
   return (
-    <div className="inline-flex shrink-0 items-center gap-1 font-mono text-xs text-neutral-600 tabular-nums select-none">
+    <div className="text-muted-foreground inline-flex shrink-0 items-center gap-1 font-mono text-xs tabular-nums select-none">
       {children}
     </div>
   );
@@ -23,7 +23,7 @@ export function TimelineShell({
 }) {
   return (
     <div
-      className="w-full rounded-xl bg-neutral-50 select-none"
+      className="bg-muted w-full rounded-xl select-none"
       onContextMenu={onContextMenu}
     >
       <div

--- a/apps/desktop/src/audio-player/timeline.tsx
+++ b/apps/desktop/src/audio-player/timeline.tsx
@@ -100,21 +100,18 @@ export function Timeline() {
           className={cn([
             "flex items-center justify-center",
             "h-7 w-7 rounded-full",
-            "border border-neutral-200 bg-white",
-            "transition-all hover:scale-110 hover:bg-neutral-100",
+            "border-border bg-card border",
+            "hover:bg-accent transition-all hover:scale-110",
             "shrink-0 shadow-xs select-none",
           ])}
         >
           {state === "playing" ? (
             <Pause
-              className="h-3.5 w-3.5 text-neutral-900"
+              className="text-foreground h-3.5 w-3.5"
               fill="currentColor"
             />
           ) : (
-            <Play
-              className="h-3.5 w-3.5 text-neutral-900"
-              fill="currentColor"
-            />
+            <Play className="text-foreground h-3.5 w-3.5" fill="currentColor" />
           )}
         </button>
       }
@@ -132,9 +129,9 @@ export function Timeline() {
                 className={cn([
                   "flex items-center justify-center",
                   "h-6 rounded-md px-1.5",
-                  "border border-neutral-200 bg-white",
-                  "transition-colors hover:bg-neutral-100",
-                  "font-mono text-xs text-neutral-700 select-none",
+                  "border-border bg-card border",
+                  "hover:bg-accent transition-colors",
+                  "text-muted-foreground font-mono text-xs select-none",
                   "shadow-xs",
                 ])}
               >
@@ -144,7 +141,7 @@ export function Timeline() {
                 <div
                   className={cn([
                     "absolute right-0 bottom-full mb-1",
-                    "rounded-lg border border-neutral-200 bg-white shadow-md",
+                    "border-border bg-card rounded-lg border shadow-md",
                     "z-50 py-1",
                   ])}
                 >
@@ -157,10 +154,10 @@ export function Timeline() {
                       }}
                       className={cn([
                         "block w-full px-3 py-1 text-left font-mono text-xs select-none",
-                        "transition-colors hover:bg-neutral-100",
+                        "hover:bg-accent transition-colors",
                         rate === playbackRate
-                          ? "font-semibold text-neutral-900"
-                          : "text-neutral-600",
+                          ? "text-foreground font-semibold"
+                          : "text-muted-foreground",
                       ])}
                     >
                       {rate}x

--- a/apps/desktop/src/billing/trial-dialog-icon.tsx
+++ b/apps/desktop/src/billing/trial-dialog-icon.tsx
@@ -18,7 +18,7 @@ export function TrialDialogIcon({ state }: { state: "started" | "ended" }) {
         aria-hidden="true"
         className={cn([
           "absolute size-14 rounded-[18px] blur-md",
-          isStarted ? "bg-amber-200/55" : "bg-neutral-400/30",
+          isStarted ? "bg-amber-200/55" : "bg-muted-foreground/30",
         ])}
       />
       <div

--- a/apps/desktop/src/billing/trial-ended-dialog.tsx
+++ b/apps/desktop/src/billing/trial-ended-dialog.tsx
@@ -23,13 +23,13 @@ export function TrialEndedDialog({
 }: TrialEndedDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[calc(100vw-48px)] max-w-[320px] gap-0 overflow-hidden rounded-[26px] border-white/45 bg-neutral-200/95 p-0 shadow-[0_24px_70px_rgba(0,0,0,0.32)] backdrop-blur-xl sm:rounded-[26px] [&>button:last-child]:hidden">
+      <DialogContent className="border-border/45 bg-card/95 w-[calc(100vw-48px)] max-w-[320px] gap-0 overflow-hidden rounded-[26px] p-0 shadow-[0_24px_70px_rgba(0,0,0,0.32)] backdrop-blur-xl sm:rounded-[26px] [&>button:last-child]:hidden">
         <DialogHeader className="items-center gap-2 px-5 pt-7 text-center sm:text-center">
           <TrialDialogIcon state="ended" />
-          <DialogTitle className="text-[13px] leading-5 font-semibold tracking-normal text-neutral-900">
+          <DialogTitle className="text-foreground text-[13px] leading-5 font-semibold tracking-normal">
             Your Pro trial has ended
           </DialogTitle>
-          <DialogDescription className="max-w-[260px] text-center text-[13px] leading-[1.36] text-neutral-800">
+          <DialogDescription className="text-foreground max-w-[260px] text-center text-[13px] leading-[1.36]">
             Your notes and recordings are safe. Free local transcription still
             works. Upgrade anytime to keep Pro features.
           </DialogDescription>
@@ -37,13 +37,13 @@ export function TrialEndedDialog({
         <DialogFooter className="grid grid-cols-2 gap-2 px-4 pt-4 pb-4 sm:grid-cols-2 sm:justify-normal">
           <Button
             variant="ghost"
-            className="h-8 rounded-full bg-neutral-300/80 px-4 text-xs font-medium text-neutral-800 shadow-none hover:bg-neutral-300 hover:text-neutral-900"
+            className="bg-accent/80 text-foreground hover:bg-accent hover:text-foreground h-8 rounded-full px-4 text-xs font-medium shadow-none"
             onClick={() => onOpenChange(false)}
           >
             Maybe later
           </Button>
           <Button
-            className="h-8 rounded-full bg-linear-to-t from-stone-600 to-stone-500 px-4 text-xs font-medium text-white shadow-sm hover:from-stone-500 hover:to-stone-500 hover:text-white"
+            className="bg-primary text-primary-foreground hover:bg-primary/90 h-8 rounded-full px-4 text-xs font-medium shadow-sm"
             onClick={() => {
               onUpgrade();
               onOpenChange(false);

--- a/apps/desktop/src/billing/trial-started-dialog.tsx
+++ b/apps/desktop/src/billing/trial-started-dialog.tsx
@@ -25,19 +25,19 @@ export function TrialStartedDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[calc(100vw-48px)] max-w-[320px] gap-0 overflow-hidden rounded-[26px] border-white/45 bg-neutral-200/95 p-0 shadow-[0_24px_70px_rgba(0,0,0,0.32)] backdrop-blur-xl sm:rounded-[26px] [&>button:last-child]:hidden">
+      <DialogContent className="border-border/45 bg-card/95 w-[calc(100vw-48px)] max-w-[320px] gap-0 overflow-hidden rounded-[26px] p-0 shadow-[0_24px_70px_rgba(0,0,0,0.32)] backdrop-blur-xl sm:rounded-[26px] [&>button:last-child]:hidden">
         <DialogHeader className="items-center gap-2 px-5 pt-7 text-center sm:text-center">
           <TrialDialogIcon state="started" />
-          <DialogTitle className="text-[13px] leading-5 font-semibold tracking-normal text-neutral-900">
+          <DialogTitle className="text-foreground text-[13px] leading-5 font-semibold tracking-normal">
             Your Pro trial just started
           </DialogTitle>
-          <DialogDescription className="w-full text-center text-[13px] leading-[1.36] text-neutral-800">
+          <DialogDescription className="text-foreground w-full text-center text-[13px] leading-[1.36]">
             Your {days}-day Pro trial starts now. No payment needed.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="px-4 pt-4 pb-4 sm:justify-center">
           <Button
-            className="h-8 w-full rounded-full bg-linear-to-t from-stone-600 to-stone-500 px-4 text-xs font-medium text-white shadow-sm hover:from-stone-500 hover:to-stone-500 hover:text-white"
+            className="bg-primary text-primary-foreground hover:bg-primary/90 h-8 w-full rounded-full px-4 text-xs font-medium shadow-sm"
             onClick={() => onOpenChange(false)}
           >
             Got it

--- a/apps/desktop/src/calendar/components/apple/permission.tsx
+++ b/apps/desktop/src/calendar/components/apple/permission.tsx
@@ -25,7 +25,7 @@ function ActionLink({
       onClick={onClick}
       disabled={disabled}
       className={cn([
-        "underline transition-colors hover:text-neutral-900",
+        "hover:text-foreground underline transition-colors",
         disabled && "cursor-not-allowed opacity-50",
       ])}
     >
@@ -96,7 +96,7 @@ export function AccessPermissionRow({
           disabled={isPending}
           className={cn([
             "size-8",
-            isAuthorized && "bg-stone-100 text-stone-800 hover:bg-stone-200",
+            isAuthorized && "bg-muted text-foreground hover:bg-accent",
           ])}
           aria-label={
             isAuthorized
@@ -130,12 +130,12 @@ export function TroubleShootingLink({
 }) {
   const [showActions, setShowActions] = useState(false);
   return (
-    <div className={cn(["text-xs text-neutral-600", className])}>
+    <div className={cn(["text-muted-foreground text-xs", className])}>
       {!showActions ? (
         <button
           type="button"
           onClick={() => setShowActions(true)}
-          className="underline transition-colors hover:text-neutral-900"
+          className="hover:text-foreground underline transition-colors"
         >
           Having trouble?
         </button>

--- a/apps/desktop/src/calendar/components/calendar-selection.tsx
+++ b/apps/desktop/src/calendar/components/calendar-selection.tsx
@@ -69,19 +69,19 @@ export function CalendarSelection({
       >
         {isLoading ? (
           <>
-            <Loader2Icon className="mb-2 size-6 animate-spin text-neutral-300" />
-            <p className="text-xs text-neutral-500">Loading calendars…</p>
+            <Loader2Icon className="text-muted-foreground/70 mb-2 size-6 animate-spin" />
+            <p className="text-muted-foreground text-xs">Loading calendars…</p>
           </>
         ) : (
           <>
-            <CalendarOffIcon className="mb-2 size-6 text-neutral-300" />
-            <div className="flex items-center gap-1 text-xs text-neutral-500">
+            <CalendarOffIcon className="text-muted-foreground/70 mb-2 size-6" />
+            <div className="text-muted-foreground flex items-center gap-1 text-xs">
               <p>No calendars found</p>
               {onRefresh ? (
                 <button
                   type="button"
                   onClick={onRefresh}
-                  className="rounded p-1 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-700"
+                  className="text-muted-foreground hover:bg-accent hover:text-muted-foreground rounded p-1 transition-colors"
                   aria-label="Refresh calendars"
                 >
                   <RefreshCwIcon className="size-3" />
@@ -163,12 +163,12 @@ function CalendarGroupAccordionHeader({
       onContextMenu={hasMenu ? showContextMenu : undefined}
       className={cn([
         "group -mx-2 flex items-center gap-1 rounded-md px-2",
-        !disableHoverTone && "hover:bg-neutral-50",
+        !disableHoverTone && "hover:bg-accent",
       ])}
     >
       <AccordionHeader className="max-w-full min-w-0">
         <AccordionTriggerPrimitive className="flex max-w-full min-w-0 cursor-pointer items-center py-2 text-left hover:no-underline">
-          <span className="truncate text-xs font-medium text-neutral-600">
+          <span className="text-muted-foreground truncate text-xs font-medium">
             {group.sourceName}
           </span>
         </AccordionTriggerPrimitive>
@@ -178,7 +178,7 @@ function CalendarGroupAccordionHeader({
 
       <ChevronDown
         className={cn([
-          "size-4 shrink-0 text-neutral-500 opacity-0 transition-all duration-200 group-hover:opacity-100 focus-within:opacity-100",
+          "text-muted-foreground size-4 shrink-0 opacity-0 transition-all duration-200 group-hover:opacity-100 focus-within:opacity-100",
           "group-data-[state=open]/group:rotate-180",
         ])}
       />
@@ -197,7 +197,7 @@ function CalendarGroupHeader({ group }: { group: CalendarGroup }) {
       onContextMenu={showContextMenu}
       className="group flex items-center justify-between gap-2 py-1"
     >
-      <span className="truncate text-xs font-medium text-neutral-600">
+      <span className="text-muted-foreground truncate text-xs font-medium">
         {group.sourceName}
       </span>
       <CalendarGroupMenuButton onClick={showContextMenu} />
@@ -215,9 +215,9 @@ function CalendarGroupMenuButton({
       type="button"
       onClick={onClick}
       className={cn([
-        "shrink-0 rounded p-1 text-neutral-400 transition-colors",
+        "text-muted-foreground shrink-0 rounded p-1 transition-colors",
         "opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
-        "hover:bg-neutral-200 hover:text-neutral-700",
+        "hover:bg-accent hover:text-muted-foreground",
       ])}
       aria-label="Open calendar account actions"
     >
@@ -254,7 +254,12 @@ function CalendarToggleRow({
             : { borderColor: color }
         }
       >
-        {enabled && <CheckIcon className="size-3 text-white" strokeWidth={3} />}
+        {enabled && (
+          <CheckIcon
+            className="text-primary-foreground size-3"
+            strokeWidth={3}
+          />
+        )}
       </div>
       <span className="truncate text-sm">{calendar.title}</span>
     </button>

--- a/apps/desktop/src/calendar/components/calendar-view.tsx
+++ b/apps/desktop/src/calendar/components/calendar-view.tsx
@@ -221,11 +221,11 @@ export function CalendarView() {
         data-tauri-drag-region
         className={cn([
           "flex items-center justify-between",
-          "h-12 border-b border-neutral-200 py-2 pr-3 pl-3 select-none",
+          "border-border h-12 border-b py-2 pr-3 pl-3 select-none",
         ])}
       >
         <div className="flex items-center gap-2">
-          <h2 className="text-sm font-semibold text-neutral-900">
+          <h2 className="text-foreground text-sm font-semibold">
             {isMonthView
               ? format(currentMonth, "MMMM yyyy")
               : format(compactVisibleStart, "MMMM yyyy")}
@@ -235,35 +235,35 @@ export function CalendarView() {
         <ButtonGroup
           data-tauri-drag-region="false"
           className={cn([
-            "h-8 overflow-hidden rounded-full border border-neutral-200",
-            "bg-white shadow-xs",
+            "border-border h-8 overflow-hidden rounded-full border",
+            "bg-card shadow-xs",
           ])}
         >
           <Button
             variant="ghost"
             size="icon"
-            className="h-full w-10 rounded-none border-0 bg-transparent shadow-none hover:bg-neutral-50"
+            className="hover:bg-accent h-full w-10 rounded-none border-0 bg-transparent shadow-none"
             onClick={goToPrev}
           >
             <ChevronLeftIcon className="h-4 w-4" />
           </Button>
-          <ButtonGroupSeparator className="bg-neutral-200" />
+          <ButtonGroupSeparator className="bg-accent" />
           <Button
             variant="ghost"
             size="sm"
             className={cn([
               "h-full rounded-none border-0",
-              "bg-transparent px-3 text-sm shadow-none hover:bg-neutral-50",
+              "hover:bg-accent bg-transparent px-3 text-sm shadow-none",
             ])}
             onClick={goToToday}
           >
             Today
           </Button>
-          <ButtonGroupSeparator className="bg-neutral-200" />
+          <ButtonGroupSeparator className="bg-accent" />
           <Button
             variant="ghost"
             size="icon"
-            className="h-full w-10 rounded-none border-0 bg-transparent shadow-none hover:bg-neutral-50"
+            className="hover:bg-accent h-full w-10 rounded-none border-0 bg-transparent shadow-none"
             onClick={goToNext}
           >
             <ChevronRightIcon className="h-4 w-4" />
@@ -274,7 +274,7 @@ export function CalendarView() {
       {isMonthView ? (
         <>
           <div
-            className="grid border-b border-neutral-200"
+            className="border-border grid border-b"
             style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
           >
             {visibleHeaders.map((day, i) => (
@@ -283,11 +283,10 @@ export function CalendarView() {
                 className={cn([
                   "text-center text-xs font-medium",
                   "py-2",
-                  i < visibleHeaders.length - 1 &&
-                    "border-r border-r-neutral-200",
+                  i < visibleHeaders.length - 1 && "border-r-border border-r",
                   day === "Sat" || day === "Sun"
-                    ? "text-neutral-400"
-                    : "text-neutral-900",
+                    ? "text-muted-foreground"
+                    : "text-foreground",
                 ])}
               >
                 {day}
@@ -331,11 +330,11 @@ export function CalendarView() {
                 <div
                   key={`header-${day.toISOString()}`}
                   className={cn([
-                    "snap-start border-r border-b border-r-neutral-200 border-b-neutral-200",
+                    "border-r-border border-b-border snap-start border-r border-b",
                     "py-2 text-center text-xs font-medium",
                     label === "Sat" || label === "Sun"
-                      ? "text-neutral-400"
-                      : "text-neutral-900",
+                      ? "text-muted-foreground"
+                      : "text-foreground",
                   ])}
                 >
                   {label}
@@ -425,7 +424,7 @@ function CalendarSyncHeaderControls() {
       {showSyncIndicator ? (
         <Tooltip delayDuration={0}>
           <TooltipTrigger asChild>
-            <span className="flex size-6 items-center justify-center text-neutral-500">
+            <span className="text-muted-foreground flex size-6 items-center justify-center">
               <Spinner size={12} />
             </span>
           </TooltipTrigger>

--- a/apps/desktop/src/calendar/components/day-cell.tsx
+++ b/apps/desktop/src/calendar/components/day-cell.tsx
@@ -95,26 +95,26 @@ export function DayCell({
   return (
     <div
       className={cn([
-        "border-r border-b border-r-neutral-200 border-b-neutral-100",
+        "border-r-border border-b-border border-r border-b",
         "flex min-w-0 flex-col p-1.5 select-none",
-        (day.getDay() === 0 || day.getDay() === 6) && "bg-neutral-50",
+        (day.getDay() === 0 || day.getDay() === 6) && "bg-muted",
       ])}
     >
       <div className="flex shrink-0 justify-end">
         <div
           className={cn([
             "mb-1 flex h-7 w-7 items-center justify-center rounded-full text-sm font-medium",
-            today && "bg-neutral-900 text-white",
-            !today && !isCurrentMonth && "text-neutral-300",
+            today && "bg-primary text-primary-foreground",
+            !today && !isCurrentMonth && "text-muted-foreground/70",
             !today &&
               isCurrentMonth &&
               (day.getDay() === 0 || day.getDay() === 6) &&
-              "text-neutral-400",
+              "text-muted-foreground",
             !today &&
               isCurrentMonth &&
               day.getDay() !== 0 &&
               day.getDay() !== 6 &&
-              "text-neutral-900",
+              "text-foreground",
           ])}
         >
           {format(day, "d")}
@@ -133,7 +133,7 @@ export function DayCell({
         {overflow > 0 && (
           <Popover>
             <PopoverTrigger asChild>
-              <button className="shrink-0 cursor-pointer pl-1 text-left text-xs text-neutral-400 hover:text-neutral-600">
+              <button className="text-muted-foreground hover:text-muted-foreground shrink-0 cursor-pointer pl-1 text-left text-xs">
                 +{overflow} more
               </button>
             </PopoverTrigger>
@@ -144,7 +144,7 @@ export function DayCell({
               onClick={(e) => e.stopPropagation()}
             >
               <AppFloatingPanel className="p-2">
-                <div className="mb-2 text-sm font-medium text-neutral-900">
+                <div className="text-foreground mb-2 text-sm font-medium">
                   {format(day, "MMM d, yyyy")}
                 </div>
                 <div className="flex flex-col gap-0.5">

--- a/apps/desktop/src/calendar/components/event-chip.tsx
+++ b/apps/desktop/src/calendar/components/event-chip.tsx
@@ -111,7 +111,7 @@ export function EventChip({ eventId }: { eventId: string }) {
         {isAllDay ? (
           <button
             className={cn([
-              "w-full truncate rounded px-1.5 py-0.5 text-left text-xs leading-tight text-white",
+              "text-primary-foreground w-full truncate rounded px-1.5 py-0.5 text-left text-xs leading-tight",
               "cursor-pointer select-none hover:opacity-80",
             ])}
             style={{ backgroundColor: color }}
@@ -133,7 +133,7 @@ export function EventChip({ eventId }: { eventId: string }) {
             />
             <span className="truncate">{title}</span>
             {startedAt && (
-              <span className="ml-auto shrink-0 font-mono text-neutral-400">
+              <span className="text-muted-foreground ml-auto shrink-0 font-mono">
                 {startedAt}
               </span>
             )}
@@ -181,7 +181,7 @@ function EventPopoverContent({ eventId }: { eventId: string }) {
       <EventDisplay event={event} />
       <Button
         size="sm"
-        className="min-h-8 w-full bg-stone-800 text-white hover:bg-stone-700"
+        className="bg-primary text-primary-foreground hover:bg-primary/90 min-h-8 w-full"
         onClick={handleOpen}
       >
         Open note

--- a/apps/desktop/src/calendar/components/oauth/provider-content.tsx
+++ b/apps/desktop/src/calendar/components/oauth/provider-content.tsx
@@ -55,7 +55,7 @@ export function OAuthProviderContent({
           <TooltipTrigger asChild>
             <span
               tabIndex={0}
-              className="cursor-not-allowed text-xs text-neutral-400 opacity-50"
+              className="text-muted-foreground cursor-not-allowed text-xs opacity-50"
             >
               Connect {config.displayName} Calendar
             </span>
@@ -73,7 +73,7 @@ export function OAuthProviderContent({
       <div className="pt-1 pb-2">
         <button
           onClick={upgradeToPro}
-          className="cursor-pointer text-xs text-neutral-600 underline transition-colors hover:text-neutral-900"
+          className="text-muted-foreground hover:text-foreground cursor-pointer text-xs underline transition-colors"
         >
           Upgrade to connect
         </button>
@@ -135,7 +135,7 @@ export function OAuthProviderContent({
     <div className="pt-1 pb-2">
       <button
         onClick={handleAddAccount}
-        className="cursor-pointer text-xs text-neutral-600 underline transition-colors hover:text-neutral-900"
+        className="text-muted-foreground hover:text-foreground cursor-pointer text-xs underline transition-colors"
       >
         Connect {config.displayName} Calendar
       </button>
@@ -162,17 +162,17 @@ function ReconnectRequiredContent({
       </div>
 
       {errorDescription && (
-        <p className="text-xs text-neutral-600">{errorDescription}</p>
+        <p className="text-muted-foreground text-xs">{errorDescription}</p>
       )}
 
       <div className="flex items-center gap-2">
         <button
           onClick={onReconnect}
-          className="cursor-pointer text-xs text-neutral-600 underline transition-colors hover:text-neutral-900"
+          className="text-muted-foreground hover:text-foreground cursor-pointer text-xs underline transition-colors"
         >
           Reconnect
         </button>
-        <span className="text-xs text-neutral-400">or</span>
+        <span className="text-muted-foreground text-xs">or</span>
         <button
           onClick={onDisconnect}
           className="cursor-pointer text-xs text-red-500 underline transition-colors hover:text-red-700"

--- a/apps/desktop/src/calendar/components/session-chip.tsx
+++ b/apps/desktop/src/calendar/components/session-chip.tsx
@@ -90,10 +90,10 @@ export function SessionChip({ sessionId }: { sessionId: string }) {
           ])}
           onContextMenu={showContextMenu}
         >
-          <div className="w-[4px] shrink-0 self-stretch rounded-full border border-neutral-300 bg-transparent" />
+          <div className="border-border w-[4px] shrink-0 self-stretch rounded-full border bg-transparent" />
           <span className="truncate">{title}</span>
           {createdAt && (
-            <span className="ml-auto shrink-0 font-mono text-neutral-400">
+            <span className="text-muted-foreground ml-auto shrink-0 font-mono">
               {createdAt}
             </span>
           )}
@@ -136,14 +136,16 @@ function SessionPopoverContent({ sessionId }: { sessionId: string }) {
 
   return (
     <div className="flex flex-col gap-3 p-4">
-      <div className="text-base font-medium text-neutral-900">
+      <div className="text-foreground text-base font-medium">
         {session.title as string}
       </div>
-      <div className="h-px bg-neutral-200" />
-      {createdAt && <div className="text-sm text-neutral-700">{createdAt}</div>}
+      <div className="bg-accent h-px" />
+      {createdAt && (
+        <div className="text-muted-foreground text-sm">{createdAt}</div>
+      )}
       <Button
         size="sm"
-        className="min-h-8 w-full bg-stone-800 text-white hover:bg-stone-700"
+        className="bg-primary text-primary-foreground hover:bg-primary/90 min-h-8 w-full"
         onClick={handleOpen}
       >
         Open note

--- a/apps/desktop/src/calendar/components/sidebar.tsx
+++ b/apps/desktop/src/calendar/components/sidebar.tsx
@@ -26,10 +26,10 @@ import { openIntegrationUrl } from "~/shared/integration";
 
 function getProviderBadgeClassName(badge: string) {
   if (badge === "Beta") {
-    return "text-xs font-medium text-stone-600";
+    return "text-xs font-medium text-muted-foreground";
   }
 
-  return "rounded-full border border-neutral-300 px-2 text-xs font-light text-neutral-500";
+  return "rounded-full border border-border px-2 text-xs font-light text-muted-foreground";
 }
 
 function getDefaultOpenProviderIds(
@@ -124,7 +124,7 @@ export function CalendarSidebarContent({
         provider.disabled ? (
           <div
             key={provider.id}
-            className="flex items-center gap-2 border-b border-neutral-100 py-3 opacity-50 last:border-none"
+            className="border-border flex items-center gap-2 border-b py-3 opacity-50 last:border-none"
           >
             <ProviderIcon provider={provider} />
             <span className="text-sm font-medium">{provider.displayName}</span>
@@ -245,14 +245,14 @@ function ProviderAccordionItem({
   return (
     <AccordionItem
       value={provider.id}
-      className="group/provider border-b border-neutral-100 last:border-none"
+      className="group/provider border-border border-b last:border-none"
     >
       <div
         onContextMenu={
           providerMenuItems.length > 0 ? showProviderMenu : undefined
         }
         className={cn([
-          "group/row relative grid items-center gap-1 rounded-md hover:bg-neutral-50",
+          "group/row hover:bg-accent relative grid items-center gap-1 rounded-md",
           hasAddAccountButton
             ? "grid-cols-[minmax(0,1fr)_auto_auto]"
             : "grid-cols-[minmax(0,1fr)_auto]",
@@ -291,7 +291,7 @@ function ProviderAccordionItem({
           <button
             type="button"
             onClick={handleUpgradeToPro}
-            className="pointer-events-none absolute top-1/2 right-1 z-10 shrink-0 translate-x-1 -translate-y-1/2 rounded-full border-2 border-stone-600 bg-stone-800 px-3 py-1 text-xs font-medium text-white opacity-0 shadow-[0_4px_14px_rgba(87,83,78,0.18)] transition-all duration-150 group-focus-within/row:pointer-events-auto group-focus-within/row:translate-x-0 group-focus-within/row:opacity-100 group-hover/row:pointer-events-auto group-hover/row:translate-x-0 group-hover/row:opacity-100 hover:bg-stone-700 focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:outline-none"
+            className="border-primary bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-ring pointer-events-none absolute top-1/2 right-1 z-10 shrink-0 translate-x-1 -translate-y-1/2 rounded-full border-2 px-3 py-1 text-xs font-medium opacity-0 shadow-[0_4px_14px_rgba(87,83,78,0.18)] transition-all duration-150 group-focus-within/row:pointer-events-auto group-focus-within/row:translate-x-0 group-focus-within/row:opacity-100 group-hover/row:pointer-events-auto group-hover/row:translate-x-0 group-hover/row:opacity-100 focus-visible:ring-2 focus-visible:outline-none"
             aria-label={`Upgrade to Pro for ${provider.displayName}`}
           >
             Upgrade to Pro
@@ -300,7 +300,7 @@ function ProviderAccordionItem({
           <button
             type="button"
             onClick={handleAddAccount}
-            className="shrink-0 rounded p-1 text-neutral-500 transition-colors hover:bg-neutral-200 hover:text-neutral-900"
+            className="text-muted-foreground hover:bg-accent hover:text-foreground shrink-0 rounded p-1 transition-colors"
             aria-label={`Add ${provider.displayName} account`}
           >
             <PlusIcon className="size-4" />
@@ -310,7 +310,7 @@ function ProviderAccordionItem({
         {!requiresPro && (
           <ChevronDown
             className={cn([
-              "size-4 shrink-0 text-neutral-500 opacity-0 transition-all duration-200 group-focus-within/row:opacity-100 group-hover/row:opacity-100",
+              "text-muted-foreground size-4 shrink-0 opacity-0 transition-all duration-200 group-focus-within/row:opacity-100 group-hover/row:opacity-100",
               "group-data-[state=open]/provider:rotate-180",
             ])}
           />

--- a/apps/desktop/src/changelog/index.tsx
+++ b/apps/desktop/src/changelog/index.tsx
@@ -65,7 +65,7 @@ function ExternalLink({
 }) {
   return (
     <a
-      className="text-blue-600 underline hover:text-blue-800"
+      className="text-blue-600 underline decoration-blue-400/40 underline-offset-2 hover:text-blue-700 dark:text-blue-400 dark:decoration-blue-500/50 dark:hover:text-blue-300"
       href={href}
       onClick={(e) => {
         e.preventDefault();
@@ -85,7 +85,7 @@ function ChangelogBody({
   loading: boolean;
 }) {
   if (loading) {
-    return <p className="text-neutral-500">Loading...</p>;
+    return <p className="text-muted-foreground">Loading...</p>;
   }
 
   if (content) {
@@ -111,7 +111,9 @@ function ChangelogBody({
   }
 
   return (
-    <p className="text-neutral-500">No changelog available for this version.</p>
+    <p className="text-muted-foreground">
+      No changelog available for this version.
+    </p>
   );
 }
 
@@ -133,7 +135,7 @@ function ChangelogHeader({
     >
       <div className="flex w-full min-w-0 items-center justify-between gap-0">
         <div className="min-w-0 flex-1">
-          <h1 className="truncate text-xl font-semibold text-neutral-900">
+          <h1 className="text-foreground truncate text-xl font-semibold">
             What's new in {version}?
           </h1>
         </div>
@@ -142,7 +144,7 @@ function ChangelogHeader({
           <Button
             size="icon"
             variant="ghost"
-            className="text-neutral-500 hover:text-black"
+            className="text-muted-foreground hover:text-foreground"
             aria-label="Close changelog"
             title="Close"
             onClick={onClose}

--- a/apps/desktop/src/chat/components/body/empty.tsx
+++ b/apps/desktop/src/chat/components/body/empty.tsx
@@ -65,7 +65,9 @@ export function ChatBodyEmpty({
             <span
               className={cn([
                 "text-sm font-medium",
-                isDarkAppearance ? "text-primary-foreground" : "text-foreground",
+                isDarkAppearance
+                  ? "text-primary-foreground"
+                  : "text-foreground",
               ])}
             >
               Anarlog AI

--- a/apps/desktop/src/chat/components/body/empty.tsx
+++ b/apps/desktop/src/chat/components/body/empty.tsx
@@ -9,7 +9,7 @@ import { useCallback } from "react";
 import { cn } from "@hypr/utils";
 
 import type { ContextRef } from "~/chat/context/entities";
-import { useShell } from "~/contexts/shell";
+import { useChatAppearance } from "~/chat/hooks/use-chat-appearance";
 import { useTabs } from "~/store/zustand/tabs";
 
 const SUGGESTIONS = [
@@ -43,10 +43,8 @@ export function ChatBodyEmpty({
     contextRefs?: ContextRef[],
   ) => void;
 }) {
-  const { chat } = useShell();
+  const { isDarkAppearance } = useChatAppearance();
   const openNew = useTabs((state) => state.openNew);
-  const isDarkSurface =
-    chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
 
   const handleGoToSettings = useCallback(() => {
     openNew({ type: "settings", state: { tab: "intelligence" } });
@@ -67,7 +65,7 @@ export function ChatBodyEmpty({
             <span
               className={cn([
                 "text-sm font-medium",
-                isDarkSurface ? "text-primary-foreground" : "text-foreground",
+                isDarkAppearance ? "text-primary-foreground" : "text-foreground",
               ])}
             >
               Anarlog AI
@@ -77,7 +75,7 @@ export function ChatBodyEmpty({
           <p
             className={cn([
               "mb-2 text-sm",
-              isDarkSurface
+              isDarkAppearance
                 ? "text-primary-foreground/80"
                 : "text-muted-foreground",
             ])}
@@ -107,7 +105,7 @@ export function ChatBodyEmpty({
           <span
             className={cn([
               "text-sm font-medium",
-              isDarkSurface ? "text-primary-foreground" : "text-foreground",
+              isDarkAppearance ? "text-primary-foreground" : "text-foreground",
             ])}
           >
             Anarlog AI
@@ -117,7 +115,7 @@ export function ChatBodyEmpty({
         <p
           className={cn([
             "mb-2 text-sm",
-            isDarkSurface
+            isDarkAppearance
               ? "text-primary-foreground/80"
               : "text-muted-foreground",
           ])}
@@ -133,7 +131,7 @@ export function ChatBodyEmpty({
                 onClick={() => handleSuggestionClick(prompt)}
                 className={cn([
                   "inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[11px]",
-                  isDarkSurface
+                  isDarkAppearance
                     ? "border-primary bg-primary/80 text-primary-foreground hover:bg-primary/70"
                     : "border-border bg-card text-muted-foreground hover:bg-accent",
                   "transition-colors",

--- a/apps/desktop/src/chat/components/body/empty.tsx
+++ b/apps/desktop/src/chat/components/body/empty.tsx
@@ -67,7 +67,7 @@ export function ChatBodyEmpty({
             <span
               className={cn([
                 "text-sm font-medium",
-                isDarkSurface ? "text-white" : "text-neutral-800",
+                isDarkSurface ? "text-primary-foreground" : "text-foreground",
               ])}
             >
               Anarlog AI
@@ -77,7 +77,9 @@ export function ChatBodyEmpty({
           <p
             className={cn([
               "mb-2 text-sm",
-              isDarkSurface ? "text-stone-200" : "text-neutral-700",
+              isDarkSurface
+                ? "text-primary-foreground/80"
+                : "text-muted-foreground",
             ])}
           >
             Hi, I'm Anarlog AI. Set up a language model and I'll be ready to
@@ -86,8 +88,8 @@ export function ChatBodyEmpty({
           <button
             onClick={handleGoToSettings}
             className={cn([
-              "inline-flex w-fit items-center gap-1.5 rounded-full border border-stone-600 bg-stone-800 px-3 py-1.5 text-xs font-medium text-white",
-              "shadow-[0_4px_14px_rgba(87,83,78,0.18)] transition-colors hover:bg-stone-700",
+              "border-primary bg-primary text-primary-foreground inline-flex w-fit items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium",
+              "hover:bg-primary/90 shadow-[0_4px_14px_rgba(87,83,78,0.18)] transition-colors",
             ])}
           >
             <SparklesIcon size={12} />
@@ -105,7 +107,7 @@ export function ChatBodyEmpty({
           <span
             className={cn([
               "text-sm font-medium",
-              isDarkSurface ? "text-white" : "text-neutral-800",
+              isDarkSurface ? "text-primary-foreground" : "text-foreground",
             ])}
           >
             Anarlog AI
@@ -115,7 +117,9 @@ export function ChatBodyEmpty({
         <p
           className={cn([
             "mb-2 text-sm",
-            isDarkSurface ? "text-stone-200" : "text-neutral-700",
+            isDarkSurface
+              ? "text-primary-foreground/80"
+              : "text-muted-foreground",
           ])}
         >
           Hi, I'm Anarlog AI. I can help you pull context from your notes, find
@@ -130,8 +134,8 @@ export function ChatBodyEmpty({
                 className={cn([
                   "inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[11px]",
                   isDarkSurface
-                    ? "border-stone-600 bg-stone-700 text-stone-100 hover:bg-stone-600"
-                    : "border-neutral-300 bg-white text-neutral-700 hover:bg-neutral-100",
+                    ? "border-primary bg-primary/80 text-primary-foreground hover:bg-primary/70"
+                    : "border-border bg-card text-muted-foreground hover:bg-accent",
                   "transition-colors",
                 ])}
               >

--- a/apps/desktop/src/chat/components/body/empty.tsx
+++ b/apps/desktop/src/chat/components/body/empty.tsx
@@ -134,7 +134,7 @@ export function ChatBodyEmpty({
                 className={cn([
                   "inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[11px]",
                   isDarkAppearance
-                    ? "border-primary bg-primary/80 text-primary-foreground hover:bg-primary/70"
+                    ? "border-border bg-primary-foreground text-primary hover:bg-primary-foreground/90"
                     : "border-border bg-card text-muted-foreground hover:bg-accent",
                   "transition-colors",
                 ])}

--- a/apps/desktop/src/chat/components/body/index.tsx
+++ b/apps/desktop/src/chat/components/body/index.tsx
@@ -81,7 +81,7 @@ export function ChatBody({
         <Button
           onClick={scrollToBottom}
           size="sm"
-          className="absolute bottom-3 left-1/2 z-20 flex -translate-x-1/2 transform items-center gap-1 rounded-full border border-neutral-200 bg-white text-neutral-700 shadow-xs hover:bg-neutral-50"
+          className="border-border bg-card text-muted-foreground hover:bg-accent absolute bottom-3 left-1/2 z-20 flex -translate-x-1/2 transform items-center gap-1 rounded-full border shadow-xs"
           variant="outline"
         >
           <ChevronDownIcon size={12} />

--- a/apps/desktop/src/chat/components/body/index.tsx
+++ b/apps/desktop/src/chat/components/body/index.tsx
@@ -9,6 +9,7 @@ import { ChatBodyNonEmpty } from "./non-empty";
 import { useChatAutoScroll } from "./use-chat-auto-scroll";
 
 import type { ContextRef } from "~/chat/context/entities";
+import { chatFloatingControlClassNames } from "~/chat/surface";
 import type { HyprUIMessage } from "~/chat/types";
 import { useShell } from "~/contexts/shell";
 
@@ -81,7 +82,10 @@ export function ChatBody({
         <Button
           onClick={scrollToBottom}
           size="sm"
-          className="border-border bg-card text-muted-foreground hover:bg-accent absolute bottom-3 left-1/2 z-20 flex -translate-x-1/2 transform items-center gap-1 rounded-full border shadow-xs"
+          className={cn([
+            "absolute bottom-3 left-1/2 z-20 flex -translate-x-1/2 transform items-center gap-1 rounded-full border shadow-xs",
+            chatFloatingControlClassNames(),
+          ])}
           variant="outline"
         >
           <ChevronDownIcon size={12} />

--- a/apps/desktop/src/chat/components/chat-panel.test.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.test.tsx
@@ -31,7 +31,11 @@ vi.mock("./content", () => ({
 }));
 
 vi.mock("./session-provider", () => ({
-  ChatSession: ({ children }: { children: (props: object) => React.ReactNode }) =>
+  ChatSession: ({
+    children,
+  }: {
+    children: (props: object) => React.ReactNode;
+  }) =>
     children({
       messages: [],
       status: "ready",

--- a/apps/desktop/src/chat/components/chat-panel.test.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.test.tsx
@@ -38,6 +38,29 @@ vi.mock("~/contexts/shell", () => ({
   useShell: () => ({ chat: mocks.chat }),
 }));
 
+const appearanceState = vi.hoisted(() => ({
+  isDarkAppearance: true,
+}));
+
+vi.mock("~/chat/hooks/use-chat-appearance", () => ({
+  useChatAppearance: () => ({
+    isDarkAppearance: appearanceState.isDarkAppearance,
+    toolbarSurface: appearanceState.isDarkAppearance ? "dark" : "light",
+    panelClassName: appearanceState.isDarkAppearance
+      ? "bg-primary text-primary-foreground"
+      : "bg-card text-foreground",
+    panelBorderClassName: appearanceState.isDarkAppearance
+      ? "border-primary/80"
+      : "border-border",
+    elevatedSurfaceClassName: appearanceState.isDarkAppearance
+      ? "bg-primary-foreground/95 text-primary"
+      : "bg-muted text-foreground",
+    inputEditorClassName: appearanceState.isDarkAppearance
+      ? "text-primary"
+      : "text-foreground",
+  }),
+}));
+
 vi.mock("~/store/tinybase/store/main", () => ({
   STORE_ID: "main",
   UI: {
@@ -51,9 +74,10 @@ describe("ChatView", () => {
   beforeEach(() => {
     cleanup();
     mocks.toolbarControls.mockClear();
+    appearanceState.isDarkAppearance = true;
   });
 
-  it("uses the modal dark surface for the right panel layout", () => {
+  it("uses the dark stone surface when the app is in dark appearance", () => {
     const { container } = render(<ChatView layout="right-panel" />);
     const root = container.firstElementChild;
 
@@ -67,5 +91,16 @@ describe("ChatView", () => {
         surface: "dark",
       }),
     );
+  });
+
+  it("uses the light card surface when the app is in light appearance", () => {
+    appearanceState.isDarkAppearance = false;
+
+    const { container } = render(<ChatView layout="right-panel" />);
+    const root = container.firstElementChild;
+
+    expect(root?.className).toContain("bg-card");
+    expect(root?.className).toContain("text-foreground");
+    expect(screen.getByTestId("chat-toolbar").dataset.surface).toBe("light");
   });
 });

--- a/apps/desktop/src/chat/components/chat-panel.test.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.test.tsx
@@ -2,69 +2,69 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  toolbarControls: vi.fn(() => <div data-testid="chat-toolbar" />),
   chat: {
-    groupId: undefined as string | undefined,
-    selectChat: vi.fn(),
-    sessionId: "chat-session-id",
-    setGroupId: vi.fn(),
+    groupId: "group-1",
+    sessionId: "session-1",
     startNewChat: vi.fn(),
+    selectChat: vi.fn(),
   },
-  toolbarControls: vi.fn(),
 }));
 
 vi.mock("./toolbar-controls", () => ({
-  ChatToolbarControls: (props: {
-    layout?: "floating" | "right-panel";
-    surface?: "light" | "dark";
-  }) => {
+  ChatToolbarControls: (props: Record<string, unknown>) => {
     mocks.toolbarControls(props);
-    return <div data-surface={props.surface} data-testid="chat-toolbar" />;
+    return (
+      <div data-surface={props.surface as string} data-testid="chat-toolbar" />
+    );
   },
 }));
 
-vi.mock("./use-session-tab", () => ({
-  useSessionTab: () => ({ currentSessionId: "current-session-id" }),
+vi.mock("./body", () => ({
+  ChatBody: () => <div data-testid="chat-body" />,
+}));
+
+vi.mock("./content", () => ({
+  ChatContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("./session-provider", () => ({
+  ChatSession: ({ children }: { children: (props: object) => React.ReactNode }) =>
+    children({
+      messages: [],
+      status: "ready",
+      error: undefined,
+      regenerate: vi.fn(),
+      contextEntities: [],
+      sendMessage: vi.fn(),
+      pendingRefs: [],
+    }),
 }));
 
 vi.mock("~/ai/hooks", () => ({
-  useLanguageModel: () => undefined,
+  useLanguageModel: () => ({ id: "model-1" }),
 }));
 
 vi.mock("~/chat/store/use-chat-actions", () => ({
-  useChatActions: () => ({ handleSendMessage: vi.fn() }),
+  useChatActions: () => ({
+    handleSendMessage: vi.fn(),
+  }),
+}));
+
+vi.mock("./use-session-tab", () => ({
+  useSessionTab: () => ({ currentSessionId: "session-1" }),
 }));
 
 vi.mock("~/contexts/shell", () => ({
   useShell: () => ({ chat: mocks.chat }),
 }));
 
-const appearanceState = vi.hoisted(() => ({
-  isDarkAppearance: true,
-}));
-
-vi.mock("~/chat/hooks/use-chat-appearance", () => ({
-  useChatAppearance: () => ({
-    isDarkAppearance: appearanceState.isDarkAppearance,
-    toolbarSurface: appearanceState.isDarkAppearance ? "dark" : "light",
-    panelClassName: appearanceState.isDarkAppearance
-      ? "bg-primary text-primary-foreground"
-      : "bg-card text-foreground",
-    panelBorderClassName: appearanceState.isDarkAppearance
-      ? "border-primary/80"
-      : "border-border",
-    elevatedSurfaceClassName: appearanceState.isDarkAppearance
-      ? "bg-primary-foreground/95 text-primary"
-      : "bg-muted text-foreground",
-    inputEditorClassName: appearanceState.isDarkAppearance
-      ? "text-primary"
-      : "text-foreground",
-  }),
-}));
-
 vi.mock("~/store/tinybase/store/main", () => ({
   STORE_ID: "main",
   UI: {
-    useValues: () => ({}),
+    useValues: () => ({ user_id: "user-1" }),
   },
 }));
 
@@ -74,15 +74,15 @@ describe("ChatView", () => {
   beforeEach(() => {
     cleanup();
     mocks.toolbarControls.mockClear();
-    appearanceState.isDarkAppearance = true;
   });
 
-  it("uses the dark stone surface when the app is in dark appearance", () => {
+  it("uses the dark stone shell in the right panel layout", () => {
     const { container } = render(<ChatView layout="right-panel" />);
     const root = container.firstElementChild;
 
     expect(root?.className).toContain("bg-primary");
     expect(root?.className).toContain("text-primary-foreground");
+    expect(root?.className).not.toContain("bg-card");
     expect(root?.firstElementChild?.className).toContain("h-12");
     expect(screen.getByTestId("chat-toolbar").dataset.surface).toBe("dark");
     expect(mocks.toolbarControls).toHaveBeenCalledWith(
@@ -93,14 +93,13 @@ describe("ChatView", () => {
     );
   });
 
-  it("uses the light card surface when the app is in light appearance", () => {
-    appearanceState.isDarkAppearance = false;
-
-    const { container } = render(<ChatView layout="right-panel" />);
+  it("uses the dark stone shell in the floating layout", () => {
+    const { container } = render(<ChatView layout="floating" />);
     const root = container.firstElementChild;
 
-    expect(root?.className).toContain("bg-card");
-    expect(root?.className).toContain("text-foreground");
-    expect(screen.getByTestId("chat-toolbar").dataset.surface).toBe("light");
+    expect(root?.className).toContain("bg-primary");
+    expect(root?.className).toContain("text-primary-foreground");
+    expect(root?.firstElementChild?.className).toContain("h-11");
+    expect(screen.getByTestId("chat-toolbar").dataset.surface).toBe("dark");
   });
 });

--- a/apps/desktop/src/chat/components/chat-panel.test.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.test.tsx
@@ -2,7 +2,9 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  toolbarControls: vi.fn(() => <div data-testid="chat-toolbar" />),
+  toolbarControls: vi.fn((_props: Record<string, unknown>) => (
+    <div data-testid="chat-toolbar" />
+  )),
   chat: {
     groupId: "group-1",
     sessionId: "session-1",

--- a/apps/desktop/src/chat/components/chat-panel.test.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.test.tsx
@@ -57,8 +57,8 @@ describe("ChatView", () => {
     const { container } = render(<ChatView layout="right-panel" />);
     const root = container.firstElementChild;
 
-    expect(root?.className).toContain("bg-stone-800");
-    expect(root?.className).toContain("text-white");
+    expect(root?.className).toContain("bg-primary");
+    expect(root?.className).toContain("text-primary-foreground");
     expect(root?.firstElementChild?.className).toContain("h-12");
     expect(screen.getByTestId("chat-toolbar").dataset.surface).toBe("dark");
     expect(mocks.toolbarControls).toHaveBeenCalledWith(

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -47,14 +47,14 @@ export function ChatView({
     <div
       className={cn([
         "flex h-full min-h-0 flex-col overflow-hidden",
-        "bg-stone-800 text-white",
+        "bg-primary text-primary-foreground",
       ])}
     >
       <div
         className={cn([
           "flex shrink-0 items-center pr-0 pl-0",
           isFloating ? "h-11" : "h-12",
-          "border-b border-stone-700/80",
+          "border-primary/80 border-b",
         ])}
       >
         <ChatToolbarControls

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -9,6 +9,7 @@ import { ChatToolbarControls } from "./toolbar-controls";
 import { useSessionTab } from "./use-session-tab";
 
 import { useLanguageModel } from "~/ai/hooks";
+import { useChatAppearance } from "~/chat/hooks/use-chat-appearance";
 import { useChatActions } from "~/chat/store/use-chat-actions";
 import { useShell } from "~/contexts/shell";
 import * as main from "~/store/tinybase/store/main";
@@ -24,6 +25,8 @@ export function ChatView({
 }) {
   const { chat } = useShell();
   const { groupId, sessionId, setGroupId } = chat;
+  const { panelClassName, panelBorderClassName, toolbarSurface } =
+    useChatAppearance();
   const isFloating = layout === "floating";
 
   const { currentSessionId } = useSessionTab();
@@ -47,14 +50,15 @@ export function ChatView({
     <div
       className={cn([
         "flex h-full min-h-0 flex-col overflow-hidden",
-        "bg-primary text-primary-foreground",
+        panelClassName,
       ])}
     >
       <div
         className={cn([
           "flex shrink-0 items-center pr-0 pl-0",
           isFloating ? "h-11" : "h-12",
-          "border-primary/80 border-b",
+          panelBorderClassName,
+          "border-b",
         ])}
       >
         <ChatToolbarControls
@@ -64,7 +68,7 @@ export function ChatView({
           onOpenFloating={onOpenFloating}
           onOpenRightPanel={onOpenRightPanel}
           onSelectChat={chat.selectChat}
-          surface="dark"
+          surface={toolbarSurface}
         />
       </div>
       {user_id && (

--- a/apps/desktop/src/chat/components/context-bar.test.tsx
+++ b/apps/desktop/src/chat/components/context-bar.test.tsx
@@ -57,7 +57,8 @@ vi.mock("~/chat/hooks/use-chat-appearance", () => ({
     toolbarSurface: "dark",
     panelClassName: "bg-primary text-primary-foreground",
     panelBorderClassName: "border-primary/80",
-    elevatedSurfaceClassName: "bg-primary-foreground text-primary border-border",
+    elevatedSurfaceClassName:
+      "bg-primary-foreground text-primary border-border",
     inputEditorClassName: "text-primary",
   }),
 }));

--- a/apps/desktop/src/chat/components/context-bar.test.tsx
+++ b/apps/desktop/src/chat/components/context-bar.test.tsx
@@ -51,6 +51,17 @@ vi.mock("~/contexts/shell", () => ({
   }),
 }));
 
+vi.mock("~/chat/hooks/use-chat-appearance", () => ({
+  useChatAppearance: () => ({
+    isDarkAppearance: true,
+    toolbarSurface: "dark",
+    panelClassName: "bg-primary text-primary-foreground",
+    panelBorderClassName: "border-primary/80",
+    elevatedSurfaceClassName: "bg-primary-foreground/95 text-primary",
+    inputEditorClassName: "text-primary",
+  }),
+}));
+
 vi.mock("~/search/contexts/engine", () => ({
   useSearchEngine: () => ({
     search: searchMock,

--- a/apps/desktop/src/chat/components/context-bar.test.tsx
+++ b/apps/desktop/src/chat/components/context-bar.test.tsx
@@ -57,7 +57,7 @@ vi.mock("~/chat/hooks/use-chat-appearance", () => ({
     toolbarSurface: "dark",
     panelClassName: "bg-primary text-primary-foreground",
     panelBorderClassName: "border-primary/80",
-    elevatedSurfaceClassName: "bg-primary-foreground/95 text-primary",
+    elevatedSurfaceClassName: "bg-primary-foreground text-primary border-border",
     inputEditorClassName: "text-primary",
   }),
 }));
@@ -216,7 +216,8 @@ describe("ContextBar session picker", () => {
 
     const outer = document.querySelector("[data-chat-context-bar]");
 
-    expect(outer?.className).toContain("bg-primary-foreground/95");
+    expect(outer?.className).toContain("bg-primary-foreground");
+    expect(outer?.className).toContain("text-primary");
     expect(outer?.className).not.toContain("bg-card");
   });
 });

--- a/apps/desktop/src/chat/components/context-bar.test.tsx
+++ b/apps/desktop/src/chat/components/context-bar.test.tsx
@@ -199,4 +199,13 @@ describe("ContextBar session picker", () => {
     expect(outer?.className).not.toContain("mx-2");
     expect(outer?.className).not.toContain("mr-0");
   });
+
+  it("uses an elevated surface that contrasts with the dark chat panel", () => {
+    renderContextBar();
+
+    const outer = document.querySelector("[data-chat-context-bar]");
+
+    expect(outer?.className).toContain("bg-primary-foreground/95");
+    expect(outer?.className).not.toContain("bg-card");
+  });
 });

--- a/apps/desktop/src/chat/components/context-bar.tsx
+++ b/apps/desktop/src/chat/components/context-bar.tsx
@@ -377,7 +377,7 @@ export function ContextBar({
     <div
       data-chat-context-bar
       className={cn([
-        "border-border bg-card shrink-0 rounded-t-xl border-t border-r border-l",
+        "border-border bg-primary-foreground/95 shrink-0 rounded-t-xl border-t border-r border-l",
         isRightPanel ? "mx-3" : "mx-2",
       ])}
     >

--- a/apps/desktop/src/chat/components/context-bar.tsx
+++ b/apps/desktop/src/chat/components/context-bar.tsx
@@ -18,6 +18,7 @@ import { cn, safeParseDate } from "@hypr/utils";
 import type { ContextRef } from "~/chat/context/entities";
 import { type ContextChipProps, renderChip } from "~/chat/context/registry";
 import type { DisplayEntity } from "~/chat/context/use-chat-context-pipeline";
+import { useChatAppearance } from "~/chat/hooks/use-chat-appearance";
 import { useShell } from "~/contexts/shell";
 import { useSearchEngine } from "~/search/contexts/engine";
 import { getSessionEvent } from "~/session/utils";
@@ -354,6 +355,7 @@ export function ContextBar({
   onAddEntity?: (ref: ContextRef) => void;
 }) {
   const { chat } = useShell();
+  const { elevatedSurfaceClassName } = useChatAppearance();
   const isRightPanel = chat.mode === "RightPanelOpen";
   const chips = useMemo(
     () =>
@@ -377,7 +379,8 @@ export function ContextBar({
     <div
       data-chat-context-bar
       className={cn([
-        "border-border bg-primary-foreground/95 shrink-0 rounded-t-xl border-t border-r border-l",
+        "border-border shrink-0 rounded-t-xl border-t border-r border-l",
+        elevatedSurfaceClassName,
         isRightPanel ? "mx-3" : "mx-2",
       ])}
     >

--- a/apps/desktop/src/chat/components/context-bar.tsx
+++ b/apps/desktop/src/chat/components/context-bar.tsx
@@ -163,15 +163,15 @@ function ContextChip({
           className={cn([
             "group max-w-48 min-w-0 rounded-md px-1.5 py-0.5 text-xs",
             pending
-              ? "bg-neutral-500/5 text-neutral-400"
-              : "bg-white text-neutral-600 shadow-xs",
+              ? "bg-muted0/5 text-muted-foreground"
+              : "bg-card text-muted-foreground shadow-xs",
             "inline-flex shrink items-center gap-1",
             isClickable
-              ? "cursor-pointer hover:bg-neutral-500/20"
+              ? "hover:bg-accent0/20 cursor-pointer"
               : "cursor-default",
           ])}
         >
-          {Icon && <Icon className="size-3 shrink-0 text-neutral-400" />}
+          {Icon && <Icon className="text-muted-foreground size-3 shrink-0" />}
           <span className="truncate">{chip.label}</span>
           {chip.removable && onRemove && (
             <button
@@ -180,7 +180,7 @@ function ContextChip({
                 e.stopPropagation();
                 onRemove(chip.key);
               }}
-              className="ml-0.5 hidden items-center justify-center rounded-sm group-hover:inline-flex hover:bg-neutral-500/20"
+              className="hover:bg-accent0/20 ml-0.5 hidden items-center justify-center rounded-sm group-hover:inline-flex"
             >
               <XIcon className="size-2.5" />
             </button>
@@ -234,7 +234,7 @@ function ChipList({
         <button
           type="button"
           onClick={() => setExpanded((v) => !v)}
-          className="inline-flex shrink-0 items-center gap-0.5 rounded-md bg-neutral-500/10 px-1 py-0.5 text-xs text-neutral-400 transition-colors hover:bg-neutral-500/20 hover:text-neutral-600"
+          className="bg-muted0/10 text-muted-foreground hover:bg-accent0/20 hover:text-muted-foreground inline-flex shrink-0 items-center gap-0.5 rounded-md px-1 py-0.5 text-xs transition-colors"
         >
           {!expanded && hiddenCount > 0 && <span>+{hiddenCount}</span>}
           <ChevronDownIcon
@@ -291,7 +291,7 @@ function SessionPicker({
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder="Search sessions..."
-        className="w-full rounded-md border border-neutral-200 bg-white px-2.5 py-1.5 text-xs outline-none focus:border-neutral-400"
+        className="border-border bg-card focus:border-border w-full rounded-md border px-2.5 py-1.5 text-xs outline-none"
       />
       <div className="flex max-h-48 flex-col gap-0.5 overflow-y-auto">
         {results.map((result) => (
@@ -302,18 +302,18 @@ function SessionPicker({
               onSelect(result.id);
               onClose();
             }}
-            className="flex flex-col items-start rounded-md px-2 py-1.5 text-left transition-colors hover:bg-neutral-100"
+            className="hover:bg-accent flex flex-col items-start rounded-md px-2 py-1.5 text-left transition-colors"
           >
-            <span className="w-full truncate text-xs font-medium text-neutral-700">
+            <span className="text-muted-foreground w-full truncate text-xs font-medium">
               {result.title || "Untitled"}
             </span>
-            <span className="text-[10px] text-neutral-400">
+            <span className="text-muted-foreground text-[10px]">
               {result.dateLabel ?? "Unknown date"}
             </span>
           </button>
         ))}
         {results.length === 0 && (
-          <span className="px-2 py-1.5 text-xs text-neutral-400">
+          <span className="text-muted-foreground px-2 py-1.5 text-xs">
             {searchResults.isFetching ? "Searching..." : "No sessions found"}
           </span>
         )}
@@ -330,7 +330,7 @@ function AddSessionButton({ onAdd }: { onAdd: (sessionId: string) => void }) {
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="inline-flex shrink-0 items-center justify-center rounded-md bg-neutral-500/10 p-0.5 text-neutral-400 transition-colors hover:bg-neutral-500/20 hover:text-neutral-600"
+          className="bg-muted0/10 text-muted-foreground hover:bg-accent0/20 hover:text-muted-foreground inline-flex shrink-0 items-center justify-center rounded-md p-0.5 transition-colors"
         >
           <PlusIcon className="size-3.5" />
         </button>
@@ -377,7 +377,7 @@ export function ContextBar({
     <div
       data-chat-context-bar
       className={cn([
-        "shrink-0 rounded-t-xl border-t border-r border-l border-neutral-200 bg-white",
+        "border-border bg-card shrink-0 rounded-t-xl border-t border-r border-l",
         isRightPanel ? "mx-3" : "mx-2",
       ])}
     >

--- a/apps/desktop/src/chat/components/context-bar.tsx
+++ b/apps/desktop/src/chat/components/context-bar.tsx
@@ -163,11 +163,11 @@ function ContextChip({
           className={cn([
             "group max-w-48 min-w-0 rounded-md px-1.5 py-0.5 text-xs",
             pending
-              ? "bg-muted0/5 text-muted-foreground"
+              ? "bg-muted/5 text-muted-foreground"
               : "bg-card text-muted-foreground shadow-xs",
             "inline-flex shrink items-center gap-1",
             isClickable
-              ? "hover:bg-accent0/20 cursor-pointer"
+              ? "hover:bg-accent/20 cursor-pointer"
               : "cursor-default",
           ])}
         >
@@ -180,7 +180,7 @@ function ContextChip({
                 e.stopPropagation();
                 onRemove(chip.key);
               }}
-              className="hover:bg-accent0/20 ml-0.5 hidden items-center justify-center rounded-sm group-hover:inline-flex"
+              className="hover:bg-accent/20 ml-0.5 hidden items-center justify-center rounded-sm group-hover:inline-flex"
             >
               <XIcon className="size-2.5" />
             </button>
@@ -234,7 +234,7 @@ function ChipList({
         <button
           type="button"
           onClick={() => setExpanded((v) => !v)}
-          className="bg-muted0/10 text-muted-foreground hover:bg-accent0/20 hover:text-muted-foreground inline-flex shrink-0 items-center gap-0.5 rounded-md px-1 py-0.5 text-xs transition-colors"
+          className="bg-muted/10 text-muted-foreground hover:bg-accent/20 hover:text-muted-foreground inline-flex shrink-0 items-center gap-0.5 rounded-md px-1 py-0.5 text-xs transition-colors"
         >
           {!expanded && hiddenCount > 0 && <span>+{hiddenCount}</span>}
           <ChevronDownIcon
@@ -330,7 +330,7 @@ function AddSessionButton({ onAdd }: { onAdd: (sessionId: string) => void }) {
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="bg-muted0/10 text-muted-foreground hover:bg-accent0/20 hover:text-muted-foreground inline-flex shrink-0 items-center justify-center rounded-md p-0.5 transition-colors"
+          className="bg-muted/10 text-muted-foreground hover:bg-accent/20 hover:text-muted-foreground inline-flex shrink-0 items-center justify-center rounded-md p-0.5 transition-colors"
         >
           <PlusIcon className="size-3.5" />
         </button>

--- a/apps/desktop/src/chat/components/input/chat-input.css
+++ b/apps/desktop/src/chat/components/input/chat-input.css
@@ -14,7 +14,9 @@
 [data-chat-input-surface="elevated"]
   .chat-input-editor.tiptap
   .is-editor-empty:first-child::before,
-[data-chat-input-surface="elevated"] .chat-input-editor.tiptap .is-empty::before {
+[data-chat-input-surface="elevated"]
+  .chat-input-editor.tiptap
+  .is-empty::before {
   color: hsl(var(--muted-foreground)) !important;
 }
 

--- a/apps/desktop/src/chat/components/input/chat-input.css
+++ b/apps/desktop/src/chat/components/input/chat-input.css
@@ -1,0 +1,31 @@
+[data-chat-input-surface="elevated"] {
+  background-color: hsl(var(--primary-foreground));
+  color: hsl(var(--primary));
+}
+
+.dark [data-chat-input-surface="elevated"] .chat-input-editor.tiptap,
+.dark [data-chat-input-surface="elevated"] .chat-input-editor.tiptap p,
+[data-chat-input-surface="elevated"] .chat-input-editor.tiptap,
+[data-chat-input-surface="elevated"] .chat-input-editor.tiptap p {
+  color: hsl(var(--primary)) !important;
+  caret-color: hsl(var(--primary));
+}
+
+[data-chat-input-surface="elevated"]
+  .chat-input-editor.tiptap
+  .is-editor-empty:first-child::before,
+[data-chat-input-surface="elevated"] .chat-input-editor.tiptap .is-empty::before {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+[data-chat-input-surface="elevated"] .chat-input-send:disabled {
+  border-color: hsl(var(--border)) !important;
+  color: hsl(var(--muted-foreground) / 0.6) !important;
+  cursor: default;
+}
+
+[data-chat-input-surface="elevated"]
+  .chat-input-send:disabled
+  .chat-input-send-shortcut {
+  color: hsl(var(--muted-foreground) / 0.6) !important;
+}

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -63,7 +63,8 @@ vi.mock("~/contexts/shell", () => ({
 vi.mock("~/chat/hooks/use-chat-appearance", () => ({
   useChatAppearance: () => ({
     isDarkAppearance: true,
-    elevatedSurfaceClassName: "bg-primary-foreground text-primary border-border",
+    elevatedSurfaceClassName:
+      "bg-primary-foreground text-primary border-border",
     inputEditorClassName: "chat-input-editor text-primary",
     sendButtonDisabledClassName:
       "cursor-default border-border text-muted-foreground/60",

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -114,14 +114,17 @@ describe("ChatMessageInput", () => {
     expect(clearContentMock).toHaveBeenCalled();
   });
 
-  it("keeps typed text visible on the white input surface", () => {
+  it("keeps typed text visible on the elevated input surface", () => {
     render(
       <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
     );
 
-    expect(screen.getByTestId("chat-editor").className).toContain(
-      "text-foreground",
-    );
+    const editor = screen.getByTestId("chat-editor");
+    const surface = editor.closest("[data-chat-message-input]")?.parentElement;
+
+    expect(editor.className).toContain("text-primary");
+    expect(surface?.className).toContain("bg-primary-foreground/95");
+    expect(surface?.className).not.toContain("bg-card");
   });
 
   it("uses balanced outer padding in the right panel", () => {

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -120,7 +120,7 @@ describe("ChatMessageInput", () => {
     );
 
     expect(screen.getByTestId("chat-editor").className).toContain(
-      "text-neutral-900",
+      "text-foreground",
     );
   });
 

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -60,6 +60,17 @@ vi.mock("~/contexts/shell", () => ({
   }),
 }));
 
+vi.mock("~/chat/hooks/use-chat-appearance", () => ({
+  useChatAppearance: () => ({
+    isDarkAppearance: true,
+    toolbarSurface: "dark",
+    panelClassName: "bg-primary text-primary-foreground",
+    panelBorderClassName: "border-primary/80",
+    elevatedSurfaceClassName: "bg-primary-foreground/95 text-primary",
+    inputEditorClassName: "text-primary",
+  }),
+}));
+
 vi.mock("~/editor-bridge/mention-config", () => ({
   useMentionConfig: () => undefined,
 }));

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -63,11 +63,11 @@ vi.mock("~/contexts/shell", () => ({
 vi.mock("~/chat/hooks/use-chat-appearance", () => ({
   useChatAppearance: () => ({
     isDarkAppearance: true,
-    toolbarSurface: "dark",
-    panelClassName: "bg-primary text-primary-foreground",
-    panelBorderClassName: "border-primary/80",
-    elevatedSurfaceClassName: "bg-primary-foreground/95 text-primary",
-    inputEditorClassName: "text-primary",
+    elevatedSurfaceClassName: "bg-primary-foreground text-primary border-border",
+    inputEditorClassName: "chat-input-editor text-primary",
+    sendButtonDisabledClassName:
+      "cursor-default border-border text-muted-foreground/60",
+    sendButtonShortcutDisabledClassName: "text-muted-foreground/60",
   }),
 }));
 
@@ -125,7 +125,19 @@ describe("ChatMessageInput", () => {
     expect(clearContentMock).toHaveBeenCalled();
   });
 
-  it("keeps typed text visible on the elevated input surface", () => {
+  it("marks the send control for disabled surface styling before the draft has content", () => {
+    render(
+      <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
+    );
+
+    const sendButton = screen.getByRole("button", { name: /send/i });
+
+    expect(sendButton.disabled).toBe(true);
+    expect(sendButton.className).toContain("chat-input-send");
+    expect(sendButton.className).not.toContain("bg-primary");
+  });
+
+  it("uses the elevated dark input surface for typed text", () => {
     render(
       <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
     );
@@ -133,9 +145,10 @@ describe("ChatMessageInput", () => {
     const editor = screen.getByTestId("chat-editor");
     const surface = editor.closest("[data-chat-message-input]")?.parentElement;
 
-    expect(editor.className).toContain("text-primary");
-    expect(surface?.className).toContain("bg-primary-foreground/95");
-    expect(surface?.className).not.toContain("bg-card");
+    expect(editor.className).toContain("chat-input-editor");
+    expect(surface?.getAttribute("data-chat-input-surface")).toBe("elevated");
+    expect(surface?.className).toContain("bg-primary-foreground");
+    expect(surface?.className).toContain("text-primary");
   });
 
   it("uses balanced outer padding in the right panel", () => {

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -131,7 +131,9 @@ describe("ChatMessageInput", () => {
       <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
     );
 
-    const sendButton = screen.getByRole("button", { name: /send/i });
+    const sendButton = screen.getByRole<HTMLButtonElement>("button", {
+      name: /send/i,
+    });
 
     expect(sendButton.disabled).toBe(true);
     expect(sendButton.className).toContain("chat-input-send");

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -9,6 +9,7 @@ import { cn } from "@hypr/utils";
 import { useAutoFocusEditor, useDraftState, useSubmit } from "./hooks";
 
 import type { ContextRef } from "~/chat/context/entities";
+import { useChatAppearance } from "~/chat/hooks/use-chat-appearance";
 import { useShell } from "~/contexts/shell";
 import { useMentionConfig } from "~/editor-bridge/mention-config";
 
@@ -34,6 +35,8 @@ export function ChatMessageInput({
   onContextRefsChange?: (refs: ContextRef[]) => void;
 }) {
   const { chat } = useShell();
+  const { elevatedSurfaceClassName, inputEditorClassName } =
+    useChatAppearance();
   const editorRef = useRef<ChatEditorHandle>(null);
   const disabled =
     typeof disabledProp === "object" ? disabledProp.disabled : disabledProp;
@@ -57,12 +60,19 @@ export function ChatMessageInput({
   const isRightPanel = chat.mode === "RightPanelOpen";
 
   return (
-    <Container hasContextBar={hasContextBar} isRightPanel={isRightPanel}>
+    <Container
+      elevatedSurfaceClassName={elevatedSurfaceClassName}
+      hasContextBar={hasContextBar}
+      isRightPanel={isRightPanel}
+    >
       <div data-chat-message-input className="flex flex-col px-2 pt-3 pb-2">
         <div className="mb-1 min-h-0 flex-1">
           <ChatEditor
             ref={editorRef}
-            className="text-primary max-h-[40vh] overflow-y-auto overscroll-contain text-sm"
+            className={cn([
+              inputEditorClassName,
+              "max-h-[40vh] overflow-y-auto overscroll-contain text-sm [&_p]:text-inherit",
+            ])}
             initialContent={initialContent}
             mentionConfig={mentionConfig}
             placeholder={chatPlaceholder}
@@ -119,10 +129,12 @@ export function ChatMessageInput({
 
 function Container({
   children,
+  elevatedSurfaceClassName,
   hasContextBar,
   isRightPanel,
 }: {
   children: React.ReactNode;
+  elevatedSurfaceClassName: string;
   hasContextBar?: boolean;
   isRightPanel: boolean;
 }) {
@@ -135,7 +147,8 @@ function Container({
     >
       <div
         className={cn([
-          "border-border bg-primary-foreground/95 flex max-h-full flex-col border",
+          "border-border flex max-h-full flex-col border",
+          elevatedSurfaceClassName,
           hasContextBar ? "rounded-t-none rounded-b-xl" : "rounded-xl",
           hasContextBar && "border-t-0",
         ])}

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -1,3 +1,5 @@
+import "./chat-input.css";
+
 import { SquareIcon } from "lucide-react";
 import { useRef } from "react";
 
@@ -35,8 +37,7 @@ export function ChatMessageInput({
   onContextRefsChange?: (refs: ContextRef[]) => void;
 }) {
   const { chat } = useShell();
-  const { elevatedSurfaceClassName, inputEditorClassName } =
-    useChatAppearance();
+  const { elevatedSurfaceClassName } = useChatAppearance();
   const editorRef = useRef<ChatEditorHandle>(null);
   const disabled =
     typeof disabledProp === "object" ? disabledProp.disabled : disabledProp;
@@ -70,8 +71,8 @@ export function ChatMessageInput({
           <ChatEditor
             ref={editorRef}
             className={cn([
-              inputEditorClassName,
-              "max-h-[40vh] overflow-y-auto overscroll-contain text-sm [&_p]:text-inherit",
+              "chat-input-editor",
+              "max-h-[40vh] overflow-y-auto overscroll-contain text-sm",
             ])}
             initialContent={initialContent}
             mentionConfig={mentionConfig}
@@ -97,24 +98,20 @@ export function ChatMessageInput({
               onClick={handleSubmit}
               disabled={isSendDisabled}
               className={cn([
-                "inline-flex h-7 items-center gap-1.5 rounded-lg pr-1.5 pl-2.5 text-xs font-medium transition-all duration-100",
-                "border",
-                isSendDisabled
-                  ? "border-border text-muted-foreground/70 cursor-default"
-                  : [
-                      "border-primary bg-primary text-primary-foreground",
-                      "hover:bg-primary/90",
-                      "active:bg-primary/80 active:scale-[0.97]",
-                    ],
+                "chat-input-send",
+                "inline-flex h-7 items-center gap-1.5 rounded-lg border pr-1.5 pl-2.5 text-xs font-medium transition-all duration-100",
+                !isSendDisabled && [
+                  "border-stone-600 bg-primary text-primary-foreground",
+                  "hover:bg-primary/90",
+                  "active:bg-primary/80 active:scale-[0.97]",
+                ],
               ])}
             >
               Send
               <span
                 className={cn([
-                  "font-mono text-xs",
-                  isSendDisabled
-                    ? "text-muted-foreground/70"
-                    : "text-muted-foreground",
+                  "chat-input-send-shortcut font-mono text-xs",
+                  !isSendDisabled && "text-stone-400",
                 ])}
               >
                 ⌘ ↩
@@ -146,8 +143,9 @@ function Container({
       ])}
     >
       <div
+        data-chat-input-surface="elevated"
         className={cn([
-          "border-border flex max-h-full flex-col border",
+          "flex max-h-full flex-col border",
           elevatedSurfaceClassName,
           hasContextBar ? "rounded-t-none rounded-b-xl" : "rounded-xl",
           hasContextBar && "border-t-0",

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -101,7 +101,7 @@ export function ChatMessageInput({
                 "chat-input-send",
                 "inline-flex h-7 items-center gap-1.5 rounded-lg border pr-1.5 pl-2.5 text-xs font-medium transition-all duration-100",
                 !isSendDisabled && [
-                  "border-stone-600 bg-primary text-primary-foreground",
+                  "bg-primary text-primary-foreground border-stone-600",
                   "hover:bg-primary/90",
                   "active:bg-primary/80 active:scale-[0.97]",
                 ],

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -62,7 +62,7 @@ export function ChatMessageInput({
         <div className="mb-1 min-h-0 flex-1">
           <ChatEditor
             ref={editorRef}
-            className="text-foreground max-h-[40vh] overflow-y-auto overscroll-contain text-sm"
+            className="text-primary max-h-[40vh] overflow-y-auto overscroll-contain text-sm"
             initialContent={initialContent}
             mentionConfig={mentionConfig}
             placeholder={chatPlaceholder}
@@ -135,7 +135,7 @@ function Container({
     >
       <div
         className={cn([
-          "border-border bg-card flex max-h-full flex-col border",
+          "border-border bg-primary-foreground/95 flex max-h-full flex-col border",
           hasContextBar ? "rounded-t-none rounded-b-xl" : "rounded-xl",
           hasContextBar && "border-t-0",
         ])}

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -62,7 +62,7 @@ export function ChatMessageInput({
         <div className="mb-1 min-h-0 flex-1">
           <ChatEditor
             ref={editorRef}
-            className="max-h-[40vh] overflow-y-auto overscroll-contain text-sm text-neutral-900"
+            className="text-foreground max-h-[40vh] overflow-y-auto overscroll-contain text-sm"
             initialContent={initialContent}
             mentionConfig={mentionConfig}
             placeholder={chatPlaceholder}
@@ -90,11 +90,11 @@ export function ChatMessageInput({
                 "inline-flex h-7 items-center gap-1.5 rounded-lg pr-1.5 pl-2.5 text-xs font-medium transition-all duration-100",
                 "border",
                 isSendDisabled
-                  ? "cursor-default border-neutral-200 text-neutral-300"
+                  ? "border-border text-muted-foreground/70 cursor-default"
                   : [
-                      "border-stone-600 bg-stone-800 text-white",
-                      "hover:bg-stone-700",
-                      "active:scale-[0.97] active:bg-stone-600",
+                      "border-primary bg-primary text-primary-foreground",
+                      "hover:bg-primary/90",
+                      "active:bg-primary/80 active:scale-[0.97]",
                     ],
               ])}
             >
@@ -102,7 +102,9 @@ export function ChatMessageInput({
               <span
                 className={cn([
                   "font-mono text-xs",
-                  isSendDisabled ? "text-neutral-300" : "text-stone-400",
+                  isSendDisabled
+                    ? "text-muted-foreground/70"
+                    : "text-muted-foreground",
                 ])}
               >
                 ⌘ ↩
@@ -133,7 +135,7 @@ function Container({
     >
       <div
         className={cn([
-          "flex max-h-full flex-col border border-neutral-200 bg-white",
+          "border-border bg-card flex max-h-full flex-col border",
           hasContextBar ? "rounded-t-none rounded-b-xl" : "rounded-xl",
           hasContextBar && "border-t-0",
         ])}

--- a/apps/desktop/src/chat/components/message/normal.tsx
+++ b/apps/desktop/src/chat/components/message/normal.tsx
@@ -85,7 +85,7 @@ export function NormalMessage({
             {handleReload && (
               <button
                 onClick={handleReload}
-                className="text-muted-foreground hover:text-muted-foreground p-1 transition-colors"
+                className="text-muted-foreground hover:text-foreground p-1 transition-colors"
                 aria-label="Regenerate message"
               >
                 <RotateCcwIcon size={14} />

--- a/apps/desktop/src/chat/components/message/normal.tsx
+++ b/apps/desktop/src/chat/components/message/normal.tsx
@@ -77,7 +77,7 @@ export function NormalMessage({
           <div className="mt-1 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
             <button
               onClick={handleCopy}
-              className={`p-1 transition-colors ${copied ? "text-green-500" : "text-neutral-400 hover:text-neutral-600"}`}
+              className={`p-1 transition-colors ${copied ? "text-green-500" : "text-muted-foreground hover:text-foreground"}`}
               aria-label="Copy message"
             >
               {copied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
@@ -85,7 +85,7 @@ export function NormalMessage({
             {handleReload && (
               <button
                 onClick={handleReload}
-                className="p-1 text-neutral-400 transition-colors hover:text-neutral-600"
+                className="text-muted-foreground hover:text-muted-foreground p-1 transition-colors"
                 aria-label="Regenerate message"
               >
                 <RotateCcwIcon size={14} />
@@ -137,7 +137,7 @@ function Reasoning({ part }: { part: Extract<Part, { type: "reasoning" }> }) {
       title={title}
       disabled={streaming}
     >
-      <div className="text-sm whitespace-pre-wrap text-neutral-500">
+      <div className="text-muted-foreground text-sm whitespace-pre-wrap">
         {part.text}
       </div>
     </Disclosure>

--- a/apps/desktop/src/chat/components/message/shared.test.tsx
+++ b/apps/desktop/src/chat/components/message/shared.test.tsx
@@ -1,15 +1,26 @@
 import { cleanup, render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const shellState = vi.hoisted(() => ({
-  mode: "FloatingOpen" as "FloatingOpen" | "FloatingClosed" | "RightPanelOpen",
+const appearanceState = vi.hoisted(() => ({
+  isDarkAppearance: true,
 }));
 
-vi.mock("~/contexts/shell", () => ({
-  useShell: () => ({
-    chat: {
-      mode: shellState.mode,
-    },
+vi.mock("~/chat/hooks/use-chat-appearance", () => ({
+  useChatAppearance: () => ({
+    isDarkAppearance: appearanceState.isDarkAppearance,
+    toolbarSurface: appearanceState.isDarkAppearance ? "dark" : "light",
+    panelClassName: appearanceState.isDarkAppearance
+      ? "bg-primary text-primary-foreground"
+      : "bg-card text-foreground",
+    panelBorderClassName: appearanceState.isDarkAppearance
+      ? "border-primary/80"
+      : "border-border",
+    elevatedSurfaceClassName: appearanceState.isDarkAppearance
+      ? "bg-primary-foreground/95 text-primary"
+      : "bg-muted text-foreground",
+    inputEditorClassName: appearanceState.isDarkAppearance
+      ? "text-primary"
+      : "text-foreground",
   }),
 }));
 
@@ -18,7 +29,7 @@ import { MessageBubble } from "./shared";
 describe("MessageBubble", () => {
   beforeEach(() => {
     cleanup();
-    shellState.mode = "FloatingOpen";
+    appearanceState.isDarkAppearance = true;
   });
 
   it("uses contrasting tokens for assistant bubbles on dark chat surfaces", () => {

--- a/apps/desktop/src/chat/components/message/shared.test.tsx
+++ b/apps/desktop/src/chat/components/message/shared.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const shellState = vi.hoisted(() => ({
+  mode: "FloatingOpen" as "FloatingOpen" | "FloatingClosed" | "RightPanelOpen",
+}));
+
+vi.mock("~/contexts/shell", () => ({
+  useShell: () => ({
+    chat: {
+      mode: shellState.mode,
+    },
+  }),
+}));
+
+import { MessageBubble } from "./shared";
+
+describe("MessageBubble", () => {
+  beforeEach(() => {
+    cleanup();
+    shellState.mode = "FloatingOpen";
+  });
+
+  it("uses contrasting tokens for assistant bubbles on dark chat surfaces", () => {
+    const { container } = render(
+      <MessageBubble variant="assistant">Hello</MessageBubble>,
+    );
+
+    const bubble = container.firstChild as HTMLElement;
+
+    expect(bubble.className).toContain("bg-primary-foreground/95");
+    expect(bubble.className).toContain("text-primary");
+    expect(bubble.className).not.toContain("bg-card/95");
+    expect(bubble.className).not.toContain("text-foreground");
+  });
+
+  it("keeps dark text on light-blue user bubbles", () => {
+    const { container } = render(
+      <MessageBubble variant="user">Hello</MessageBubble>,
+    );
+
+    const bubble = container.firstChild as HTMLElement;
+
+    expect(bubble.className).toContain("bg-blue-100");
+    expect(bubble.className).toContain("text-primary");
+    expect(bubble.className).not.toContain("text-foreground");
+  });
+});

--- a/apps/desktop/src/chat/components/message/shared.test.tsx
+++ b/apps/desktop/src/chat/components/message/shared.test.tsx
@@ -53,7 +53,7 @@ describe("MessageBubble", () => {
     const bubble = container.firstChild as HTMLElement;
 
     expect(bubble.className).toContain("bg-blue-100");
-    expect(bubble.className).toContain("text-primary");
+    expect(bubble.className).toContain("text-neutral-800");
     expect(bubble.className).not.toContain("text-foreground");
   });
 });

--- a/apps/desktop/src/chat/components/message/shared.tsx
+++ b/apps/desktop/src/chat/components/message/shared.tsx
@@ -42,15 +42,15 @@ export function MessageBubble({
       className={cn([
         "select-text-deep text-sm",
         variant === "user" &&
-          "w-fit max-w-full rounded-2xl bg-blue-100 px-3 py-1 text-neutral-800 [&_p]:[text-wrap:wrap]",
+          "text-foreground w-fit max-w-full rounded-2xl bg-blue-100 px-3 py-1 [&_p]:[text-wrap:wrap]",
         variant === "assistant" &&
           (isDarkSurface
-            ? "rounded-2xl bg-white/95 px-3 py-1 text-neutral-800"
-            : "text-neutral-800"),
+            ? "bg-card/95 text-foreground rounded-2xl px-3 py-1"
+            : "text-foreground"),
         variant === "loading" &&
           (isDarkSurface
-            ? "w-fit rounded-2xl bg-white/95 px-3 py-1 text-neutral-800"
-            : "text-neutral-800"),
+            ? "bg-card/95 text-foreground w-fit rounded-2xl px-3 py-1"
+            : "text-foreground"),
         variant === "error" &&
           "rounded-2xl border border-red-200 bg-red-50 px-3 py-1 text-red-600",
         withActionButton && "group relative",
@@ -82,8 +82,8 @@ export function ActionButton({
         "transition-opacity",
         "rounded-full p-1",
         variant === "default" && [
-          "bg-neutral-200 hover:bg-neutral-300",
-          "text-neutral-600 hover:text-neutral-800",
+          "bg-accent hover:bg-accent",
+          "text-muted-foreground hover:text-foreground",
         ],
         variant === "error" && [
           "bg-red-100 hover:bg-red-200",
@@ -111,7 +111,7 @@ export function Disclosure({
     <details
       className={cn([
         "group my-2 rounded-md border px-2 py-1 transition-colors",
-        "cursor-pointer border-neutral-200 hover:border-neutral-300",
+        "border-border hover:border-border cursor-pointer",
       ])}
     >
       <summary
@@ -122,7 +122,7 @@ export function Disclosure({
         }}
         className={cn([
           "w-full",
-          "text-xs text-neutral-500",
+          "text-muted-foreground text-xs",
           "list-none select-none marker:hidden",
           "flex items-center gap-2",
           disabled && "cursor-default",
@@ -135,9 +135,7 @@ export function Disclosure({
         </span>
         <ChevronRight className="h-3 w-3 shrink-0 transition-transform group-open:rotate-90" />
       </summary>
-      <div className="mt-1 border-t border-neutral-200 px-1 pt-2">
-        {children}
-      </div>
+      <div className="border-border mt-1 border-t px-1 pt-2">{children}</div>
     </details>
   );
 }

--- a/apps/desktop/src/chat/components/message/shared.tsx
+++ b/apps/desktop/src/chat/components/message/shared.tsx
@@ -40,7 +40,7 @@ export function MessageBubble({
       className={cn([
         "select-text-deep text-sm",
         variant === "user" &&
-          "text-primary w-fit max-w-full rounded-2xl bg-blue-100 px-3 py-1 [&_p]:[text-wrap:wrap]",
+          "w-fit max-w-full rounded-2xl bg-blue-100 px-3 py-1 text-neutral-800 [&_p]:[text-wrap:wrap]",
         variant === "assistant" &&
           (isDarkAppearance
             ? "bg-primary-foreground/95 text-primary rounded-2xl px-3 py-1"

--- a/apps/desktop/src/chat/components/message/shared.tsx
+++ b/apps/desktop/src/chat/components/message/shared.tsx
@@ -42,14 +42,14 @@ export function MessageBubble({
       className={cn([
         "select-text-deep text-sm",
         variant === "user" &&
-          "text-foreground w-fit max-w-full rounded-2xl bg-blue-100 px-3 py-1 [&_p]:[text-wrap:wrap]",
+          "text-primary w-fit max-w-full rounded-2xl bg-blue-100 px-3 py-1 [&_p]:[text-wrap:wrap]",
         variant === "assistant" &&
           (isDarkSurface
-            ? "bg-card/95 text-foreground rounded-2xl px-3 py-1"
+            ? "bg-primary-foreground/95 text-primary rounded-2xl px-3 py-1"
             : "text-foreground"),
         variant === "loading" &&
           (isDarkSurface
-            ? "bg-card/95 text-foreground w-fit rounded-2xl px-3 py-1"
+            ? "bg-primary-foreground/95 text-primary w-fit rounded-2xl px-3 py-1"
             : "text-foreground"),
         variant === "error" &&
           "rounded-2xl border border-red-200 bg-red-50 px-3 py-1 text-red-600",

--- a/apps/desktop/src/chat/components/message/shared.tsx
+++ b/apps/desktop/src/chat/components/message/shared.tsx
@@ -3,7 +3,7 @@ import { type ReactNode } from "react";
 
 import { cn } from "@hypr/utils";
 
-import { useShell } from "~/contexts/shell";
+import { useChatAppearance } from "~/chat/hooks/use-chat-appearance";
 
 export function MessageContainer({
   align = "start",
@@ -33,9 +33,7 @@ export function MessageBubble({
   withActionButton?: boolean;
   children: ReactNode;
 }) {
-  const { chat } = useShell();
-  const isDarkSurface =
-    chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
+  const { isDarkAppearance } = useChatAppearance();
 
   return (
     <div
@@ -44,11 +42,11 @@ export function MessageBubble({
         variant === "user" &&
           "text-primary w-fit max-w-full rounded-2xl bg-blue-100 px-3 py-1 [&_p]:[text-wrap:wrap]",
         variant === "assistant" &&
-          (isDarkSurface
+          (isDarkAppearance
             ? "bg-primary-foreground/95 text-primary rounded-2xl px-3 py-1"
             : "text-foreground"),
         variant === "loading" &&
-          (isDarkSurface
+          (isDarkAppearance
             ? "bg-primary-foreground/95 text-primary w-fit rounded-2xl px-3 py-1"
             : "text-foreground"),
         variant === "error" &&

--- a/apps/desktop/src/chat/components/message/tool/edit-summary.tsx
+++ b/apps/desktop/src/chat/components/message/tool/edit-summary.tsx
@@ -48,7 +48,7 @@ export const ToolEditSummary = defineTool({
         <div className="space-y-2">
           <ToolCardFooterError text={parsed.message ?? "Unknown error"} />
           {parsed.candidates && parsed.candidates.length > 0 ? (
-            <div className="space-y-1 rounded-md border border-neutral-200 bg-neutral-50 p-2 text-[12px] text-neutral-700">
+            <div className="border-border bg-muted text-muted-foreground space-y-1 rounded-md border p-2 text-[12px]">
               {parsed.candidates.map((candidate) => (
                 <div key={candidate.enhancedNoteId}>
                   {candidate.title} ({candidate.enhancedNoteId})

--- a/apps/desktop/src/chat/components/message/tool/generic.tsx
+++ b/apps/desktop/src/chat/components/message/tool/generic.tsx
@@ -71,7 +71,7 @@ export function ToolGeneric({ part }: { part: Record<string, unknown> }) {
             </p>
           ) : null}
           {outputText ? (
-            <p className="text-xs whitespace-pre-wrap text-neutral-600">
+            <p className="text-muted-foreground text-xs whitespace-pre-wrap">
               {outputText}
             </p>
           ) : null}
@@ -97,10 +97,10 @@ function InputDisplay({ input }: { input: unknown }) {
   if (entries.length === 0) return null;
 
   return (
-    <dl className="flex flex-col gap-1 text-xs text-neutral-500">
+    <dl className="text-muted-foreground flex flex-col gap-1 text-xs">
       {entries.map(([key, value]) => (
         <div key={key}>
-          <dt className="inline font-medium text-neutral-600">{key}: </dt>
+          <dt className="text-muted-foreground inline font-medium">{key}: </dt>
           <dd className="inline wrap-break-word whitespace-pre-wrap">
             {typeof value === "string" ? value : JSON.stringify(value)}
           </dd>

--- a/apps/desktop/src/chat/components/message/tool/search.tsx
+++ b/apps/desktop/src/chat/components/message/tool/search.tsx
@@ -191,7 +191,7 @@ function RenderContent({ part }: { part: Part }) {
                   key={result.id || index}
                   className="basis-full pl-1 sm:basis-1/2 lg:basis-1/3"
                 >
-                  <Card className="h-full bg-neutral-50">
+                  <Card className="bg-muted h-full">
                     <CardContent className="px-2 py-0.5">
                       <RenderSession result={result} />
                     </CardContent>
@@ -199,8 +199,8 @@ function RenderContent({ part }: { part: Part }) {
                 </CarouselItem>
               ))}
             </CarouselContent>
-            <CarouselPrevious className="-left-4 h-6 w-6 bg-neutral-100 hover:bg-neutral-200" />
-            <CarouselNext className="-right-4 h-6 w-6 bg-neutral-100 hover:bg-neutral-200" />
+            <CarouselPrevious className="bg-muted hover:bg-accent -left-4 h-6 w-6" />
+            <CarouselNext className="bg-muted hover:bg-accent -right-4 h-6 w-6" />
           </Carousel>
         </div>
       </div>
@@ -250,7 +250,7 @@ function RenderSession({ result }: { result: SearchResult }) {
     >
       <span className="truncate font-medium">{result.title || "Untitled"}</span>
       {dateLabel && (
-        <span className="text-[11px] text-neutral-400 tabular-nums">
+        <span className="text-muted-foreground text-[11px] tabular-nums">
           {dateLabel}
         </span>
       )}

--- a/apps/desktop/src/chat/components/message/tool/shared.tsx
+++ b/apps/desktop/src/chat/components/message/tool/shared.tsx
@@ -17,7 +17,7 @@ export function ToolCard({
     <div
       className={cn([
         "my-2.5 overflow-hidden rounded-xl border shadow-sm",
-        failed ? "border-red-200" : "border-neutral-200/80",
+        failed ? "border-red-200" : "border-border/80",
       ])}
     >
       {children}
@@ -42,7 +42,7 @@ export function ToolCardHeader({
     <div
       className={cn([
         "flex items-center gap-2.5 px-3.5 py-2 text-[13px]",
-        failed ? "bg-red-50 text-red-700" : "bg-neutral-50/80 text-neutral-600",
+        failed ? "bg-red-50 text-red-700" : "bg-muted/80 text-muted-foreground",
       ])}
     >
       {running ? (
@@ -55,7 +55,7 @@ export function ToolCardHeader({
               ? "text-red-500"
               : done
                 ? "text-emerald-500"
-                : "text-neutral-400",
+                : "text-muted-foreground",
           ])}
         >
           {icon}
@@ -81,8 +81,10 @@ export function ToolCardFooterError({ text }: { text: string }) {
 
 function ToolCardFooterRaw({ text }: { text: string }) {
   return (
-    <div className="border-t border-neutral-200/80 bg-neutral-50/80 px-3.5 py-2.5">
-      <p className="text-[13px] whitespace-pre-wrap text-neutral-600">{text}</p>
+    <div className="border-border/80 bg-muted/80 border-t px-3.5 py-2.5">
+      <p className="text-muted-foreground text-[13px] whitespace-pre-wrap">
+        {text}
+      </p>
     </div>
   );
 }
@@ -129,10 +131,10 @@ export function ToolCardFooters({
 
 export function MarkdownPreview({ children }: { children: string }) {
   return (
-    <div className="rounded-lg border border-neutral-200/80 bg-white">
+    <div className="border-border/80 bg-card rounded-lg border">
       <div className="max-h-64 overflow-y-auto px-3 py-2.5">
         <Streamdown
-          className="text-[13px] leading-relaxed text-neutral-700"
+          className="text-muted-foreground text-[13px] leading-relaxed"
           linkSafety={{ enabled: false }}
         >
           {children}

--- a/apps/desktop/src/chat/components/message/tool/update-prompt-template.tsx
+++ b/apps/desktop/src/chat/components/message/tool/update-prompt-template.tsx
@@ -30,7 +30,7 @@ export const ToolUpdatePromptTemplate = defineTool({
   renderBody: (input) =>
     typeof input?.content === "string" ? (
       <ToolCardBody>
-        <pre className="max-h-48 overflow-auto rounded-md border border-neutral-200 bg-neutral-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-neutral-700">
+        <pre className="border-border bg-muted text-muted-foreground max-h-48 overflow-auto rounded-md border p-3 font-mono text-[11px] whitespace-pre-wrap">
           {input.content}
         </pre>
       </ToolCardBody>
@@ -40,7 +40,7 @@ export const ToolUpdatePromptTemplate = defineTool({
       {parsed?.status === "error" ? (
         <ToolCardFooterError text={parsed.message ?? "Unknown error"} />
       ) : parsed?.message ? (
-        <p className="text-xs text-neutral-600">{parsed.message}</p>
+        <p className="text-muted-foreground text-xs">{parsed.message}</p>
       ) : null}
     </ToolCardFooters>
   ),

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -13,6 +13,8 @@ import { cn } from "@hypr/utils";
 
 import { ChatView } from "./chat-panel";
 
+import { chatFloatingPanelShellClassNames } from "~/chat/surface";
+import { useChatAppearance } from "~/chat/hooks/use-chat-appearance";
 import { useShell } from "~/contexts/shell";
 
 const FLOATING_PANEL_MIN_WIDTH = 360;
@@ -76,6 +78,7 @@ export function PersistentChatPanel({
   floatingContainerRef: React.RefObject<HTMLDivElement | null>;
 }) {
   const { chat } = useShell();
+  const { isDarkAppearance } = useChatAppearance();
   const isVisible = chat.mode === "FloatingOpen";
 
   const [hasBeenOpened, setHasBeenOpened] = useState(false);
@@ -306,9 +309,7 @@ export function PersistentChatPanel({
               data-chat-size="floating"
               className={cn([
                 "relative flex min-h-0 flex-col overflow-hidden",
-                "bg-primary text-primary-foreground",
-                "border-primary rounded-2xl border-2",
-                "shadow-[0_4px_28px_rgba(87,83,78,0.45)]",
+                chatFloatingPanelShellClassNames(isDarkAppearance),
               ])}
               style={panelStyle}
               initial={panelMotion.initial}

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -14,7 +14,6 @@ import { cn } from "@hypr/utils";
 import { ChatView } from "./chat-panel";
 
 import { chatFloatingPanelShellClassNames } from "~/chat/surface";
-import { useChatAppearance } from "~/chat/hooks/use-chat-appearance";
 import { useShell } from "~/contexts/shell";
 
 const FLOATING_PANEL_MIN_WIDTH = 360;
@@ -78,7 +77,6 @@ export function PersistentChatPanel({
   floatingContainerRef: React.RefObject<HTMLDivElement | null>;
 }) {
   const { chat } = useShell();
-  const { isDarkAppearance } = useChatAppearance();
   const isVisible = chat.mode === "FloatingOpen";
 
   const [hasBeenOpened, setHasBeenOpened] = useState(false);
@@ -309,7 +307,7 @@ export function PersistentChatPanel({
               data-chat-size="floating"
               className={cn([
                 "relative flex min-h-0 flex-col overflow-hidden",
-                chatFloatingPanelShellClassNames(isDarkAppearance),
+                chatFloatingPanelShellClassNames(),
               ])}
               style={panelStyle}
               initial={panelMotion.initial}

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -306,8 +306,8 @@ export function PersistentChatPanel({
               data-chat-size="floating"
               className={cn([
                 "relative flex min-h-0 flex-col overflow-hidden",
-                "bg-stone-800 text-white",
-                "rounded-2xl border-2 border-stone-600",
+                "bg-primary text-primary-foreground",
+                "border-primary rounded-2xl border-2",
                 "shadow-[0_4px_28px_rgba(87,83,78,0.45)]",
               ])}
               style={panelStyle}

--- a/apps/desktop/src/chat/components/toolbar-controls.test.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.test.tsx
@@ -77,10 +77,12 @@ describe("ChatToolbarControls", () => {
     });
 
     expect(newChatButton.className).toContain("rounded-full");
-    expect(newChatButton.className).toContain("hover:!bg-white/7");
+    expect(newChatButton.className).toContain("hover:!bg-primary-foreground/7");
     expect(newChatButton.getAttribute("title")).toBeNull();
     expect(rightPanelButton.className).toContain("rounded-full");
-    expect(rightPanelButton.className).toContain("hover:!bg-white/7");
+    expect(rightPanelButton.className).toContain(
+      "hover:!bg-primary-foreground/7",
+    );
     expect(rightPanelButton.getAttribute("title")).toBeNull();
   });
 

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -76,8 +76,7 @@ export function ChatToolbarControls({
           className={cn([
             isDark
               ? darkToolbarButtonClassName
-              : isRightPanel &&
-                "bg-neutral-100 text-neutral-900 hover:bg-neutral-100",
+              : isRightPanel && "bg-muted text-foreground hover:bg-accent",
             isRightPanel && "mr-1",
           ])}
         />
@@ -87,7 +86,7 @@ export function ChatToolbarControls({
 }
 
 const darkToolbarButtonClassName =
-  "size-8 bg-transparent text-stone-300 hover:!bg-white/7 hover:!text-white focus-visible:!bg-white/7 focus-visible:!text-white active:!bg-white/10";
+  "size-8 bg-transparent text-primary-foreground/60 hover:!bg-primary-foreground/7 hover:!text-primary-foreground focus-visible:!bg-primary-foreground/7 focus-visible:!text-primary-foreground active:!bg-primary-foreground/10";
 
 function ChatActionButton({
   className,
@@ -106,7 +105,7 @@ function ChatActionButton({
       onClick={onClick}
       size="icon"
       variant="ghost"
-      className={cn(["rounded-full text-neutral-600", className])}
+      className={cn(["text-muted-foreground rounded-full", className])}
     >
       {icon}
     </Button>
@@ -148,16 +147,16 @@ function ChatGroups({
           className={cn([
             "group flex h-8 max-w-full min-w-0 justify-start gap-1.5 px-2 py-0 text-left",
             isDark
-              ? "w-fit rounded-full text-stone-100 hover:bg-white/7 hover:text-white data-[state=open]:bg-white/7"
-              : "text-neutral-700",
+              ? "text-primary-foreground hover:bg-primary-foreground/7 hover:text-primary-foreground data-[state=open]:bg-primary-foreground/7 w-fit rounded-full"
+              : "text-muted-foreground",
           ])}
         >
           <h3
             className={cn([
               "max-w-64 min-w-0 truncate text-left font-medium",
               isDark
-                ? "text-[15px] text-stone-100"
-                : "text-xs text-neutral-700",
+                ? "text-primary-foreground text-[15px]"
+                : "text-muted-foreground text-xs",
             ])}
           >
             {currentChatTitle || "Ask Anarlog AI anything"}
@@ -165,7 +164,7 @@ function ChatGroups({
           <ChevronDown
             className={cn([
               "h-3.5 w-3.5 shrink-0 transition-transform duration-200",
-              isDark ? "text-stone-300" : "text-neutral-400",
+              isDark ? "text-primary-foreground/60" : "text-muted-foreground",
               isDropdownOpen && "rotate-180",
             ])}
           />
@@ -179,7 +178,7 @@ function ChatGroups({
       >
         <AppFloatingPanel className="flex flex-col gap-0.5 p-1.5">
           <div className="px-2 py-1.5">
-            <h4 className="text-[10px] font-semibold tracking-wider text-neutral-500 uppercase">
+            <h4 className="text-muted-foreground text-[10px] font-semibold tracking-wider uppercase">
               Recent Chats
             </h4>
           </div>
@@ -199,8 +198,8 @@ function ChatGroups({
             </div>
           ) : (
             <div className="px-3 py-6 text-center">
-              <MessageCircle className="mx-auto mb-1.5 h-6 w-6 text-neutral-300" />
-              <p className="text-xs text-neutral-400">No recent chats</p>
+              <MessageCircle className="text-muted-foreground/70 mx-auto mb-1.5 h-6 w-6" />
+              <p className="text-muted-foreground text-xs">No recent chats</p>
             </div>
           )}
         </AppFloatingPanel>
@@ -237,8 +236,8 @@ function ChatGroupItem({
       className={cn([
         "group h-auto w-full justify-start px-2.5 py-1.5",
         isActive
-          ? "bg-neutral-100 shadow-xs hover:bg-neutral-100"
-          : "hover:bg-neutral-50 active:bg-neutral-100",
+          ? "bg-muted hover:bg-accent shadow-xs"
+          : "hover:bg-accent active:bg-muted",
       ])}
     >
       <div className="flex w-full items-center gap-2.5">
@@ -247,8 +246,8 @@ function ChatGroupItem({
             className={cn([
               "h-3.5 w-3.5 transition-colors",
               isActive
-                ? "text-neutral-700"
-                : "text-neutral-400 group-hover:text-neutral-600",
+                ? "text-muted-foreground"
+                : "text-muted-foreground group-hover:text-muted-foreground",
             ])}
           />
         </div>
@@ -256,12 +255,12 @@ function ChatGroupItem({
           <div
             className={cn([
               "truncate text-sm font-medium",
-              isActive ? "text-neutral-900" : "text-neutral-700",
+              isActive ? "text-foreground" : "text-muted-foreground",
             ])}
           >
             {chatGroup.title}
           </div>
-          <div className="mt-0.5 text-[11px] text-neutral-500">
+          <div className="text-muted-foreground mt-0.5 text-[11px]">
             {formattedTime}
           </div>
         </div>

--- a/apps/desktop/src/chat/hooks/use-chat-appearance.ts
+++ b/apps/desktop/src/chat/hooks/use-chat-appearance.ts
@@ -1,42 +1,26 @@
-import { useSyncExternalStore } from "react";
-
 import {
   chatElevatedSurfaceClassNames,
   chatInputEditorClassNames,
   chatPanelBorderClassNames,
   chatPanelClassNames,
+  chatSendButtonDisabledClassNames,
+  chatSendButtonShortcutDisabledClassNames,
   chatToolbarSurface,
   isChatDarkAppearance,
 } from "~/chat/surface";
-import { useConfigValue } from "~/shared/config";
-import type { ThemePreference } from "~/shared/theme/resolve";
-
-function subscribePrefersDark(onStoreChange: () => void): () => void {
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  mediaQuery.addEventListener("change", onStoreChange);
-  return () => mediaQuery.removeEventListener("change", onStoreChange);
-}
-
-function getPrefersDark(): boolean {
-  return window.matchMedia("(prefers-color-scheme: dark)").matches;
-}
 
 export function useChatAppearance() {
-  const theme = useConfigValue("theme") as ThemePreference;
-  const prefersDark = useSyncExternalStore(
-    subscribePrefersDark,
-    getPrefersDark,
-    () => false,
-  );
-  const isDarkAppearance = isChatDarkAppearance(theme, prefersDark);
+  const isDarkAppearance = isChatDarkAppearance();
 
   return {
     isDarkAppearance,
-    toolbarSurface: chatToolbarSurface(isDarkAppearance),
-    panelClassName: chatPanelClassNames(isDarkAppearance),
-    panelBorderClassName: chatPanelBorderClassNames(isDarkAppearance),
-    elevatedSurfaceClassName:
-      chatElevatedSurfaceClassNames(isDarkAppearance),
-    inputEditorClassName: chatInputEditorClassNames(isDarkAppearance),
+    toolbarSurface: chatToolbarSurface(),
+    panelClassName: chatPanelClassNames(),
+    panelBorderClassName: chatPanelBorderClassNames(),
+    elevatedSurfaceClassName: chatElevatedSurfaceClassNames(),
+    inputEditorClassName: chatInputEditorClassNames(),
+    sendButtonDisabledClassName: chatSendButtonDisabledClassNames(),
+    sendButtonShortcutDisabledClassName:
+      chatSendButtonShortcutDisabledClassNames(),
   };
 }

--- a/apps/desktop/src/chat/hooks/use-chat-appearance.ts
+++ b/apps/desktop/src/chat/hooks/use-chat-appearance.ts
@@ -1,0 +1,42 @@
+import { useSyncExternalStore } from "react";
+
+import {
+  chatElevatedSurfaceClassNames,
+  chatInputEditorClassNames,
+  chatPanelBorderClassNames,
+  chatPanelClassNames,
+  chatToolbarSurface,
+  isChatDarkAppearance,
+} from "~/chat/surface";
+import { useConfigValue } from "~/shared/config";
+import type { ThemePreference } from "~/shared/theme/resolve";
+
+function subscribePrefersDark(onStoreChange: () => void): () => void {
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  mediaQuery.addEventListener("change", onStoreChange);
+  return () => mediaQuery.removeEventListener("change", onStoreChange);
+}
+
+function getPrefersDark(): boolean {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+export function useChatAppearance() {
+  const theme = useConfigValue("theme") as ThemePreference;
+  const prefersDark = useSyncExternalStore(
+    subscribePrefersDark,
+    getPrefersDark,
+    () => false,
+  );
+  const isDarkAppearance = isChatDarkAppearance(theme, prefersDark);
+
+  return {
+    isDarkAppearance,
+    toolbarSurface: chatToolbarSurface(isDarkAppearance),
+    panelClassName: chatPanelClassNames(isDarkAppearance),
+    panelBorderClassName: chatPanelBorderClassNames(isDarkAppearance),
+    elevatedSurfaceClassName:
+      chatElevatedSurfaceClassNames(isDarkAppearance),
+    inputEditorClassName: chatInputEditorClassNames(isDarkAppearance),
+  };
+}

--- a/apps/desktop/src/chat/surface.test.ts
+++ b/apps/desktop/src/chat/surface.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  chatElevatedSurfaceClassNames,
+  chatInputEditorClassNames,
+  chatPanelClassNames,
+  chatToolbarSurface,
+  isChatDarkAppearance,
+} from "./surface";
+
+describe("chat surface tokens", () => {
+  it("follows the saved app appearance", () => {
+    expect(isChatDarkAppearance("dark", false)).toBe(true);
+    expect(isChatDarkAppearance("light", true)).toBe(false);
+    expect(isChatDarkAppearance("system", true)).toBe(true);
+    expect(isChatDarkAppearance("system", false)).toBe(false);
+  });
+
+  it("uses a light card shell in light appearance", () => {
+    expect(chatPanelClassNames(false)).toContain("bg-card");
+    expect(chatPanelClassNames(false)).toContain("text-foreground");
+    expect(chatToolbarSurface(false)).toBe("light");
+  });
+
+  it("uses elevated light surfaces with dark text in dark appearance", () => {
+    expect(chatElevatedSurfaceClassNames(true)).toContain(
+      "bg-primary-foreground/95",
+    );
+    expect(chatElevatedSurfaceClassNames(true)).toContain("text-primary");
+    expect(chatInputEditorClassNames(true)).toBe("text-primary");
+  });
+});

--- a/apps/desktop/src/chat/surface.test.ts
+++ b/apps/desktop/src/chat/surface.test.ts
@@ -2,31 +2,52 @@ import { describe, expect, it } from "vitest";
 
 import {
   chatElevatedSurfaceClassNames,
+  chatFloatingControlClassNames,
+  chatFloatingPanelShellClassNames,
   chatInputEditorClassNames,
   chatPanelClassNames,
+  chatSendButtonDisabledClassNames,
   chatToolbarSurface,
   isChatDarkAppearance,
 } from "./surface";
 
 describe("chat surface tokens", () => {
-  it("follows the saved app appearance", () => {
-    expect(isChatDarkAppearance("dark", false)).toBe(true);
-    expect(isChatDarkAppearance("light", true)).toBe(false);
-    expect(isChatDarkAppearance("system", true)).toBe(true);
-    expect(isChatDarkAppearance("system", false)).toBe(false);
+  it("always uses the dark stone chat chrome regardless of app theme", () => {
+    expect(isChatDarkAppearance()).toBe(true);
+    expect(chatToolbarSurface()).toBe("dark");
   });
 
-  it("uses a light card shell in light appearance", () => {
-    expect(chatPanelClassNames(false)).toContain("bg-card");
-    expect(chatPanelClassNames(false)).toContain("text-foreground");
-    expect(chatToolbarSurface(false)).toBe("light");
+  it("maps the original stone-800 shell to primary tokens", () => {
+    expect(chatPanelClassNames()).toContain("bg-primary");
+    expect(chatPanelClassNames()).toContain("text-primary-foreground");
+    expect(chatPanelClassNames()).not.toContain("bg-card");
   });
 
-  it("uses elevated light surfaces with dark text in dark appearance", () => {
-    expect(chatElevatedSurfaceClassNames(true)).toContain(
-      "bg-primary-foreground/95",
+  it("maps the original white elevated surfaces to primary-foreground tokens", () => {
+    expect(chatElevatedSurfaceClassNames()).toContain("bg-primary-foreground");
+    expect(chatElevatedSurfaceClassNames()).toContain("text-primary");
+    expect(chatElevatedSurfaceClassNames()).toContain("border-border");
+    expect(chatInputEditorClassNames()).toContain("text-primary");
+    expect(chatInputEditorClassNames()).toContain("chat-input-editor");
+  });
+
+  it("uses elevated controls on the dark chat panel", () => {
+    expect(chatFloatingControlClassNames()).toContain("bg-primary-foreground");
+    expect(chatFloatingControlClassNames()).toContain("text-primary");
+  });
+
+  it("uses a dark drop shadow on the floating shell", () => {
+    expect(chatFloatingPanelShellClassNames()).toContain(
+      "shadow-[0_16px_48px_rgba(0,0,0,0.55)]",
     );
-    expect(chatElevatedSurfaceClassNames(true)).toContain("text-primary");
-    expect(chatInputEditorClassNames(true)).toBe("text-primary");
+    expect(chatFloatingPanelShellClassNames()).toContain("border-stone-600");
+    expect(chatFloatingPanelShellClassNames()).toContain("bg-primary");
+  });
+
+  it("styles disabled send controls on the elevated input surface", () => {
+    expect(chatSendButtonDisabledClassNames()).toContain(
+      "text-muted-foreground/60",
+    );
+    expect(chatSendButtonDisabledClassNames()).toContain("border-border");
   });
 });

--- a/apps/desktop/src/chat/surface.ts
+++ b/apps/desktop/src/chat/surface.ts
@@ -1,0 +1,47 @@
+import type { ThemePreference } from "~/shared/theme/resolve";
+import { resolveIsDarkMode } from "~/shared/theme/resolve";
+
+export type ChatToolbarSurface = "light" | "dark";
+
+export function isChatDarkAppearance(
+  theme: ThemePreference,
+  prefersDark: boolean,
+): boolean {
+  return resolveIsDarkMode(theme, prefersDark);
+}
+
+export function chatPanelClassNames(isDarkAppearance: boolean): string {
+  return isDarkAppearance
+    ? "bg-primary text-primary-foreground"
+    : "bg-card text-foreground";
+}
+
+export function chatPanelBorderClassNames(isDarkAppearance: boolean): string {
+  return isDarkAppearance ? "border-primary/80" : "border-border";
+}
+
+export function chatFloatingPanelShellClassNames(
+  isDarkAppearance: boolean,
+): string {
+  return isDarkAppearance
+    ? "bg-primary text-primary-foreground border-primary rounded-2xl border-2 shadow-[0_4px_28px_rgba(87,83,78,0.45)]"
+    : "bg-card text-foreground border-border rounded-2xl border shadow-lg";
+}
+
+export function chatElevatedSurfaceClassNames(
+  isDarkAppearance: boolean,
+): string {
+  return isDarkAppearance
+    ? "bg-primary-foreground/95 text-primary"
+    : "bg-muted text-foreground";
+}
+
+export function chatInputEditorClassNames(isDarkAppearance: boolean): string {
+  return isDarkAppearance ? "text-primary" : "text-foreground";
+}
+
+export function chatToolbarSurface(
+  isDarkAppearance: boolean,
+): ChatToolbarSurface {
+  return isDarkAppearance ? "dark" : "light";
+}

--- a/apps/desktop/src/chat/surface.ts
+++ b/apps/desktop/src/chat/surface.ts
@@ -38,5 +38,5 @@ export function chatToolbarSurface(): ChatToolbarSurface {
 }
 
 export function chatFloatingControlClassNames(): string {
-  return "border-border bg-primary-foreground text-primary hover:bg-accent";
+  return "border-border bg-primary-foreground text-primary hover:bg-primary-foreground/90";
 }

--- a/apps/desktop/src/chat/surface.ts
+++ b/apps/desktop/src/chat/surface.ts
@@ -1,47 +1,42 @@
-import type { ThemePreference } from "~/shared/theme/resolve";
-import { resolveIsDarkMode } from "~/shared/theme/resolve";
-
 export type ChatToolbarSurface = "light" | "dark";
 
-export function isChatDarkAppearance(
-  theme: ThemePreference,
-  prefersDark: boolean,
-): boolean {
-  return resolveIsDarkMode(theme, prefersDark);
+// Chat chrome always uses the original stone-800 shell, independent of app theme.
+export function isChatDarkAppearance(): boolean {
+  return true;
 }
 
-export function chatPanelClassNames(isDarkAppearance: boolean): string {
-  return isDarkAppearance
-    ? "bg-primary text-primary-foreground"
-    : "bg-card text-foreground";
+export function chatPanelClassNames(): string {
+  return "bg-primary text-primary-foreground";
 }
 
-export function chatPanelBorderClassNames(isDarkAppearance: boolean): string {
-  return isDarkAppearance ? "border-primary/80" : "border-border";
+export function chatPanelBorderClassNames(): string {
+  return "border-stone-700/80";
 }
 
-export function chatFloatingPanelShellClassNames(
-  isDarkAppearance: boolean,
-): string {
-  return isDarkAppearance
-    ? "bg-primary text-primary-foreground border-primary rounded-2xl border-2 shadow-[0_4px_28px_rgba(87,83,78,0.45)]"
-    : "bg-card text-foreground border-border rounded-2xl border shadow-lg";
+export function chatFloatingPanelShellClassNames(): string {
+  return "bg-primary text-primary-foreground rounded-2xl border-2 border-stone-600 shadow-[0_16px_48px_rgba(0,0,0,0.55)]";
 }
 
-export function chatElevatedSurfaceClassNames(
-  isDarkAppearance: boolean,
-): string {
-  return isDarkAppearance
-    ? "bg-primary-foreground/95 text-primary"
-    : "bg-muted text-foreground";
+export function chatElevatedSurfaceClassNames(): string {
+  return "bg-primary-foreground text-primary border-border";
 }
 
-export function chatInputEditorClassNames(isDarkAppearance: boolean): string {
-  return isDarkAppearance ? "text-primary" : "text-foreground";
+export function chatInputEditorClassNames(): string {
+  return "chat-input-editor text-primary";
 }
 
-export function chatToolbarSurface(
-  isDarkAppearance: boolean,
-): ChatToolbarSurface {
-  return isDarkAppearance ? "dark" : "light";
+export function chatSendButtonDisabledClassNames(): string {
+  return "cursor-default border-border text-muted-foreground/60";
+}
+
+export function chatSendButtonShortcutDisabledClassNames(): string {
+  return "text-muted-foreground/60";
+}
+
+export function chatToolbarSurface(): ChatToolbarSurface {
+  return "dark";
+}
+
+export function chatFloatingControlClassNames(): string {
+  return "border-border bg-primary-foreground text-primary hover:bg-accent";
 }

--- a/apps/desktop/src/composer/index.tsx
+++ b/apps/desktop/src/composer/index.tsx
@@ -257,10 +257,12 @@ function ComposerInput({
 
       <div className="mt-3 flex items-center justify-between gap-3">
         <div className="text-primary-foreground/40 flex items-center gap-2 text-[11px]">
-          <span className="bg-card/6 rounded-full px-2 py-1">
+          <span className="bg-primary-foreground/8 rounded-full px-2 py-1">
             Esc to dismiss
           </span>
-          <span className="bg-card/6 rounded-full px-2 py-1">⌘ ↩ to send</span>
+          <span className="bg-primary-foreground/8 rounded-full px-2 py-1">
+            ⌘ ↩ to send
+          </span>
         </div>
 
         {isStreaming ? (

--- a/apps/desktop/src/composer/index.tsx
+++ b/apps/desktop/src/composer/index.tsx
@@ -115,15 +115,15 @@ function ComposerSettingsCard() {
     <div
       className={cn([
         "h-full w-full rounded-[28px] px-5 py-4",
-        "bg-[rgba(23,24,28,0.88)] text-white",
+        "bg-primary/88 text-primary-foreground",
       ])}
     >
       <div className="mb-3 flex items-center justify-between gap-3">
         <div data-tauri-drag-region className="min-w-0 flex-1 pr-4">
-          <p className="text-[10px] font-semibold tracking-[0.24em] text-white/38 uppercase">
+          <p className="text-primary-foreground/38 text-[10px] font-semibold tracking-[0.24em] uppercase">
             Composer
           </p>
-          <p className="truncate pt-1 text-sm text-white/72">
+          <p className="text-primary-foreground/72 truncate pt-1 text-sm">
             Configure a chat model to use the quick composer.
           </p>
         </div>
@@ -134,8 +134,8 @@ function ComposerSettingsCard() {
           data-tauri-drag-region="false"
           className={cn([
             "inline-flex size-8 items-center justify-center rounded-full",
-            "bg-white/7 text-white/65 transition-colors",
-            "hover:bg-white/12 hover:text-white",
+            "bg-primary-foreground/7 text-primary-foreground/65 transition-colors",
+            "hover:bg-primary-foreground/12 hover:text-primary-foreground",
           ])}
         >
           <XIcon className="size-4" />
@@ -147,8 +147,8 @@ function ComposerSettingsCard() {
         onClick={() => void openSettingsInMainWindow()}
         className={cn([
           "inline-flex items-center gap-2 rounded-full px-3.5 py-2 text-sm font-medium",
-          "bg-white/7 text-white/85 transition-colors",
-          "hover:bg-white/10 hover:text-white",
+          "bg-primary-foreground/7 text-primary-foreground/85 transition-colors",
+          "hover:bg-primary-foreground/10 hover:text-primary-foreground",
         ])}
       >
         <Settings2Icon className="size-4" />
@@ -199,15 +199,17 @@ function ComposerInput({
     <div
       className={cn([
         "h-full w-full rounded-[28px] px-5 py-4",
-        "bg-[rgba(23,24,28,0.88)] text-white",
+        "bg-primary/88 text-primary-foreground",
       ])}
     >
       <div className="mb-3 flex items-start justify-between gap-4">
         <div data-tauri-drag-region className="min-w-0 flex-1 pr-4">
-          <p className="text-[10px] font-semibold tracking-[0.24em] text-white/38 uppercase">
+          <p className="text-primary-foreground/38 text-[10px] font-semibold tracking-[0.24em] uppercase">
             Composer
           </p>
-          <p className="truncate pt-1 text-[15px] text-white/90">{title}</p>
+          <p className="text-primary-foreground/90 truncate pt-1 text-[15px]">
+            {title}
+          </p>
         </div>
 
         <div data-tauri-drag-region="false" className="flex items-center gap-2">
@@ -217,8 +219,8 @@ function ComposerInput({
             data-tauri-drag-region="false"
             className={cn([
               "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium",
-              "bg-white/7 text-white/76",
-              "transition-colors hover:bg-white/12 hover:text-white",
+              "bg-primary-foreground/7 text-primary-foreground/76",
+              "hover:bg-primary-foreground/12 hover:text-primary-foreground transition-colors",
             ])}
           >
             <ArrowUpRightIcon className="size-3.5" />
@@ -230,8 +232,8 @@ function ComposerInput({
             data-tauri-drag-region="false"
             className={cn([
               "inline-flex size-8 items-center justify-center rounded-full",
-              "bg-white/7 text-white/65 transition-colors",
-              "hover:bg-white/12 hover:text-white",
+              "bg-primary-foreground/7 text-primary-foreground/65 transition-colors",
+              "hover:bg-primary-foreground/12 hover:text-primary-foreground",
             ])}
           >
             <XIcon className="size-4" />
@@ -242,9 +244,9 @@ function ComposerInput({
       <ChatEditor
         ref={editorRef}
         className={cn([
-          "max-h-[88px] min-h-[34px] overflow-y-auto text-[15px] leading-6 text-white",
+          "text-primary-foreground max-h-[88px] min-h-[34px] overflow-y-auto text-[15px] leading-6",
           "[&_.ProseMirror]:min-h-[34px] [&_.ProseMirror]:outline-none",
-          "[&_.ProseMirror]:placeholder:text-white/28",
+          "[&_.ProseMirror]:placeholder:text-primary-foreground/28",
         ])}
         initialContent={initialContent}
         mentionConfig={mentionConfig}
@@ -254,11 +256,11 @@ function ComposerInput({
       />
 
       <div className="mt-3 flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2 text-[11px] text-white/40">
-          <span className="rounded-full bg-white/6 px-2 py-1">
+        <div className="text-primary-foreground/40 flex items-center gap-2 text-[11px]">
+          <span className="bg-card/6 rounded-full px-2 py-1">
             Esc to dismiss
           </span>
-          <span className="rounded-full bg-white/6 px-2 py-1">⌘ ↩ to send</span>
+          <span className="bg-card/6 rounded-full px-2 py-1">⌘ ↩ to send</span>
         </div>
 
         {isStreaming ? (
@@ -267,8 +269,8 @@ function ComposerInput({
             onClick={onStop}
             className={cn([
               "inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium",
-              "bg-white/8 text-white/82 transition-colors",
-              "hover:bg-white/12 hover:text-white",
+              "bg-primary-foreground/8 text-primary-foreground/82 transition-colors",
+              "hover:bg-primary-foreground/12 hover:text-primary-foreground",
             ])}
           >
             <SparklesIcon className="size-3.5" />
@@ -282,9 +284,9 @@ function ComposerInput({
             className={cn([
               "inline-flex size-10 items-center justify-center rounded-full",
               disabled
-                ? "cursor-default bg-white/8 text-white/25"
+                ? "bg-primary-foreground/8 text-primary-foreground/25 cursor-default"
                 : [
-                    "bg-white text-[#111318]",
+                    "bg-primary-foreground text-primary",
                     "transition-transform hover:scale-[1.02]",
                   ],
               !hasContent && !disabled && "opacity-55",

--- a/apps/desktop/src/contacts/details.tsx
+++ b/apps/desktop/src/contacts/details.tsx
@@ -1,4 +1,3 @@
-import { Facehash } from "facehash";
 import {
   Building2,
   CircleMinus,
@@ -19,7 +18,7 @@ import {
 import { Textarea } from "@hypr/ui/components/ui/textarea";
 import { cn } from "@hypr/utils";
 
-import { getContactBgClass } from "./shared";
+import { ContactFacehash, getContactBgClass } from "./shared";
 
 import * as main from "~/store/tinybase/store/main";
 
@@ -205,13 +204,13 @@ export function DetailsColumn({
         <>
           <div
             data-tauri-drag-region
-            className="flex items-center justify-center border-b border-neutral-200 py-6"
+            className="border-border flex items-center justify-center border-b py-6"
           >
             <div
               data-tauri-drag-region="false"
               className={cn(["rounded-full", bgClass])}
             >
-              <Facehash
+              <ContactFacehash
                 name={facehashName}
                 size={64}
                 interactive={true}
@@ -223,7 +222,7 @@ export function DetailsColumn({
 
           <div className="flex-1 overflow-y-auto">
             {duplicatesWithData.length > 0 && (
-              <div className="border-b border-neutral-200 bg-red-50 px-6 py-4">
+              <div className="border-border border-b bg-red-50 px-6 py-4">
                 <h4 className="mb-1 text-sm font-semibold text-red-900">
                   Duplicate Contact
                   {duplicatesWithData.length > 1 ? "s" : ""} Found
@@ -240,7 +239,7 @@ export function DetailsColumn({
                   {duplicatesWithData.map((dup) => (
                     <div
                       key={dup.id}
-                      className="flex items-center justify-between rounded-md border border-neutral-200 bg-neutral-50 p-2"
+                      className="border-border bg-muted flex items-center justify-between rounded-md border p-2"
                     >
                       <div className="flex items-center gap-2">
                         <div
@@ -251,7 +250,7 @@ export function DetailsColumn({
                             ),
                           ])}
                         >
-                          <Facehash
+                          <ContactFacehash
                             name={String(dup.name || dup.email || dup.id)}
                             size={32}
                             interactive={false}
@@ -264,10 +263,10 @@ export function DetailsColumn({
                           />
                         </div>
                         <div>
-                          <div className="text-sm font-medium text-neutral-900">
+                          <div className="text-foreground text-sm font-medium">
                             {dup.name || "Unnamed Contact"}
                           </div>
-                          <div className="text-xs text-neutral-500">
+                          <div className="text-muted-foreground text-xs">
                             {dup.email}
                           </div>
                         </div>
@@ -286,16 +285,18 @@ export function DetailsColumn({
             )}
 
             <div>
-              <div className="flex items-center border-b border-neutral-200 px-4 py-3">
-                <div className="w-28 text-sm text-neutral-500">Name</div>
+              <div className="border-border flex items-center border-b px-4 py-3">
+                <div className="text-muted-foreground w-28 text-sm">Name</div>
                 <div className="flex-1">
                   <EditablePersonNameField personId={selectedHumanId} />
                 </div>
               </div>
               <EditablePersonJobTitleField personId={selectedHumanId} />
 
-              <div className="flex items-center border-b border-neutral-200 px-4 py-3">
-                <div className="w-28 text-sm text-neutral-500">Company</div>
+              <div className="border-border flex items-center border-b px-4 py-3">
+                <div className="text-muted-foreground w-28 text-sm">
+                  Company
+                </div>
                 <div className="flex-1">
                   <EditPersonOrganizationSelector personId={selectedHumanId} />
                 </div>
@@ -308,12 +309,12 @@ export function DetailsColumn({
             </div>
 
             {personSessions.length > 0 && (
-              <div className="border-b border-neutral-200 p-6">
-                <h3 className="mb-3 text-sm font-medium text-neutral-600">
+              <div className="border-border border-b p-6">
+                <h3 className="text-muted-foreground mb-3 text-sm font-medium">
                   Summary
                 </h3>
-                <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4">
-                  <p className="text-sm leading-relaxed text-neutral-700">
+                <div className="border-border bg-muted rounded-lg border p-4">
+                  <p className="text-muted-foreground text-sm leading-relaxed">
                     AI-generated summary of all interactions and notes with this
                     contact will appear here. This will synthesize key
                     discussion points, action items, and relationship context
@@ -324,7 +325,7 @@ export function DetailsColumn({
             )}
 
             <div className="p-6">
-              <h3 className="mb-4 text-sm font-medium text-neutral-600">
+              <h3 className="text-muted-foreground mb-4 text-sm font-medium">
                 Related Notes
               </h3>
               <div className="flex flex-col gap-2">
@@ -333,28 +334,28 @@ export function DetailsColumn({
                     <button
                       key={session.id}
                       onClick={() => handleSessionClick(session.id)}
-                      className="w-full rounded-md border border-neutral-200 p-3 text-left transition-colors hover:bg-neutral-50"
+                      className="border-border hover:bg-accent w-full rounded-md border p-3 text-left transition-colors"
                     >
                       <div className="mb-1 flex items-center gap-2">
-                        <FileText className="h-4 w-4 text-neutral-500" />
+                        <FileText className="text-muted-foreground h-4 w-4" />
                         <span className="text-sm font-medium">
                           {session.title || "Untitled Note"}
                         </span>
                       </div>
                       {session.summary && (
-                        <p className="mt-1 line-clamp-2 text-xs text-neutral-600">
+                        <p className="text-muted-foreground mt-1 line-clamp-2 text-xs">
                           {session.summary}
                         </p>
                       )}
                       {session.created_at && (
-                        <div className="mt-1 text-xs text-neutral-500">
+                        <div className="text-muted-foreground mt-1 text-xs">
                           {new Date(session.created_at).toLocaleDateString()}
                         </div>
                       )}
                     </button>
                   ))
                 ) : (
-                  <p className="text-sm text-neutral-500">
+                  <p className="text-muted-foreground text-sm">
                     No related notes found
                   </p>
                 )}
@@ -366,7 +367,7 @@ export function DetailsColumn({
         </>
       ) : (
         <div className="flex flex-1 items-center justify-center">
-          <p className="text-sm text-neutral-500">
+          <p className="text-muted-foreground text-sm">
             Select a person to view details
           </p>
         </div>
@@ -410,8 +411,8 @@ function EditablePersonJobTitleField({ personId }: { personId: string }) {
   );
 
   return (
-    <div className="flex items-center border-b border-neutral-200 px-4 py-3">
-      <div className="w-28 text-sm text-neutral-500">Job Title</div>
+    <div className="border-border flex items-center border-b px-4 py-3">
+      <div className="text-muted-foreground w-28 text-sm">Job Title</div>
       <div className="flex-1">
         <Input
           value={(value as string) || ""}
@@ -437,8 +438,8 @@ function EditablePersonEmailField({ personId }: { personId: string }) {
   );
 
   return (
-    <div className="flex items-center border-b border-neutral-200 px-4 py-3">
-      <div className="w-28 text-sm text-neutral-500">Email</div>
+    <div className="border-border flex items-center border-b px-4 py-3">
+      <div className="text-muted-foreground w-28 text-sm">Email</div>
       <div className="flex-1">
         <Input
           type="email"
@@ -465,8 +466,8 @@ function EditablePersonPhoneField({ personId }: { personId: string }) {
   );
 
   return (
-    <div className="flex items-center border-b border-neutral-200 px-4 py-3">
-      <div className="w-28 text-sm text-neutral-500">Phone</div>
+    <div className="border-border flex items-center border-b px-4 py-3">
+      <div className="text-muted-foreground w-28 text-sm">Phone</div>
       <div className="flex-1">
         <Input
           type="tel"
@@ -498,8 +499,8 @@ function EditablePersonLinkedInField({ personId }: { personId: string }) {
   );
 
   return (
-    <div className="flex items-center border-b border-neutral-200 px-4 py-3">
-      <div className="w-28 text-sm text-neutral-500">LinkedIn</div>
+    <div className="border-border flex items-center border-b px-4 py-3">
+      <div className="text-muted-foreground w-28 text-sm">LinkedIn</div>
       <div className="flex-1">
         <Input
           value={(value as string) || ""}
@@ -525,8 +526,8 @@ function EditablePersonMemoField({ personId }: { personId: string }) {
   );
 
   return (
-    <div className="flex border-b border-neutral-200 px-4 py-3">
-      <div className="w-28 pt-2 text-sm text-neutral-500">Notes</div>
+    <div className="border-border flex border-b px-4 py-3">
+      <div className="text-muted-foreground w-28 pt-2 text-sm">Notes</div>
       <div className="flex-1">
         <Textarea
           value={(value as string) || ""}
@@ -567,13 +568,13 @@ function EditPersonOrganizationSelector({ personId }: { personId: string }) {
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <div className="-mx-2 inline-flex cursor-pointer items-center rounded-lg px-2 py-1 transition-colors hover:bg-neutral-50">
+        <div className="hover:bg-accent -mx-2 inline-flex cursor-pointer items-center rounded-lg px-2 py-1 transition-colors">
           {organization?.name ? (
             <div className="flex items-center">
               <span className="text-base">{organization.name}</span>
-              <span className="group ml-2 text-neutral-400">
+              <span className="group text-muted-foreground ml-2">
                 <CircleMinus
-                  className="size-4 cursor-pointer text-neutral-400 hover:text-red-600"
+                  className="text-muted-foreground size-4 cursor-pointer hover:text-red-600"
                   onClick={(e) => {
                     e.stopPropagation();
                     handleRemoveOrganization();
@@ -582,7 +583,7 @@ function EditPersonOrganizationSelector({ personId }: { personId: string }) {
               </span>
             </div>
           ) : (
-            <span className="flex items-center gap-1 text-base text-neutral-400">
+            <span className="text-muted-foreground flex items-center gap-1 text-base">
               <Plus className="size-4" />
               Add organization
             </span>
@@ -681,12 +682,14 @@ function OrganizationControl({
 
   return (
     <div className="flex max-w-[450px] flex-col gap-3">
-      <div className="text-sm font-medium text-neutral-700">Organization</div>
+      <div className="text-muted-foreground text-sm font-medium">
+        Organization
+      </div>
 
       <form onSubmit={handleSubmit}>
         <div className="flex flex-col gap-2">
-          <div className="flex w-full items-center gap-2 rounded-xs border border-neutral-200 bg-neutral-50 px-2 py-1.5">
-            <span className="shrink-0 text-neutral-500">
+          <div className="border-border bg-muted flex w-full items-center gap-2 rounded-xs border px-2 py-1.5">
+            <span className="text-muted-foreground shrink-0">
               <SearchIcon className="size-4" />
             </span>
             <input
@@ -698,26 +701,24 @@ function OrganizationControl({
               }}
               onKeyDown={handleKeyDown}
               placeholder="Search or add company"
-              className="w-full bg-transparent text-sm placeholder:text-neutral-400 focus:outline-hidden focus-visible:ring-0 focus-visible:ring-offset-0"
+              className="placeholder:text-muted-foreground w-full bg-transparent text-sm focus:outline-hidden focus-visible:ring-0 focus-visible:ring-offset-0"
             />
           </div>
 
           {searchTerm.trim() && (
-            <div className="flex w-full flex-col overflow-hidden rounded-xs border border-neutral-200">
+            <div className="border-border flex w-full flex-col overflow-hidden rounded-xs border">
               {organizations.map((org: any, index: number) => (
                 <button
                   key={org.id}
                   type="button"
                   className={[
                     "flex items-center px-3 py-2 text-sm text-left transition-colors w-full",
-                    highlightedIndex === index
-                      ? "bg-neutral-100"
-                      : "hover:bg-neutral-100",
+                    highlightedIndex === index ? "bg-muted" : "hover:bg-accent",
                   ].join(" ")}
                   onClick={() => selectOrganization(org.id)}
                   onMouseEnter={() => setHighlightedIndex(index)}
                 >
-                  <span className="mr-2 flex size-5 shrink-0 items-center justify-center rounded-full bg-neutral-100">
+                  <span className="bg-muted mr-2 flex size-5 shrink-0 items-center justify-center rounded-full">
                     <Building2 className="size-3" />
                   </span>
                   <span className="truncate font-medium">{org.name}</span>
@@ -730,18 +731,18 @@ function OrganizationControl({
                   className={[
                     "flex items-center px-3 py-2 text-sm text-left transition-colors w-full",
                     highlightedIndex === organizations.length
-                      ? "bg-neutral-100"
-                      : "hover:bg-neutral-100",
+                      ? "bg-muted"
+                      : "hover:bg-accent",
                   ].join(" ")}
                   onClick={() => handleCreateOrganization()}
                   onMouseEnter={() => setHighlightedIndex(organizations.length)}
                 >
-                  <span className="mr-2 flex size-5 shrink-0 items-center justify-center rounded-full bg-neutral-200">
+                  <span className="bg-accent mr-2 flex size-5 shrink-0 items-center justify-center rounded-full">
                     <span className="text-xs">+</span>
                   </span>
-                  <span className="flex items-center gap-1 font-medium text-neutral-600">
+                  <span className="text-muted-foreground flex items-center gap-1 font-medium">
                     Create
-                    <span className="max-w-[140px] truncate text-neutral-900">
+                    <span className="text-foreground max-w-[140px] truncate">
                       &quot;{searchTerm.trim()}&quot;
                     </span>
                   </span>
@@ -751,21 +752,19 @@ function OrganizationControl({
           )}
 
           {!searchTerm.trim() && organizations.length > 0 && (
-            <div className="custom-scrollbar flex max-h-[40vh] w-full flex-col overflow-hidden overflow-y-auto rounded-xs border border-neutral-200">
+            <div className="custom-scrollbar border-border flex max-h-[40vh] w-full flex-col overflow-hidden overflow-y-auto rounded-xs border">
               {organizations.map((org: any, index: number) => (
                 <button
                   key={org.id}
                   type="button"
                   className={[
                     "flex items-center px-3 py-2 text-sm text-left transition-colors w-full",
-                    highlightedIndex === index
-                      ? "bg-neutral-100"
-                      : "hover:bg-neutral-100",
+                    highlightedIndex === index ? "bg-muted" : "hover:bg-accent",
                   ].join(" ")}
                   onClick={() => selectOrganization(org.id)}
                   onMouseEnter={() => setHighlightedIndex(index)}
                 >
-                  <span className="mr-2 flex size-5 shrink-0 items-center justify-center rounded-full bg-neutral-100">
+                  <span className="bg-muted mr-2 flex size-5 shrink-0 items-center justify-center rounded-full">
                     <Building2 className="size-3" />
                   </span>
                   <span className="truncate font-medium">{org.name}</span>

--- a/apps/desktop/src/contacts/new-person-form.tsx
+++ b/apps/desktop/src/contacts/new-person-form.tsx
@@ -61,20 +61,20 @@ export function NewPersonForm({
   return (
     <div className="px-2 py-2">
       <form onSubmit={handleSubmit}>
-        <div className="flex h-8 w-full items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-200/50 px-3 transition-colors focus-within:bg-neutral-200">
+        <div className="border-border bg-accent/50 focus-within:bg-accent flex h-8 w-full items-center gap-2 rounded-lg border px-3 transition-colors">
           <input
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Add person"
-            className="w-full bg-transparent text-sm placeholder:text-neutral-400 focus:outline-hidden"
+            className="placeholder:text-muted-foreground w-full bg-transparent text-sm focus:outline-hidden"
             autoFocus
           />
           {name.trim() && (
             <button
               type="submit"
-              className="shrink-0 text-neutral-500 transition-colors hover:text-neutral-700"
+              className="text-muted-foreground hover:text-muted-foreground shrink-0 transition-colors"
               aria-label="Add person"
             >
               <CornerDownLeft className="size-4" />

--- a/apps/desktop/src/contacts/organization-details.tsx
+++ b/apps/desktop/src/contacts/organization-details.tsx
@@ -1,5 +1,4 @@
 import { Icon } from "@iconify-icon/react";
-import { Facehash } from "facehash";
 import { Building2, Mail } from "lucide-react";
 
 import { commands as openerCommands } from "@hypr/plugin-opener2";
@@ -7,7 +6,7 @@ import { Button } from "@hypr/ui/components/ui/button";
 import { Input } from "@hypr/ui/components/ui/input";
 import { cn } from "@hypr/utils";
 
-import { getContactBgClass } from "./shared";
+import { ContactFacehash, getContactBgClass } from "./shared";
 
 import * as main from "~/store/tinybase/store/main";
 
@@ -38,17 +37,17 @@ export function OrganizationDetailsColumn({
         <>
           <div
             data-tauri-drag-region
-            className="flex items-center justify-center border-b border-neutral-200 py-6"
+            className="border-border flex items-center justify-center border-b py-6"
           >
-            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-neutral-200">
-              <Building2 className="h-8 w-8 text-neutral-600" />
+            <div className="bg-accent flex h-16 w-16 items-center justify-center rounded-full">
+              <Building2 className="text-muted-foreground h-8 w-8" />
             </div>
           </div>
 
           <div className="flex-1 overflow-y-auto">
             <div>
-              <div className="flex items-center border-b border-neutral-200 px-4 py-3">
-                <div className="w-28 text-sm text-neutral-500">Name</div>
+              <div className="border-border flex items-center border-b px-4 py-3">
+                <div className="text-muted-foreground w-28 text-sm">Name</div>
                 <div className="flex-1">
                   <EditableOrganizationNameField
                     organizationId={selectedOrganizationId}
@@ -58,9 +57,9 @@ export function OrganizationDetailsColumn({
             </div>
 
             <div className="p-6">
-              <h3 className="mb-4 text-sm font-medium text-neutral-600">
+              <h3 className="text-muted-foreground mb-4 text-sm font-medium">
                 People
-                <span className="font-normal text-neutral-400">
+                <span className="text-muted-foreground font-normal">
                   {" "}
                   &middot; {peopleInOrg?.length ?? 0}{" "}
                   {(peopleInOrg?.length ?? 0) === 1 ? "member" : "members"}
@@ -78,7 +77,7 @@ export function OrganizationDetailsColumn({
                       return (
                         <div
                           key={humanId}
-                          className="cursor-pointer rounded-lg border border-neutral-200 bg-white p-4 transition-all hover:shadow-xs"
+                          className="border-border bg-card cursor-pointer rounded-lg border p-4 transition-all hover:shadow-xs"
                           onClick={() => onPersonClick?.(humanId)}
                         >
                           <div className="flex flex-col items-center gap-3 text-center">
@@ -90,7 +89,7 @@ export function OrganizationDetailsColumn({
                                 ),
                               ])}
                             >
-                              <Facehash
+                              <ContactFacehash
                                 name={String(
                                   human.name || human.email || humanId,
                                 )}
@@ -111,7 +110,7 @@ export function OrganizationDetailsColumn({
                                 {human.name || human.email || "Unnamed"}
                               </div>
                               {human.job_title && (
-                                <div className="mt-1 truncate text-xs text-neutral-500">
+                                <div className="text-muted-foreground mt-1 truncate text-xs">
                                   {human.job_title as string}
                                 </div>
                               )}
@@ -159,7 +158,7 @@ export function OrganizationDetailsColumn({
                     })}
                   </div>
                 ) : (
-                  <p className="text-sm text-neutral-500">
+                  <p className="text-muted-foreground text-sm">
                     No people in this organization
                   </p>
                 )}
@@ -171,7 +170,7 @@ export function OrganizationDetailsColumn({
         </>
       ) : (
         <div className="flex flex-1 items-center justify-center">
-          <p className="text-sm text-neutral-500">
+          <p className="text-muted-foreground text-sm">
             Select an organization to view details
           </p>
         </div>

--- a/apps/desktop/src/contacts/organization-item.tsx
+++ b/apps/desktop/src/contacts/organization-item.tsx
@@ -95,11 +95,11 @@ export function OrganizationItem({
       }}
       className={cn([
         "group flex w-full items-center gap-2 overflow-hidden rounded-lg px-3 py-2 text-left text-sm transition-colors select-none",
-        active ? "bg-neutral-200" : "hover:bg-neutral-200/50",
+        active ? "bg-accent" : "hover:bg-accent/50",
       ])}
     >
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-neutral-100">
-        <Building2 className="h-4 w-4 text-neutral-500" />
+      <div className="bg-muted flex h-8 w-8 shrink-0 items-center justify-center rounded-full">
+        <Building2 className="text-muted-foreground h-4 w-4" />
       </div>
       <div className="min-w-0 flex-1">
         <div className="truncate font-medium">{organization.name}</div>
@@ -110,7 +110,7 @@ export function OrganizationItem({
           "shrink-0 rounded-xs p-1 transition-colors",
           isPinned
             ? "text-blue-600 hover:text-blue-700"
-            : "text-neutral-300 opacity-0 group-hover:opacity-100 hover:text-neutral-500",
+            : "text-muted-foreground/70 hover:text-muted-foreground opacity-0 group-hover:opacity-100",
         ])}
         aria-label={isPinned ? "Unpin organization" : "Pin organization"}
       >

--- a/apps/desktop/src/contacts/person-item.tsx
+++ b/apps/desktop/src/contacts/person-item.tsx
@@ -1,10 +1,9 @@
-import { Facehash } from "facehash";
 import { Pin } from "lucide-react";
 import React, { useCallback } from "react";
 
 import { cn } from "@hypr/utils";
 
-import { getContactBgClass } from "~/contacts/shared";
+import { ContactFacehash, getContactBgClass } from "~/contacts/shared";
 import { useNativeContextMenu } from "~/shared/hooks/useNativeContextMenu";
 import * as main from "~/store/tinybase/store/main";
 
@@ -90,11 +89,11 @@ export function PersonItem({
       }}
       className={cn([
         "group flex w-full items-center gap-2 overflow-hidden rounded-lg px-3 py-2 text-left text-sm transition-colors select-none",
-        active ? "bg-neutral-200" : "hover:bg-neutral-200/50",
+        active ? "bg-accent" : "hover:bg-accent/50",
       ])}
     >
       <div className={cn(["shrink-0 rounded-full", bgClass])}>
-        <Facehash
+        <ContactFacehash
           name={facehashName}
           size={32}
           interactive={true}
@@ -107,7 +106,9 @@ export function PersonItem({
           {personName || personEmail || "Unnamed"}
         </div>
         {personEmail && personName && (
-          <div className="truncate text-xs text-neutral-500">{personEmail}</div>
+          <div className="text-muted-foreground truncate text-xs">
+            {personEmail}
+          </div>
         )}
       </div>
       <button
@@ -116,7 +117,7 @@ export function PersonItem({
           "shrink-0 rounded-xs p-1 transition-colors",
           isPinned
             ? "text-blue-600 hover:text-blue-700"
-            : "text-neutral-300 opacity-0 group-hover:opacity-100 hover:text-neutral-500",
+            : "text-muted-foreground/70 hover:text-muted-foreground opacity-0 group-hover:opacity-100",
         ])}
         aria-label={isPinned ? "Unpin contact" : "Pin contact"}
       >

--- a/apps/desktop/src/contacts/shared.tsx
+++ b/apps/desktop/src/contacts/shared.tsx
@@ -1,6 +1,6 @@
-import { stringHash } from "facehash";
+import { Facehash, stringHash } from "facehash";
 import { ArrowDownUp, Plus, Search, X } from "lucide-react";
-import type { KeyboardEvent, RefObject } from "react";
+import type { ComponentProps, KeyboardEvent, RefObject } from "react";
 
 import { Button } from "@hypr/ui/components/ui/button";
 import {
@@ -11,25 +11,46 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@hypr/ui/components/ui/dropdown-menu";
+import { cn } from "@hypr/utils";
 
 import { CustomSidebarHeader } from "~/sidebar/custom-sidebar-header";
 
 const COLOR_PALETTES = [
-  "bg-amber-50",
-  "bg-rose-50",
-  "bg-violet-50",
-  "bg-blue-50",
-  "bg-teal-50",
-  "bg-green-50",
-  "bg-cyan-50",
-  "bg-fuchsia-50",
-  "bg-indigo-50",
-  "bg-yellow-50",
-];
+  "bg-amber-50 dark:bg-amber-950",
+  "bg-rose-50 dark:bg-rose-950",
+  "bg-violet-50 dark:bg-violet-950",
+  "bg-blue-50 dark:bg-blue-950",
+  "bg-teal-50 dark:bg-teal-950",
+  "bg-green-50 dark:bg-green-950",
+  "bg-cyan-50 dark:bg-cyan-950",
+  "bg-fuchsia-50 dark:bg-fuchsia-950",
+  "bg-indigo-50 dark:bg-indigo-950",
+  "bg-yellow-50 dark:bg-yellow-950",
+] as const;
+
+export const CONTACT_FACEHASH_CLASS = "text-foreground";
 
 export function getContactBgClass(name: string) {
   const hash = stringHash(name);
   return COLOR_PALETTES[hash % COLOR_PALETTES.length];
+}
+
+export function ContactFacehash({
+  name,
+  className,
+  colorClasses,
+  ...props
+}: ComponentProps<typeof Facehash>) {
+  const bgClass = colorClasses?.[0] ?? getContactBgClass(name);
+
+  return (
+    <Facehash
+      name={name}
+      className={cn([CONTACT_FACEHASH_CLASS, className])}
+      colorClasses={colorClasses ?? [bgClass]}
+      {...props}
+    />
+  );
 }
 
 export type SortOption =
@@ -131,8 +152,8 @@ export function ColumnHeader({
       </CustomSidebarHeader>
       {onSearchChange && (
         <div className="pb-2">
-          <div className="flex h-8 w-full items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-200/50 px-3 transition-colors focus-within:bg-neutral-200">
-            <Search className="h-4 w-4 shrink-0 text-neutral-400" />
+          <div className="border-border bg-muted focus-within:bg-accent flex h-8 w-full items-center gap-2 rounded-lg border px-3 transition-colors">
+            <Search className="text-muted-foreground h-4 w-4 shrink-0" />
             <input
               ref={searchInputRef}
               type="text"
@@ -140,12 +161,12 @@ export function ColumnHeader({
               onChange={(e) => onSearchChange(e.target.value)}
               onKeyDown={handleSearchKeyDown}
               placeholder="Search contacts..."
-              className="min-w-0 flex-1 bg-transparent text-sm placeholder:text-sm placeholder:text-neutral-400 focus:outline-hidden"
+              className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-sm placeholder:text-sm focus:outline-hidden"
             />
             {searchValue && (
               <button
                 onClick={() => onSearchChange("")}
-                className="h-4 w-4 shrink-0 text-neutral-400 transition-colors hover:text-neutral-600"
+                className="text-muted-foreground hover:text-foreground h-4 w-4 shrink-0 transition-colors"
                 aria-label="Clear search"
               >
                 <X className="h-4 w-4" />

--- a/apps/desktop/src/edit/tab-content.tsx
+++ b/apps/desktop/src/edit/tab-content.tsx
@@ -48,7 +48,7 @@ export function TabContentEdit({ tab }: { tab: EditTab }) {
   if (!edit) {
     return (
       <StandardTabWrapper>
-        <div className="flex h-full items-center justify-center text-neutral-400">
+        <div className="text-muted-foreground flex h-full items-center justify-center">
           This edit is no longer pending.
         </div>
       </StandardTabWrapper>
@@ -58,18 +58,18 @@ export function TabContentEdit({ tab }: { tab: EditTab }) {
   return (
     <StandardTabWrapper>
       <div className="flex h-full flex-col">
-        <div className="flex items-start justify-between gap-3 border-b border-neutral-200 px-4 py-3">
+        <div className="border-border flex items-start justify-between gap-3 border-b px-4 py-3">
           <div className="min-w-0 flex-1">
-            <div className="text-[13px] font-medium text-neutral-900">
+            <div className="text-foreground text-[13px] font-medium">
               {sessionTitle ?? "Untitled session"}
             </div>
-            <div className="text-[12px] text-neutral-500">
+            <div className="text-muted-foreground text-[12px]">
               {summaryTitle ?? "Summary"}
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">
             <button
-              className="rounded-md border border-neutral-300 bg-white px-4 py-1.5 text-[13px] text-neutral-600 transition-colors hover:bg-neutral-50"
+              className="border-border bg-card text-muted-foreground hover:bg-accent rounded-md border px-4 py-1.5 text-[13px] transition-colors"
               onClick={() => {
                 resolveEdit(tab.requestId, false);
                 useTabs.getState().close(tab);
@@ -78,7 +78,7 @@ export function TabContentEdit({ tab }: { tab: EditTab }) {
               Decline
             </button>
             <button
-              className="rounded-md bg-neutral-800 px-4 py-1.5 text-[13px] text-white transition-colors hover:bg-neutral-700"
+              className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-1.5 text-[13px] transition-colors"
               onClick={() => {
                 resolveEdit(tab.requestId, true);
                 useTabs.getState().close(tab);

--- a/apps/desktop/src/editor-bridge/app-link-view.tsx
+++ b/apps/desktop/src/editor-bridge/app-link-view.tsx
@@ -75,11 +75,16 @@ function Checkbox({ checked }: { checked: boolean }) {
       className={cn([
         "flex size-5 shrink-0 items-center justify-center rounded-md border-2",
         checked
-          ? "border-neutral-400 bg-neutral-400"
-          : "border-neutral-300 bg-white",
+          ? "border-muted-foreground bg-muted-foreground"
+          : "border-border bg-card",
       ])}
     >
-      {checked && <CheckIcon className="size-3.5 text-white" strokeWidth={3} />}
+      {checked && (
+        <CheckIcon
+          className="text-primary-foreground size-3.5"
+          strokeWidth={3}
+        />
+      )}
     </span>
   );
 }
@@ -135,15 +140,15 @@ export const AppLinkView = forwardRef<HTMLSpanElement, NodeViewComponentProps>(
           }}
           className={cn([
             "inline-flex max-w-full items-center gap-2.5 rounded-lg px-2 py-1 text-left align-middle",
-            "transition-colors hover:bg-neutral-100",
+            "hover:bg-accent transition-colors",
           ])}
         >
           {showCheckbox ? (
             <Checkbox checked={checked} />
           ) : attrs.provider === "slack" ? (
-            <SlackIcon className="size-4 shrink-0 text-neutral-500" />
+            <SlackIcon className="text-muted-foreground size-4 shrink-0" />
           ) : attrs.provider === "discord" ? (
-            <DiscordIcon className="size-4 shrink-0 text-neutral-500" />
+            <DiscordIcon className="text-muted-foreground size-4 shrink-0" />
           ) : (
             <img
               src="/assets/github-icon.svg"
@@ -152,10 +157,10 @@ export const AppLinkView = forwardRef<HTMLSpanElement, NodeViewComponentProps>(
             />
           )}
           <span className="min-w-0">
-            <span className="block truncate text-sm font-medium text-neutral-800">
+            <span className="text-foreground block truncate text-sm font-medium">
               {header}
             </span>
-            <span className="block truncate text-xs text-neutral-500">
+            <span className="text-muted-foreground block truncate text-xs">
               {subline}
             </span>
           </span>

--- a/apps/desktop/src/editor-bridge/session-view.tsx
+++ b/apps/desktop/src/editor-bridge/session-view.tsx
@@ -117,7 +117,7 @@ export const SessionNodeView = forwardRef<
         onClick={handleRowClick}
         className={cn([
           "group flex items-start rounded-md px-2 py-1 transition-colors",
-          "-mx-2 focus-within:bg-neutral-50 hover:bg-neutral-50",
+          "focus-within:bg-muted hover:bg-accent -mx-2",
           "cursor-pointer",
         ])}
       >
@@ -136,7 +136,7 @@ export const SessionNodeView = forwardRef<
             ref={nodeProps.contentDOMRef}
             data-session-title
             className={cn([
-              "min-w-0 text-sm text-neutral-900",
+              "text-foreground min-w-0 text-sm",
               "[&>p]:m-0 [&>p]:min-w-0 [&>p]:truncate",
               status === "done" && "[&>p]:line-through [&>p]:opacity-60",
             ])}
@@ -145,7 +145,7 @@ export const SessionNodeView = forwardRef<
           </div>
           {displayTime && (
             <span
-              className="shrink-0 font-mono text-xs text-neutral-400"
+              className="text-muted-foreground shrink-0 font-mono text-xs"
               contentEditable={false}
             >
               {displayTime}

--- a/apps/desktop/src/instruction/index.tsx
+++ b/apps/desktop/src/instruction/index.tsx
@@ -38,8 +38,8 @@ function InstructionShell({
   children?: React.ReactNode;
 }) {
   return (
-    <div className="relative flex h-full flex-col overflow-hidden bg-[linear-gradient(180deg,_rgba(250,250,249,0.92)_0%,_rgba(255,255,255,1)_24%,_rgba(255,255,255,1)_100%)] select-none">
-      <div className="pointer-events-none absolute inset-x-0 top-0 h-32 bg-linear-to-b from-stone-100/40 to-transparent" />
+    <div className="from-background via-card to-card relative flex h-full flex-col overflow-hidden bg-linear-to-b select-none">
+      <div className="from-muted/40 pointer-events-none absolute inset-x-0 top-0 h-32 bg-linear-to-b to-transparent" />
 
       <div
         data-tauri-drag-region
@@ -49,7 +49,7 @@ function InstructionShell({
           type="button"
           onClick={onBack}
           className={cn([
-            "flex h-9 items-center gap-1.5 rounded-full px-3 text-stone-400 transition-colors hover:bg-stone-100/70 hover:text-stone-700",
+            "text-muted-foreground hover:bg-muted/70 hover:text-muted-foreground flex h-9 items-center gap-1.5 rounded-full px-3 transition-colors",
           ])}
         >
           <ChevronLeft className="h-4 w-4" />
@@ -62,7 +62,7 @@ function InstructionShell({
         className="relative z-10 flex flex-1 items-center justify-center p-6"
       >
         <div className="flex w-full max-w-sm flex-col items-center gap-6 px-10 pb-10 text-center">
-          <div className="flex h-14 w-14 items-center justify-center rounded-[20px] border border-stone-200/70 bg-white/90 shadow-[0_6px_18px_rgba(28,25,23,0.05)]">
+          <div className="border-border/70 bg-card/90 flex h-14 w-14 items-center justify-center rounded-[20px] border shadow-[0_6px_18px_rgba(28,25,23,0.05)]">
             <img
               src="/assets/anarlog-icon.png"
               alt=""
@@ -71,19 +71,21 @@ function InstructionShell({
           </div>
 
           <div className="flex max-w-[17rem] flex-col gap-3">
-            <div className="text-[10px] font-medium tracking-[0.22em] text-stone-400 uppercase">
+            <div className="text-muted-foreground text-[10px] font-medium tracking-[0.22em] uppercase">
               Browser step required
             </div>
-            <h2 className="font-sans text-[22px] leading-[1.15] font-semibold text-stone-900 sm:text-[28px]">
+            <h2 className="text-foreground font-sans text-[22px] leading-[1.15] font-semibold sm:text-[28px]">
               {title}
             </h2>
-            <p className="text-sm leading-6 text-stone-500">{description}</p>
+            <p className="text-muted-foreground text-sm leading-6">
+              {description}
+            </p>
           </div>
 
           <div className="flex items-center gap-2.5 pt-1">
-            <div className="h-1.5 w-1.5 rounded-full bg-stone-400/75" />
-            <div className="h-1.5 w-1.5 rounded-full bg-stone-300" />
-            <div className="h-1.5 w-1.5 rounded-full bg-stone-300" />
+            <div className="bg-muted-foreground/75 h-1.5 w-1.5 rounded-full" />
+            <div className="bg-muted h-1.5 w-1.5 rounded-full" />
+            <div className="bg-muted h-1.5 w-1.5 rounded-full" />
           </div>
 
           {action ? <div className="w-full">{action}</div> : null}
@@ -121,7 +123,7 @@ function ExternalInstruction({
           <Button
             variant="outline"
             className={cn([
-              "h-10 w-full border-stone-300 bg-white text-stone-700 hover:bg-stone-50",
+              "bg-card text-muted-foreground hover:bg-background border-border h-10 w-full",
             ])}
             onClick={() => void openerCommands.openUrl(url, null)}
           >
@@ -211,7 +213,7 @@ function SignInInstruction({ onBack }: { onBack: () => void }) {
               Submit callback URL
             </Button>
           </div>
-          <p className="text-xs leading-5 text-neutral-500">
+          <p className="text-muted-foreground text-xs leading-5">
             Paste the browser URL here if the browser button did not reopen
             Anarlog.
           </p>
@@ -221,7 +223,7 @@ function SignInInstruction({ onBack }: { onBack: () => void }) {
           type="button"
           onClick={() => setShowCallbackInput(true)}
           className={cn([
-            "text-xs font-medium text-neutral-500 underline underline-offset-4 transition-colors hover:text-neutral-700",
+            "text-muted-foreground hover:text-muted-foreground text-xs font-medium underline underline-offset-4 transition-colors",
           ])}
         >
           Browser handoff not working? Paste the callback link instead

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -13,12 +13,12 @@ import {
   useCreateManager,
 } from "tinytick/ui-react";
 
+import "@hypr/ui/globals.css";
 import {
   getCurrentWebviewWindowLabel,
   init as initWindowsPlugin,
 } from "@hypr/plugin-windows";
 import { Toaster } from "@hypr/ui/components/ui/toast";
-import "@hypr/ui/globals.css";
 
 import { createToolRegistry } from "./contexts/tool-registry/core";
 import { env } from "./env";
@@ -29,6 +29,7 @@ import { EventListeners } from "./services/event-listeners";
 import { TaskManager } from "./services/task-manager";
 import { RawEditorSyncBridge } from "./session/raw-editor-sync";
 import { ErrorComponent, NotFoundComponent } from "./shared/control";
+import { AppThemeProvider } from "./shared/theme/provider";
 import {
   type Store,
   STORE_ID,
@@ -72,22 +73,24 @@ function App() {
   }, [store, settingsStore]);
 
   if (!store || !settingsStore || !aiTaskStore) {
-    return <div className="h-screen w-screen bg-stone-50" />;
+    return <div className="bg-background h-screen w-screen" />;
   }
 
   return (
-    <AppI18nProvider>
-      <RouterProvider
-        router={router}
-        context={{
-          persistedStore: store,
-          internalStore: store,
-          listenerStore,
-          aiTaskStore,
-          toolRegistry,
-        }}
-      />
-    </AppI18nProvider>
+    <AppThemeProvider>
+      <AppI18nProvider>
+        <RouterProvider
+          router={router}
+          context={{
+            persistedStore: store,
+            internalStore: store,
+            listenerStore,
+            aiTaskStore,
+            toolRegistry,
+          }}
+        />
+      </AppI18nProvider>
+    </AppThemeProvider>
   );
 }
 

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -29,6 +29,7 @@ import { EventListeners } from "./services/event-listeners";
 import { TaskManager } from "./services/task-manager";
 import { RawEditorSyncBridge } from "./session/raw-editor-sync";
 import { ErrorComponent, NotFoundComponent } from "./shared/control";
+import { bootstrapThemeFromSettings } from "./shared/theme/apply";
 import { AppThemeProvider } from "./shared/theme/provider";
 import {
   type Store,
@@ -136,10 +137,12 @@ initWindowsPlugin();
 
 const rootElement = document.getElementById("root")!;
 if (!rootElement.innerHTML) {
-  const root = ReactDOM.createRoot(rootElement);
-  root.render(
-    <StrictMode>
-      <AppWithTiny />
-    </StrictMode>,
-  );
+  void bootstrapThemeFromSettings().finally(() => {
+    const root = ReactDOM.createRoot(rootElement);
+    root.render(
+      <StrictMode>
+        <AppWithTiny />
+      </StrictMode>,
+    );
+  });
 }

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -136,12 +136,16 @@ function AppWithTiny() {
 initWindowsPlugin();
 
 const rootElement = document.getElementById("root")!;
-if (!rootElement.innerHTML) {
-  void bootstrapThemeFromSettings();
+async function renderApp() {
+  await bootstrapThemeFromSettings();
   const root = ReactDOM.createRoot(rootElement);
   root.render(
     <StrictMode>
       <AppWithTiny />
     </StrictMode>,
   );
+}
+
+if (!rootElement.innerHTML) {
+  void renderApp();
 }

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -137,12 +137,11 @@ initWindowsPlugin();
 
 const rootElement = document.getElementById("root")!;
 if (!rootElement.innerHTML) {
-  void bootstrapThemeFromSettings().finally(() => {
-    const root = ReactDOM.createRoot(rootElement);
-    root.render(
-      <StrictMode>
-        <AppWithTiny />
-      </StrictMode>,
-    );
-  });
+  void bootstrapThemeFromSettings();
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(
+    <StrictMode>
+      <AppWithTiny />
+    </StrictMode>,
+  );
 }

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -358,9 +358,9 @@ function LeftSurfaceChromeButton({
       disabled={disabled}
       className={cn([
         "relative flex size-7 items-center justify-center rounded-full",
-        "text-neutral-700 transition-colors hover:bg-neutral-100 hover:text-neutral-900",
-        "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
-        "disabled:text-neutral-300 disabled:hover:bg-transparent disabled:hover:text-neutral-300",
+        "text-muted-foreground hover:bg-accent hover:text-foreground transition-colors",
+        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
+        "disabled:text-muted-foreground/70 disabled:hover:text-muted-foreground/70 disabled:hover:bg-transparent",
       ])}
       onClick={onClick}
     >
@@ -369,7 +369,7 @@ function LeftSurfaceChromeButton({
         <span
           aria-hidden="true"
           data-testid="collapsed-sidebar-update-badge"
-          className="pointer-events-none absolute top-1 right-1 size-1.5 rounded-full bg-red-500 ring-2 ring-stone-50"
+          className="ring-background pointer-events-none absolute top-1 right-1 size-1.5 rounded-full bg-red-500 ring-2"
         />
       ) : null}
     </button>

--- a/apps/desktop/src/main/empty.tsx
+++ b/apps/desktop/src/main/empty.tsx
@@ -33,7 +33,7 @@ function EmptyView() {
   return (
     <div
       data-tauri-drag-region
-      className="flex h-full flex-col items-center justify-center gap-6 text-neutral-600"
+      className="flex h-full flex-col items-center justify-center gap-6"
     >
       <div className="flex min-w-[280px] flex-col gap-1 text-center">
         <ActionItem label="New Note" shortcut={["⌘", "N"]} onClick={newNote} />
@@ -42,7 +42,7 @@ function EmptyView() {
           shortcut={["⌘", "⇧", "N"]}
           onClick={newNoteAndListen}
         />
-        <div className="my-1 h-px bg-neutral-200" />
+        <div className="bg-accent my-1 h-px" />
         <ActionItem
           label="Settings"
           shortcut={["⌘", ","]}
@@ -71,9 +71,9 @@ function ActionItem({
       className={cn([
         "group",
         "flex items-center justify-between gap-8",
-        "text-sm",
+        "text-foreground text-sm",
         "rounded-full px-4 py-2",
-        "cursor-pointer transition-colors hover:bg-neutral-100",
+        "hover:bg-accent cursor-pointer transition-colors",
       ])}
     >
       <span>{label}</span>
@@ -81,7 +81,7 @@ function ActionItem({
         <Kbd
           className={cn([
             "transition-all duration-100",
-            "group-hover:-translate-y-0.5 group-hover:shadow-[0_2px_0_0_rgba(0,0,0,0.15),inset_0_1px_0_0_rgba(255,255,255,0.8)]",
+            "group-hover:-translate-y-0.5 group-hover:shadow-[0_2px_0_0_var(--kbd-shadow-outer-hover),inset_0_1px_0_0_var(--kbd-shadow-inset)]",
             "group-active:translate-y-0.5 group-active:shadow-none",
           ])}
         >

--- a/apps/desktop/src/main/top-meeting-timeline.test.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.test.tsx
@@ -236,6 +236,48 @@ describe("TopMeetingTimeline", () => {
     expect(startLabel).not.toContain("-");
   });
 
+  it("highlights the selected session with accent styling", () => {
+    const start = new Date();
+    mocks.timelineSessionsTable = {
+      "session-1": {
+        created_at: start.toISOString(),
+        event_json: "",
+        title: "Selected Meeting",
+      },
+      "session-2": {
+        created_at: new Date(start.getTime() + 60 * 60 * 1000).toISOString(),
+        event_json: "",
+        title: "Other Meeting",
+      },
+    };
+
+    render(
+      <TopMeetingTimeline
+        currentTab={{
+          active: true,
+          id: "session-1",
+          pinned: false,
+          slotId: "slot-1",
+          state: { autoStart: null, view: null },
+          type: "sessions",
+        }}
+      />,
+    );
+
+    const selectedButton = screen
+      .getByText("Selected Meeting")
+      .closest("button");
+    const otherButton = screen.getByText("Other Meeting").closest("button");
+    const selectedClasses = selectedButton?.className.split(/\s+/) ?? [];
+    const otherClasses = otherButton?.className.split(/\s+/) ?? [];
+
+    expect(selectedClasses).toContain("bg-accent");
+    expect(selectedClasses).toContain("border-ring");
+    expect(selectedClasses).not.toContain("bg-primary");
+    expect(otherClasses).toContain("bg-card");
+    expect(otherClasses).not.toContain("bg-accent");
+  });
+
   it("shows active meetings as red with a stop suffix", () => {
     const start = new Date();
     mocks.liveSessionId = "session-1";
@@ -305,7 +347,7 @@ describe("TopMeetingTimeline", () => {
     });
 
     expect(cardButton?.className).toContain("pr-8");
-    expect(spinnerSuffix.className).toContain("text-primary-foreground/70");
+    expect(spinnerSuffix.className).toContain("text-muted-foreground");
     expect(screen.getAllByTestId("timeline-spinner")).toHaveLength(1);
     expect(within(cardButton!).queryByTestId("timeline-spinner")).toBeNull();
   });

--- a/apps/desktop/src/main/top-meeting-timeline.test.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.test.tsx
@@ -265,8 +265,8 @@ describe("TopMeetingTimeline", () => {
     const cardButton = title.closest("button");
     const stopButton = screen.getByLabelText("Stop listening");
 
-    expect(cardButton?.className).toContain("bg-red-500");
-    expect(cardButton?.className).not.toContain("bg-neutral-900");
+    expect(cardButton?.className).toContain("bg-destructive");
+    expect(cardButton?.className).not.toContain("bg-primary");
 
     fireEvent.click(stopButton);
 
@@ -305,7 +305,7 @@ describe("TopMeetingTimeline", () => {
     });
 
     expect(cardButton?.className).toContain("pr-8");
-    expect(spinnerSuffix.className).toContain("text-white/70");
+    expect(spinnerSuffix.className).toContain("text-primary-foreground/70");
     expect(screen.getAllByTestId("timeline-spinner")).toHaveLength(1);
     expect(within(cardButton!).queryByTestId("timeline-spinner")).toBeNull();
   });

--- a/apps/desktop/src/main/top-meeting-timeline.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.tsx
@@ -917,7 +917,7 @@ function TimelineCardButton({
             (showLiveStop
               ? "border-destructive bg-destructive text-destructive-foreground hover:border-destructive/90 hover:bg-destructive/90"
               : item.selected
-                ? "border-primary bg-primary text-primary-foreground hover:bg-primary/90"
+                ? "border-ring bg-accent text-foreground hover:bg-accent/90"
                 : "border-border bg-card text-foreground hover:bg-accent"),
           item.type === "event" &&
             "border-border bg-card/80 text-muted-foreground hover:bg-accent border-dashed",
@@ -932,7 +932,7 @@ function TimelineCardButton({
         <FadedTimelineLabel
           className={cn([
             "font-mono text-[10px]",
-            item.selected || showLiveStop
+            showLiveStop
               ? "text-primary-foreground/65"
               : "text-muted-foreground",
           ])}
@@ -946,9 +946,7 @@ function TimelineCardButton({
           aria-label="Loading timeline item"
           className={cn([
             "absolute top-1/2 right-2 flex size-5 -translate-y-1/2 items-center justify-center",
-            item.selected
-              ? "text-primary-foreground/70"
-              : "text-muted-foreground",
+            "text-muted-foreground",
           ])}
         >
           <Spinner size={12} />

--- a/apps/desktop/src/main/top-meeting-timeline.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.tsx
@@ -476,9 +476,9 @@ export function TopMeetingTimeline({ currentTab }: { currentTab: Tab | null }) {
           <button
             type="button"
             className={cn([
-              "absolute top-1/2 z-40 flex h-6 -translate-y-1/2 items-center gap-1 rounded-full border border-neutral-200 bg-white/95 px-2.5 text-xs font-semibold text-neutral-900 shadow-md backdrop-blur",
-              "transition-colors hover:border-neutral-300 hover:bg-white hover:text-neutral-950",
-              "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+              "border-border bg-card/95 text-foreground absolute top-1/2 z-40 flex h-6 -translate-y-1/2 items-center gap-1 rounded-full border px-2.5 text-xs font-semibold shadow-md backdrop-blur",
+              "hover:border-border hover:bg-accent hover:text-foreground transition-colors",
+              "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
               todayChipDirection === "left" ? "left-3" : "right-3",
             ])}
             onClick={handleGoToToday}
@@ -521,7 +521,7 @@ function TopCurrentTimeIndicator({
     >
       <div className="absolute top-0 bottom-1 left-0 w-px -translate-x-1/2 bg-red-500/90 shadow-[0_0_0_1px_rgba(255,255,255,0.85)]" />
       <div className="absolute top-0 left-0 size-1.5 -translate-x-1/2 rounded-full bg-red-500 shadow-[0_0_0_1px_rgba(255,255,255,0.95)]" />
-      <div className="absolute top-1/2 left-0 -translate-x-1/2 -translate-y-1/2 rounded-full bg-red-500 px-2 py-1 font-mono text-[10px] leading-none font-semibold whitespace-nowrap text-white opacity-0 shadow-xs transition-opacity group-hover/timeline-strip:opacity-100">
+      <div className="bg-destructive text-destructive-foreground absolute top-1/2 left-0 -translate-x-1/2 -translate-y-1/2 rounded-full px-2 py-1 font-mono text-[10px] leading-none font-semibold whitespace-nowrap opacity-0 shadow-xs transition-opacity group-hover/timeline-strip:opacity-100">
         {label}
       </div>
     </div>
@@ -770,12 +770,12 @@ function TimelineCreateNoteCard({
       <button
         type="button"
         className={cn([
-          "flex h-10 w-full flex-col justify-center rounded-md border border-dashed border-neutral-300 bg-white/80 px-2 text-left shadow-xs",
-          "transition-colors hover:border-neutral-600 hover:bg-white focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+          "border-border bg-card/80 flex h-10 w-full flex-col justify-center rounded-md border border-dashed px-2 text-left shadow-xs",
+          "hover:border-border hover:bg-accent focus-visible:ring-ring transition-colors focus-visible:ring-2 focus-visible:outline-hidden",
         ])}
         onClick={onClick}
       >
-        <span className="flex min-w-0 items-center gap-1.5 truncate text-xs font-semibold text-neutral-700">
+        <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 truncate text-xs font-semibold">
           <PlusIcon size={12} className="shrink-0" />
           <span className="truncate">Create new note</span>
         </span>
@@ -800,8 +800,8 @@ function TimelineOpenCalendarCard({
       <button
         type="button"
         className={cn([
-          "flex h-10 w-full items-center gap-1.5 rounded-md border border-dashed border-neutral-300 bg-white/80 px-2 text-left text-xs font-semibold text-neutral-700 shadow-xs",
-          "transition-colors hover:border-neutral-600 hover:bg-white focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+          "border-border bg-card/80 text-muted-foreground flex h-10 w-full items-center gap-1.5 rounded-md border border-dashed px-2 text-left text-xs font-semibold shadow-xs",
+          "hover:border-border hover:bg-accent focus-visible:ring-ring transition-colors focus-visible:ring-2 focus-visible:outline-hidden",
         ])}
         onClick={onClick}
       >
@@ -912,15 +912,15 @@ function TimelineCardButton({
         className={cn([
           "flex h-10 w-full flex-col justify-center rounded-md border py-0 pl-2 text-left shadow-xs",
           showSuffix ? "pr-8" : "pr-2",
-          "transition-colors hover:border-neutral-700 focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+          "hover:border-border focus-visible:ring-ring transition-colors focus-visible:ring-2 focus-visible:outline-hidden",
           item.type === "session" &&
             (showLiveStop
-              ? "border-red-500 bg-red-500 text-white hover:border-red-600 hover:bg-red-600"
+              ? "border-destructive bg-destructive text-destructive-foreground hover:border-destructive/90 hover:bg-destructive/90"
               : item.selected
-                ? "border-neutral-900 bg-neutral-900 text-white hover:bg-neutral-800"
-                : "border-neutral-300 bg-white text-neutral-800 hover:bg-neutral-50"),
+                ? "border-primary bg-primary text-primary-foreground hover:bg-primary/90"
+                : "border-border bg-card text-foreground hover:bg-accent"),
           item.type === "event" &&
-            "border-dashed border-neutral-300 bg-white/80 text-neutral-600 hover:bg-white",
+            "border-border bg-card/80 text-muted-foreground hover:bg-accent border-dashed",
           item.muted && !item.selected && !showLiveStop && "opacity-60",
         ])}
       >
@@ -933,8 +933,8 @@ function TimelineCardButton({
           className={cn([
             "font-mono text-[10px]",
             item.selected || showLiveStop
-              ? "text-white/65"
-              : "text-neutral-500",
+              ? "text-primary-foreground/65"
+              : "text-muted-foreground",
           ])}
         >
           {startLabel}
@@ -946,7 +946,9 @@ function TimelineCardButton({
           aria-label="Loading timeline item"
           className={cn([
             "absolute top-1/2 right-2 flex size-5 -translate-y-1/2 items-center justify-center",
-            item.selected ? "text-white/70" : "text-neutral-500",
+            item.selected
+              ? "text-primary-foreground/70"
+              : "text-muted-foreground",
           ])}
         >
           <Spinner size={12} />
@@ -958,8 +960,8 @@ function TimelineCardButton({
           onClick={handleStopClick}
           className={cn([
             "absolute top-1/2 right-2 flex size-5 -translate-y-1/2 items-center justify-center rounded-sm",
-            "text-white/80 transition-colors hover:bg-white/15 hover:text-white",
-            "focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:outline-hidden",
+            "text-primary-foreground/80 hover:bg-primary-foreground/15 hover:text-primary-foreground transition-colors",
+            "focus-visible:ring-primary-foreground/70 focus-visible:ring-2 focus-visible:outline-hidden",
           ])}
         >
           <span

--- a/apps/desktop/src/main/update-banner.tsx
+++ b/apps/desktop/src/main/update-banner.tsx
@@ -348,9 +348,9 @@ export function SidebarTimelineUpdateButton({
       disabled={isDownloading || update.downloadStarting || update.installing}
       className={cn([
         "relative flex size-7 shrink-0 items-center justify-center rounded-full",
-        "bg-blue-600 text-white shadow-sm transition-colors hover:bg-blue-700",
-        "focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:outline-hidden",
-        "disabled:cursor-default disabled:bg-blue-600 disabled:text-white disabled:opacity-70 disabled:hover:bg-blue-600",
+        "bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm transition-colors",
+        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden",
+        "disabled:bg-primary disabled:text-primary-foreground disabled:hover:bg-primary disabled:cursor-default disabled:opacity-70",
       ])}
       onClick={isReady ? update.installUpdate : update.downloadUpdate}
     >
@@ -389,7 +389,7 @@ function UpdateBanner({
       role="status"
       aria-live="polite"
       data-testid="timeline-update-banner"
-      className="flex h-9 w-full shrink-0 items-center justify-center border-y border-stone-200/70 bg-stone-100/80 px-3 font-mono text-xs text-neutral-800"
+      className="bg-muted/80 text-foreground border-border/70 flex h-9 w-full shrink-0 items-center justify-center border-y px-3 font-mono text-xs"
     >
       <div className="flex min-w-0 items-center justify-center gap-3">
         <BannerBody status={status} errorMessage={errorMessage} />
@@ -456,8 +456,8 @@ function BannerAction({
         disabled={downloadStarting}
         className={cn([
           "inline-flex h-7 w-[104px] shrink-0 items-center justify-center gap-1.5 overflow-hidden rounded-full px-3 font-medium",
-          "bg-neutral-950 text-white transition-colors hover:bg-neutral-800",
-          "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+          "bg-primary text-primary-foreground hover:bg-primary/90 transition-colors",
+          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
           "disabled:cursor-not-allowed disabled:opacity-60",
         ])}
       >
@@ -483,8 +483,8 @@ function BannerAction({
       disabled={installing}
       className={cn([
         "inline-flex h-7 shrink-0 items-center justify-center gap-1.5 overflow-hidden rounded-full px-3 font-medium",
-        "bg-blue-600 text-white transition-colors hover:bg-blue-700",
-        "focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:outline-hidden",
+        "bg-primary text-primary-foreground hover:bg-primary/90 transition-colors",
+        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden",
         "disabled:cursor-not-allowed disabled:opacity-60",
       ])}
     >
@@ -504,12 +504,12 @@ function DownloadProgress({ progress }: { progress: number | null }) {
           ? "Downloading update"
           : `Downloading update, ${pct}% complete`
       }
-      className="relative inline-flex h-7 w-[104px] shrink-0 items-center justify-center overflow-hidden rounded-full border border-stone-300 bg-white px-3 font-medium text-neutral-800"
+      className="bg-card text-foreground border-border relative inline-flex h-7 w-[104px] shrink-0 items-center justify-center overflow-hidden rounded-full border px-3 font-medium"
     >
       {progress === null ? null : (
         <span
           aria-hidden="true"
-          className="absolute inset-y-0 left-0 bg-neutral-950/15"
+          className="bg-primary/15 absolute inset-y-0 left-0"
           style={{ width: `${pct}%` }}
         />
       )}

--- a/apps/desktop/src/onboarding/account/before-login.tsx
+++ b/apps/desktop/src/onboarding/account/before-login.tsx
@@ -22,7 +22,7 @@ export function BeforeLogin({ onContinue: _ }: { onContinue: () => void }) {
           onClick={() => {
             void auth?.signIn();
           }}
-          className="rounded-full border border-white/60 bg-white/55 px-6 py-2 text-sm font-medium text-neutral-600 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-sm transition-colors hover:bg-white/75 hover:text-neutral-800"
+          className="border-border/60 bg-card/55 text-muted-foreground hover:bg-card/75 hover:text-foreground rounded-full border px-6 py-2 text-sm font-medium shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-sm transition-colors"
         >
           Login with existing account
         </button>

--- a/apps/desktop/src/onboarding/calendar.tsx
+++ b/apps/desktop/src/onboarding/calendar.tsx
@@ -75,7 +75,7 @@ function AppleCalendarList() {
       onRefresh={handleRefresh}
       isLoading={isLoading}
       disableHoverTone
-      className="rounded-xl border border-white/45 bg-white/28 shadow-[inset_0_1px_0_rgba(255,255,255,0.4),0_8px_24px_-20px_rgba(87,83,78,0.35)] backdrop-blur-md backdrop-saturate-150"
+      className="border-border/45 bg-card/28 rounded-xl border shadow-[inset_0_1px_0_rgba(255,255,255,0.4),0_8px_24px_-20px_rgba(87,83,78,0.35)] backdrop-blur-md backdrop-saturate-150"
     />
   );
 }
@@ -102,7 +102,7 @@ function AppleCalendarProvider({
             onRequest();
           }}
           disabled={isPending}
-          className="flex h-full w-full items-center justify-center gap-3 border border-neutral-200 bg-white px-12 text-stone-800 shadow-[0_2px_6px_rgba(87,83,78,0.08),0_10px_18px_-10px_rgba(87,83,78,0.22)] transition-all duration-150 hover:bg-stone-100"
+          className="border-border bg-card text-foreground hover:bg-accent flex h-full w-full items-center justify-center gap-3 border px-12 shadow-[0_2px_6px_rgba(87,83,78,0.08),0_10px_18px_-10px_rgba(87,83,78,0.22)] transition-all duration-150"
         >
           <img
             src="/assets/apple-calendar.png"
@@ -173,7 +173,7 @@ function GoogleCalendarConnectedContent({
         onRefresh={handleRefresh}
         isLoading={isLoading}
         disableHoverTone
-        className="rounded-xl border border-white/45 bg-white/28 shadow-[inset_0_1px_0_rgba(255,255,255,0.4),0_8px_24px_-20px_rgba(87,83,78,0.35)] backdrop-blur-md backdrop-saturate-150"
+        className="border-border/45 bg-card/28 rounded-xl border shadow-[inset_0_1px_0_rgba(255,255,255,0.4),0_8px_24px_-20px_rgba(87,83,78,0.35)] backdrop-blur-md backdrop-saturate-150"
       />
 
       <OnboardingButton
@@ -185,7 +185,7 @@ function GoogleCalendarConnectedContent({
             "connect",
           )
         }
-        className="flex items-center gap-3 border border-neutral-200 bg-white text-stone-800 shadow-[0_2px_6px_rgba(87,83,78,0.08),0_10px_18px_-10px_rgba(87,83,78,0.22)] hover:bg-stone-50"
+        className="border-border bg-card text-foreground hover:bg-accent flex items-center gap-3 border shadow-[0_2px_6px_rgba(87,83,78,0.08),0_10px_18px_-10px_rgba(87,83,78,0.22)]"
       >
         {GOOGLE_PROVIDER?.icon}
         Add another account
@@ -298,7 +298,7 @@ function OutlookCalendarConnectedContent({
         onRefresh={handleRefresh}
         isLoading={isLoading}
         disableHoverTone
-        className="rounded-xl border border-white/45 bg-white/28 shadow-[inset_0_1px_0_rgba(255,255,255,0.4),0_8px_24px_-20px_rgba(87,83,78,0.35)] backdrop-blur-md backdrop-saturate-150"
+        className="border-border/45 bg-card/28 rounded-xl border shadow-[inset_0_1px_0_rgba(255,255,255,0.4),0_8px_24px_-20px_rgba(87,83,78,0.35)] backdrop-blur-md backdrop-saturate-150"
       />
 
       <OnboardingButton
@@ -310,7 +310,7 @@ function OutlookCalendarConnectedContent({
             "connect",
           )
         }
-        className="flex items-center gap-3 border border-neutral-200 bg-white text-stone-800 shadow-[0_2px_6px_rgba(87,83,78,0.08),0_10px_18px_-10px_rgba(87,83,78,0.22)] hover:bg-stone-50"
+        className="border-border bg-card text-foreground hover:bg-accent flex items-center gap-3 border shadow-[0_2px_6px_rgba(87,83,78,0.08),0_10px_18px_-10px_rgba(87,83,78,0.22)]"
       >
         {OUTLOOK_PROVIDER?.icon}
         Add another account
@@ -383,8 +383,8 @@ function OutlookCalendarProvider({ onSignIn }: { onSignIn: () => void }) {
       }
       className={
         isSignedIn
-          ? "gho flex items-center gap-3 border border-neutral-200 bg-white text-stone-800 shadow-[0_2px_6px_rgba(87,83,78,0.08),0_10px_18px_-10px_rgba(87,83,78,0.22)] hover:bg-stone-100 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-white"
-          : "border-1 border-neutral-200 bg-gray-100 text-stone-800 shadow-[0_2px_6px_rgba(87,83,78,0.01),0_10px_18px_-10px_rgba(87,83,78,0.1)] transition-all duration-150 hover:border-stone-600 hover:bg-stone-800 hover:text-white focus-visible:border-stone-600 focus-visible:bg-stone-800 focus-visible:text-white"
+          ? "gho border-border bg-card text-foreground hover:bg-accent disabled:hover:bg-card flex items-center gap-3 border shadow-[0_2px_6px_rgba(87,83,78,0.08),0_10px_18px_-10px_rgba(87,83,78,0.22)] disabled:cursor-not-allowed disabled:opacity-60"
+          : "border-border bg-muted text-foreground hover:border-primary hover:bg-primary hover:text-primary-foreground focus-visible:border-primary focus-visible:bg-primary focus-visible:text-primary-foreground border-1 shadow-[0_2px_6px_rgba(87,83,78,0.01),0_10px_18px_-10px_rgba(87,83,78,0.1)] transition-all duration-150"
       }
     >
       {!isSignedIn ? (
@@ -400,7 +400,7 @@ function OutlookCalendarProvider({ onSignIn }: { onSignIn: () => void }) {
           >
             {OUTLOOK_PROVIDER.icon}
             <div className="flex flex-col items-start justify-center">
-              <p className="text-md font-normal text-neutral-900">Outlook</p>
+              <p className="text-md text-foreground font-normal">Outlook</p>
             </div>
           </motion.span>
 
@@ -487,8 +487,8 @@ function GoogleCalendarProvider({ onSignIn }: { onSignIn: () => void }) {
         }
         className={
           isSignedIn
-            ? "flex items-center gap-3 border border-neutral-200 bg-white text-stone-800 shadow-[0_2px_6px_rgba(87,83,78,0.08),0_10px_18px_-10px_rgba(87,83,78,0.22)] hover:bg-stone-50 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-white"
-            : "border-1 border-neutral-200 bg-gray-100 text-stone-800 shadow-[0_2px_6px_rgba(87,83,78,0.01),0_10px_18px_-10px_rgba(87,83,78,0.1)] transition-all duration-150 hover:border-stone-600 hover:bg-stone-800 hover:text-white focus-visible:border-stone-600 focus-visible:bg-stone-800 focus-visible:text-white"
+            ? "border-border bg-card text-foreground hover:bg-accent disabled:hover:bg-card flex items-center gap-3 border shadow-[0_2px_6px_rgba(87,83,78,0.08),0_10px_18px_-10px_rgba(87,83,78,0.22)] disabled:cursor-not-allowed disabled:opacity-60"
+            : "border-border bg-muted text-foreground hover:border-primary hover:bg-primary hover:text-primary-foreground focus-visible:border-primary focus-visible:bg-primary focus-visible:text-primary-foreground border-1 shadow-[0_2px_6px_rgba(87,83,78,0.01),0_10px_18px_-10px_rgba(87,83,78,0.1)] transition-all duration-150"
         }
       >
         {!isSignedIn ? (
@@ -504,7 +504,7 @@ function GoogleCalendarProvider({ onSignIn }: { onSignIn: () => void }) {
             >
               {GOOGLE_PROVIDER.icon}
               <div className="flex flex-col items-start justify-center">
-                <p className="text-md font-normal text-neutral-900">Google</p>
+                <p className="text-md text-foreground font-normal">Google</p>
               </div>
             </motion.span>
 
@@ -586,7 +586,7 @@ function CalendarSectionContent({
           onReset={calendar.reset}
           onOpen={calendar.open}
           isPending={calendar.isPending}
-          className="text-sm text-neutral-500"
+          className="text-muted-foreground text-sm"
         />
       )}
     </div>

--- a/apps/desktop/src/onboarding/final.tsx
+++ b/apps/desktop/src/onboarding/final.tsx
@@ -42,7 +42,7 @@ export function FinalDescription() {
             <button
               key={social.label}
               onClick={() => void openerCommands.openUrl(social.url, null)}
-              className="inline-flex size-5 items-center justify-center rounded-md text-neutral-400 transition-colors duration-150 hover:text-neutral-700"
+              className="text-muted-foreground hover:text-muted-foreground inline-flex size-5 items-center justify-center rounded-md transition-colors duration-150"
               aria-label={social.label}
             >
               <Icon icon={social.icon} width={iconSize} height={iconSize} />

--- a/apps/desktop/src/onboarding/folder-location.tsx
+++ b/apps/desktop/src/onboarding/folder-location.tsx
@@ -111,25 +111,25 @@ export function FolderLocationSection({
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-center gap-3 rounded-lg border border-neutral-200 bg-neutral-50 px-4 py-3">
-        <FolderIcon className="size-4 shrink-0 text-neutral-500" />
+      <div className="border-border bg-muted flex items-center gap-3 rounded-lg border px-4 py-3">
+        <FolderIcon className="text-muted-foreground size-4 shrink-0" />
         <button
           onClick={handleOpenPath}
-          className="min-w-0 flex-1 truncate text-left text-sm text-neutral-600 hover:underline"
+          className="text-muted-foreground min-w-0 flex-1 truncate text-left text-sm hover:underline"
         >
           {displayPath(vaultBase, home)}
         </button>
         <button
           onClick={handleChange}
           disabled={isPending}
-          className="shrink-0 text-sm text-neutral-500 transition-colors hover:text-neutral-700 disabled:opacity-50"
+          className="text-muted-foreground hover:text-muted-foreground shrink-0 text-sm transition-colors disabled:opacity-50"
         >
           Change
         </button>
         <button
           onClick={onContinue}
           disabled={isPending}
-          className="shrink-0 rounded-full bg-stone-600 px-3 py-1 text-sm font-medium text-white duration-150 hover:scale-[1.01] active:scale-[0.99] disabled:opacity-50"
+          className="bg-primary text-primary-foreground hover:bg-primary/90 shrink-0 rounded-full px-3 py-1 text-sm font-medium duration-150 hover:scale-[1.01] active:scale-[0.99] disabled:opacity-50"
         >
           Confirm
         </button>

--- a/apps/desktop/src/onboarding/index.tsx
+++ b/apps/desktop/src/onboarding/index.tsx
@@ -134,7 +134,7 @@ function OnboardingScreenContent({
   }, [onFinish, queryClient]);
 
   return (
-    <div className="relative flex h-full min-h-0 flex-col overflow-hidden bg-white">
+    <div className="bg-card relative flex h-full min-h-0 flex-col overflow-hidden">
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
         <motion.div
           className="absolute inset-0"
@@ -154,13 +154,13 @@ function OnboardingScreenContent({
           >
             <source src="/assets/onboarding-video.mp4" type="video/mp4" />
           </video>
-          <div className="absolute inset-0 bg-linear-to-t from-stone-50/8 via-stone-50/18 to-transparent" />
+          <div className="from-background/8 via-background/18 absolute inset-0 bg-linear-to-t to-transparent" />
         </motion.div>
         <div className="absolute inset-x-0 top-0 h-[80%] [mask-image:linear-gradient(to_bottom,black,black_18%,rgba(0,0,0,0.9)_36%,rgba(0,0,0,0.6)_58%,transparent)] backdrop-blur-[32px]" />
         <div className="absolute inset-x-0 top-0 h-[92%] [mask-image:linear-gradient(to_bottom,black,rgba(0,0,0,0.8)_34%,rgba(0,0,0,0.35)_62%,transparent)] backdrop-blur-[12px]" />
-        <div className="absolute inset-x-0 top-0 h-[84%] bg-linear-to-b from-stone-50 via-stone-50/82 via-stone-50/97 via-18% via-42% to-stone-50/0" />
+        <div className="from-background via-background/82 via-background/97 to-background/0 absolute inset-x-0 top-0 h-[84%] bg-linear-to-b via-18% via-42%" />
         <motion.div
-          className="absolute inset-0 bg-stone-50"
+          className="bg-background absolute inset-0"
           initial={{ opacity: 1 }}
           animate={{ opacity: 0 }}
           transition={{ duration: 1.0, ease: "easeOut", delay: 0.1 }}
@@ -174,13 +174,13 @@ function OnboardingScreenContent({
         <button
           onClick={() => setIsMuted((prev) => !prev)}
           data-tauri-drag-region="false"
-          className="rounded-full p-1.5 transition-colors hover:bg-neutral-100"
+          className="hover:bg-accent rounded-full p-1.5 transition-colors"
           aria-label={isMuted ? "Unmute" : "Mute"}
         >
           {isMuted ? (
-            <VolumeXIcon size={16} className="text-neutral-400" />
+            <VolumeXIcon size={16} className="text-muted-foreground" />
           ) : (
-            <Volume2Icon size={16} className="text-neutral-600" />
+            <Volume2Icon size={16} className="text-muted-foreground" />
           )}
         </button>
       </div>
@@ -192,7 +192,7 @@ function OnboardingScreenContent({
           headerClassName,
         ])}
       >
-        <h1 className="font-hand text-4xl leading-none font-semibold tracking-normal text-neutral-900">
+        <h1 className="font-hand text-foreground text-4xl leading-none font-semibold tracking-normal">
           Welcome to Anarlog
         </h1>
       </div>

--- a/apps/desktop/src/onboarding/permissions.tsx
+++ b/apps/desktop/src/onboarding/permissions.tsx
@@ -51,8 +51,8 @@ function PermissionBlock({
       className={cn([
         "group flex min-w-0 flex-1 basis-0 items-center gap-3 rounded-xl px-3 py-3 text-left transition-all",
         isAuthorized
-          ? "border border-neutral-200 bg-white"
-          : "border border-stone-600 bg-stone-800 text-white shadow-[0_4px_14px_rgba(87,83,78,0.18)] hover:bg-stone-700 active:scale-[0.98]",
+          ? "border-border bg-card border"
+          : "border-primary bg-primary text-primary-foreground hover:bg-primary/90 border shadow-[0_4px_14px_rgba(87,83,78,0.18)] active:scale-[0.98]",
         (isPending || isAuthorized) && "cursor-default",
         isPending && "opacity-50",
       ])}
@@ -67,7 +67,7 @@ function PermissionBlock({
           "flex size-6 shrink-0 items-center justify-center rounded-md",
           isAuthorized
             ? "bg-green-50 text-green-600"
-            : "bg-white/10 text-white",
+            : "bg-primary-foreground/10 text-primary-foreground",
         ])}
       >
         {isAuthorized ? (
@@ -80,7 +80,7 @@ function PermissionBlock({
         <span
           className={cn([
             "text-sm font-medium",
-            isAuthorized ? "text-neutral-900" : "text-white",
+            isAuthorized ? "text-foreground" : "text-primary-foreground",
           ])}
         >
           {title}
@@ -88,14 +88,16 @@ function PermissionBlock({
         <p
           className={cn([
             "truncate text-xs @[480px]:block",
-            isAuthorized ? "text-neutral-500" : "text-white/70",
+            isAuthorized
+              ? "text-muted-foreground"
+              : "text-primary-foreground/70",
           ])}
         >
           {body}
         </p>
       </div>
       {!isAuthorized && (
-        <div className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-white/80">
+        <div className="text-primary-foreground/80 inline-flex shrink-0 items-center gap-1 text-xs font-medium">
           <span className="hidden @[480px]:inline">{ctaLabel}</span>
           <ArrowRightIcon className="size-3.5 transition-transform group-hover:translate-x-0.5" />
         </div>

--- a/apps/desktop/src/onboarding/shared.tsx
+++ b/apps/desktop/src/onboarding/shared.tsx
@@ -74,8 +74,8 @@ export function OnboardingSection({
               className={cn([
                 "transition-all duration-300",
                 isCompleted
-                  ? "text-xs font-normal text-neutral-300"
-                  : "font-sans text-xl font-semibold text-neutral-900",
+                  ? "text-muted-foreground/70 text-xs font-normal"
+                  : "text-foreground font-sans text-xl font-semibold",
               ])}
             >
               {isCompleted ? (completedTitle ?? title) : title}
@@ -86,7 +86,7 @@ export function OnboardingSection({
                   <button
                     onClick={onBack}
                     aria-label="Go to previous section"
-                    className="rounded p-0.5 text-neutral-400 transition-colors hover:text-neutral-600"
+                    className="text-muted-foreground hover:text-muted-foreground rounded p-0.5 transition-colors"
                   >
                     <ChevronLeftIcon className="size-3" />
                   </button>
@@ -98,7 +98,7 @@ export function OnboardingSection({
                         onSkip?.();
                         onNext?.();
                       }}
-                      className="flex items-center gap-1 text-sm text-neutral-400 transition-colors hover:text-neutral-600"
+                      className="text-muted-foreground hover:text-muted-foreground flex items-center gap-1 text-sm transition-colors"
                     >
                       Skip
                       <ChevronRightIcon className="size-3" />
@@ -107,7 +107,7 @@ export function OnboardingSection({
                     <button
                       onClick={onNext}
                       aria-label="Go to next section"
-                      className="rounded p-0.5 text-neutral-400 transition-colors hover:text-neutral-600"
+                      className="text-muted-foreground hover:text-muted-foreground rounded p-0.5 transition-colors"
                     >
                       <ChevronRightIcon className="size-3" />
                     </button>
@@ -116,7 +116,7 @@ export function OnboardingSection({
             )}
           </div>
           {isActive && description && (
-            <div className="text-sm text-neutral-500">{description}</div>
+            <div className="text-muted-foreground text-sm">{description}</div>
           )}
         </div>
       </div>
@@ -152,10 +152,11 @@ export function OnboardingButton({
       className={cn([
         "w-fit rounded-full px-6 py-2.5 text-sm font-medium transition-all duration-200",
         variant === "primary" &&
-          "border-2 border-stone-600 bg-stone-800 text-white shadow-[0_2px_6px_rgba(87,83,78,0.22),0_10px_18px_-10px_rgba(87,83,78,0.65)] hover:bg-stone-700",
+          "border-primary bg-primary text-primary-foreground hover:bg-primary/90 border-2 shadow-[0_2px_6px_rgba(87,83,78,0.22),0_10px_18px_-10px_rgba(87,83,78,0.65)]",
         variant === "secondary" &&
-          "border border-neutral-300 text-neutral-600 hover:border-neutral-400 hover:text-neutral-800",
-        variant === "ghost" && "text-neutral-500 hover:text-neutral-700",
+          "border-border text-muted-foreground hover:border-border hover:text-foreground border",
+        variant === "ghost" &&
+          "text-muted-foreground hover:text-muted-foreground",
         className,
       ])}
     />
@@ -175,11 +176,13 @@ export function StepRow({
         <CheckCircle2Icon className="size-4 text-emerald-600" />
       )}
       {status === "active" && (
-        <Loader2Icon className="size-4 animate-spin text-neutral-400" />
+        <Loader2Icon className="text-muted-foreground size-4 animate-spin" />
       )}
       {status === "failed" && <XCircleIcon className="size-4 text-red-400" />}
       <span
-        className={status === "failed" ? "text-red-500" : "text-neutral-500"}
+        className={
+          status === "failed" ? "text-red-500" : "text-muted-foreground"
+        }
       >
         {label}
       </span>

--- a/apps/desktop/src/routes/__root.tsx
+++ b/apps/desktop/src/routes/__root.tsx
@@ -11,7 +11,7 @@ export const Route = createRootRouteWithContext<Partial<Context>>()({
 
 function Component() {
   return (
-    <Suspense fallback={<div className="h-screen w-screen bg-stone-50" />}>
+    <Suspense fallback={<div className="bg-background h-screen w-screen" />}>
       <MainAppLayout />
     </Suspense>
   );

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -103,10 +103,7 @@ function LiveTranscriptFooterContent({
   return (
     <div className={cn(["w-full select-none", fillHeight && "h-full min-h-0"])}>
       <div
-        className={cn([
-          "rounded-xl bg-neutral-50",
-          fillHeight && "h-full min-h-0",
-        ])}
+        className={cn(["bg-muted rounded-xl", fillHeight && "h-full min-h-0"])}
       >
         <LiveTranscriptContent
           fillHeight={fillHeight}
@@ -175,7 +172,7 @@ function LiveTranscriptContent({
       ])}
     >
       {segments.length === 0 ? (
-        <span className="py-4 text-center text-xs text-neutral-400">
+        <span className="text-muted-foreground py-4 text-center text-xs">
           Transcript will appear here as you speak.
         </span>
       ) : (
@@ -224,7 +221,7 @@ function CollapsedFooterMessage({ message }: { message: string }) {
       ])}
     >
       <div className="min-w-0 flex-1 select-none">
-        <p className="truncate text-left text-xs text-neutral-600 [direction:rtl]">
+        <p className="text-muted-foreground truncate text-left text-xs [direction:rtl]">
           {message}
         </p>
       </div>
@@ -363,7 +360,7 @@ function TranscriptSegmentRow({
       >
         <span className="min-w-0 truncate">{label}</span>
       </span>
-      <span className="min-w-0 text-xs leading-5 text-neutral-700">
+      <span className="text-muted-foreground min-w-0 text-xs leading-5">
         {getSegmentText(segment)}
       </span>
     </div>

--- a/apps/desktop/src/session/components/bottom-accessory/expand-toggle.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/expand-toggle.tsx
@@ -27,13 +27,13 @@ export function ExpandToggle({
         "absolute left-3 z-10",
         "relative flex h-5 items-center justify-center gap-1",
         hasLabel ? "px-3" : "w-10",
-        "rounded-t-[10px] rounded-b-none border-x border-t border-neutral-200",
+        "border-border rounded-t-[10px] rounded-b-none border-x border-t",
         "after:pointer-events-none after:absolute after:right-px after:-bottom-px after:left-px after:h-0.5 after:bg-inherit after:content-['']",
-        "text-neutral-400",
+        "text-muted-foreground",
         isExpanded
-          ? (expandedClassName ?? "bg-white")
-          : (collapsedClassName ?? "bg-white"),
-        "transition-colors hover:bg-neutral-100 hover:text-neutral-600",
+          ? (expandedClassName ?? "bg-card")
+          : (collapsedClassName ?? "bg-card"),
+        "hover:bg-accent hover:text-muted-foreground transition-colors",
         "hover:cursor-pointer",
       ])}
       aria-label={

--- a/apps/desktop/src/session/components/bottom-accessory/global-live.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/global-live.tsx
@@ -92,8 +92,8 @@ function GlobalLiveTranscriptAccessoryContent({
         }))
       }
       label="Live"
-      collapsedClassName="bg-neutral-50"
-      expandedClassName="bg-neutral-50"
+      collapsedClassName="bg-muted"
+      expandedClassName="bg-muted"
     />
   ) : null;
 

--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -424,7 +424,7 @@ describe("useSessionBottomAccessory", () => {
     }
 
     expect(toggle.props.label).toBe("Live");
-    expect(toggle.props.expandedClassName).toBe("bg-neutral-50");
+    expect(toggle.props.expandedClassName).toBe("bg-muted");
 
     act(() => {
       toggle.props.onToggle();

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -152,8 +152,8 @@ export function useSessionBottomAccessory({
           isExpanded={effectiveExpanded}
           onToggle={() => setIsExpanded((v) => !v)}
           label="Live"
-          collapsedClassName="bg-neutral-50"
-          expandedClassName="bg-neutral-50"
+          collapsedClassName="bg-muted"
+          expandedClassName="bg-muted"
         />
       ) : null,
       bottomAccessoryState,
@@ -187,7 +187,7 @@ export function useSessionBottomAccessory({
           onToggle={() => setIsExpanded((v) => !v)}
           label="Transcript"
           showExpandedCloseIcon
-          collapsedClassName="bg-neutral-50"
+          collapsedClassName="bg-muted"
         />
       ),
       bottomAccessoryState,
@@ -254,13 +254,13 @@ function PostSessionTabButton({
       type="button"
       onClick={() => onSelect(tab)}
       className={cn([
-        "relative flex h-5 items-center justify-center gap-1 border-t border-neutral-200 px-3",
+        "border-border relative flex h-5 items-center justify-center gap-1 border-t px-3",
         "after:pointer-events-none after:absolute after:right-px after:-bottom-px after:left-px after:h-0.5 after:bg-inherit after:content-['']",
         "text-[10px] font-medium transition-colors",
         isActive && isExpanded
-          ? "bg-neutral-50 text-neutral-600"
-          : "bg-white text-neutral-400",
-        "hover:cursor-pointer hover:bg-neutral-100 hover:text-neutral-600",
+          ? "bg-muted text-muted-foreground"
+          : "bg-card text-muted-foreground",
+        "hover:bg-accent hover:text-muted-foreground hover:cursor-pointer",
         className,
       ])}
       aria-label={

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -142,7 +142,7 @@ function PastNotesPanel({
   return (
     <TranscriptCard fillHeight={fillHeight}>
       <div className="flex shrink-0 items-center justify-between px-3 py-1.5">
-        <span className="text-xs font-medium text-neutral-500">
+        <span className="text-muted-foreground text-xs font-medium">
           Related meetings
         </span>
       </div>
@@ -154,20 +154,20 @@ function PastNotesPanel({
         ])}
       >
         <div className="relative flex flex-col gap-4 pt-2">
-          <div className="absolute top-2 bottom-0 left-[3px] w-px bg-neutral-200" />
+          <div className="bg-accent absolute top-2 bottom-0 left-[3px] w-px" />
           {notes.map((note) => (
             <div
               key={note.sessionId}
               className="relative grid min-w-0 grid-cols-1 overflow-hidden pl-5"
             >
-              <div className="absolute top-1.5 left-0 h-2 w-2 rounded-full border border-neutral-300 bg-white" />
+              <div className="border-border bg-card absolute top-1.5 left-0 h-2 w-2 rounded-full border" />
               <div className="flex min-w-0 flex-col gap-1 overflow-hidden">
                 <div className="flex min-w-0 items-center justify-between gap-2">
                   <div className="flex min-w-0 items-baseline gap-2">
-                    <span className="shrink-0 text-[11px] text-neutral-400">
+                    <span className="text-muted-foreground shrink-0 text-[11px]">
                       {note.dateLabel}
                     </span>
-                    <span className="min-w-0 truncate text-xs font-medium text-neutral-700">
+                    <span className="text-muted-foreground min-w-0 truncate text-xs font-medium">
                       {note.title}
                     </span>
                   </div>
@@ -182,7 +182,7 @@ function PastNotesPanel({
                   ) : null}
                 </div>
                 {note.summary ? (
-                  <ul className="min-w-0 list-outside list-disc space-y-1 overflow-hidden pr-1 pl-4 text-xs leading-5 text-neutral-500">
+                  <ul className="text-muted-foreground min-w-0 list-outside list-disc space-y-1 overflow-hidden pr-1 pl-4 text-xs leading-5">
                     {splitKeyFacts(note.summary).map((fact) => (
                       <li key={fact} className="min-w-0 break-words">
                         <span className="line-clamp-2">{fact}</span>
@@ -190,7 +190,7 @@ function PastNotesPanel({
                     ))}
                   </ul>
                 ) : (
-                  <p className="text-xs leading-5 text-neutral-400">
+                  <p className="text-muted-foreground text-xs leading-5">
                     {note.isGenerating
                       ? "Generating key facts..."
                       : "Key facts will be generated when this tab opens."}
@@ -238,9 +238,9 @@ function RegeneratePastNoteButton({
           disabled={isDisabled}
           onClick={onClick}
           className={cn([
-            "h-5 w-5 shrink-0 text-neutral-400",
-            "hover:bg-neutral-200/60 hover:text-neutral-700",
-            "disabled:cursor-not-allowed disabled:text-neutral-300",
+            "text-muted-foreground h-5 w-5 shrink-0",
+            "hover:bg-accent/60 hover:text-muted-foreground",
+            "disabled:text-muted-foreground/70 disabled:cursor-not-allowed",
           ])}
         >
           {isGenerating ? (
@@ -360,13 +360,15 @@ function BatchingTranscriptPanel({
   return (
     <TranscriptCard fillHeight={fillHeight}>
       <div className="flex shrink-0 items-center justify-between px-3 py-1.5">
-        <span className="text-xs font-medium text-neutral-500">Transcript</span>
+        <span className="text-muted-foreground text-xs font-medium">
+          Transcript
+        </span>
         <div className="flex items-center gap-1 px-1 py-0.5">
           <Spinner size={10} />
-          <span className="text-[11px] text-neutral-500">
+          <span className="text-muted-foreground text-[11px]">
             {phaseLabel}
             {typeof percentage === "number" && percentage > 0 && (
-              <span className="ml-1 text-neutral-400 tabular-nums">
+              <span className="text-muted-foreground ml-1 tabular-nums">
                 {Math.round(percentage * 100)}%
               </span>
             )}
@@ -418,14 +420,14 @@ function BatchTranscriptSkeleton({ fillHeight }: { fillHeight: boolean }) {
             <div className="flex w-[72px] shrink-0 flex-col gap-3 pt-0.5">
               <div
                 className={cn([
-                  "h-2.5 rounded-full bg-neutral-200/80",
+                  "bg-accent/80 h-2.5 rounded-full",
                   "animate-pulse",
                   row.speaker,
                 ])}
               />
               <div
                 className={cn([
-                  "h-1.5 rounded-full bg-neutral-100",
+                  "bg-muted h-1.5 rounded-full",
                   "animate-pulse",
                   row.time,
                 ])}
@@ -436,7 +438,7 @@ function BatchTranscriptSkeleton({ fillHeight }: { fillHeight: boolean }) {
                 <div
                   key={lineIndex}
                   className={cn([
-                    "h-2.5 rounded-full bg-neutral-100",
+                    "bg-muted h-2.5 rounded-full",
                     "animate-pulse",
                     lineWidth,
                   ])}
@@ -479,7 +481,7 @@ function BatchProgressTimeline({
         <div
           className={cn([
             "flex h-7 w-7 items-center justify-center rounded-full",
-            "border border-neutral-200 bg-white shadow-xs",
+            "border-border bg-card border shadow-xs",
             "shrink-0",
           ])}
         >
@@ -496,13 +498,13 @@ function BatchProgressTimeline({
       }
       main={
         <div className="flex h-6 items-center">
-          <div className="relative h-2 w-full overflow-hidden rounded-full bg-neutral-200/80">
+          <div className="bg-accent/80 relative h-2 w-full overflow-hidden rounded-full">
             <div
-              className="absolute inset-y-0 left-0 rounded-full bg-neutral-400 transition-[width] duration-300 ease-out"
+              className="bg-muted-foreground absolute inset-y-0 left-0 rounded-full transition-[width] duration-300 ease-out"
               style={{ width: `${Math.max(progress * 100, 8)}%` }}
             />
             <div className="absolute inset-0 flex items-center justify-center">
-              <span className="px-2 text-[10px] font-medium tracking-[0.02em] text-neutral-500">
+              <span className="text-muted-foreground px-2 text-[10px] font-medium tracking-[0.02em]">
                 {phaseLabel}
               </span>
             </div>
@@ -528,7 +530,7 @@ function StopTranscriptionButton({
           variant="ghost"
           size="icon"
           className={cn([
-            "text-neutral-500 hover:text-neutral-700",
+            "text-muted-foreground hover:text-muted-foreground",
             compact ? "h-5 w-5" : "h-6 w-6",
           ])}
           onClick={onClick}
@@ -584,7 +586,7 @@ function TranscriptReadyPanel({
                 disabled
                 className={cn([
                   "flex items-center gap-1 rounded-full px-1.5 py-0.5",
-                  "text-[11px] font-medium text-neutral-300",
+                  "text-muted-foreground/70 text-[11px] font-medium",
                   "cursor-not-allowed",
                 ])}
               >
@@ -603,10 +605,10 @@ function TranscriptReadyPanel({
             aria-label="Copy transcript"
             className={cn([
               "flex items-center gap-1 rounded-full px-1.5 py-0.5",
-              "text-[11px] font-medium text-neutral-500",
-              "transition-colors hover:bg-neutral-200/60 hover:text-neutral-700",
-              "disabled:cursor-not-allowed disabled:text-neutral-300",
-              "disabled:hover:bg-transparent disabled:hover:text-neutral-300",
+              "text-muted-foreground text-[11px] font-medium",
+              "hover:bg-accent/60 hover:text-muted-foreground transition-colors",
+              "disabled:text-muted-foreground/70 disabled:cursor-not-allowed",
+              "disabled:hover:text-muted-foreground/70 disabled:hover:bg-transparent",
             ])}
           >
             <CopyIcon size={10} />
@@ -617,8 +619,8 @@ function TranscriptReadyPanel({
             onClick={regenerate}
             className={cn([
               "flex items-center gap-1 rounded-full px-1.5 py-0.5",
-              "text-[11px] font-medium text-neutral-500",
-              "transition-colors hover:bg-neutral-200/60 hover:text-neutral-700",
+              "text-muted-foreground text-[11px] font-medium",
+              "hover:bg-accent/60 hover:text-muted-foreground transition-colors",
             ])}
           >
             <RefreshCw size={10} />
@@ -697,7 +699,9 @@ function TranscriptEmptyPanel({
         {error ? (
           <span className="text-xs text-red-500">{error}</span>
         ) : (
-          <span className="text-xs text-neutral-400">No transcript yet</span>
+          <span className="text-muted-foreground text-xs">
+            No transcript yet
+          </span>
         )}
 
         <div className="flex items-center gap-1.5">
@@ -705,7 +709,7 @@ function TranscriptEmptyPanel({
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 gap-1.5 text-xs text-neutral-500"
+              className="text-muted-foreground h-7 gap-1.5 text-xs"
               onClick={regenerate}
             >
               <RefreshCw size={12} />
@@ -750,7 +754,7 @@ function TranscriptCard({
     <div
       data-session-transcript-card
       className={cn([
-        "overflow-hidden rounded-b-xl border border-neutral-200 bg-white",
+        "border-border bg-card overflow-hidden rounded-b-xl border",
         fillHeight && "flex h-full flex-col",
         fillHeight && reserveMinHeight && "min-h-[114px]",
         !fillHeight && reserveMinHeight && "min-h-[96px]",

--- a/apps/desktop/src/session/components/floating/listen.tsx
+++ b/apps/desktop/src/session/components/floating/listen.tsx
@@ -52,7 +52,7 @@ export function ListenButton({
   return (
     <div className="flex flex-col items-center gap-2">
       {countdown.label && (
-        <div className="text-xs whitespace-nowrap text-neutral-500">
+        <div className="text-muted-foreground text-xs whitespace-nowrap">
           <span>{countdown.label}</span>
         </div>
       )}

--- a/apps/desktop/src/session/components/floating/options-menu.tsx
+++ b/apps/desktop/src/session/components/floating/options-menu.tsx
@@ -52,7 +52,7 @@ export function OptionsMenu({
 
   const moreButton = (
     <button
-      className="absolute top-1/2 right-2 z-10 -translate-y-1/2 cursor-pointer text-white/70 transition-colors hover:text-white disabled:opacity-50"
+      className="text-primary-foreground/70 hover:text-primary-foreground absolute top-1/2 right-2 z-10 -translate-y-1/2 cursor-pointer transition-colors disabled:opacity-50"
       disabled={disabled}
       onClick={(e) => {
         e.stopPropagation();

--- a/apps/desktop/src/session/components/floating/shared.tsx
+++ b/apps/desktop/src/session/components/floating/shared.tsx
@@ -44,7 +44,7 @@ export function FloatingButton({
       className={cn([
         "rounded-full border-2 transition-[border-color,opacity] duration-200 focus-visible:ring-0",
         error && "border-red-500",
-        !error && "border-neutral-200",
+        !error && "border-border",
         subtle && "opacity-40 hover:opacity-100",
         className,
       ])}

--- a/apps/desktop/src/session/components/listen-action.tsx
+++ b/apps/desktop/src/session/components/listen-action.tsx
@@ -48,7 +48,7 @@ export function ListenActionButton({ sessionId }: { sessionId: string }) {
         <FloatingButton
           onClick={startListening}
           disabled={isDisabled}
-          className="w-[148px] justify-start gap-2 border-stone-600 bg-stone-800 pr-7 pl-3 text-white shadow-[0_4px_14px_rgba(87,83,78,0.4)] hover:bg-stone-700"
+          className="border-primary bg-primary text-primary-foreground hover:bg-primary/90 w-[148px] justify-start gap-2 pr-7 pl-3 shadow-[0_4px_14px_rgba(87,83,78,0.4)]"
           tooltip={
             warningMessage
               ? {

--- a/apps/desktop/src/session/components/note-input/enhanced/config-error.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/config-error.tsx
@@ -16,7 +16,7 @@ export function ConfigError({ status }: { status: LLMConnectionStatus }) {
 
   return (
     <div className="flex h-full min-h-[400px] flex-col items-center justify-center">
-      <p className="mb-6 max-w-lg text-center text-sm text-neutral-700">
+      <p className="text-muted-foreground mb-6 max-w-lg text-center text-sm">
         {message}
       </p>
       <Button

--- a/apps/desktop/src/session/components/note-input/enhanced/enhance-error.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/enhance-error.tsx
@@ -39,8 +39,8 @@ export function EnhanceError({
 
   return (
     <div className="flex h-full min-h-[400px] flex-col items-center justify-center gap-4">
-      <AlertCircleIcon size={24} className="text-neutral-400" />
-      <p className="max-w-lg text-center text-sm text-neutral-700">
+      <AlertCircleIcon size={24} className="text-muted-foreground" />
+      <p className="text-muted-foreground max-w-lg text-center text-sm">
         {error?.message || "Something went wrong while generating the summary."}
       </p>
       <Button

--- a/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
@@ -35,7 +35,7 @@ export function StreamingView({ enhancedNoteId }: { enhancedNoteId: string }) {
     <div className="pb-2">
       {statusText ? (
         <div className="flex flex-col gap-1">
-          <p className="text-sm text-neutral-500">{statusText}</p>
+          <p className="text-muted-foreground text-sm">{statusText}</p>
           <RotatingTip />
         </div>
       ) : (
@@ -68,5 +68,7 @@ function RotatingTip() {
     return () => clearInterval(id);
   }, []);
 
-  return <p className="pl-3 text-xs text-neutral-400">└ Tip: {TIPS[index]}</p>;
+  return (
+    <p className="text-muted-foreground pl-3 text-xs">└ Tip: {TIPS[index]}</p>
+  );
 }

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -304,8 +304,8 @@ function HeaderTabEnhanced({
             className="w-72"
           >
             <AppFloatingPanel className="flex flex-col gap-2 p-3">
-              <p className="text-xs leading-5 text-neutral-700">
-                <span className="font-medium text-neutral-900">
+              <p className="text-muted-foreground text-xs leading-5">
+                <span className="text-foreground font-medium">
                   {templateTitle}
                 </span>{" "}
                 was used to generate this summary.
@@ -313,7 +313,7 @@ function HeaderTabEnhanced({
               <button
                 type="button"
                 onClick={handleExploreTemplatesClick}
-                className="w-fit text-xs font-medium text-neutral-900 underline underline-offset-2 hover:text-neutral-600"
+                className="text-foreground hover:text-muted-foreground w-fit text-xs font-medium underline underline-offset-2"
               >
                 Explore more templates
               </button>
@@ -389,11 +389,11 @@ function HeaderTabEnhanced({
         className={cn([
           "group/tab relative my-2 shrink-0 cursor-pointer border-b-2 px-1 py-0.5 text-xs font-medium transition-all duration-200 select-none",
           isActive
-            ? ["text-neutral-900", "border-neutral-900"]
+            ? ["text-foreground", "border-foreground"]
             : [
-                "text-neutral-600",
+                "text-muted-foreground",
                 "border-transparent",
-                "hover:text-neutral-800",
+                "hover:text-foreground",
               ],
         ])}
       >
@@ -403,7 +403,7 @@ function HeaderTabEnhanced({
             type="button"
             onClick={handleCancelClick}
             className={cn([
-              "inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-xs hover:bg-neutral-100",
+              "hover:bg-accent inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-xs",
               !isActive && "opacity-50",
             ])}
             aria-label="Cancel enhancement"
@@ -434,9 +434,9 @@ function HeaderTabEnhanced({
         "group relative inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-xs transition-colors",
         isError
           ? [
-              "text-red-600 hover:bg-red-50 hover:text-neutral-900 focus-visible:bg-red-50 focus-visible:text-neutral-900",
+              "hover:text-foreground focus-visible:text-foreground text-red-600 hover:bg-red-50 focus-visible:bg-red-50",
             ]
-          : ["hover:bg-neutral-100 focus-visible:bg-neutral-100"],
+          : ["hover:bg-accent focus-visible:bg-muted"],
       ])}
     >
       {isError && (
@@ -928,7 +928,7 @@ function CreateOtherFormatButton({
         <button
           className={cn([
             "relative my-2 shrink-0 px-1 py-0.5 text-xs font-medium whitespace-nowrap transition-all duration-200 select-none",
-            "text-neutral-600 hover:text-neutral-800",
+            "text-muted-foreground hover:text-foreground",
             "flex items-center gap-1",
             "border-b-2 border-transparent",
           ])}
@@ -940,13 +940,13 @@ function CreateOtherFormatButton({
       <PopoverContent variant="app" className="w-80" align="start">
         <div className="flex flex-col gap-1">
           <AppFloatingPanel className="flex flex-col overflow-hidden">
-            <div className="border-b border-neutral-200 py-2">
+            <div className="border-border border-b py-2">
               <div
                 className={cn([
-                  "flex h-9 items-center gap-2 rounded-md bg-white px-3",
+                  "bg-card flex h-9 items-center gap-2 rounded-md px-3",
                 ])}
               >
-                <SearchIcon className="h-4 w-4 text-neutral-400" />
+                <SearchIcon className="text-muted-foreground h-4 w-4" />
                 <input
                   ref={searchInputRef}
                   autoFocus
@@ -955,14 +955,14 @@ function CreateOtherFormatButton({
                   onChange={(e) => setSearch(e.target.value)}
                   onKeyDown={handleSearchInputKeyDown}
                   placeholder="Search templates..."
-                  className="flex-1 bg-transparent text-sm placeholder:text-neutral-400 focus:outline-hidden"
+                  className="placeholder:text-muted-foreground flex-1 bg-transparent text-sm focus:outline-hidden"
                 />
                 {search && (
                   <button
                     onClick={() => setSearch("")}
-                    className="rounded-xs p-0.5 hover:bg-neutral-100"
+                    className="hover:bg-accent rounded-xs p-0.5"
                   >
-                    <XIcon className="h-3 w-3 text-neutral-400" />
+                    <XIcon className="text-muted-foreground h-3 w-3" />
                   </button>
                 )}
               </div>
@@ -1005,7 +1005,7 @@ function CreateOtherFormatButton({
                           );
                         })
                       ) : (
-                        <div className="px-2 py-3 text-sm text-neutral-500">
+                        <div className="text-muted-foreground px-2 py-3 text-sm">
                           {section.emptyMessage}
                         </div>
                       )}
@@ -1020,7 +1020,7 @@ function CreateOtherFormatButton({
             onClick={handleSeeAllTemplates}
             className={cn([
               "flex h-7 w-full items-center justify-center gap-1 rounded-lg px-3 text-xs font-medium",
-              "text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-neutral-900",
+              "text-muted-foreground hover:bg-accent hover:text-foreground transition-colors",
             ])}
           >
             See all templates
@@ -1443,7 +1443,7 @@ function TemplateSection({
           ) : null)}
         <p
           className={cn([
-            "font-mono text-[11px] font-medium tracking-wide text-neutral-500",
+            "text-muted-foreground font-mono text-[11px] font-medium tracking-wide",
             uppercase && "uppercase",
           ])}
         >
@@ -1476,29 +1476,31 @@ function TemplateResultButton({
     <button
       ref={buttonRef}
       className={cn([
-        "w-full rounded-md px-3 py-2 text-left transition-colors hover:bg-neutral-100 focus:bg-neutral-100 focus:outline-hidden",
+        "hover:bg-accent focus:bg-muted w-full rounded-md px-3 py-2 text-left transition-colors focus:outline-hidden",
         "flex flex-col gap-0.5",
       ])}
       onClick={onClick}
       onKeyDown={onKeyDown}
     >
-      <span className="truncate text-sm font-medium text-neutral-900">
+      <span className="text-foreground truncate text-sm font-medium">
         {title}
       </span>
       {description ? (
-        <span className="line-clamp-2 text-xs text-neutral-500">
+        <span className="text-muted-foreground line-clamp-2 text-xs">
           {description}
         </span>
       ) : null}
       {creatorLabel ? (
-        <span className="text-[11px] text-neutral-400">{creatorLabel}</span>
+        <span className="text-muted-foreground text-[11px]">
+          {creatorLabel}
+        </span>
       ) : null}
       {tags && tags.length > 0 ? (
         <span className="mt-1 flex flex-wrap gap-1">
           {tags.map((tag, index) => (
             <span
               key={`${tag}-${index}`}
-              className="rounded-xs bg-neutral-100 px-1.5 py-0.5 text-[11px] text-neutral-500"
+              className="bg-muted text-muted-foreground rounded-xs px-1.5 py-0.5 text-[11px]"
             >
               {tag}
             </span>

--- a/apps/desktop/src/session/components/note-input/search/bar.tsx
+++ b/apps/desktop/src/session/components/note-input/search/bar.tsx
@@ -39,8 +39,8 @@ function ToggleButton({
           className={cn([
             "rounded-sm p-0.5 transition-colors",
             active
-              ? "bg-neutral-300 text-neutral-700"
-              : "text-neutral-400 hover:bg-neutral-100 hover:text-neutral-500",
+              ? "bg-accent text-muted-foreground"
+              : "text-muted-foreground hover:bg-accent hover:text-muted-foreground",
           ])}
         >
           {children}
@@ -71,8 +71,8 @@ function IconButton({
       className={cn([
         "rounded-sm p-0.5 transition-colors",
         disabled
-          ? "cursor-not-allowed text-neutral-300"
-          : "text-neutral-500 hover:bg-neutral-100",
+          ? "text-muted-foreground/70 cursor-not-allowed"
+          : "text-muted-foreground hover:bg-accent",
       ])}
     >
       {children}
@@ -197,7 +197,7 @@ export function SearchBar({
 
   return (
     <div className="flex flex-col gap-1">
-      <div className="flex h-7 items-center gap-1.5 rounded-lg bg-neutral-100 px-2">
+      <div className="bg-muted flex h-7 items-center gap-1.5 rounded-lg px-2">
         <input
           ref={searchInputRef}
           type="text"
@@ -205,7 +205,7 @@ export function SearchBar({
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleSearchKeyDown}
           placeholder="Search..."
-          className="h-full min-w-0 flex-1 bg-transparent text-xs placeholder:text-neutral-400 focus:outline-hidden"
+          className="placeholder:text-muted-foreground h-full min-w-0 flex-1 bg-transparent text-xs focus:outline-hidden"
         />
         <div className="flex items-center gap-0.5">
           <ToggleButton
@@ -235,7 +235,7 @@ export function SearchBar({
             <ReplaceIcon className="size-3.5" />
           </ToggleButton>
         </div>
-        <span className="text-[10px] whitespace-nowrap text-neutral-400 tabular-nums">
+        <span className="text-muted-foreground text-[10px] whitespace-nowrap tabular-nums">
           {displayCount}
         </span>
         <div className="flex items-center">
@@ -278,7 +278,7 @@ export function SearchBar({
       </div>
 
       {showReplace && (
-        <div className="flex h-7 items-center gap-1.5 rounded-lg bg-neutral-100 px-2">
+        <div className="bg-muted flex h-7 items-center gap-1.5 rounded-lg px-2">
           <input
             ref={replaceInputRef}
             type="text"
@@ -286,7 +286,7 @@ export function SearchBar({
             onChange={(e) => setReplaceQuery(e.target.value)}
             onKeyDown={handleReplaceKeyDown}
             placeholder="Replace with..."
-            className="h-full min-w-0 flex-1 bg-transparent text-xs placeholder:text-neutral-400 focus:outline-hidden"
+            className="placeholder:text-muted-foreground h-full min-w-0 flex-1 bg-transparent text-xs focus:outline-hidden"
           />
           <div className="flex items-center gap-0.5">
             <IconButton

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -135,7 +135,7 @@ export function TranscriptViewer({
         className={cn([
           "absolute bottom-3 left-1/2 z-30 -translate-x-1/2",
           "rounded-full px-4 py-2",
-          "bg-linear-to-t from-neutral-200 to-neutral-100 text-neutral-900",
+          "from-muted to-accent text-foreground bg-linear-to-t",
           "shadow-xs hover:scale-[102%] hover:shadow-md active:scale-[98%]",
           "text-xs font-light",
           "transition-opacity duration-150",

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
@@ -23,7 +23,7 @@ export function SegmentHeader({
   const label = useSpeakerLabel(segment.key, speakerLabelManager);
   const timestamp = getTimestampRange(segment);
   const headerClassName = cn([
-    "sticky top-0 z-20 bg-neutral-50",
+    "bg-muted sticky top-0 z-20",
     "-mx-3 px-3 py-1",
     "text-xs font-light",
     "flex items-center justify-between",
@@ -37,7 +37,7 @@ export function SegmentHeader({
         color={color}
         label={label}
       />
-      <span className="font-mono text-neutral-500">{timestamp}</span>
+      <span className="text-muted-foreground font-mono">{timestamp}</span>
     </div>
   );
 }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/selection-menu.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/selection-menu.tsx
@@ -14,12 +14,12 @@ import { useAutoCloser } from "~/shared/hooks/useAutoCloser";
 const MENU_CONTAINER_CLASSES = [
   "pointer-events-auto",
   "flex gap-1",
-  "bg-white shadow-lg rounded-md border border-neutral-200 p-1",
+  "bg-card shadow-lg rounded-md border border-border p-1",
 ];
 
 const MENU_BUTTON_CLASSES = [
   "px-2 py-1 text-xs rounded-xs",
-  "hover:bg-neutral-100 transition-colors",
+  "hover:bg-accent transition-colors",
 ];
 
 export function SelectionMenu({
@@ -141,7 +141,7 @@ function SelectionHighlight({
             top: rect.top,
             width: rect.width,
             height: rect.height,
-            backgroundColor: "rgba(59, 130, 246, 0.3)",
+            backgroundColor: "var(--selection-overlay)",
             pointerEvents: "none",
             zIndex: 40,
           }}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/separator.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/separator.tsx
@@ -5,12 +5,12 @@ export function TranscriptSeparator() {
     <div
       className={cn([
         "flex items-center gap-3",
-        "text-xs font-light text-neutral-400",
+        "text-muted-foreground text-xs font-light",
       ])}
     >
-      <div className="flex-1 border-t border-neutral-200/40" />
+      <div className="border-border/40 flex-1 border-t" />
       <span>~ ~ ~ ~ ~ ~ ~ ~ ~</span>
-      <div className="flex-1 border-t border-neutral-200/40" />
+      <div className="border-border/40 flex-1 border-t" />
     </div>
   );
 }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -62,7 +62,7 @@ export function SpeakerAssignPopover({
           type="button"
           className={cn([
             "-ml-1 cursor-pointer rounded-xs px-1",
-            "transition-colors hover:bg-neutral-100",
+            "hover:bg-accent transition-colors",
           ])}
           style={{ color }}
         >
@@ -320,13 +320,13 @@ function ParticipantList({
 
   return (
     <AppFloatingPanel className="overflow-hidden">
-      <div className="border-b border-neutral-100 p-2">
+      <div className="border-border border-b p-2">
         <input
           autoFocus
           type="search"
           className={cn([
-            "h-8 w-full rounded-md border border-neutral-200 bg-white px-2 text-sm outline-hidden",
-            "placeholder:text-neutral-400 focus:border-neutral-300",
+            "border-border bg-card h-8 w-full rounded-md border px-2 text-sm outline-hidden",
+            "placeholder:text-muted-foreground focus:border-border",
           ])}
           placeholder="Search contacts"
           value={query}
@@ -343,7 +343,7 @@ function ParticipantList({
 
         {groups.map((group) => (
           <div key={group.title}>
-            <div className="px-3 pt-2 pb-1 text-[11px] font-medium text-neutral-400 uppercase">
+            <div className="text-muted-foreground px-3 pt-2 pb-1 text-[11px] font-medium uppercase">
               {group.title}
             </div>
             {group.options.map((option) => (
@@ -357,7 +357,7 @@ function ParticipantList({
         ))}
 
         {!createOption && groups.length === 0 && (
-          <p className="px-3 py-2 text-xs text-neutral-400">
+          <p className="text-muted-foreground px-3 py-2 text-xs">
             {query.trim() ? "No matching contacts" : "No contacts"}
           </p>
         )}
@@ -378,7 +378,7 @@ function ParticipantOptionButton({
       type="button"
       className={cn([
         "w-full px-3 py-1.5 text-left text-sm",
-        "hover:bg-neutral-100",
+        "hover:bg-accent",
       ])}
       onClick={() => onSelect(option)}
     >
@@ -386,7 +386,7 @@ function ParticipantOptionButton({
         {option.isNew ? `Add "${option.name}"` : option.name}
       </span>
       {!option.isNew && option.email && (
-        <span className="block truncate text-xs text-neutral-400">
+        <span className="text-muted-foreground block truncate text-xs">
           {option.email}
         </span>
       )}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/word-span.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/word-span.tsx
@@ -34,7 +34,7 @@ export function WordSpan(props: WordSpanProps) {
   const className = useMemo(
     () =>
       cn([
-        canSeek && "cursor-pointer hover:bg-neutral-200/60",
+        canSeek && "hover:bg-accent/60 cursor-pointer",
         !props.word.is_final && ["opacity-60", "italic"],
       ]),
     [canSeek, props.word.is_final],

--- a/apps/desktop/src/session/components/note-input/transcript/screens/batch.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/screens/batch.tsx
@@ -26,12 +26,12 @@ export function BatchState({
         gap={4}
       />
       <div className="flex max-w-sm flex-col items-center gap-2 text-center">
-        <p className="text-base font-semibold text-neutral-700">
+        <p className="text-muted-foreground text-base font-semibold">
           {isFallbackFromLive
             ? "Live transcription stopped"
             : "Recording continues"}
         </p>
-        <p className="text-sm leading-relaxed text-neutral-400">
+        <p className="text-muted-foreground text-sm leading-relaxed">
           {isFallbackFromLive
             ? `${error ? degradedMessage(error) : "Live transcription is unavailable."} ${continuation}`
             : `${continuation}`}

--- a/apps/desktop/src/session/components/note-input/transcript/screens/empty.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/screens/empty.tsx
@@ -25,17 +25,17 @@ export function TranscriptEmptyState({
       <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
         <AlertCircleIcon className="h-8 w-8 text-red-400" />
         <div className="flex max-w-md flex-col gap-1">
-          <p className="text-sm font-medium text-neutral-700">
+          <p className="text-muted-foreground text-sm font-medium">
             Batch transcription failed
           </p>
-          <p className="text-xs text-neutral-500">{error}</p>
+          <p className="text-muted-foreground text-xs">{error}</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-3 text-neutral-400">
+    <div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-3">
       {isBatching ? (
         <Spinner size={28} />
       ) : (
@@ -44,7 +44,7 @@ export function TranscriptEmptyState({
       {isBatching ? (
         <div className="flex flex-col items-center gap-1">
           {typeof percentage === "number" && percentage > 0 ? (
-            <p className="text-2xl font-medium text-neutral-500 tabular-nums">
+            <p className="text-muted-foreground text-2xl font-medium tabular-nums">
               {Math.round(percentage * 100)}%
             </p>
           ) : null}
@@ -56,10 +56,10 @@ export function TranscriptEmptyState({
         </div>
       ) : (
         <div className="flex max-w-sm flex-col items-center gap-1 text-center">
-          <p className="text-sm text-neutral-500">
+          <p className="text-muted-foreground text-sm">
             {hasAudio ? "Recording available" : "No transcript available"}
           </p>
-          <p className="text-xs text-neutral-400">
+          <p className="text-muted-foreground text-xs">
             {hasAudio
               ? "Use the refresh button above to generate a transcript, or upload a file."
               : "Upload audio or a transcript file to populate this note."}

--- a/apps/desktop/src/session/components/note-input/transcript/screens/listening.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/screens/listening.tsx
@@ -10,17 +10,17 @@ export function TranscriptListeningState({
   const isFinalizing = status === "finalizing";
 
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-3 text-neutral-400">
+    <div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-3">
       {isFinalizing ? (
         <Spinner size={28} />
       ) : (
         <AudioLinesIcon className="h-8 w-8" />
       )}
       <div className="flex max-w-sm flex-col items-center gap-1 text-center">
-        <p className="text-sm text-neutral-500">
+        <p className="text-muted-foreground text-sm">
           {isFinalizing ? "Finalizing transcript..." : "Listening..."}
         </p>
-        <p className="text-xs text-neutral-400">
+        <p className="text-muted-foreground text-xs">
           {isFinalizing
             ? "Transcript is still being written."
             : "Transcript will appear here when the first segment arrives."}

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -212,7 +212,7 @@ function SidebarModeStopButton({ sessionId }: { sessionId: string }) {
       className={cn([
         "group inline-flex items-center justify-center rounded-full text-sm font-medium",
         finalizing
-          ? ["cursor-wait bg-neutral-100 text-neutral-500"]
+          ? ["bg-muted text-muted-foreground cursor-wait"]
           : [colors.button],
         "h-7 w-20",
         "disabled:pointer-events-none disabled:opacity-50",

--- a/apps/desktop/src/session/components/outer-header/metadata/date.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/date.tsx
@@ -26,13 +26,13 @@ export function DateEditor({ sessionId }: { sessionId: string }) {
     return (
       <div className="flex h-9 items-center justify-between gap-3">
         <div className="min-w-0 flex-1">
-          <div className="text-sm text-neutral-700">{noteDate}</div>
+          <div className="text-muted-foreground text-sm">{noteDate}</div>
         </div>
         <Button
           type="button"
           variant="ghost"
           size="icon"
-          className="size-7 rounded-md text-neutral-500 hover:bg-neutral-100 hover:text-neutral-900"
+          className="text-muted-foreground hover:bg-accent hover:text-foreground size-7 rounded-md"
           onClick={() => setIsEditing(true)}
           aria-label="Edit date"
         >
@@ -138,7 +138,7 @@ function EditableDateForm({
                 type="button"
                 variant="ghost"
                 size="icon"
-                className="size-7 shrink-0 rounded-md text-neutral-400 hover:bg-red-50 hover:text-red-600"
+                className="text-muted-foreground size-7 shrink-0 rounded-md hover:bg-red-50 hover:text-red-600"
                 onClick={onCancel}
                 aria-label="Cancel date edit"
               >
@@ -152,7 +152,7 @@ function EditableDateForm({
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="size-7 shrink-0 rounded-md text-neutral-400 hover:bg-green-50 hover:text-green-600"
+                  className="text-muted-foreground size-7 shrink-0 rounded-md hover:bg-green-50 hover:text-green-600"
                   onClick={() => void form.handleSubmit()}
                   disabled={!canSubmit}
                   aria-label="Save date"

--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -65,8 +65,8 @@ const TriggerInner = forwardRef<
       title={label}
       className={cn([
         "rounded-full",
-        "text-neutral-600 hover:bg-neutral-100 hover:text-black",
-        open && "bg-neutral-100",
+        "text-muted-foreground hover:bg-accent hover:text-black",
+        open && "bg-muted",
       ])}
     >
       <CalendarIcon size={16} />
@@ -182,16 +182,16 @@ export function EventDisplay({
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="text-base font-medium text-neutral-900">
+      <div className="text-foreground text-base font-medium">
         {event.title || "Untitled Event"}
       </div>
 
-      <div className="h-px bg-neutral-200" />
+      <div className="bg-accent h-px" />
 
       {shouldShowLocation && (
         <>
-          <div className="flex items-center gap-2 text-sm text-neutral-700">
-            <MapPinIcon size={16} className="shrink-0 text-neutral-500" />
+          <div className="text-muted-foreground flex items-center gap-2 text-sm">
+            <MapPinIcon size={16} className="text-muted-foreground shrink-0" />
             <span>{event.location}</span>
           </div>
         </>
@@ -200,8 +200,8 @@ export function EventDisplay({
       {event.meetingLink && (
         <>
           <div className="flex items-center justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-2 text-sm text-neutral-700">
-              <VideoIcon size={16} className="shrink-0 text-neutral-500" />
+            <div className="text-muted-foreground flex min-w-0 items-center gap-2 text-sm">
+              <VideoIcon size={16} className="text-muted-foreground shrink-0" />
               <span className="truncate">
                 {meetingDomain || "Meeting link"}
               </span>
@@ -219,15 +219,17 @@ export function EventDisplay({
       )}
 
       {event.startedAt && (
-        <div className="text-sm text-neutral-700">{formatEventDateTime()}</div>
+        <div className="text-muted-foreground text-sm">
+          {formatEventDateTime()}
+        </div>
       )}
 
       {children}
 
       {event.description && (
         <>
-          <div className="h-px bg-neutral-200" />
-          <div className="select-text-deep max-h-40 overflow-y-auto text-sm break-words whitespace-pre-wrap text-neutral-700">
+          <div className="bg-accent h-px" />
+          <div className="select-text-deep text-muted-foreground max-h-40 overflow-y-auto text-sm break-words whitespace-pre-wrap">
             {renderDescriptionWithLinks(event.description)}
           </div>
         </>
@@ -292,7 +294,7 @@ function renderDescriptionWithLinks(description: string): React.ReactNode {
       <a
         key={`description-link-${linkIndex}`}
         href={url}
-        className="cursor-pointer underline transition-colors hover:text-neutral-900"
+        className="hover:text-foreground cursor-pointer underline transition-colors"
         onClick={(e) => {
           e.preventDefault();
           void openerCommands.openUrl(url, null);

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/chip.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/chip.tsx
@@ -106,7 +106,7 @@ function EnhanceContactButton({
           variant="ghost"
           size="sm"
           aria-label={`Enhance contact ${label}`}
-          className="ml-0.5 h-3.5 w-3.5 p-0 text-neutral-500 hover:bg-transparent hover:text-neutral-800"
+          className="text-muted-foreground hover:text-foreground ml-0.5 h-3.5 w-3.5 p-0 hover:bg-transparent"
           disabled={isDisabled}
           onClick={(e) => {
             e.stopPropagation();

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/dropdown.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/dropdown.tsx
@@ -49,9 +49,7 @@ export function ParticipantDropdown({
             tabIndex={-1}
             className={cn([
               "w-full px-3 py-1.5 text-left text-sm",
-              selectedIndex === index
-                ? "bg-neutral-100"
-                : "hover:bg-neutral-50",
+              selectedIndex === index ? "bg-muted" : "hover:bg-accent",
             ])}
             onClick={() => onSelect(option)}
             onMouseEnter={() => onHover(index)}

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/index.tsx
@@ -3,7 +3,7 @@ import { ParticipantInput } from "./input";
 export function ParticipantsDisplay({ sessionId }: { sessionId: string }) {
   return (
     <div className="flex flex-col gap-2">
-      <div className="h-px bg-neutral-200" />
+      <div className="bg-accent h-px" />
       <ParticipantInput sessionId={sessionId} />
     </div>
   );

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
@@ -89,7 +89,7 @@ export function ParticipantInput({ sessionId }: { sessionId: string }) {
         <input
           ref={inputRef}
           type="text"
-          className="min-w-[120px] flex-1 bg-transparent text-sm outline-hidden placeholder:text-neutral-400"
+          className="placeholder:text-muted-foreground min-w-[120px] flex-1 bg-transparent text-sm outline-hidden"
           placeholder={placeholder}
           value={inputValue}
           onChange={(e) => handleInputChange(e.target.value)}

--- a/apps/desktop/src/session/components/outer-header/overflow/delete.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/delete.tsx
@@ -34,8 +34,8 @@ export function DeleteRecording({ sessionId }: { sessionId: string }) {
       onClick={handleDeleteRecording}
       disabled={isDisabled}
       className={cn([
-        "cursor-pointer text-red-600",
-        "hover:bg-red-50 hover:text-red-700",
+        "cursor-pointer text-red-600 dark:text-red-400",
+        "hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-950/50 dark:hover:text-red-300",
       ])}
     >
       {isDeletingRecording ? (
@@ -82,8 +82,8 @@ export function DeleteNote({ sessionId }: { sessionId: string }) {
     <DropdownMenuItem
       onClick={handleDeleteNote}
       className={cn([
-        "cursor-pointer text-red-600",
-        "hover:bg-red-50 hover:text-red-700",
+        "cursor-pointer text-red-600 dark:text-red-400",
+        "hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-950/50 dark:hover:text-red-300",
       ])}
     >
       <TrashIcon />

--- a/apps/desktop/src/session/components/outer-header/overflow/export-modal.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/export-modal.tsx
@@ -455,14 +455,14 @@ export function ExportModal({
       >
         <div
           className={cn([
-            "rounded-xl border border-neutral-200/80 bg-[#faf8f5]",
+            "border-border/80 bg-background rounded-xl border",
             "shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)]",
             "flex flex-col gap-4 p-5 text-center",
           ])}
         >
           <div className="flex flex-col gap-1">
             <h2 className="text-base font-semibold">Export</h2>
-            <p className="text-sm text-neutral-500">
+            <p className="text-muted-foreground text-sm">
               Choose a file format and what to include.
             </p>
           </div>
@@ -481,7 +481,7 @@ export function ExportModal({
                       name="export-format"
                       checked={format === f}
                       onChange={() => setFormat(f)}
-                      className="accent-stone-800"
+                      className="accent-primary"
                     />
                     {f === "md"
                       ? "Markdown"
@@ -511,7 +511,7 @@ export function ExportModal({
                       type="checkbox"
                       checked={checked}
                       onChange={(e) => setter(e.target.checked)}
-                      className="accent-stone-800"
+                      className="accent-primary"
                     />
                     {label}
                   </label>
@@ -525,7 +525,7 @@ export function ExportModal({
             disabled={
               isPending || isTranscriptPending || !hasAnyContentSelected
             }
-            className="h-10 w-full rounded-full border-2 border-stone-600 bg-stone-800 text-sm font-medium text-white shadow-[0_4px_14px_rgba(87,83,78,0.4)] transition-all duration-200 hover:bg-stone-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="border-primary bg-primary text-primary-foreground hover:bg-primary/90 h-10 w-full rounded-full border-2 text-sm font-medium shadow-[0_4px_14px_rgba(87,83,78,0.4)] transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isPending
               ? "Exporting..."

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -74,7 +74,7 @@ export function OverflowButton({
           <Button
             size="icon"
             variant="ghost"
-            className="rounded-full text-neutral-600 hover:bg-neutral-100 hover:text-black"
+            className="text-muted-foreground hover:bg-accent hover:text-foreground rounded-full"
           >
             <MoreHorizontalIcon size={16} />
           </Button>

--- a/apps/desktop/src/session/components/session-preview-card.tsx
+++ b/apps/desktop/src/session/components/session-preview-card.tsx
@@ -49,7 +49,7 @@ const previewCardComponents: typeof streamdownComponents = {
         {...props}
         title={title}
         className={cn([
-          "block max-h-32 w-full rounded-md bg-white object-contain",
+          "bg-card block max-h-32 w-full rounded-md object-contain",
           props.className,
         ])}
         style={{
@@ -277,10 +277,10 @@ function ParticipantsList({ mappingIds }: { mappingIds: string[] }) {
   const remaining = names.length - visible.length;
 
   return (
-    <div className="line-clamp-2 text-xs text-neutral-500">
+    <div className="text-muted-foreground line-clamp-2 text-xs">
       {visible.join(", ")}
       {remaining > 0 && (
-        <span className="text-neutral-500"> and {remaining} more</span>
+        <span className="text-muted-foreground"> and {remaining} more</span>
       )}
     </div>
   );
@@ -361,14 +361,14 @@ export function SessionPreviewCard({
       >
         <div className="flex flex-col gap-1">
           {dateDisplay && (
-            <div className="text-xs text-neutral-500">{dateDisplay}</div>
+            <div className="text-muted-foreground text-xs">{dateDisplay}</div>
           )}
 
           <div className="text-sm font-medium">{title || "Untitled"}</div>
           <ParticipantsList mappingIds={participantMappingIds} />
 
           {previewMarkdown || previewPlainText ? (
-            <div className="mt-1 flex max-h-32 flex-col overflow-hidden mask-[linear-gradient(to_bottom,black_60%,transparent)] text-neutral-600">
+            <div className="text-muted-foreground mt-1 flex max-h-32 flex-col overflow-hidden mask-[linear-gradient(to_bottom,black_60%,transparent)]">
               {previewHasImage && previewImage ? (
                 <img
                   src={previewImage.src}

--- a/apps/desktop/src/session/components/streamdown.tsx
+++ b/apps/desktop/src/session/components/streamdown.tsx
@@ -1,7 +1,8 @@
 import { parseImageMetadata } from "@hypr/editor/node-views";
 import { cn } from "@hypr/utils";
 
-const HEADING_SHARED = "text-gray-700 font-semibold text-sm mb-1 min-h-6";
+const HEADING_SHARED =
+  "text-muted-foreground font-semibold text-sm mb-1 min-h-6";
 const HEADING_WITH_MARGIN = "mt-4 first:mt-0";
 
 export const streamdownComponents = {

--- a/apps/desktop/src/settings/ai/llm/health.tsx
+++ b/apps/desktop/src/settings/ai/llm/health.tsx
@@ -15,7 +15,7 @@ export function HealthStatusIndicator() {
   const health = useConnectionHealth();
 
   if (health.status === "pending") {
-    return <Spinner size={14} className="shrink-0 text-neutral-400" />;
+    return <Spinner size={14} className="text-muted-foreground shrink-0" />;
   }
 
   return null;

--- a/apps/desktop/src/settings/ai/llm/select.tsx
+++ b/apps/desktop/src/settings/ai/llm/select.tsx
@@ -39,6 +39,7 @@ import {
 import { listOpenRouterModels } from "~/settings/ai/shared/list-openrouter";
 import { ModelCombobox } from "~/settings/ai/shared/model-combobox";
 import { useConfigValues } from "~/shared/config";
+import { SettingsAlert } from "~/shared/ui/settings-alert";
 import * as settings from "~/store/tinybase/store/settings";
 
 export function SelectProviderAndModel() {
@@ -169,18 +170,14 @@ export function SelectProviderAndModel() {
   return (
     <div className="flex flex-col gap-4">
       {!isConfigured && (
-        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3">
-          <span className="text-sm text-red-600">
-            <strong className="font-medium">Language model</strong> is needed to
-            make Anarlog summarize and chat about your conversations.
-          </span>
-        </div>
+        <SettingsAlert>
+          <strong className="font-medium">Language model</strong> is needed to
+          make Anarlog summarize and chat about your conversations.
+        </SettingsAlert>
       )}
 
       {hasError && health.message && (
-        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3">
-          <span className="text-sm text-red-600">{health.message}</span>
-        </div>
+        <SettingsAlert>{health.message}</SettingsAlert>
       )}
 
       <h3 className="text-md font-sans font-semibold">Model being used</h3>
@@ -190,7 +187,7 @@ export function SelectProviderAndModel() {
             value={current_llm_provider || ""}
             onValueChange={handleProviderChange}
           >
-            <SelectTrigger className="bg-white shadow-none focus:ring-0">
+            <SelectTrigger className="bg-card shadow-none focus:ring-0">
               <SelectValue placeholder="Select a provider" />
             </SelectTrigger>
             <SelectContent>
@@ -206,19 +203,20 @@ export function SelectProviderAndModel() {
                     key={provider.id}
                     value={provider.id}
                     disabled={locked}
+                    className="data-disabled:text-muted-foreground data-disabled:!opacity-100"
                   >
                     <div className="flex flex-col gap-0.5">
                       <div className="flex items-center gap-2">
                         <ProviderIconSlot>{provider.icon}</ProviderIconSlot>
                         <span>{provider.displayName}</span>
                         {requiresPro ? (
-                          <span className="rounded-full border border-neutral-200 px-2 py-0.5 text-[10px] tracking-wide text-neutral-500 uppercase">
+                          <span className="border-border text-muted-foreground rounded-full border px-2 py-0.5 text-[10px] tracking-wide uppercase">
                             Pro
                           </span>
                         ) : null}
                       </div>
                       {locked ? (
-                        <span className="text-[11px] text-neutral-500">
+                        <span className="text-muted-foreground text-[11px]">
                           Upgrade to Pro to use this provider.
                         </span>
                       ) : null}
@@ -230,7 +228,7 @@ export function SelectProviderAndModel() {
           </Select>
         </div>
 
-        <span className="text-neutral-500">/</span>
+        <span className="text-muted-foreground">/</span>
 
         <div className="min-w-0 flex-3">
           <ModelCombobox

--- a/apps/desktop/src/settings/ai/shared/hypr-cloud-button.tsx
+++ b/apps/desktop/src/settings/ai/shared/hypr-cloud-button.tsx
@@ -5,7 +5,7 @@ export function HyprProviderRow({ children }: { children: React.ReactNode }) {
     <div
       className={cn([
         "flex flex-col gap-3",
-        "rounded-md border bg-white px-3 py-2",
+        "bg-card rounded-md border px-3 py-2",
       ])}
     >
       {children}
@@ -40,8 +40,8 @@ export function HyprCloudCTAButton({
         "rounded-full px-4 text-center font-mono text-xs",
         "transition-all duration-150",
         isPaid
-          ? "bg-linear-to-t from-neutral-200 to-neutral-100 text-neutral-900 shadow-xs hover:shadow-md"
-          : "bg-linear-to-t from-stone-600 to-stone-500 text-white shadow-md hover:scale-[102%] hover:shadow-lg active:scale-[98%]",
+          ? "from-muted to-accent text-foreground bg-linear-to-t shadow-xs hover:shadow-md"
+          : "bg-primary text-primary-foreground hover:bg-primary/90 shadow-md hover:scale-[102%] hover:shadow-lg active:scale-[98%]",
       ])}
     >
       {showShimmer && (

--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -55,14 +55,45 @@ export function AnarlogProviderIcon() {
     <img
       src={ANARLOG_ICON_SRC}
       alt="Anarlog"
+      data-slot="provider-logo"
       className="size-4 object-contain object-center [clip-path:inset(6%_round_18%)]"
+    />
+  );
+}
+
+export function ProviderBrandImage({
+  src,
+  alt,
+  className,
+}: {
+  src: string;
+  alt: string;
+  className?: string;
+}) {
+  return (
+    <img
+      src={src}
+      alt={alt}
+      data-slot="provider-brand-icon"
+      className={cn([
+        "object-contain object-center [filter:var(--provider-brand-filter)]",
+        className,
+      ])}
     />
   );
 }
 
 export function ProviderIconSlot({ children }: { children: ReactNode }) {
   return (
-    <span className="flex size-5 shrink-0 items-center justify-center">
+    <span
+      data-slot="provider-icon"
+      className={cn([
+        "text-foreground flex size-5 shrink-0 items-center justify-center",
+        "[&_svg]:block [&_svg]:size-full [&_svg]:text-inherit",
+        "[&_iconify-icon]:text-inherit",
+        "[&_[data-slot=provider-brand-icon]]:[filter:var(--provider-brand-filter)]",
+      ])}
+    >
       {children}
     </span>
   );
@@ -166,21 +197,22 @@ export function NonHyprProviderCard({
       disabled={config.disabled || locked}
       value={config.id}
       className={cn([
-        "rounded-[22px] border-2 bg-neutral-50",
-        isConfigured ? "border-solid border-neutral-300" : "border-dashed",
+        "bg-muted rounded-[22px] border-2",
+        isConfigured ? "border-border border-solid" : "border-dashed",
       ])}
     >
       <AccordionTrigger
         className={cn([
           "gap-2 px-4 capitalize hover:no-underline",
-          (config.disabled || locked) && "cursor-not-allowed opacity-30",
+          (config.disabled || locked) &&
+            "text-muted-foreground cursor-not-allowed",
         ])}
       >
         <div className="flex items-center gap-2">
           <ProviderIconSlot>{config.icon}</ProviderIconSlot>
           <span>{config.displayName}</span>
           {config.badge && (
-            <span className="rounded-full border border-neutral-300 px-2 text-xs font-light text-neutral-500">
+            <span className="border-border text-muted-foreground rounded-full border px-2 text-xs font-light">
               {config.badge}
             </span>
           )}
@@ -225,7 +257,7 @@ export function NonHyprProviderCard({
                   href={config.links.download.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-0.5 text-neutral-600 hover:text-neutral-900 hover:underline"
+                  className="text-muted-foreground hover:text-foreground inline-flex items-center gap-0.5 hover:underline"
                 >
                   {config.links.download.label}
                   <ExternalLink size={12} />
@@ -236,7 +268,7 @@ export function NonHyprProviderCard({
                   href={config.links.models.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-0.5 text-neutral-600 hover:text-neutral-900 hover:underline"
+                  className="text-muted-foreground hover:text-foreground inline-flex items-center gap-0.5 hover:underline"
                 >
                   {config.links.models.label}
                   <ExternalLink size={12} />
@@ -247,7 +279,7 @@ export function NonHyprProviderCard({
                   href={config.links.setup.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-0.5 text-neutral-600 hover:text-neutral-900 hover:underline"
+                  className="text-muted-foreground hover:text-foreground inline-flex items-center gap-0.5 hover:underline"
                 >
                   {config.links.setup.label}
                   <ExternalLink size={12} />
@@ -257,7 +289,7 @@ export function NonHyprProviderCard({
           )}
           {((!showBaseUrl && config.baseUrl) || !showApiKey) && (
             <details className="flex flex-col gap-4 pt-2">
-              <summary className="cursor-pointer text-xs text-neutral-600 hover:text-neutral-900 hover:underline">
+              <summary className="text-muted-foreground hover:text-foreground cursor-pointer text-xs hover:underline">
                 Advanced
               </summary>
               <div className="mt-4 flex flex-col gap-4">
@@ -373,7 +405,7 @@ function FormField({
   return (
     <div className="flex flex-col gap-2">
       <label className="block text-xs font-medium">{label}</label>
-      <InputGroup className="bg-white">
+      <InputGroup className="bg-card">
         <InputGroupInput
           name={field.name}
           type={type}

--- a/apps/desktop/src/settings/ai/shared/model-combobox.tsx
+++ b/apps/desktop/src/settings/ai/shared/model-combobox.tsx
@@ -147,7 +147,7 @@ export function ModelCombobox({
           disabled={disabled || isLoadingModels}
           aria-expanded={open}
           className={cn([
-            "w-full justify-between bg-white font-normal shadow-none focus-visible:ring-0",
+            "bg-card w-full justify-between font-normal shadow-none focus-visible:ring-0",
             "rounded-full px-3",
           ])}
         >
@@ -219,7 +219,7 @@ export function ModelCombobox({
                     }}
                     className={cn([
                       "cursor-pointer",
-                      "hover:bg-neutral-200! focus:bg-neutral-200! aria-selected:bg-transparent",
+                      "hover:bg-accent! focus:bg-accent! aria-selected:bg-transparent",
                     ])}
                   >
                     <span className="truncate">
@@ -247,7 +247,7 @@ export function ModelCombobox({
                       }}
                       className={cn([
                         "cursor-pointer opacity-50",
-                        "hover:bg-neutral-200! focus:bg-neutral-200! aria-selected:bg-transparent",
+                        "hover:bg-accent! focus:bg-accent! aria-selected:bg-transparent",
                       ])}
                     >
                       <Tooltip delayDuration={10}>
@@ -283,7 +283,7 @@ export function ModelCombobox({
                     }}
                     className={cn([
                       "cursor-pointer",
-                      "hover:bg-neutral-200! focus:bg-neutral-200! aria-selected:bg-transparent",
+                      "hover:bg-accent! focus:bg-accent! aria-selected:bg-transparent",
                     ])}
                   >
                     <CirclePlus className="mr-2 h-4 w-4" />

--- a/apps/desktop/src/settings/ai/stt/health.tsx
+++ b/apps/desktop/src/settings/ai/stt/health.tsx
@@ -19,7 +19,7 @@ export function HealthStatusIndicator() {
   const health = useConnectionHealth();
 
   if (health.status === "pending") {
-    return <Spinner size={14} className="shrink-0 text-neutral-400" />;
+    return <Spinner size={14} className="text-muted-foreground shrink-0" />;
   }
 
   return null;

--- a/apps/desktop/src/settings/ai/stt/model-icon.tsx
+++ b/apps/desktop/src/settings/ai/stt/model-icon.tsx
@@ -18,7 +18,7 @@ export function getLocalModelIcon(model: string): ModelIconSpec | null {
     return {
       label: "A",
       title: "Anarlog Pro",
-      className: "border-neutral-200 bg-white text-neutral-700",
+      className: "border-border bg-card text-muted-foreground",
       imageSrc: ANARLOG_ICON_SRC,
       imageClassName: "size-4 object-contain",
     };
@@ -28,7 +28,7 @@ export function getLocalModelIcon(model: string): ModelIconSpec | null {
     return {
       label: "Q",
       title: "Qwen",
-      className: "border-neutral-200 bg-white text-neutral-700",
+      className: "border-border bg-card text-muted-foreground",
       imageSrc: `${MODEL_ICON_ASSET_BASE}/qwen-logo.svg`,
       imageClassName: "size-4 object-contain",
     };
@@ -38,7 +38,7 @@ export function getLocalModelIcon(model: string): ModelIconSpec | null {
     return {
       label: "O",
       title: "Meta Omnilingual",
-      className: "border-neutral-200 bg-white text-neutral-700",
+      className: "border-border bg-card text-muted-foreground",
       imageSrc: `${MODEL_ICON_ASSET_BASE}/meta-logo.svg`,
       imageClassName: "size-4 object-contain",
     };
@@ -48,7 +48,7 @@ export function getLocalModelIcon(model: string): ModelIconSpec | null {
     return {
       label: "W",
       title: "OpenAI Whisper",
-      className: "border-neutral-200 bg-white text-neutral-700",
+      className: "border-border bg-card text-muted-foreground",
       imageSrc: `${MODEL_ICON_ASSET_BASE}/openai-logo.svg`,
       imageClassName: "size-4 object-contain",
     };
@@ -58,7 +58,7 @@ export function getLocalModelIcon(model: string): ModelIconSpec | null {
     return {
       label: "P",
       title: "NVIDIA Parakeet",
-      className: "border-neutral-200 bg-white text-neutral-700",
+      className: "border-border bg-card text-muted-foreground",
       imageSrc: `${MODEL_ICON_ASSET_BASE}/nvidia-logo.svg`,
       imageClassName: "size-4 object-cover object-left",
     };
@@ -98,7 +98,7 @@ export function getLocalModelBackendBadge(model: string): ModelIconSpec | null {
     return {
       label: "NPU",
       title: "Apple NPU",
-      className: "border-neutral-200 bg-neutral-50 text-neutral-600",
+      className: "border-border bg-muted text-muted-foreground",
     };
   }
 

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -46,6 +46,7 @@ import {
   requiresEntitlement,
 } from "~/settings/ai/shared/eligibility";
 import { useConfigValues } from "~/shared/config";
+import { SettingsAlert } from "~/shared/ui/settings-alert";
 import * as settings from "~/store/tinybase/store/settings";
 import {
   isConfiguredSttModel,
@@ -134,18 +135,14 @@ export function SelectProviderAndModel() {
   return (
     <div className="flex flex-col gap-4">
       {!isConfigured && (
-        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3">
-          <span className="text-sm text-red-600">
-            <strong className="font-medium">Transcription model</strong> is
-            needed to make Anarlog listen to your conversations.
-          </span>
-        </div>
+        <SettingsAlert>
+          <strong className="font-medium">Transcription model</strong> is needed
+          to make Anarlog listen to your conversations.
+        </SettingsAlert>
       )}
 
       {hasError && health.message && (
-        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3">
-          <span className="text-sm text-red-600">{health.message}</span>
-        </div>
+        <SettingsAlert>{health.message}</SettingsAlert>
       )}
 
       <h3 className="text-md font-sans font-semibold">Model being used</h3>
@@ -155,7 +152,7 @@ export function SelectProviderAndModel() {
             value={current_stt_provider || ""}
             onValueChange={handleProviderChange}
           >
-            <SelectTrigger className="bg-white shadow-none focus:ring-0">
+            <SelectTrigger className="bg-card shadow-none focus:ring-0">
               <SelectValue placeholder="Select a provider" />
             </SelectTrigger>
             <SelectContent>
@@ -171,20 +168,24 @@ export function SelectProviderAndModel() {
                   <SelectItem
                     key={provider.id}
                     value={provider.id}
-                    disabled={provider.disabled || !configured || locked}
+                    disabled={provider.disabled || locked}
+                    className={cn([
+                      "data-disabled:text-muted-foreground data-disabled:!opacity-100",
+                      !configured && !locked && "text-muted-foreground",
+                    ])}
                   >
                     <div className="flex flex-col gap-0.5">
                       <div className="flex items-center gap-2">
                         <ProviderIconSlot>{provider.icon}</ProviderIconSlot>
                         <span>{provider.displayName}</span>
                         {requiresPro ? (
-                          <span className="rounded-full border border-neutral-200 px-2 py-0.5 text-[10px] tracking-wide text-neutral-500 uppercase">
+                          <span className="border-border text-muted-foreground rounded-full border px-2 py-0.5 text-[10px] tracking-wide uppercase">
                             Pro
                           </span>
                         ) : null}
                       </div>
                       {locked ? (
-                        <span className="text-[11px] text-neutral-500">
+                        <span className="text-muted-foreground text-[11px]">
                           Upgrade to Pro to use this provider.
                         </span>
                       ) : null}
@@ -196,7 +197,7 @@ export function SelectProviderAndModel() {
           </Select>
         </div>
 
-        <span className="text-neutral-500">/</span>
+        <span className="text-muted-foreground">/</span>
 
         {current_stt_provider === "custom" ? (
           <div className="min-w-0 flex-3">
@@ -216,7 +217,7 @@ export function SelectProviderAndModel() {
             >
               <SelectTrigger
                 className={cn([
-                  "bg-white text-left shadow-none focus:ring-0",
+                  "bg-card text-left shadow-none focus:ring-0",
                   "[&>span]:flex [&>span]:w-full [&>span]:items-center [&>span]:justify-between [&>span]:gap-2",
                   isConfigured && "[&>svg:last-child]:hidden",
                 ])}
@@ -243,7 +244,7 @@ export function SelectProviderAndModel() {
                   return (
                     <span key={model.id}>
                       {categoryLabel && (
-                        <div className="px-2 pt-2 pb-1 text-[11px] font-medium tracking-wide text-neutral-400 uppercase">
+                        <div className="text-muted-foreground px-2 pt-2 pb-1 text-[11px] font-medium tracking-wide uppercase">
                           {categoryLabel}
                         </div>
                       )}
@@ -499,14 +500,14 @@ function ModelSelectItem({
               "rounded-md px-1.5 py-0.5 font-medium",
               model.mode === "realtime"
                 ? "bg-sky-50 text-sky-700"
-                : "bg-neutral-100 text-neutral-600",
+                : "bg-muted text-muted-foreground",
             ])}
           >
             {model.mode === "realtime" ? "Realtime" : "Batch"}
           </span>
         )}
         {!model.isDownloaded && sizeLabel && (
-          <span className="font-mono text-neutral-500">{sizeLabel}</span>
+          <span className="text-muted-foreground font-mono">{sizeLabel}</span>
         )}
       </div>
     </div>
@@ -518,7 +519,10 @@ function ModelSelectItem({
         <SelectItem
           key={model.id}
           value={model.id}
-          className={cn([showLocalActions && "pr-20"])}
+          className={cn([
+            showLocalActions && "pr-20",
+            isDeprecated && "text-muted-foreground focus:text-muted-foreground",
+          ])}
         >
           {content}
         </SelectItem>
@@ -552,13 +556,13 @@ function ModelSelectItem({
         "group",
       ])}
     >
-      <div className="min-w-0 flex-1 text-neutral-400">{content}</div>
+      <div className="text-muted-foreground min-w-0 flex-1">{content}</div>
       {isDownloading ? (
         <span
           className={cn([
             "rounded-full px-2 py-0.5 text-[11px] font-medium",
             "flex items-center gap-1",
-            "bg-linear-to-t from-neutral-200 to-neutral-100 text-neutral-500",
+            "from-muted to-accent text-muted-foreground bg-linear-to-t",
           ])}
         >
           <Loader2 className="size-3 animate-spin" />
@@ -571,8 +575,8 @@ function ModelSelectItem({
             "opacity-0 group-hover:opacity-100",
             "transition-all duration-150",
             isCloud
-              ? "bg-linear-to-t from-stone-600 to-stone-500 py-1 text-white shadow-xs hover:shadow-md"
-              : "bg-linear-to-t from-neutral-200 to-neutral-100 py-0.5 text-neutral-900 shadow-xs hover:shadow-md",
+              ? "bg-primary text-primary-foreground hover:bg-primary/90 py-1 shadow-xs hover:shadow-md"
+              : "from-muted to-accent text-foreground bg-linear-to-t py-0.5 shadow-xs hover:shadow-md",
           ])}
           onClick={handleAction}
         >
@@ -588,7 +592,13 @@ function ModelSelectedValue({ model }: { model: ModelEntry }) {
     <LocalModelLabel
       model={model.id}
       label={model.displayName ?? displayModelId(model.id)}
-      className="min-w-0 flex-1"
+      className={cn([
+        "min-w-0 flex-1",
+        model.status === "deprecated" && "opacity-60",
+      ])}
+      labelClassName={cn([
+        model.status === "deprecated" && "text-muted-foreground",
+      ])}
     />
   );
 }
@@ -642,7 +652,7 @@ function LocalModelDropdownActions({ model }: { model: LocalModel }) {
         aria-label="Show in Finder"
         className={cn([
           "flex size-6 items-center justify-center rounded-full",
-          "text-neutral-500 hover:text-neutral-900",
+          "text-muted-foreground hover:text-foreground",
         ])}
         onPointerDown={stopSelect}
         onClick={(event) => {

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -352,6 +352,7 @@ type ModelEntry = {
   id: string;
   isDownloaded: boolean;
   displayName?: string;
+  isDeprecated?: boolean;
   category?: ModelCategory;
   sizeBytes?: number | null;
   mode?: "realtime" | "batch";
@@ -485,6 +486,7 @@ function ModelSelectItem({
   const label = model.displayName ?? displayModelId(model.id);
   const sizeLabel = formatModelSize(model.sizeBytes);
   const showLocalActions = model.isDownloaded && isLocalModelId(model.id);
+  const isDeprecated = model.isDeprecated === true;
   const content = (
     <div className="flex min-w-0 flex-1 items-center justify-between gap-3">
       <LocalModelLabel
@@ -588,17 +590,14 @@ function ModelSelectItem({
 }
 
 function ModelSelectedValue({ model }: { model: ModelEntry }) {
+  const isDeprecated = model.isDeprecated === true;
+
   return (
     <LocalModelLabel
       model={model.id}
       label={model.displayName ?? displayModelId(model.id)}
-      className={cn([
-        "min-w-0 flex-1",
-        model.status === "deprecated" && "opacity-60",
-      ])}
-      labelClassName={cn([
-        model.status === "deprecated" && "text-muted-foreground",
-      ])}
+      className={cn(["min-w-0 flex-1", isDeprecated && "opacity-60"])}
+      labelClassName={cn([isDeprecated && "text-muted-foreground"])}
     />
   );
 }

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -11,7 +11,7 @@ import type { ReactNode } from "react";
 import type { LocalModel } from "@hypr/plugin-local-stt";
 
 import { env } from "~/env";
-import { AnarlogProviderIcon } from "~/settings/ai/shared";
+import { AnarlogProviderIcon, ProviderBrandImage } from "~/settings/ai/shared";
 import { type ProviderRequirement } from "~/settings/ai/shared/eligibility";
 import { sortProviders } from "~/settings/ai/shared/sort-providers";
 import { localSttQueries } from "~/stt/useLocalSttModel";
@@ -123,7 +123,9 @@ const _PROVIDERS = [
     id: "deepgram",
     displayName: "Deepgram",
     badge: null,
-    icon: <Icon icon="simple-icons:deepgram" className="size-4" />,
+    icon: (
+      <Icon icon="simple-icons:deepgram" className="text-foreground size-4" />
+    ),
     baseUrl: "https://api.deepgram.com/v1",
     models: [
       "nova-3-general",
@@ -168,7 +170,7 @@ const _PROVIDERS = [
     displayName: "Gladia",
     badge: null,
     icon: (
-      <img
+      <ProviderBrandImage
         src="/assets/gladia.jpeg"
         alt="Gladia"
         className="size-4 rounded-xs"
@@ -184,7 +186,7 @@ const _PROVIDERS = [
     displayName: "Soniox",
     badge: null,
     icon: (
-      <img
+      <ProviderBrandImage
         src="/assets/soniox-black.png"
         alt="Soniox"
         className="size-5 rounded-xs"
@@ -220,7 +222,7 @@ const _PROVIDERS = [
     displayName: "pyannoteAI",
     badge: "Batch only",
     icon: (
-      <img
+      <ProviderBrandImage
         src="/assets/pyannote-logo-black.png"
         alt="pyannoteAI"
         className="size-4"
@@ -236,13 +238,11 @@ const _PROVIDERS = [
     displayName: "AquaVoice",
     badge: "Batch only",
     icon: (
-      <span className="flex size-4 items-center justify-center">
-        <img
-          src="/assets/aquavoice-black.png"
-          alt="AquaVoice"
-          className="size-3.5 rounded-xs object-contain object-center"
-        />
-      </span>
+      <ProviderBrandImage
+        src="/assets/aquavoice-black.png"
+        alt="AquaVoice"
+        className="size-3.5 rounded-xs"
+      />
     ),
     baseUrl: "https://api.aquavoice.com/api/v1",
     models: ["avalon-v1-en"],
@@ -253,7 +253,9 @@ const _PROVIDERS = [
     id: "custom",
     displayName: "Custom",
     badge: null,
-    icon: <Icon icon="mingcute:random-fill" />,
+    icon: (
+      <Icon icon="mingcute:random-fill" className="text-foreground size-4" />
+    ),
     baseUrl: undefined,
     models: [],
     requirements: [

--- a/apps/desktop/src/settings/data/import-preview.tsx
+++ b/apps/desktop/src/settings/data/import-preview.tsx
@@ -64,7 +64,7 @@ export function ImportPreview({
         </div>
         {hasData ? (
           <TooltipProvider delayDuration={100}>
-            <div className="flex flex-wrap items-center gap-3 text-xs text-neutral-600">
+            <div className="text-muted-foreground flex flex-wrap items-center gap-3 text-xs">
               {statItems.map(({ icon: Icon, label, count }) => (
                 <Tooltip key={label}>
                   <TooltipTrigger asChild>
@@ -79,7 +79,9 @@ export function ImportPreview({
             </div>
           </TooltipProvider>
         ) : (
-          <p className="text-xs text-neutral-500">No data found to import.</p>
+          <p className="text-muted-foreground text-xs">
+            No data found to import.
+          </p>
         )}
       </div>
       <div className="flex shrink-0 items-center gap-2">

--- a/apps/desktop/src/settings/data/index.tsx
+++ b/apps/desktop/src/settings/data/index.tsx
@@ -100,7 +100,7 @@ export function Data() {
 
   return (
     <div>
-      <StyledStreamdown className="text-neutral-500">
+      <StyledStreamdown className="text-muted-foreground">
         {
           "Import data from other apps. Read more about [import](https://char.com/docs/data/#import) and [export](https://char.com/docs/data/#export)."
         }

--- a/apps/desktop/src/settings/data/source-item.tsx
+++ b/apps/desktop/src/settings/data/source-item.tsx
@@ -21,12 +21,12 @@ export function SourceItem({
     <div className="flex items-center justify-between gap-4">
       <div className="min-w-0 flex-1">
         <h3 className="mb-1 text-sm font-medium">{source.name}</h3>
-        <p className="text-xs text-neutral-600">
+        <p className="text-muted-foreground text-xs">
           Import data from `
           <button
             type="button"
             onClick={() => openerCommands.revealItemInDir(source.revealPath)}
-            className="cursor-pointer underline hover:text-neutral-900"
+            className="hover:text-foreground cursor-pointer underline"
           >
             {source.path}
           </button>

--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -81,7 +81,7 @@ export function SettingsAccount() {
               </Button>
             }
           >
-            <p className="text-xs text-neutral-500">
+            <p className="text-muted-foreground text-xs">
               If the browser does not reopen Anarlog, use the paste-link
               fallback in the sign-in instruction window.
             </p>
@@ -98,7 +98,7 @@ export function SettingsAccount() {
             <div className="flex min-w-0 flex-1 flex-col gap-4">
               <div className="flex flex-col gap-2">
                 <h3 className="text-sm font-medium">Sign in to Anarlog</h3>
-                <div className="text-sm text-neutral-600">
+                <div className="text-muted-foreground text-sm">
                   Sign in to unlock cloud transcription and AI models, plus Pro
                   features like sharing.
                 </div>
@@ -106,7 +106,7 @@ export function SettingsAccount() {
               <button
                 type="button"
                 onClick={handleSignIn}
-                className="h-10 w-fit rounded-full border-2 border-stone-600 bg-stone-800 px-6 text-sm font-medium text-white shadow-[0_4px_14px_rgba(87,83,78,0.4)] transition-all duration-200 hover:bg-stone-700"
+                className="border-primary bg-primary text-primary-foreground hover:bg-primary/90 h-10 w-fit rounded-full border-2 px-6 text-sm font-medium shadow-[0_4px_14px_rgba(87,83,78,0.4)] transition-all duration-200"
               >
                 Get started
               </button>
@@ -133,7 +133,7 @@ export function SettingsAccount() {
             onClick={() => signOutMutation.mutate()}
             disabled={signOutMutation.isPending}
             className={cn([
-              "border-red-200 text-red-700 hover:border-red-300 hover:bg-red-50 hover:text-red-800",
+              "border-alert-border text-alert-foreground hover:bg-alert hover:text-alert-foreground",
             ])}
           >
             {signOutMutation.isPending ? "Signing out..." : "Sign out"}
@@ -226,7 +226,9 @@ function PlanBillingSection({
       if (compact) {
         if (!isPaid) {
           return (
-            <span className="text-xs text-neutral-400">{action.label}</span>
+            <span className="text-muted-foreground text-xs">
+              {action.label}
+            </span>
           );
         }
 
@@ -236,7 +238,7 @@ function PlanBillingSection({
             onClick={handleOpenBillingPortal}
             disabled={actionPending}
             className={cn([
-              "group relative min-w-[88px] text-xs font-medium text-neutral-500 transition-colors hover:text-neutral-700 disabled:opacity-50",
+              "group text-muted-foreground hover:text-muted-foreground relative min-w-[88px] text-xs font-medium transition-colors disabled:opacity-50",
             ])}
           >
             <span className="block transition-opacity duration-150 group-hover:opacity-0">
@@ -251,7 +253,7 @@ function PlanBillingSection({
 
       if (!isPaid) {
         return (
-          <div className="flex h-8 w-full items-center justify-center rounded-full border border-neutral-200 bg-neutral-50 text-xs text-neutral-500">
+          <div className="border-border bg-muted text-muted-foreground flex h-8 w-full items-center justify-center rounded-full border text-xs">
             {action.label}
           </div>
         );
@@ -263,7 +265,7 @@ function PlanBillingSection({
           onClick={handleOpenBillingPortal}
           disabled={actionPending}
           className={cn([
-            "group relative flex h-8 w-full items-center justify-center overflow-hidden rounded-full border border-neutral-300 bg-linear-to-b from-white to-stone-50 text-xs font-medium text-neutral-600 shadow-xs transition-all hover:scale-[102%] hover:shadow-md active:scale-[98%] disabled:opacity-50 disabled:hover:scale-100",
+            "group border-border from-card to-background text-muted-foreground relative flex h-8 w-full items-center justify-center overflow-hidden rounded-full border bg-linear-to-b text-xs font-medium shadow-xs transition-all hover:scale-[102%] hover:shadow-md active:scale-[98%] disabled:opacity-50 disabled:hover:scale-100",
           ])}
         >
           <span className="transition-opacity duration-150 group-hover:opacity-0">
@@ -321,8 +323,8 @@ function PlanBillingSection({
           className={cn([
             "text-xs font-medium transition-colors",
             isUpgrade
-              ? "text-stone-600 hover:text-stone-800"
-              : "text-neutral-500 hover:text-neutral-700",
+              ? "text-muted-foreground hover:text-foreground"
+              : "text-muted-foreground hover:text-muted-foreground",
           ])}
         >
           {label}
@@ -333,8 +335,8 @@ function PlanBillingSection({
     const buttonClass = cn([
       "flex h-8 w-full cursor-pointer items-center justify-center rounded-full text-xs font-medium transition-all hover:scale-[102%] active:scale-[98%] disabled:opacity-50 disabled:hover:scale-100",
       isUpgrade
-        ? "bg-linear-to-t from-stone-600 to-stone-500 text-white shadow-md hover:shadow-lg"
-        : "border border-neutral-300 bg-linear-to-b from-white to-stone-50 text-neutral-700 shadow-xs hover:shadow-md",
+        ? "bg-primary text-primary-foreground hover:bg-primary/90 shadow-md hover:shadow-lg"
+        : "border-border from-card to-background text-muted-foreground border bg-linear-to-b shadow-xs hover:shadow-md",
     ]);
 
     return (
@@ -357,7 +359,7 @@ function PlanBillingSection({
           <button
             type="button"
             onClick={handleOpenBillingPortal}
-            className="text-xs text-neutral-500 transition-colors hover:text-neutral-700"
+            className="text-muted-foreground hover:text-muted-foreground text-xs transition-colors"
           >
             Manage billing
           </button>
@@ -365,7 +367,7 @@ function PlanBillingSection({
       </div>
 
       <div className="mb-4 flex items-center gap-2">
-        <p className="text-sm text-neutral-600">{statusText}</p>
+        <p className="text-muted-foreground text-sm">{statusText}</p>
         <RefreshBillingButton />
       </div>
 
@@ -385,11 +387,13 @@ function GuestPlanSection({ onSignIn }: { onSignIn: () => Promise<void> }) {
 
     if (action.style === "current") {
       if (compact) {
-        return <span className="text-xs text-neutral-400">{action.label}</span>;
+        return (
+          <span className="text-muted-foreground text-xs">{action.label}</span>
+        );
       }
 
       return (
-        <div className="flex h-8 w-full items-center justify-center rounded-full border border-neutral-200 bg-neutral-50 text-xs text-neutral-500">
+        <div className="border-border bg-muted text-muted-foreground flex h-8 w-full items-center justify-center rounded-full border text-xs">
           {action.label}
         </div>
       );
@@ -407,7 +411,7 @@ function GuestPlanSection({ onSignIn }: { onSignIn: () => Promise<void> }) {
         <button
           type="button"
           onClick={onSignIn}
-          className="text-xs font-medium text-stone-600 transition-colors hover:text-stone-800"
+          className="text-muted-foreground hover:text-foreground text-xs font-medium transition-colors"
         >
           Sign in
         </button>
@@ -418,7 +422,7 @@ function GuestPlanSection({ onSignIn }: { onSignIn: () => Promise<void> }) {
       <button
         type="button"
         onClick={onSignIn}
-        className="flex h-8 w-full cursor-pointer items-center justify-center rounded-full bg-linear-to-t from-stone-600 to-stone-500 text-xs font-medium text-white shadow-md transition-all hover:scale-[102%] hover:shadow-lg active:scale-[98%]"
+        className="bg-primary text-primary-foreground hover:bg-primary/90 flex h-8 w-full cursor-pointer items-center justify-center rounded-full text-xs font-medium shadow-md transition-all hover:scale-[102%] hover:shadow-lg active:scale-[98%]"
       >
         {label}
       </button>
@@ -426,10 +430,10 @@ function GuestPlanSection({ onSignIn }: { onSignIn: () => Promise<void> }) {
   };
 
   return (
-    <section className="border-t border-neutral-100 pt-6">
+    <section className="border-border border-t pt-6">
       <div className="mb-4 flex flex-col gap-1">
         <h2 className="font-sans text-lg font-semibold">Plans</h2>
-        <p className="text-sm text-neutral-600">
+        <p className="text-muted-foreground text-sm">
           Compare Free, Lite, and Pro before you sign in.
         </p>
       </div>
@@ -472,7 +476,7 @@ function PlanTierList({
   return (
     <div ref={containerRef}>
       {isWide ? (
-        <div className="grid grid-cols-3 divide-x divide-neutral-100 border-t border-neutral-100">
+        <div className="divide-border border-border grid grid-cols-3 divide-x border-t">
           {PLAN_TIERS.map((tier) => {
             const isCurrent = tier.id === currentTier;
             const action = getActionForTier(
@@ -486,31 +490,31 @@ function PlanTierList({
                 key={tier.id}
                 className={cn([
                   "flex flex-col p-3",
-                  isCurrent && "bg-stone-50/60",
+                  isCurrent && "bg-background/60",
                 ])}
               >
                 <div className="mb-2 flex items-center gap-2">
-                  <span className="font-sans text-base font-medium text-stone-800">
+                  <span className="text-foreground font-sans text-base font-medium">
                     {tier.name}
                   </span>
                   {isCurrent && isTrialing && (
-                    <span className="rounded-full bg-stone-600 px-2 py-0.5 text-[10px] font-medium tracking-wide text-white uppercase">
+                    <span className="bg-primary text-primary-foreground rounded-full px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase">
                       Trial
                     </span>
                   )}
                 </div>
 
                 <div className="mb-2">
-                  <span className="font-sans text-xl text-stone-700">
+                  <span className="text-muted-foreground font-sans text-xl">
                     {tier.price}
                   </span>
                   {tier.period && (
-                    <span className="ml-1 text-sm text-neutral-500">
+                    <span className="text-muted-foreground ml-1 text-sm">
                       {tier.period}
                     </span>
                   )}
                   {tier.subtitle && (
-                    <div className="mt-0.5 text-xs text-neutral-400">
+                    <div className="text-muted-foreground mt-0.5 text-xs">
                       {tier.subtitle}
                     </div>
                   )}
@@ -539,21 +543,21 @@ function PlanTierList({
               <div
                 key={tier.id}
                 className={cn([
-                  "border-b border-neutral-100 py-3 last:border-b-0",
-                  isCurrent && "-mx-2 rounded-md bg-stone-50/60 px-2",
+                  "border-border border-b py-3 last:border-b-0",
+                  isCurrent && "bg-background/60 -mx-2 rounded-md px-2",
                 ])}
               >
                 <div className="flex items-center justify-between gap-3">
                   <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-                    <span className="text-sm font-medium text-stone-800">
+                    <span className="text-foreground text-sm font-medium">
                       {tier.name}
                     </span>
-                    <span className="text-sm text-neutral-500">
+                    <span className="text-muted-foreground text-sm">
                       {tier.price}
                       {tier.period}
                     </span>
                     {isCurrent && isTrialing && (
-                      <span className="rounded-full bg-stone-600 px-1.5 py-px text-[10px] font-medium tracking-wide text-white uppercase">
+                      <span className="bg-primary text-primary-foreground rounded-full px-1.5 py-px text-[10px] font-medium tracking-wide uppercase">
                         Trial
                       </span>
                     )}
@@ -582,7 +586,7 @@ function RefreshBillingButton() {
     <button
       type="button"
       onClick={handleClick}
-      className="text-neutral-400 transition-colors hover:text-neutral-600"
+      className="text-muted-foreground hover:text-muted-foreground transition-colors"
       aria-label="Refresh billing status"
     >
       <RefreshCw className="size-3" />
@@ -602,12 +606,12 @@ function Container({
   children?: ReactNode;
 }) {
   return (
-    <section className="border-b border-neutral-200 pb-4 last:border-b-0">
+    <section className="border-border border-b pb-4 last:border-b-0">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex min-w-0 flex-1 flex-col gap-2">
           <h3 className="text-sm font-medium">{title}</h3>
           {description && (
-            <div className="text-sm text-neutral-600">{description}</div>
+            <div className="text-muted-foreground text-sm">{description}</div>
           )}
         </div>
         {action ? <div className="shrink-0">{action}</div> : null}

--- a/apps/desktop/src/settings/general/app-settings.tsx
+++ b/apps/desktop/src/settings/general/app-settings.tsx
@@ -95,7 +95,7 @@ function SettingRow({
     <div className="flex items-center justify-between gap-4">
       <div className="flex-1">
         <h3 className="mb-1 text-sm font-medium">{title}</h3>
-        <p className="text-xs text-neutral-600">{description}</p>
+        <p className="text-muted-foreground text-xs">{description}</p>
       </div>
       <Switch checked={checked} onCheckedChange={onChange} aria-label={title} />
     </div>

--- a/apps/desktop/src/settings/general/index.tsx
+++ b/apps/desktop/src/settings/general/index.tsx
@@ -16,6 +16,7 @@ import { NotificationSettingsView } from "./notification";
 import { Permissions } from "./permissions";
 import { SpokenLanguagesView } from "./spoken-languages";
 import { StorageSettingsView } from "./storage";
+import { ThemeSelector } from "./theme";
 import { TimezoneSelector } from "./timezone";
 import { WeekStartSelector } from "./week-start";
 
@@ -134,6 +135,7 @@ export function SettingsApp() {
   return (
     <div className="flex flex-col gap-8">
       <SettingsPageTitle title={t`App`} />
+      <ThemeSelector />
       <form.Field name="autostart">
         {(autostartField) => (
           <form.Field name="auto_start_scheduled_meetings">

--- a/apps/desktop/src/settings/general/main-language.tsx
+++ b/apps/desktop/src/settings/general/main-language.tsx
@@ -49,7 +49,7 @@ export function MainLanguageView({
         <h3 className="mb-1 text-sm font-medium">
           <Trans>Main language</Trans>
         </h3>
-        <p className="text-xs text-neutral-600">
+        <p className="text-muted-foreground text-xs">
           <Trans>
             Language for summaries, chats, and AI-generated responses
           </Trans>

--- a/apps/desktop/src/settings/general/notification.tsx
+++ b/apps/desktop/src/settings/general/notification.tsx
@@ -208,7 +208,7 @@ export function NotificationSettingsView() {
           <div className="flex items-start justify-between gap-4">
             <div className="flex-1">
               <h3 className="mb-1 text-sm font-medium">Event notifications</h3>
-              <p className="text-xs text-neutral-600">
+              <p className="text-muted-foreground text-xs">
                 Get notified 5 minutes before calendar events start
               </p>
             </div>
@@ -228,7 +228,7 @@ export function NotificationSettingsView() {
                 <h3 className="mb-1 text-sm font-medium">
                   Microphone detection
                 </h3>
-                <p className="text-xs text-neutral-600">
+                <p className="text-muted-foreground text-xs">
                   Automatically detect when a meeting starts based on microphone
                   activity.
                 </p>
@@ -246,7 +246,7 @@ export function NotificationSettingsView() {
                     <div className="mb-4 flex items-center justify-between gap-4">
                       <div className="flex-1">
                         <h4 className="text-sm font-medium">Detection delay</h4>
-                        <p className="text-xs text-neutral-600">
+                        <p className="text-muted-foreground text-xs">
                           How long the mic must be active before triggering
                         </p>
                       </div>
@@ -276,7 +276,7 @@ export function NotificationSettingsView() {
                   <h4 className="text-sm font-medium">
                     Exclude apps from detection
                   </h4>
-                  <p className="text-xs text-neutral-600">
+                  <p className="text-muted-foreground text-xs">
                     Search installed apps to exclude them. Click an excluded app
                     to include it again.
                   </p>
@@ -308,7 +308,7 @@ export function NotificationSettingsView() {
                               className={cn([
                                 "flex items-center gap-1 px-2 py-0.5 text-xs",
                                 isDefault
-                                  ? ["bg-neutral-200 text-neutral-700"]
+                                  ? ["bg-accent text-muted-foreground"]
                                   : ["bg-muted"],
                               ])}
                               title={isDefault ? "default" : undefined}
@@ -367,7 +367,7 @@ export function NotificationSettingsView() {
                                   }
                                   className={cn([
                                     "cursor-pointer",
-                                    "hover:bg-neutral-200! focus:bg-neutral-200! aria-selected:bg-transparent",
+                                    "hover:bg-accent! focus:bg-accent! aria-selected:bg-transparent",
                                   ])}
                                 >
                                   <span className="flex-1 truncate">
@@ -403,7 +403,7 @@ export function NotificationSettingsView() {
                 <h3 className="mb-1 text-sm font-medium">
                   Respect Do-Not-Disturb mode
                 </h3>
-                <p className="text-xs text-neutral-600">
+                <p className="text-muted-foreground text-xs">
                   Don't show notifications when Do-Not-Disturb is enabled on
                   your system
                 </p>

--- a/apps/desktop/src/settings/general/permissions.tsx
+++ b/apps/desktop/src/settings/general/permissions.tsx
@@ -22,7 +22,7 @@ function ActionLink({
       onClick={onClick}
       disabled={disabled}
       className={cn([
-        "underline transition-colors hover:text-neutral-900",
+        "hover:text-foreground underline transition-colors",
         disabled && "cursor-not-allowed opacity-50",
       ])}
     >
@@ -72,14 +72,14 @@ function PermissionRow({
           {!isAuthorized && <AlertCircleIcon className="size-4" />}
           <h3 className="text-sm font-medium">{title}</h3>
         </div>
-        <div className="text-xs text-neutral-600">
+        <div className="text-muted-foreground text-xs">
           {!showActions ? (
             <div>
               {!isAuthorized && <span>{description} · </span>}
               <button
                 type="button"
                 onClick={() => setShowActions(true)}
-                className="underline transition-colors hover:text-neutral-900"
+                className="hover:text-foreground underline transition-colors"
               >
                 Having trouble?
               </button>
@@ -109,7 +109,7 @@ function PermissionRow({
         disabled={isPending}
         className={cn([
           "size-8",
-          isAuthorized && "bg-stone-100 text-stone-800 hover:bg-stone-200",
+          isAuthorized && "bg-muted text-foreground hover:bg-accent",
         ])}
         aria-label={
           isAuthorized
@@ -136,7 +136,7 @@ function PermissionGroup({
 }) {
   return (
     <div>
-      <h3 className="mb-3 text-xs font-semibold tracking-wide text-neutral-500 uppercase">
+      <h3 className="text-muted-foreground mb-3 text-xs font-semibold tracking-wide uppercase">
         {title}
       </h3>
       <div className="flex flex-col gap-4">{children}</div>

--- a/apps/desktop/src/settings/general/searchable-select.tsx
+++ b/apps/desktop/src/settings/general/searchable-select.tsx
@@ -80,7 +80,7 @@ export function SearchableSelect({
           role="combobox"
           aria-expanded={open}
           className={cn([
-            "justify-between bg-white font-normal shadow-none focus-visible:ring-0",
+            "bg-card justify-between font-normal shadow-none focus-visible:ring-0",
             "rounded-full px-3",
             className,
           ])}
@@ -133,12 +133,12 @@ export function SearchableSelect({
                     onSelect={() => handleSelect(option.value)}
                     className={cn([
                       "cursor-pointer",
-                      "hover:bg-neutral-200! focus:bg-neutral-200! aria-selected:bg-transparent",
+                      "hover:bg-accent! focus:bg-accent! aria-selected:bg-transparent",
                     ])}
                   >
                     <span className="flex-1 truncate">{option.label}</span>
                     {option.detail && (
-                      <span className="shrink-0 font-mono text-[10px] text-neutral-400">
+                      <span className="text-muted-foreground shrink-0 font-mono text-[10px]">
                         {option.detail}
                       </span>
                     )}

--- a/apps/desktop/src/settings/general/spoken-languages.tsx
+++ b/apps/desktop/src/settings/general/spoken-languages.tsx
@@ -115,14 +115,14 @@ export function SpokenLanguagesView({
       <h3 className="mb-1 text-sm font-medium">
         <Trans>Additional spoken languages</Trans>
       </h3>
-      <p className="mb-3 text-xs text-neutral-600">
+      <p className="text-muted-foreground mb-3 text-xs">
         <Trans>The main language is always included for transcription</Trans>
       </p>
       <div className="relative">
         <div
           className={cn([
-            "flex min-h-[38px] w-full flex-wrap items-center gap-1.5 rounded-2xl border border-neutral-200 bg-white px-2 py-1.5 focus-within:border-neutral-300",
-            languageInputFocused && "border-neutral-300",
+            "border-border bg-card focus-within:border-border flex min-h-[38px] w-full flex-wrap items-center gap-1.5 rounded-2xl border px-2 py-1.5",
+            languageInputFocused && "border-border",
           ])}
           onClick={() =>
             document.getElementById("language-search-input")?.focus()
@@ -150,7 +150,7 @@ export function SpokenLanguagesView({
             </Badge>
           ))}
           {selectedLanguageCodes.length === 0 && (
-            <Search className="size-4 shrink-0 text-neutral-700" />
+            <Search className="text-muted-foreground size-4 shrink-0" />
           )}
           <input
             id="language-search-input"
@@ -176,7 +176,7 @@ export function SpokenLanguagesView({
             placeholder={
               selectedLanguageCodes.length === 0 ? t`Add language` : ""
             }
-            className="min-w-[120px] flex-1 bg-transparent text-sm placeholder:text-neutral-500 focus:outline-hidden"
+            className="placeholder:text-muted-foreground min-w-[120px] flex-1 bg-transparent text-sm focus:outline-hidden"
           />
         </div>
 
@@ -184,7 +184,7 @@ export function SpokenLanguagesView({
           <div
             id="language-options"
             role="listbox"
-            className="absolute top-full right-0 left-0 z-10 mt-1 flex max-h-60 w-full flex-col overflow-hidden overflow-y-auto rounded-2xl border border-neutral-200 bg-white shadow-md"
+            className="border-border bg-card absolute top-full right-0 left-0 z-10 mt-1 flex max-h-60 w-full flex-col overflow-hidden overflow-y-auto rounded-2xl border shadow-md"
           >
             {filteredLanguages.length > 0 ? (
               filteredLanguages.map((langCode, index) => (
@@ -204,8 +204,8 @@ export function SpokenLanguagesView({
                   className={cn([
                     "flex w-full items-center justify-between px-3 py-2 text-left text-sm transition-colors",
                     languageSelectedIndex === index
-                      ? "bg-neutral-200"
-                      : "hover:bg-neutral-100",
+                      ? "bg-accent"
+                      : "hover:bg-accent",
                   ])}
                 >
                   <span className="truncate font-medium">
@@ -214,7 +214,7 @@ export function SpokenLanguagesView({
                 </button>
               ))
             ) : (
-              <div className="px-3 py-2 text-center text-sm text-neutral-500">
+              <div className="text-muted-foreground px-3 py-2 text-center text-sm">
                 <Trans>No matching languages found</Trans>
               </div>
             )}

--- a/apps/desktop/src/settings/general/storage/index.tsx
+++ b/apps/desktop/src/settings/general/storage/index.tsx
@@ -158,17 +158,19 @@ function AudioRetentionRow() {
   return (
     <div className="flex items-center gap-3">
       <div className="flex w-24 shrink-0 cursor-default items-center gap-2">
-        <Settings2Icon className="size-4 text-neutral-500" />
+        <Settings2Icon className="text-muted-foreground size-4" />
         <span className="text-sm font-medium">Audio</span>
       </div>
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm text-neutral-700">
+        <p className="text-muted-foreground truncate text-sm">
           Save audio after meeting
         </p>
-        <p className="text-xs text-neutral-500">{selectedOption.description}</p>
+        <p className="text-muted-foreground text-xs">
+          {selectedOption.description}
+        </p>
       </div>
       <Select value={audioRetention} onValueChange={setAudioRetention}>
-        <SelectTrigger className="w-36 bg-white shadow-none focus:ring-0">
+        <SelectTrigger className="bg-card w-36 shadow-none focus:ring-0">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -270,12 +272,12 @@ function ChangeContentPathDialog({
               className={cn([
                 "flex items-center gap-3 rounded-lg border px-3 py-2",
                 isNewPathChosen && isNewPathEmpty === false
-                  ? "border-yellow-400 bg-neutral-50"
-                  : "border-neutral-900",
+                  ? "bg-muted border-yellow-400"
+                  : "border-foreground",
               ])}
             >
               <div className="min-w-0 flex-1">
-                <p className="text-sm text-neutral-700">
+                <p className="text-muted-foreground text-sm">
                   {selectedPath
                     ? displayPath(selectedPath, home)
                     : displayPath(currentPath, home)}
@@ -306,7 +308,7 @@ function ChangeContentPathDialog({
                   <button
                     key={vault.path}
                     onClick={() => selectPath(vault.path)}
-                    className="flex cursor-pointer items-center gap-2 rounded-full border border-neutral-200 bg-neutral-50 px-3 py-2 text-left text-sm text-neutral-500 transition-colors hover:bg-neutral-100"
+                    className="border-border bg-muted text-muted-foreground hover:bg-accent flex cursor-pointer items-center gap-2 rounded-full border px-3 py-2 text-left text-sm transition-colors"
                   >
                     <img
                       src="/assets/obsidian-icon.svg"
@@ -334,10 +336,10 @@ function ChangeContentPathDialog({
                   onCheckedChange={(v) => setMoveVault(v === true)}
                 />
                 <div className="flex flex-row gap-1">
-                  <span className="text-sm font-semibold text-neutral-600">
+                  <span className="text-muted-foreground text-sm font-semibold">
                     Move
                   </span>
-                  <span className="text-sm text-neutral-600">
+                  <span className="text-muted-foreground text-sm">
                     existing data to new location
                   </span>
                 </div>
@@ -394,7 +396,7 @@ function StoragePathRow({
       <Tooltip delayDuration={0}>
         <TooltipTrigger asChild>
           <div className="flex w-24 shrink-0 cursor-default items-center gap-2">
-            <Icon className="size-4 text-neutral-500" />
+            <Icon className="text-muted-foreground size-4" />
             <span className="text-sm font-medium">{title}</span>
           </div>
         </TooltipTrigger>
@@ -404,7 +406,7 @@ function StoragePathRow({
       </Tooltip>
       <button
         onClick={() => path && openerCommands.openPath(path, null)}
-        className="min-w-0 flex-1 cursor-pointer truncate text-left text-sm text-neutral-500 hover:underline"
+        className="text-muted-foreground min-w-0 flex-1 cursor-pointer truncate text-left text-sm hover:underline"
       >
         {displayPath(path, home)}
       </button>

--- a/apps/desktop/src/settings/general/storage/obsidian-vault-list.tsx
+++ b/apps/desktop/src/settings/general/storage/obsidian-vault-list.tsx
@@ -19,7 +19,7 @@ export function ObsidianVaultList({
 
   return (
     <div className="flex flex-col gap-1.5">
-      <p className="text-xs font-medium text-neutral-400">
+      <p className="text-muted-foreground text-xs font-medium">
         Detected Obsidian vaults
       </p>
       {vaults.map((vault) => (
@@ -28,7 +28,7 @@ export function ObsidianVaultList({
           disabled={disabled}
           onClick={() => onSelect(vault.path)}
           className={cn([
-            "flex items-center gap-2 rounded-full border border-neutral-200 bg-neutral-50 px-3 py-2 text-left text-sm text-neutral-500 transition-colors hover:border-neutral-300 hover:bg-neutral-100 disabled:opacity-50",
+            "border-border bg-muted text-muted-foreground hover:border-border hover:bg-accent flex items-center gap-2 rounded-full border px-3 py-2 text-left text-sm transition-colors disabled:opacity-50",
           ])}
         >
           <img
@@ -40,7 +40,7 @@ export function ObsidianVaultList({
             {displayPath(vault.path, home)}
           </span>
           {actionLabel && (
-            <span className="shrink-0 text-xs text-neutral-400">
+            <span className="text-muted-foreground shrink-0 text-xs">
               {actionLabel}
             </span>
           )}

--- a/apps/desktop/src/settings/general/theme.tsx
+++ b/apps/desktop/src/settings/general/theme.tsx
@@ -1,0 +1,62 @@
+import { Trans, useLingui } from "@lingui/react/macro";
+import { useMemo } from "react";
+
+import {
+  SearchableSelect,
+  type SearchableSelectOption,
+} from "./searchable-select";
+
+import { useConfigValue } from "~/shared/config";
+import {
+  applyDocumentTheme,
+  writeStoredThemePreference,
+} from "~/shared/theme/apply";
+import type { ThemePreference } from "~/shared/theme/resolve";
+import * as settings from "~/store/tinybase/store/settings";
+
+const THEME_OPTIONS: ThemePreference[] = ["light", "dark", "system"];
+
+export function ThemeSelector() {
+  const { t } = useLingui();
+  const value = useConfigValue("theme") as ThemePreference;
+  const setTheme = settings.UI.useSetValueCallback(
+    "theme",
+    (next: string) => next,
+    [],
+    settings.STORE_ID,
+  );
+
+  const options: SearchableSelectOption[] = useMemo(
+    () => [
+      { value: "light", label: t`Light` },
+      { value: "dark", label: t`Dark` },
+      { value: "system", label: t`System` },
+    ],
+    [t],
+  );
+
+  return (
+    <div className="flex flex-row items-center justify-between">
+      <div>
+        <h3 className="mb-1 text-sm font-medium">
+          <Trans>Appearance</Trans>
+        </h3>
+        <p className="text-muted-foreground text-xs">
+          <Trans>Choose light, dark, or match your system setting.</Trans>
+        </p>
+      </div>
+      <SearchableSelect
+        value={THEME_OPTIONS.includes(value) ? value : "system"}
+        onChange={(next) => {
+          const preference = next as ThemePreference;
+          writeStoredThemePreference(preference);
+          applyDocumentTheme(preference);
+          setTheme(next);
+        }}
+        options={options}
+        placeholder={t`Select appearance`}
+        className="w-40"
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/settings/general/timezone.tsx
+++ b/apps/desktop/src/settings/general/timezone.tsx
@@ -58,7 +58,7 @@ export function TimezoneSelector() {
     <div className="flex flex-row items-center justify-between">
       <div>
         <h3 className="mb-1 text-sm font-medium">Timezone</h3>
-        <p className="text-xs text-neutral-600">
+        <p className="text-muted-foreground text-xs">
           Override the timezone used for the sidebar timeline
         </p>
       </div>

--- a/apps/desktop/src/settings/general/week-start.tsx
+++ b/apps/desktop/src/settings/general/week-start.tsx
@@ -47,7 +47,7 @@ export function WeekStartSelector() {
     <div className="flex flex-row items-center justify-between">
       <div>
         <h3 className="mb-1 text-sm font-medium">Week starts on</h3>
-        <p className="text-xs text-neutral-600">
+        <p className="text-muted-foreground text-xs">
           First day of the week in the calendar view
         </p>
       </div>

--- a/apps/desktop/src/settings/todo/filter-field.tsx
+++ b/apps/desktop/src/settings/todo/filter-field.tsx
@@ -56,7 +56,7 @@ export function TodoFilterField({
     <div className="flex items-center justify-between gap-4">
       <div className="flex-1">
         <h3 className="mb-1 text-sm font-medium">{label}</h3>
-        <p className="text-xs text-neutral-500">{description}</p>
+        <p className="text-muted-foreground text-xs">{description}</p>
         {invalidMessage ? (
           <p className="mt-2 text-xs text-red-600">{invalidMessage}</p>
         ) : null}

--- a/apps/desktop/src/settings/todo/github.tsx
+++ b/apps/desktop/src/settings/todo/github.tsx
@@ -96,7 +96,7 @@ export function GitHubTodoProviderContent({
 
   return (
     <div className="flex flex-col gap-4">
-      <p className="text-xs text-neutral-400">
+      <p className="text-muted-foreground text-xs">
         Only public repositories are supported.{" "}
         {!auth.session ? (
           <span>Sign in for private repo access.</span>
@@ -104,7 +104,7 @@ export function GitHubTodoProviderContent({
           <button
             type="button"
             onClick={upgradeToPro}
-            className="underline transition-colors hover:text-neutral-700"
+            className="hover:text-muted-foreground underline transition-colors"
           >
             Upgrade for private repos.
           </button>
@@ -119,7 +119,7 @@ export function GitHubTodoProviderContent({
                 "todo",
               )
             }
-            className="underline transition-colors hover:text-neutral-700"
+            className="hover:text-muted-foreground underline transition-colors"
           >
             Connect GitHub for private repos.
           </button>
@@ -134,7 +134,7 @@ export function GitHubTodoProviderContent({
                 "todo",
               )
             }
-            className="underline transition-colors hover:text-neutral-700"
+            className="hover:text-muted-foreground underline transition-colors"
           >
             Disconnect private repo access.
           </button>
@@ -143,7 +143,7 @@ export function GitHubTodoProviderContent({
 
       {hasRepository && !showAddInput ? (
         <div className="flex items-center gap-2">
-          <span className="text-sm text-neutral-700">
+          <span className="text-muted-foreground text-sm">
             {normalizedRepository}
           </span>
           <button
@@ -154,14 +154,14 @@ export function GitHubTodoProviderContent({
                 null,
               )
             }
-            className="text-neutral-400 transition-colors hover:text-neutral-700"
+            className="text-muted-foreground hover:text-muted-foreground transition-colors"
           >
             <ExternalLinkIcon className="size-3.5" />
           </button>
           <button
             type="button"
             onClick={() => setRepository("")}
-            className="text-neutral-400 transition-colors hover:text-neutral-700"
+            className="text-muted-foreground hover:text-muted-foreground transition-colors"
           >
             <XIcon className="size-3.5" />
           </button>
@@ -195,7 +195,7 @@ export function GitHubTodoProviderContent({
               <button
                 type="submit"
                 disabled={!isValidInput}
-                className="text-xs text-neutral-600 underline transition-colors hover:text-neutral-900 disabled:cursor-not-allowed disabled:opacity-40"
+                className="text-muted-foreground hover:text-foreground text-xs underline transition-colors disabled:cursor-not-allowed disabled:opacity-40"
               >
                 Add
               </button>
@@ -206,7 +206,7 @@ export function GitHubTodoProviderContent({
                   setInputValue("");
                   setDebouncedInput("");
                 }}
-                className="text-xs text-neutral-400 underline transition-colors hover:text-neutral-600"
+                className="text-muted-foreground hover:text-muted-foreground text-xs underline transition-colors"
               >
                 Cancel
               </button>
@@ -224,8 +224,8 @@ export function GitHubTodoProviderContent({
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={() => handleSelect(repo)}
                 className={cn([
-                  "flex w-full items-center px-3 py-1.5 text-left text-sm text-neutral-700",
-                  "transition-colors hover:bg-neutral-50",
+                  "text-muted-foreground flex w-full items-center px-3 py-1.5 text-left text-sm",
+                  "hover:bg-accent transition-colors",
                 ])}
               >
                 {repo}
@@ -237,7 +237,7 @@ export function GitHubTodoProviderContent({
         <button
           type="button"
           onClick={() => setShowAddInput(true)}
-          className="flex w-fit items-center gap-1 text-xs text-neutral-500 transition-colors hover:text-neutral-800"
+          className="text-muted-foreground hover:text-foreground flex w-fit items-center gap-1 text-xs transition-colors"
         >
           <PlusIcon className="size-3" />
           {hasRepository ? "Replace repository" : "Add repository"}

--- a/apps/desktop/src/settings/todo/index.tsx
+++ b/apps/desktop/src/settings/todo/index.tsx
@@ -30,9 +30,9 @@ export function SettingsTodo() {
           <AccordionItem
             key={provider.id}
             value={provider.id}
-            className="group/provider border-b border-neutral-100 last:border-none"
+            className="group/provider border-border border-b last:border-none"
           >
-            <div className="group grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-full hover:bg-neutral-50">
+            <div className="group hover:bg-accent grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-full">
               <AccordionHeader className="min-w-0">
                 <AccordionTriggerPrimitive className="flex w-full min-w-0 items-center gap-2 py-3 text-left text-sm font-medium transition-all hover:no-underline">
                   {provider.icon}
@@ -41,7 +41,7 @@ export function SettingsTodo() {
               </AccordionHeader>
               <ChevronDown
                 className={cn([
-                  "size-4 shrink-0 text-neutral-500 opacity-0 transition-all duration-200 group-hover:opacity-100 focus-within:opacity-100",
+                  "text-muted-foreground size-4 shrink-0 opacity-0 transition-all duration-200 group-hover:opacity-100 focus-within:opacity-100",
                   "group-data-[state=open]/provider:rotate-180",
                 ])}
               />

--- a/apps/desktop/src/settings/todo/provider-content.tsx
+++ b/apps/desktop/src/settings/todo/provider-content.tsx
@@ -67,7 +67,7 @@ function OAuthTodoProviderContent({ config }: { config: TodoProvider }) {
           <TooltipTrigger asChild>
             <span
               tabIndex={0}
-              className="cursor-not-allowed text-xs text-neutral-400 opacity-50"
+              className="text-muted-foreground cursor-not-allowed text-xs opacity-50"
             >
               Connect {config.displayName}
             </span>
@@ -86,7 +86,7 @@ function OAuthTodoProviderContent({ config }: { config: TodoProvider }) {
         <button
           type="button"
           onClick={upgradeToPro}
-          className="cursor-pointer text-xs text-neutral-600 underline transition-colors hover:text-neutral-900"
+          className="text-muted-foreground hover:text-foreground cursor-pointer text-xs underline transition-colors"
         >
           Upgrade to connect
         </button>
@@ -110,7 +110,7 @@ function OAuthTodoProviderContent({ config }: { config: TodoProvider }) {
         <button
           type="button"
           onClick={handleConnect}
-          className="cursor-pointer text-xs text-neutral-600 underline transition-colors hover:text-neutral-900"
+          className="text-muted-foreground hover:text-foreground cursor-pointer text-xs underline transition-colors"
         >
           Connect {config.displayName}
         </button>
@@ -175,7 +175,7 @@ function ConnectionActions({
         >
           Reconnect required
         </button>
-        <span className="text-xs text-neutral-400">or</span>
+        <span className="text-muted-foreground text-xs">or</span>
         <button
           type="button"
           onClick={() =>
@@ -206,7 +206,7 @@ function ConnectionActions({
             "todo",
           )
         }
-        className="cursor-pointer text-xs text-neutral-500 underline transition-colors hover:text-neutral-700"
+        className="text-muted-foreground hover:text-muted-foreground cursor-pointer text-xs underline transition-colors"
       >
         Disconnect
       </button>

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -25,9 +25,9 @@ export function ChatCTA({
       type="button"
       onClick={handleClick}
       className={cn([
-        "inline-flex max-w-full items-center gap-2 rounded-full border-2 border-stone-600 bg-stone-800",
-        "px-4 py-2 text-sm text-white shadow-[0_4px_14px_rgba(87,83,78,0.4)]",
-        "transition-colors hover:bg-stone-700",
+        "border-primary bg-primary inline-flex max-w-full items-center gap-2 rounded-full border-2",
+        "text-primary-foreground px-4 py-2 text-sm shadow-[0_4px_14px_rgba(87,83,78,0.4)]",
+        "hover:bg-primary/90 transition-colors",
       ])}
     >
       <MessageCircle className="size-4 shrink-0" aria-hidden="true" />

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -26,7 +26,7 @@ export function ChatCTA({
       onClick={handleClick}
       className={cn([
         "border-primary bg-primary inline-flex max-w-full items-center gap-2 rounded-full border-2",
-        "text-primary-foreground px-4 py-2 text-sm shadow-[0_4px_14px_rgba(87,83,78,0.4)]",
+        "text-primary-foreground px-4 py-2 text-sm shadow-[0_6px_20px_rgba(0,0,0,0.45)]",
         "hover:bg-primary/90 transition-colors",
       ])}
     >

--- a/apps/desktop/src/shared/control.tsx
+++ b/apps/desktop/src/shared/control.tsx
@@ -38,7 +38,7 @@ export const ErrorComponent: ErrorRouteComponent = ({ error }) => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.3, ease: "easeOut" }}
         >
-          <div className="rounded-xl border border-neutral-200 bg-white p-6 shadow-xs">
+          <div className="border-border bg-card rounded-xl border p-6 shadow-xs">
             <div className="flex flex-col items-center gap-4 text-center">
               <motion.div
                 className="flex h-12 w-12 items-center justify-center rounded-full bg-red-50"
@@ -54,10 +54,10 @@ export const ErrorComponent: ErrorRouteComponent = ({ error }) => {
               </motion.div>
 
               <div className="flex flex-col gap-1.5">
-                <h2 className="text-base font-semibold text-neutral-900">
+                <h2 className="text-foreground text-base font-semibold">
                   Something went wrong
                 </h2>
-                <p className="max-w-[260px] text-sm leading-relaxed text-neutral-500">
+                <p className="text-muted-foreground max-w-[260px] text-sm leading-relaxed">
                   {error.message || "An unexpected error occurred."}
                 </p>
               </div>
@@ -93,10 +93,10 @@ export const NotFoundComponent: NotFoundRouteComponent = () => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.3, ease: "easeOut" }}
         >
-          <div className="rounded-xl border border-neutral-200 bg-white p-6 shadow-xs">
+          <div className="border-border bg-card rounded-xl border p-6 shadow-xs">
             <div className="flex flex-col items-center gap-4 text-center">
               <motion.div
-                className="flex h-12 w-12 items-center justify-center rounded-full bg-neutral-100"
+                className="bg-muted flex h-12 w-12 items-center justify-center rounded-full"
                 initial={{ scale: 0.8 }}
                 animate={{ scale: 1 }}
                 transition={{
@@ -105,12 +105,12 @@ export const NotFoundComponent: NotFoundRouteComponent = () => {
                   stiffness: 200,
                 }}
               >
-                <Search className="h-6 w-6 text-neutral-400" />
+                <Search className="text-muted-foreground h-6 w-6" />
               </motion.div>
 
               <div className="flex flex-col gap-1.5">
                 <motion.span
-                  className="block text-4xl font-bold text-neutral-300"
+                  className="text-muted-foreground/70 block text-4xl font-bold"
                   initial={{ scale: 0.9, opacity: 0 }}
                   animate={{ scale: 1, opacity: 1 }}
                   transition={{
@@ -121,10 +121,10 @@ export const NotFoundComponent: NotFoundRouteComponent = () => {
                 >
                   404
                 </motion.span>
-                <h2 className="text-base font-semibold text-neutral-900">
+                <h2 className="text-foreground text-base font-semibold">
                   Page not found
                 </h2>
-                <p className="text-sm text-neutral-500">
+                <p className="text-muted-foreground text-sm">
                   The page you're looking for doesn't exist.
                 </p>
               </div>

--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -138,9 +138,9 @@ describe("MainChatPanels", () => {
     const rightPanel = document.querySelector("[data-chat-right-panel]");
 
     expect(rightPanel).toBeInstanceOf(HTMLDivElement);
-    expect(rightPanel?.className).toContain("bg-stone-800");
+    expect(rightPanel?.className).toContain("bg-primary");
     expect(rightPanel?.className).toContain("border-x");
-    expect(rightPanel?.className).toContain("border-stone-600");
+    expect(rightPanel?.className).toContain("border-primary");
     expect(rightPanel?.className).not.toContain("border-b-0");
     expect(rightPanel?.className).toContain("rounded-tr-xl");
     expect(rightPanel?.className).not.toContain("rounded-t-xl");

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -44,7 +44,7 @@ export function MainChatPanels({ children }: { children: React.ReactNode }) {
             >
               <div
                 data-chat-right-panel
-                className="-mb-1 h-[calc(100%+0.25rem)] min-h-0 overflow-hidden rounded-tr-xl border-x border-stone-600 bg-stone-800"
+                className="border-primary bg-primary -mb-1 h-[calc(100%+0.25rem)] min-h-0 overflow-hidden rounded-tr-xl border-x"
               >
                 <ChatView
                   layout="right-panel"

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -153,14 +153,14 @@ function MainPanel({
         data-main-has-after-border={afterBorder ? "" : undefined}
         data-main-show-after-border-divider={afterBorder ? "" : undefined}
         className={cn([
-          "relative flex min-h-0 flex-1 flex-col overflow-hidden bg-white",
+          "bg-card relative flex min-h-0 flex-1 flex-col overflow-hidden",
           mergeAfterBorder && afterBorder
             ? "rounded-t-xl rounded-b-none"
             : "rounded-xl",
           !noBorder &&
             (mergeAfterBorder && afterBorder
-              ? "border border-b-0 border-neutral-200"
-              : "border border-neutral-200"),
+              ? "border-border border border-b-0"
+              : "border-border border"),
         ])}
       >
         {children}

--- a/apps/desktop/src/shared/main/shell-scaffold.tsx
+++ b/apps/desktop/src/shared/main/shell-scaffold.tsx
@@ -29,7 +29,7 @@ export function MainShellScaffold({
     <SyncWrapper>
       <div
         className={cn([
-          "flex h-full gap-1 overflow-hidden bg-stone-50",
+          "bg-background flex h-full gap-1 overflow-hidden",
           !hasTopMainSurfaceChrome && "pl-1",
           hasTopMainSurfaceChrome && [
             "[&_[data-chat-floating-anchor]]:rounded-t-xl",

--- a/apps/desktop/src/shared/open-note-dialog.tsx
+++ b/apps/desktop/src/shared/open-note-dialog.tsx
@@ -190,7 +190,7 @@ export function OpenNoteDialog({
       >
         <div
           className={cn([
-            "rounded-xl border border-neutral-200/80 bg-[#faf8f5]",
+            "border-border/80 bg-background rounded-xl border",
             "shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)]",
             "overflow-hidden",
           ])}
@@ -205,8 +205,8 @@ export function OpenNoteDialog({
               }
             }}
           >
-            <div className="flex items-center gap-3 border-b border-neutral-200/60 px-4 py-3">
-              <SearchIcon className="h-4 w-4 shrink-0 text-neutral-400" />
+            <div className="border-border/60 flex items-center gap-3 border-b px-4 py-3">
+              <SearchIcon className="text-muted-foreground h-4 w-4 shrink-0" />
               <CommandPrimitive.Input
                 ref={focusInput}
                 value={query}
@@ -214,7 +214,7 @@ export function OpenNoteDialog({
                 placeholder="Find a note..."
                 className={cn([
                   "flex-1 bg-transparent text-sm",
-                  "outline-hidden placeholder:text-neutral-400",
+                  "placeholder:text-muted-foreground outline-hidden",
                 ])}
               />
               <button
@@ -222,8 +222,8 @@ export function OpenNoteDialog({
                 className={cn([
                   "h-5 w-5 rounded-full",
                   "flex items-center justify-center",
-                  "bg-neutral-200/80 hover:bg-neutral-300/80",
-                  "text-xs text-neutral-500",
+                  "bg-accent/80 hover:bg-accent/80",
+                  "text-muted-foreground text-xs",
                   "transition-colors",
                 ])}
               >
@@ -233,7 +233,7 @@ export function OpenNoteDialog({
 
             <CommandPrimitive.List className="max-h-80 overflow-y-auto p-2">
               {!hasAnyResults ? (
-                <CommandPrimitive.Empty className="py-6 text-center text-sm text-neutral-500">
+                <CommandPrimitive.Empty className="text-muted-foreground py-6 text-center text-sm">
                   No notes found.
                 </CommandPrimitive.Empty>
               ) : (
@@ -244,7 +244,7 @@ export function OpenNoteDialog({
                         filteredOtherSessions.length > 0 ? "pb-1.5" : ""
                       }
                       heading={
-                        <div className="px-2 py-1.5 text-xs font-medium tracking-wider text-neutral-500 uppercase">
+                        <div className="text-muted-foreground px-2 py-1.5 text-xs font-medium tracking-wider uppercase">
                           Recent
                         </div>
                       }
@@ -256,12 +256,12 @@ export function OpenNoteDialog({
                           onSelect={() => handleSelect(session.id)}
                           className={cn([
                             "flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5",
-                            "text-sm text-neutral-700",
-                            "data-[selected=true]:bg-neutral-200/60",
+                            "text-muted-foreground text-sm",
+                            "data-[selected=true]:bg-accent/60",
                             "transition-colors",
                           ])}
                         >
-                          <FileTextIcon className="h-4 w-4 shrink-0 text-neutral-400" />
+                          <FileTextIcon className="text-muted-foreground h-4 w-4 shrink-0" />
                           <span className="truncate">{session.title}</span>
                         </CommandPrimitive.Item>
                       ))}
@@ -273,9 +273,9 @@ export function OpenNoteDialog({
                       heading={
                         <div className="flex flex-col gap-3">
                           {filteredRecentSessions.length > 0 && (
-                            <div className="mx-2 h-px bg-neutral-200" />
+                            <div className="bg-accent mx-2 h-px" />
                           )}
-                          <div className="px-2 py-1.5 text-xs font-medium tracking-wider text-neutral-500 uppercase">
+                          <div className="text-muted-foreground px-2 py-1.5 text-xs font-medium tracking-wider uppercase">
                             All Notes
                           </div>
                         </div>
@@ -288,12 +288,12 @@ export function OpenNoteDialog({
                           onSelect={() => handleSelect(session.id)}
                           className={cn([
                             "flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5",
-                            "text-sm text-neutral-700",
-                            "data-[selected=true]:bg-neutral-200/60",
+                            "text-muted-foreground text-sm",
+                            "data-[selected=true]:bg-accent/60",
                             "transition-colors",
                           ])}
                         >
-                          <FileTextIcon className="h-4 w-4 shrink-0 text-neutral-400" />
+                          <FileTextIcon className="text-muted-foreground h-4 w-4 shrink-0" />
                           <span className="truncate">{session.title}</span>
                         </CommandPrimitive.Item>
                       ))}
@@ -306,8 +306,8 @@ export function OpenNoteDialog({
             <div
               className={cn([
                 "flex items-center justify-center gap-4 px-4 py-2.5",
-                "border-t border-neutral-200/60",
-                "text-xs text-neutral-400",
+                "border-border/60 border-t",
+                "text-muted-foreground text-xs",
               ])}
             >
               <span className="flex items-center gap-1.5">

--- a/apps/desktop/src/shared/theme/apply.test.ts
+++ b/apps/desktop/src/shared/theme/apply.test.ts
@@ -1,10 +1,38 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadSettings = vi.hoisted(() => vi.fn());
+
+vi.mock("@hypr/plugin-settings", () => ({
+  commands: {
+    load: loadSettings,
+  },
+}));
 
 import {
+  bootstrapThemeFromSettings,
   normalizeThemePreference,
   resolveBootIsDark,
   themePreferenceFromSettings,
 } from "./apply";
+
+function mockSystemTheme(prefersDark: boolean) {
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: prefersDark,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+}
+
+beforeEach(() => {
+  loadSettings.mockReset();
+  localStorage.clear();
+  document.documentElement.className = "";
+  mockSystemTheme(false);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("normalizeThemePreference", () => {
   it("returns stored theme values", () => {
@@ -50,5 +78,53 @@ describe("resolveBootIsDark", () => {
   it("treats invalid boot values like system to avoid theme flashes", () => {
     expect(resolveBootIsDark("legacy-value", true)).toBe(true);
     expect(resolveBootIsDark("legacy-value", false)).toBe(false);
+  });
+});
+
+describe("bootstrapThemeFromSettings", () => {
+  it("applies persisted settings before resolving when load is prompt", async () => {
+    loadSettings.mockResolvedValue({
+      status: "ok",
+      data: { general: { theme: "dark" } },
+    });
+
+    await bootstrapThemeFromSettings({ timeoutMs: 100 });
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(localStorage.getItem("hypr-theme")).toBe("dark");
+  });
+
+  it("does not hold startup past the deadline when settings load stalls", async () => {
+    vi.useFakeTimers();
+
+    let resolveLoad!: (value: {
+      status: "ok";
+      data: { general: { theme: "dark" } };
+    }) => void;
+    loadSettings.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLoad = resolve;
+      }),
+    );
+
+    const bootstrap = bootstrapThemeFromSettings({ timeoutMs: 20 });
+    let resolved = false;
+    void bootstrap.then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(resolved).toBe(true);
+    expect(localStorage.getItem("hypr-theme")).toBe(null);
+
+    resolveLoad({
+      status: "ok",
+      data: { general: { theme: "dark" } },
+    });
+    await Promise.resolve();
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(localStorage.getItem("hypr-theme")).toBe("dark");
   });
 });

--- a/apps/desktop/src/shared/theme/apply.test.ts
+++ b/apps/desktop/src/shared/theme/apply.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  normalizeThemePreference,
-  resolveBootIsDark,
-} from "./apply";
+import { normalizeThemePreference, resolveBootIsDark } from "./apply";
 
 describe("normalizeThemePreference", () => {
   it("returns stored theme values", () => {

--- a/apps/desktop/src/shared/theme/apply.test.ts
+++ b/apps/desktop/src/shared/theme/apply.test.ts
@@ -30,4 +30,9 @@ describe("resolveBootIsDark", () => {
     expect(resolveBootIsDark(null, true)).toBe(true);
     expect(resolveBootIsDark(null, false)).toBe(false);
   });
+
+  it("treats invalid boot values like system to avoid theme flashes", () => {
+    expect(resolveBootIsDark("legacy-value", true)).toBe(true);
+    expect(resolveBootIsDark("legacy-value", false)).toBe(false);
+  });
 });

--- a/apps/desktop/src/shared/theme/apply.test.ts
+++ b/apps/desktop/src/shared/theme/apply.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeThemePreference,
+  resolveBootIsDark,
+} from "./apply";
+
+describe("normalizeThemePreference", () => {
+  it("returns stored theme values", () => {
+    expect(normalizeThemePreference("light")).toBe("light");
+    expect(normalizeThemePreference("dark")).toBe("dark");
+    expect(normalizeThemePreference("system")).toBe("system");
+  });
+
+  it("falls back to system for missing or invalid values", () => {
+    expect(normalizeThemePreference(null)).toBe("system");
+    expect(normalizeThemePreference("invalid")).toBe("system");
+  });
+});
+
+describe("resolveBootIsDark", () => {
+  it("honors explicit light and dark preferences", () => {
+    expect(resolveBootIsDark("light", true)).toBe(false);
+    expect(resolveBootIsDark("dark", false)).toBe(true);
+  });
+
+  it("follows system preference when stored theme is system or missing", () => {
+    expect(resolveBootIsDark("system", true)).toBe(true);
+    expect(resolveBootIsDark("system", false)).toBe(false);
+    expect(resolveBootIsDark(null, true)).toBe(true);
+    expect(resolveBootIsDark(null, false)).toBe(false);
+  });
+});

--- a/apps/desktop/src/shared/theme/apply.test.ts
+++ b/apps/desktop/src/shared/theme/apply.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeThemePreference, resolveBootIsDark } from "./apply";
+import {
+  normalizeThemePreference,
+  resolveBootIsDark,
+  themePreferenceFromSettings,
+} from "./apply";
 
 describe("normalizeThemePreference", () => {
   it("returns stored theme values", () => {
@@ -12,6 +16,21 @@ describe("normalizeThemePreference", () => {
   it("falls back to system for missing or invalid values", () => {
     expect(normalizeThemePreference(null)).toBe("system");
     expect(normalizeThemePreference("invalid")).toBe("system");
+  });
+});
+
+describe("themePreferenceFromSettings", () => {
+  it("reads the persisted general.theme value", () => {
+    expect(
+      themePreferenceFromSettings({
+        general: { theme: "dark" },
+      }),
+    ).toBe("dark");
+  });
+
+  it("falls back to system when theme is missing", () => {
+    expect(themePreferenceFromSettings({ general: {} })).toBe("system");
+    expect(themePreferenceFromSettings(undefined)).toBe("system");
   });
 });
 

--- a/apps/desktop/src/shared/theme/apply.ts
+++ b/apps/desktop/src/shared/theme/apply.ts
@@ -1,3 +1,5 @@
+import { commands as settingsCommands } from "@hypr/plugin-settings";
+
 import { resolveIsDarkMode, type ThemePreference } from "./resolve";
 
 const THEME_STORAGE_KEY = "hypr-theme";
@@ -26,7 +28,11 @@ export function resolveBootIsDark(
 }
 
 export function writeStoredThemePreference(theme: ThemePreference): void {
-  localStorage.setItem(THEME_STORAGE_KEY, theme);
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // Ignore unavailable storage in tests or restricted webviews.
+  }
 }
 
 export function applyDocumentTheme(theme: ThemePreference): boolean {
@@ -34,4 +40,33 @@ export function applyDocumentTheme(theme: ThemePreference): boolean {
   const isDark = resolveIsDarkMode(theme, prefersDark);
   document.documentElement.classList.toggle("dark", isDark);
   return isDark;
+}
+
+export function themePreferenceFromSettings(
+  settings: Record<string, unknown> | undefined,
+): ThemePreference {
+  const general = settings?.general;
+  const theme =
+    general && typeof general === "object" && "theme" in general
+      ? (general as { theme?: unknown }).theme
+      : null;
+
+  return normalizeThemePreference(typeof theme === "string" ? theme : null);
+}
+
+export async function bootstrapThemeFromSettings(): Promise<void> {
+  try {
+    const result = await settingsCommands.load();
+    if (result.status !== "ok") {
+      return;
+    }
+
+    const preference = themePreferenceFromSettings(
+      result.data as Record<string, unknown>,
+    );
+    applyDocumentTheme(preference);
+    writeStoredThemePreference(preference);
+  } catch {
+    // Non-Tauri dev sessions can skip persisted settings bootstrap.
+  }
 }

--- a/apps/desktop/src/shared/theme/apply.ts
+++ b/apps/desktop/src/shared/theme/apply.ts
@@ -1,0 +1,22 @@
+import { resolveIsDarkMode, type ThemePreference } from "./resolve";
+
+const THEME_STORAGE_KEY = "hypr-theme";
+
+export function readStoredThemePreference(): ThemePreference | null {
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  if (stored === "light" || stored === "dark" || stored === "system") {
+    return stored;
+  }
+  return null;
+}
+
+export function writeStoredThemePreference(theme: ThemePreference): void {
+  localStorage.setItem(THEME_STORAGE_KEY, theme);
+}
+
+export function applyDocumentTheme(theme: ThemePreference): boolean {
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const isDark = resolveIsDarkMode(theme, prefersDark);
+  document.documentElement.classList.toggle("dark", isDark);
+  return isDark;
+}

--- a/apps/desktop/src/shared/theme/apply.ts
+++ b/apps/desktop/src/shared/theme/apply.ts
@@ -2,7 +2,9 @@ import { resolveIsDarkMode, type ThemePreference } from "./resolve";
 
 const THEME_STORAGE_KEY = "hypr-theme";
 
-export function readStoredThemePreference(): ThemePreference | null {
+/** Keep `public/theme-boot.js` aligned with normalizeThemePreference + resolveIsDarkMode. */
+
+export function readStoredThemePreference(): ThemePreference {
   const stored = localStorage.getItem(THEME_STORAGE_KEY);
   return normalizeThemePreference(stored);
 }

--- a/apps/desktop/src/shared/theme/apply.ts
+++ b/apps/desktop/src/shared/theme/apply.ts
@@ -3,6 +3,7 @@ import { commands as settingsCommands } from "@hypr/plugin-settings";
 import { resolveIsDarkMode, type ThemePreference } from "./resolve";
 
 const THEME_STORAGE_KEY = "hypr-theme";
+const THEME_BOOTSTRAP_TIMEOUT_MS = 150;
 
 /** Keep `public/theme-boot.js` aligned with normalizeThemePreference + resolveIsDarkMode. */
 
@@ -54,7 +55,7 @@ export function themePreferenceFromSettings(
   return normalizeThemePreference(typeof theme === "string" ? theme : null);
 }
 
-export async function bootstrapThemeFromSettings(): Promise<void> {
+async function loadThemeFromSettings(): Promise<void> {
   try {
     const result = await settingsCommands.load();
     if (result.status !== "ok") {
@@ -69,4 +70,22 @@ export async function bootstrapThemeFromSettings(): Promise<void> {
   } catch {
     // Non-Tauri dev sessions can skip persisted settings bootstrap.
   }
+}
+
+export async function bootstrapThemeFromSettings({
+  timeoutMs = THEME_BOOTSTRAP_TIMEOUT_MS,
+}: {
+  timeoutMs?: number;
+} = {}): Promise<void> {
+  const themeLoad = loadThemeFromSettings();
+
+  if (timeoutMs <= 0) {
+    await themeLoad;
+    return;
+  }
+
+  await Promise.race([
+    themeLoad,
+    new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+  ]);
 }

--- a/apps/desktop/src/shared/theme/apply.ts
+++ b/apps/desktop/src/shared/theme/apply.ts
@@ -4,10 +4,23 @@ const THEME_STORAGE_KEY = "hypr-theme";
 
 export function readStoredThemePreference(): ThemePreference | null {
   const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  return normalizeThemePreference(stored);
+}
+
+export function normalizeThemePreference(
+  stored: string | null,
+): ThemePreference {
   if (stored === "light" || stored === "dark" || stored === "system") {
     return stored;
   }
-  return null;
+  return "system";
+}
+
+export function resolveBootIsDark(
+  stored: string | null,
+  prefersDark: boolean,
+): boolean {
+  return resolveIsDarkMode(normalizeThemePreference(stored), prefersDark);
 }
 
 export function writeStoredThemePreference(theme: ThemePreference): void {

--- a/apps/desktop/src/shared/theme/provider.test.tsx
+++ b/apps/desktop/src/shared/theme/provider.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const themeState = vi.hoisted(() => ({
+  settingsReady: false,
+  theme: "system" as "light" | "dark" | "system",
+}));
+
+const applyDocumentTheme = vi.hoisted(() => vi.fn(() => false));
+const writeStoredThemePreference = vi.hoisted(() => vi.fn());
+
+vi.mock("./apply", () => ({
+  applyDocumentTheme,
+  writeStoredThemePreference,
+}));
+
+vi.mock("./use-settings-theme-ready", () => ({
+  useSettingsThemeReady: () => themeState.settingsReady,
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValue: () => themeState.theme,
+}));
+
+import { AppThemeProvider } from "./provider";
+
+describe("AppThemeProvider", () => {
+  beforeEach(() => {
+    cleanup();
+    themeState.settingsReady = false;
+    themeState.theme = "system";
+    applyDocumentTheme.mockClear();
+    writeStoredThemePreference.mockClear();
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not clobber the boot theme before settings hydrate", () => {
+    render(
+      <AppThemeProvider>
+        <div>child</div>
+      </AppThemeProvider>,
+    );
+
+    expect(applyDocumentTheme).not.toHaveBeenCalled();
+    expect(writeStoredThemePreference).not.toHaveBeenCalled();
+  });
+
+  it("applies the hydrated settings theme once the persister is ready", () => {
+    themeState.settingsReady = true;
+    themeState.theme = "light";
+
+    render(
+      <AppThemeProvider>
+        <div>child</div>
+      </AppThemeProvider>,
+    );
+
+    expect(applyDocumentTheme).toHaveBeenCalledWith("light");
+    expect(writeStoredThemePreference).toHaveBeenCalledWith("light");
+  });
+});

--- a/apps/desktop/src/shared/theme/provider.tsx
+++ b/apps/desktop/src/shared/theme/provider.tsx
@@ -2,13 +2,19 @@ import { type ReactNode, useLayoutEffect } from "react";
 
 import { applyDocumentTheme, writeStoredThemePreference } from "./apply";
 import type { ThemePreference } from "./resolve";
+import { useSettingsThemeReady } from "./use-settings-theme-ready";
 
 import { useConfigValue } from "~/shared/config";
 
 export function AppThemeProvider({ children }: { children: ReactNode }) {
   const theme = useConfigValue("theme") as ThemePreference;
+  const settingsReady = useSettingsThemeReady();
 
   useLayoutEffect(() => {
+    if (!settingsReady) {
+      return;
+    }
+
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
     const applyTheme = () => {
@@ -24,7 +30,7 @@ export function AppThemeProvider({ children }: { children: ReactNode }) {
 
     mediaQuery.addEventListener("change", applyTheme);
     return () => mediaQuery.removeEventListener("change", applyTheme);
-  }, [theme]);
+  }, [theme, settingsReady]);
 
   return children;
 }

--- a/apps/desktop/src/shared/theme/provider.tsx
+++ b/apps/desktop/src/shared/theme/provider.tsx
@@ -1,0 +1,30 @@
+import { type ReactNode, useLayoutEffect } from "react";
+
+import { applyDocumentTheme, writeStoredThemePreference } from "./apply";
+import type { ThemePreference } from "./resolve";
+
+import { useConfigValue } from "~/shared/config";
+
+export function AppThemeProvider({ children }: { children: ReactNode }) {
+  const theme = useConfigValue("theme") as ThemePreference;
+
+  useLayoutEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    const applyTheme = () => {
+      applyDocumentTheme(theme);
+      writeStoredThemePreference(theme);
+    };
+
+    applyTheme();
+
+    if (theme !== "system") {
+      return;
+    }
+
+    mediaQuery.addEventListener("change", applyTheme);
+    return () => mediaQuery.removeEventListener("change", applyTheme);
+  }, [theme]);
+
+  return children;
+}

--- a/apps/desktop/src/shared/theme/resolve.test.ts
+++ b/apps/desktop/src/shared/theme/resolve.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveIsDarkMode } from "./resolve";
+
+describe("resolveIsDarkMode", () => {
+  it("returns true for dark theme", () => {
+    expect(resolveIsDarkMode("dark", false)).toBe(true);
+  });
+
+  it("returns false for light theme", () => {
+    expect(resolveIsDarkMode("light", true)).toBe(false);
+  });
+
+  it("follows system preference for system theme", () => {
+    expect(resolveIsDarkMode("system", true)).toBe(true);
+    expect(resolveIsDarkMode("system", false)).toBe(false);
+  });
+});

--- a/apps/desktop/src/shared/theme/resolve.ts
+++ b/apps/desktop/src/shared/theme/resolve.ts
@@ -1,0 +1,14 @@
+export type ThemePreference = "light" | "dark" | "system";
+
+export function resolveIsDarkMode(
+  theme: ThemePreference,
+  prefersDark: boolean,
+): boolean {
+  if (theme === "dark") {
+    return true;
+  }
+  if (theme === "light") {
+    return false;
+  }
+  return prefersDark;
+}

--- a/apps/desktop/src/shared/theme/use-settings-theme-ready.ts
+++ b/apps/desktop/src/shared/theme/use-settings-theme-ready.ts
@@ -1,10 +1,10 @@
-import { Status } from "tinybase/persisters";
-
 import * as settings from "~/store/tinybase/store/settings";
+
+const PERSISTER_STATUS_LOADING = 1;
 
 export function useSettingsThemeReady(): boolean {
   const persister = settings.UI.usePersister(settings.STORE_ID);
   const persisterStatus = settings.UI.usePersisterStatus(settings.STORE_ID);
 
-  return persister != null && persisterStatus !== Status.Loading;
+  return persister != null && persisterStatus !== PERSISTER_STATUS_LOADING;
 }

--- a/apps/desktop/src/shared/theme/use-settings-theme-ready.ts
+++ b/apps/desktop/src/shared/theme/use-settings-theme-ready.ts
@@ -1,0 +1,10 @@
+import { Status } from "tinybase/persisters";
+
+import * as settings from "~/store/tinybase/store/settings";
+
+export function useSettingsThemeReady(): boolean {
+  const persister = settings.UI.usePersister(settings.STORE_ID);
+  const persisterStatus = settings.UI.usePersisterStatus(settings.STORE_ID);
+
+  return persister != null && persisterStatus !== Status.Loading;
+}

--- a/apps/desktop/src/shared/ui/resource-list/layout.tsx
+++ b/apps/desktop/src/shared/ui/resource-list/layout.tsx
@@ -1,7 +1,7 @@
 export function ResourceDetailEmpty({ message }: { message: string }) {
   return (
     <div className="flex h-full items-center justify-center">
-      <p className="text-sm text-neutral-500">{message}</p>
+      <p className="text-muted-foreground text-sm">{message}</p>
     </div>
   );
 }

--- a/apps/desktop/src/shared/ui/resource-list/preview-header.tsx
+++ b/apps/desktop/src/shared/ui/resource-list/preview-header.tsx
@@ -71,7 +71,7 @@ export function ResourcePreviewHeader({
           {titleMeta}
         </div>
         {description && (
-          <p className="mt-1 min-h-[24px] text-sm text-neutral-500">
+          <p className="text-muted-foreground mt-1 min-h-[24px] text-sm">
             {description}
           </p>
         )}
@@ -80,7 +80,7 @@ export function ResourcePreviewHeader({
             {targets.map((target, index) => (
               <span
                 key={index}
-                className="inline-flex h-6 items-center rounded-md bg-neutral-100 px-2 py-0.5 text-xs text-neutral-600"
+                className="bg-muted text-muted-foreground inline-flex h-6 items-center rounded-md px-2 py-0.5 text-xs"
               >
                 {target}
               </span>
@@ -88,7 +88,7 @@ export function ResourcePreviewHeader({
           </div>
         )}
         {footer === undefined ? (
-          <p className="mt-2 text-xs text-neutral-400">
+          <p className="text-muted-foreground mt-2 text-xs">
             {getTemplateCreatorLabel({ isUserTemplate: false })}
           </p>
         ) : (

--- a/apps/desktop/src/shared/ui/settings-alert.tsx
+++ b/apps/desktop/src/shared/ui/settings-alert.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@hypr/utils";
+
+export function SettingsAlert({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn([
+        "bg-alert text-alert-foreground border-alert-border rounded-lg border px-4 py-3 text-sm",
+        className,
+      ])}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/desktop/src/shared/ui/template-category-label.tsx
+++ b/apps/desktop/src/shared/ui/template-category-label.tsx
@@ -52,7 +52,7 @@ export function TemplateCategoryLabel({
   return (
     <span
       className={cn([
-        "flex items-center gap-1.5 font-mono text-xs text-stone-400",
+        "text-muted-foreground flex items-center gap-1.5 font-mono text-xs",
         className,
       ])}
     >

--- a/apps/desktop/src/sidebar/contacts.tsx
+++ b/apps/desktop/src/sidebar/contacts.tsx
@@ -374,7 +374,7 @@ function ContactsList({
           </div>
         )}
         {pinnedItems.length > 0 && nonPinnedItems.length > 0 && (
-          <div className="mx-3 my-1 h-px bg-neutral-200" />
+          <div className="bg-accent mx-3 my-1 h-px" />
         )}
         {nonPinnedItems.map((item) =>
           item.kind === "person" ? (

--- a/apps/desktop/src/sidebar/custom-sidebar-header.tsx
+++ b/apps/desktop/src/sidebar/custom-sidebar-header.tsx
@@ -116,9 +116,9 @@ function CustomSidebarHeaderButton({
       disabled={disabled}
       className={cn([
         "relative z-50 flex size-6 shrink-0 items-center justify-center rounded-full",
-        "text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-neutral-900",
-        "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
-        "disabled:text-neutral-300 disabled:hover:bg-transparent disabled:hover:text-neutral-300",
+        "text-muted-foreground hover:bg-accent hover:text-foreground transition-colors",
+        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
+        "disabled:text-muted-foreground/70 disabled:hover:text-muted-foreground/70 disabled:hover:bg-transparent",
       ])}
       onClick={onClick}
     >

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -117,7 +117,7 @@ export function SettingsNav() {
         <div className="flex flex-col gap-4 pb-2">
           {groups.map((group) => (
             <div key={group.label} className="flex flex-col gap-0.5">
-              <span className="px-3 pb-1 text-[11px] font-medium tracking-wider text-neutral-400 uppercase">
+              <span className="text-muted-foreground px-3 pb-1 text-[11px] font-medium tracking-wider uppercase">
                 {group.label}
               </span>
               {group.items.map((item) => {
@@ -144,8 +144,8 @@ export function SettingsNav() {
                       "flex w-full items-center gap-2 rounded-full px-3 py-2 text-left text-sm",
                       "transition-colors",
                       isSettingsItem && activeTab === item.id
-                        ? "bg-neutral-200 font-medium text-neutral-900"
-                        : "text-neutral-600 hover:bg-neutral-200/50 hover:text-neutral-800",
+                        ? "bg-sidebar-accent text-foreground font-medium"
+                        : "text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground",
                     ])}
                   >
                     <item.icon size={15} />

--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -171,7 +171,7 @@ describe("TimelineView", () => {
     });
     const actionTabs = getSidebarActionTabs();
 
-    expect(actionTabs.className).not.toContain("bg-neutral-100/80");
+    expect(actionTabs.className).not.toContain("bg-muted/80");
     expect(actionTabs.className).not.toContain("rounded-full");
     expect(newNoteButton.className).toContain("flex-1");
     expect(newNoteButton.className).toContain("justify-center");

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -439,12 +439,9 @@ export function TimelineView({
                 />
               )}
               <div
-                className={cn([
-                  "sticky top-0 z-10",
-                  "bg-neutral-50 py-1 pr-1 pl-3",
-                ])}
+                className={cn(["sticky top-0 z-10", "bg-muted py-1 pr-1 pl-3"])}
               >
-                <div className="text-base font-bold text-neutral-900">
+                <div className="text-foreground text-base font-bold">
                   {bucket.label}
                 </div>
               </div>
@@ -499,12 +496,12 @@ export function TimelineView({
           className={cn([
             "pointer-events-none absolute inset-x-0 top-0 z-[15]",
             showCalendarSyncStatus
-              ? "h-28 bg-neutral-50"
+              ? "bg-background h-28"
               : areSidebarActionsHidden
-                ? "h-20 bg-linear-to-b from-neutral-50 via-neutral-50/95 via-60% to-neutral-50/0"
+                ? "from-background via-background/95 to-background/0 h-20 bg-linear-to-b via-60%"
                 : isScrolledToTop
-                  ? "h-24 bg-neutral-50"
-                  : "h-28 bg-linear-to-b from-neutral-50 via-neutral-50/95 via-55% to-neutral-50/0",
+                  ? "bg-muted h-24"
+                  : "from-background via-background/95 to-background/0 h-28 bg-linear-to-b via-55%",
           ])}
         />
       )}
@@ -537,8 +534,8 @@ export function TimelineView({
               onClick={handleOpenCalendar}
               size="sm"
               className={cn([
-                "rounded-full bg-white hover:bg-neutral-50",
-                "border border-neutral-200 text-neutral-700",
+                "bg-card hover:bg-accent rounded-full",
+                "border-border text-muted-foreground border",
                 "flex items-center gap-1",
                 "px-3",
                 "shadow-xs",
@@ -625,7 +622,7 @@ function SidebarTimelineActions({
       data-sidebar-timeline-actions
       className={cn([
         "absolute inset-x-0 top-10 z-30 pt-1 pb-2",
-        "bg-neutral-50",
+        "bg-muted",
         "transition-[opacity,transform] duration-150 ease-out",
         hideActionContainer
           ? "pointer-events-none -translate-y-2 opacity-0"
@@ -727,12 +724,12 @@ function SidebarTimelineActionButton({
       data-sidebar-timeline-action={id}
       className={cn([
         "flex h-8 min-w-8 items-center overflow-hidden rounded-full",
-        "text-sm font-medium text-neutral-700",
+        "text-muted-foreground text-sm font-medium",
         "transition-[width,flex-grow,background-color,color] duration-150 ease-out",
-        "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
         active
-          ? "flex-1 justify-center bg-neutral-200/70 px-3 text-neutral-950"
-          : "w-8 flex-none justify-center px-2 hover:bg-neutral-200/70 hover:text-neutral-950",
+          ? "bg-accent/70 text-foreground flex-1 justify-center px-3"
+          : "hover:bg-accent/70 hover:text-foreground w-8 flex-none justify-center px-2",
       ])}
       onClick={onClick}
       onFocus={() => onExpand(id)}
@@ -741,7 +738,7 @@ function SidebarTimelineActionButton({
       <span
         className={cn([
           "flex size-4 shrink-0 items-center justify-center",
-          active ? "text-neutral-700" : "text-neutral-600",
+          active ? "text-muted-foreground" : "text-muted-foreground",
         ])}
       >
         {icon}
@@ -810,9 +807,9 @@ function TimelineNowChip({
       type="button"
       aria-label="Go back to now"
       className={cn([
-        "flex h-6 items-center gap-1 rounded-full border border-neutral-200 bg-white/95 px-2.5 text-xs font-semibold text-neutral-900 shadow-md backdrop-blur",
-        "transition-colors hover:border-neutral-300 hover:bg-white hover:text-neutral-950",
-        "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
+        "border-border bg-card/95 text-foreground flex h-6 items-center gap-1 rounded-full border px-2.5 text-xs font-semibold shadow-md backdrop-blur",
+        "hover:border-border hover:bg-accent hover:text-foreground transition-colors",
+        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
         className,
       ])}
       onClick={onClick}
@@ -867,7 +864,7 @@ function TodayBucket({
       return (
         <>
           <CurrentTimeIndicator ref={registerIndicator} timezone={timezone} />
-          <div className="px-3 py-4 text-center text-sm text-neutral-400">
+          <div className="text-muted-foreground px-3 py-4 text-center text-sm">
             No items today
           </div>
         </>

--- a/apps/desktop/src/sidebar/timeline/item.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.test.tsx
@@ -180,9 +180,9 @@ describe("TimelineItemComponent", () => {
 
     const rowButton = screen.getByText("Live Note").closest("button");
 
-    expect(rowButton?.className).toContain("bg-red-500");
-    expect(rowButton?.className).toContain("text-white");
-    expect(rowButton?.className).not.toContain("bg-neutral-200");
+    expect(rowButton?.className).toContain("bg-destructive");
+    expect(rowButton?.className).toContain("text-destructive-foreground");
+    expect(rowButton?.className).not.toContain("bg-accent");
     expect(screen.getByTestId("dancing-sticks").dataset.amplitude).toBe("0.5");
 
     fireEvent.click(screen.getByRole("button", { name: "Stop listening" }));

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -145,12 +145,12 @@ function ItemBase({
           "w-full rounded-lg px-3 py-2 text-left",
           showTrailingStatus && "pr-10",
           ignored ? "cursor-default" : "cursor-pointer",
-          multiSelected && "bg-neutral-200",
-          !multiSelected && selected && "bg-neutral-200",
-          !multiSelected && !selected && "hover:bg-neutral-200/50",
+          multiSelected && "bg-accent",
+          !multiSelected && selected && "bg-accent",
+          !multiSelected && !selected && "hover:bg-accent/50",
           isLive && [
-            "bg-red-500 text-white hover:bg-red-600",
-            "focus-visible:ring-2 focus-visible:ring-red-500/40 focus-visible:outline-hidden",
+            "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+            "focus-visible:ring-destructive/40 focus-visible:ring-2 focus-visible:outline-hidden",
           ],
           ignored && "opacity-40",
           !ignored && muted && !isLive && "opacity-65",
@@ -171,7 +171,9 @@ function ItemBase({
               <div
                 className={cn([
                   "font-mono text-xs",
-                  isLive ? "text-white/65" : "text-neutral-500",
+                  isLive
+                    ? "text-destructive-foreground/65"
+                    : "text-muted-foreground",
                 ])}
               >
                 {displayTime}
@@ -183,7 +185,7 @@ function ItemBase({
       {showSpinner ? (
         <div
           aria-hidden
-          className="pointer-events-none absolute top-1/2 right-3 flex size-5 -translate-y-1/2 items-center justify-center text-neutral-400"
+          className="text-muted-foreground pointer-events-none absolute top-1/2 right-3 flex size-5 -translate-y-1/2 items-center justify-center"
         >
           <Spinner size={14} />
         </div>
@@ -199,8 +201,8 @@ function ItemBase({
           }}
           className={cn([
             "absolute top-1/2 right-3 flex size-5 -translate-y-1/2 items-center justify-center rounded-sm",
-            "text-white/80 transition-colors hover:bg-white/15 hover:text-white",
-            "focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:outline-hidden",
+            "text-destructive-foreground/80 hover:bg-destructive-foreground/15 hover:text-destructive-foreground transition-colors",
+            "focus-visible:ring-destructive-foreground/70 focus-visible:ring-2 focus-visible:outline-hidden",
           ])}
         >
           <span

--- a/apps/desktop/src/sidebar/timeline/realtime.tsx
+++ b/apps/desktop/src/sidebar/timeline/realtime.tsx
@@ -40,7 +40,7 @@ export const CurrentTimeIndicator = forwardRef<
       <div className="absolute inset-x-0 top-0 -translate-y-1/2">
         <div className="absolute top-1/2 right-0 left-0 h-px -translate-y-1/2 bg-red-400/90 mix-blend-multiply" />
         <div className="relative flex h-5 items-center justify-center">
-          <div className="rounded-full bg-red-500 px-2 py-0.5 font-mono text-[11px] font-semibold text-white opacity-0 shadow-xs transition-opacity group-hover:opacity-100">
+          <div className="bg-destructive text-destructive-foreground rounded-full px-2 py-0.5 font-mono text-[11px] font-semibold opacity-0 shadow-xs transition-opacity group-hover:opacity-100">
             {label}
           </div>
         </div>

--- a/apps/desktop/src/sidebar/toast/component.tsx
+++ b/apps/desktop/src/sidebar/toast/component.tsx
@@ -17,11 +17,11 @@ export function Toast({
       <div
         className={cn([
           "relative z-50 inline-flex max-w-[calc(100vw-24px)] items-center gap-3 py-1.5 pr-1.5 pl-4",
-          "rounded-full bg-white",
-          "border shadow-lg",
+          "bg-secondary text-secondary-foreground rounded-full",
+          "border shadow-lg backdrop-blur-none",
           toast.variant === "error"
-            ? "border-red-200 shadow-red-100"
-            : "border-neutral-200",
+            ? "border-alert-border shadow-red-100 dark:shadow-red-950/30"
+            : "border-border",
         ])}
       >
         {toast.icon ? <span className="shrink-0">{toast.icon}</span> : null}
@@ -29,7 +29,9 @@ export function Toast({
         <div
           className={cn([
             "max-w-50 truncate text-sm",
-            toast.variant === "error" ? "text-red-500" : "text-neutral-600",
+            toast.variant === "error"
+              ? "text-alert-foreground"
+              : "text-muted-foreground",
           ])}
         >
           {toast.description}
@@ -87,14 +89,14 @@ function getActions(
 
 function getActionClassName(toast: ToastType, index: number) {
   if (toast.variant === "error" && index === 0) {
-    return "bg-red-50 text-red-500 hover:bg-red-100 hover:text-red-600";
+    return "bg-alert text-alert-foreground hover:bg-alert/90";
   }
 
   if (index === 0) {
-    return "bg-neutral-900 text-white hover:bg-neutral-800";
+    return "bg-primary text-primary-foreground hover:bg-primary/90";
   }
 
-  return "border border-neutral-200 bg-white text-neutral-700 hover:bg-neutral-50";
+  return "border-border bg-card text-foreground hover:bg-accent border";
 }
 
 function getProgress(toast: ToastType) {
@@ -116,7 +118,7 @@ function getProgress(toast: ToastType) {
 
 function ProgressPill({ progress }: { progress: number }) {
   return (
-    <span className="rounded-full bg-neutral-100 px-2.5 py-1.5 text-xs font-medium whitespace-nowrap text-neutral-600">
+    <span className="bg-muted text-muted-foreground rounded-full px-2.5 py-1.5 text-xs font-medium whitespace-nowrap">
       {Math.round(progress)}%
     </span>
   );

--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
@@ -288,11 +288,11 @@ function ToastPill({
       <div
         className={cn([
           "flex items-center gap-3 py-1.5 pr-1.5 pl-4",
-          "rounded-full bg-white",
-          "border border-neutral-200 shadow-lg",
+          "bg-secondary text-secondary-foreground rounded-full",
+          "border-border border shadow-lg backdrop-blur-none",
         ])}
       >
-        <span className="max-w-50 truncate text-sm text-neutral-600">
+        <span className="text-muted-foreground max-w-50 truncate text-sm">
           {label}...
         </span>
 
@@ -301,8 +301,8 @@ function ToastPill({
           className={cn([
             "rounded-full px-3 py-1.5 text-xs font-medium",
             "whitespace-nowrap",
-            "bg-red-50 text-red-500",
-            "hover:bg-red-100 hover:text-red-600",
+            "bg-alert text-alert-foreground",
+            "hover:bg-alert/90",
             "transition-colors",
           ])}
         >
@@ -314,8 +314,7 @@ function ToastPill({
           className={cn([
             "rounded-full px-3 py-1.5 text-xs font-medium",
             "whitespace-nowrap",
-            "border border-neutral-200 bg-white text-neutral-700",
-            "hover:bg-neutral-50",
+            "border-border bg-card text-foreground hover:bg-accent border",
             "transition-colors",
           ])}
         >

--- a/apps/desktop/src/store/tinybase/persister/settings/persister.ts
+++ b/apps/desktop/src/store/tinybase/persister/settings/persister.ts
@@ -11,6 +11,10 @@ import {
   storeToSettings,
 } from "./transform";
 
+import {
+  themePreferenceFromSettings,
+  writeStoredThemePreference,
+} from "~/shared/theme/apply";
 import { createFileListener } from "~/store/tinybase/persister/shared/listener";
 import type { Schemas, Store } from "~/store/tinybase/store/settings";
 import { StoreOrMergeableStore } from "~/store/tinybase/store/shared";
@@ -81,12 +85,16 @@ function createPersisterBuilder<T>(transform: TransformUtils<T>) {
           result.data as Record<string, unknown>,
           languageDefaults,
         );
+        writeStoredThemePreference(themePreferenceFromSettings(settings));
 
         return transform.toStore(settings as T);
       },
       async () => {
         const languageDefaults = await getLanguageDefaults();
         const settings = transform.fromStore(store, languageDefaults);
+        writeStoredThemePreference(
+          themePreferenceFromSettings(settings as Record<string, unknown>),
+        );
         const result = await commands.save(
           settings as Parameters<typeof commands.save>[0],
         );

--- a/apps/desktop/src/store/tinybase/store/settings.ts
+++ b/apps/desktop/src/store/tinybase/store/settings.ts
@@ -52,6 +52,11 @@ export const SETTINGS_MAPPING = {
       path: ["general", "sidebar_timeline_enabled"],
       default: false as boolean,
     },
+    theme: {
+      type: "string",
+      path: ["general", "theme"],
+      default: "system" as string,
+    },
     save_recordings: {
       type: "boolean",
       path: ["general", "save_recordings"],

--- a/apps/desktop/src/styles/dark-theme.css
+++ b/apps/desktop/src/styles/dark-theme.css
@@ -1,0 +1,36 @@
+@layer base {
+  .dark {
+    color-scheme: dark;
+  }
+}
+
+@layer theme {
+  :root {
+    --provider-brand-filter: none;
+  }
+
+  .dark {
+    --provider-brand-filter: brightness(0) invert(1);
+    --kbd-press-shadow-outer: rgba(0, 0, 0, 0.35);
+    --kbd-press-shadow-inset: rgba(255, 255, 255, 0.08);
+    --selection-overlay: rgba(96, 165, 250, 0.25);
+  }
+}
+
+.dark .ProseMirror-search-match {
+  background-color: rgb(113 63 18 / 0.45);
+  border-radius: 2px;
+}
+
+.dark .ProseMirror-active-search-match {
+  background-color: rgb(202 138 4) !important;
+  border-radius: 2px;
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background: #44403c;
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: #57534e;
+}

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -2,7 +2,10 @@
 @import "./scrollbar.utilities.css";
 
 @import "tailwindcss";
+@import "./dark-theme.css";
 @import "../../../../packages/ui/src/styles/scroll-fade.css";
+
+@custom-variant dark (&:where(.dark, .dark *));
 
 @source "../../node_modules/streamdown/dist/index.js";
 @source "../../../../packages/tiptap/src";
@@ -11,6 +14,12 @@
   --font-sans:
     system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-hand: "Bradley Hand", "Segoe Print", "Comic Sans MS", cursive;
+
+  --color-sidebar-accent: hsl(var(--sidebar-accent));
+
+  --kbd-press-shadow-outer: rgba(0, 0, 0, 0.1);
+  --kbd-press-shadow-inset: rgba(255, 255, 255, 0.8);
+  --selection-overlay: rgba(59, 130, 246, 0.3);
 
   --animate-shimmer: shimmer 2s infinite;
   --animate-reveal-left: reveal-left 0.5s ease-out forwards;
@@ -81,8 +90,8 @@
     100% {
       transform: translateY(0);
       box-shadow:
-        0 1px 0 0 rgba(0, 0, 0, 0.1),
-        inset 0 1px 0 0 rgba(255, 255, 255, 0.8);
+        0 1px 0 0 var(--kbd-press-shadow-outer),
+        inset 0 1px 0 0 var(--kbd-press-shadow-inset);
     }
   }
 }
@@ -101,7 +110,7 @@
   ::before,
   ::backdrop,
   ::file-selector-button {
-    border-color: var(--color-gray-200, currentcolor);
+    border-color: var(--color-border, currentcolor);
   }
 }
 

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -15,6 +15,24 @@
     system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-hand: "Bradley Hand", "Segoe Print", "Comic Sans MS", cursive;
 
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+
   --color-sidebar-accent: hsl(var(--sidebar-accent));
 
   --kbd-press-shadow-outer: rgba(0, 0, 0, 0.1);

--- a/apps/desktop/src/task/resource-view.tsx
+++ b/apps/desktop/src/task/resource-view.tsx
@@ -75,12 +75,12 @@ export function ResourceView({ resource }: { resource: TaskResource }) {
   return (
     <div className="w-full max-w-3xl px-6 py-6">
       {isLoading ? (
-        <div className="flex items-center justify-center py-12 text-neutral-400">
+        <div className="text-muted-foreground flex items-center justify-center py-12">
           Loading...
         </div>
       ) : null}
       {error ? (
-        <div className="flex items-center justify-center py-12 text-neutral-400">
+        <div className="text-muted-foreground flex items-center justify-center py-12">
           Failed to load {isPR ? "pull request" : "issue"}
         </div>
       ) : null}
@@ -88,22 +88,22 @@ export function ResourceView({ resource }: { resource: TaskResource }) {
         <>
           <div className="mb-4">
             <div className="flex items-start justify-between gap-3">
-              <h1 className="text-xl leading-snug font-semibold text-neutral-900">
+              <h1 className="text-foreground text-xl leading-snug font-semibold">
                 {issue.title}
-                <span className="ml-2 font-normal text-neutral-400">
+                <span className="text-muted-foreground ml-2 font-normal">
                   #{issue.number}
                 </span>
               </h1>
               <button
                 type="button"
-                className="shrink-0 rounded-md p-1.5 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-600"
+                className="text-muted-foreground hover:bg-accent hover:text-muted-foreground shrink-0 rounded-md p-1.5 transition-colors"
                 onClick={() => openerCommands.openUrl(url, null)}
                 title="Open on GitHub"
               >
                 <ExternalLinkIcon className="size-4" />
               </button>
             </div>
-            <div className="mt-2 flex items-center gap-2 text-sm text-neutral-500">
+            <div className="text-muted-foreground mt-2 flex items-center gap-2 text-sm">
               <StateBadge isPR={isPR} isMerged={isMerged} isClosed={isClosed} />
               <span>
                 {issue.user?.login} opened on{" "}
@@ -145,8 +145,10 @@ export function ResourceView({ resource }: { resource: TaskResource }) {
           ) : null}
 
           {issue.assignees && issue.assignees.length > 0 ? (
-            <div className="mb-4 flex items-center gap-2 text-sm text-neutral-500">
-              <span className="font-medium text-neutral-600">Assignees:</span>
+            <div className="text-muted-foreground mb-4 flex items-center gap-2 text-sm">
+              <span className="text-muted-foreground font-medium">
+                Assignees:
+              </span>
               {issue.assignees.map((assignee) => (
                 <span key={assignee.id} className="flex items-center gap-1">
                   {assignee.avatar_url ? (
@@ -163,9 +165,9 @@ export function ResourceView({ resource }: { resource: TaskResource }) {
           ) : null}
 
           {issue.body ? (
-            <div className="border-t border-neutral-200 pt-4">
+            <div className="border-border border-t pt-4">
               <Streamdown
-                className="mt-1 text-sm text-neutral-700"
+                className="text-muted-foreground mt-1 text-sm"
                 components={streamdownComponents}
                 isAnimating={false}
                 rehypePlugins={rehypePlugins}
@@ -174,14 +176,14 @@ export function ResourceView({ resource }: { resource: TaskResource }) {
               </Streamdown>
             </div>
           ) : (
-            <div className="border-t border-neutral-200 pt-4 text-sm text-neutral-400 italic">
+            <div className="border-border text-muted-foreground border-t pt-4 text-sm italic">
               No description provided.
             </div>
           )}
 
           {comments && comments.length > 0 ? (
-            <div className="mt-6 border-t border-neutral-200 pt-4">
-              <div className="mb-4 flex items-center gap-2 text-sm font-medium text-neutral-600">
+            <div className="border-border mt-6 border-t pt-4">
+              <div className="text-muted-foreground mb-4 flex items-center gap-2 text-sm font-medium">
                 <MessageSquareIcon className="size-4" />
                 <span>
                   {comments.length}{" "}
@@ -192,9 +194,9 @@ export function ResourceView({ resource }: { resource: TaskResource }) {
                 {comments.map((comment) => (
                   <div
                     key={comment.id}
-                    className="rounded-lg border border-neutral-200 bg-neutral-50/50"
+                    className="border-border bg-muted/50 rounded-lg border"
                   >
-                    <div className="flex items-center gap-2 border-b border-neutral-200 px-4 py-2.5 text-sm">
+                    <div className="border-border flex items-center gap-2 border-b px-4 py-2.5 text-sm">
                       {comment.user?.avatar_url ? (
                         <img
                           src={comment.user.avatar_url}
@@ -202,10 +204,10 @@ export function ResourceView({ resource }: { resource: TaskResource }) {
                           className="size-5 rounded-full"
                         />
                       ) : null}
-                      <span className="font-medium text-neutral-700">
+                      <span className="text-muted-foreground font-medium">
                         {comment.user?.login}
                       </span>
-                      <span className="text-neutral-400">
+                      <span className="text-muted-foreground">
                         commented on{" "}
                         {new Date(comment.created_at).toLocaleDateString(
                           "en-US",
@@ -220,7 +222,7 @@ export function ResourceView({ resource }: { resource: TaskResource }) {
                     <div className="px-4 py-3">
                       {comment.body ? (
                         <Streamdown
-                          className="mt-1 text-sm text-neutral-700"
+                          className="text-muted-foreground mt-1 text-sm"
                           components={streamdownComponents}
                           isAnimating={false}
                           rehypePlugins={rehypePlugins}
@@ -228,7 +230,7 @@ export function ResourceView({ resource }: { resource: TaskResource }) {
                           {comment.body}
                         </Streamdown>
                       ) : (
-                        <span className="text-sm text-neutral-400 italic">
+                        <span className="text-muted-foreground text-sm italic">
                           No content.
                         </span>
                       )}

--- a/apps/desktop/src/task/tab-content.tsx
+++ b/apps/desktop/src/task/tab-content.tsx
@@ -76,7 +76,7 @@ export function TabContentTask({ tab }: { tab: TaskTab }) {
                 <div key={key}>
                   {index > 0 ? (
                     <div className="max-w-3xl px-6">
-                      <div className="border-t-2 border-neutral-200" />
+                      <div className="border-border border-t-2" />
                     </div>
                   ) : null}
                   <div ref={(element) => registerRef(key, element)}>
@@ -123,8 +123,8 @@ function ResourceNav({
               className={cn([
                 "w-full rounded-md px-2 py-1.5 text-left text-xs transition-colors",
                 isActive
-                  ? "font-medium text-neutral-900"
-                  : "text-neutral-500 hover:text-neutral-700",
+                  ? "text-foreground font-medium"
+                  : "text-muted-foreground hover:text-muted-foreground",
               ])}
             >
               <span className="line-clamp-2">

--- a/apps/desktop/src/templates/details.tsx
+++ b/apps/desktop/src/templates/details.tsx
@@ -74,7 +74,7 @@ export function TemplateDetailsColumn({
 function TemplateDetailEmpty({ onCreate }: { onCreate: () => void }) {
   return (
     <div className="flex h-full flex-col items-center justify-center gap-3">
-      <p className="text-sm text-neutral-500">No templates yet</p>
+      <p className="text-muted-foreground text-sm">No templates yet</p>
       <Button
         type="button"
         size="sm"
@@ -117,7 +117,7 @@ function WebTemplatePreview({
         category={template.category}
         targets={template.targets}
         titleMeta={
-          <span className="shrink-0 text-sm font-normal whitespace-nowrap text-neutral-400">
+          <span className="text-muted-foreground shrink-0 text-sm font-normal whitespace-nowrap">
             {getTemplateCreatorLabel({
               isUserTemplate: false,
               format: "short",
@@ -132,7 +132,7 @@ function WebTemplatePreview({
               size="sm"
               variant="ghost"
               onClick={() => onSetDefault(nextTemplate)}
-              className="shrink-0 text-neutral-600 hover:text-black"
+              className="text-muted-foreground shrink-0 hover:text-black"
             >
               Set as default
             </Button>
@@ -141,7 +141,7 @@ function WebTemplatePreview({
               size="icon"
               variant="ghost"
               onClick={() => onFavorite(nextTemplate)}
-              className="text-neutral-500 hover:text-neutral-800"
+              className="text-muted-foreground hover:text-foreground"
               title="Favorite template"
               aria-label="Favorite template"
             >
@@ -154,9 +154,8 @@ function WebTemplatePreview({
                   size="icon"
                   variant="ghost"
                   className={cn([
-                    "text-neutral-500 hover:text-neutral-800",
-                    actionsOpen &&
-                      "bg-neutral-100 text-neutral-800 hover:bg-neutral-100",
+                    "text-muted-foreground hover:text-foreground",
+                    actionsOpen && "bg-muted text-foreground hover:bg-accent",
                   ])}
                   aria-label="Template actions"
                 >

--- a/apps/desktop/src/templates/sections-editor.tsx
+++ b/apps/desktop/src/templates/sections-editor.tsx
@@ -179,7 +179,7 @@ export function SectionsList({
         <Button
           variant="outline"
           size="sm"
-          className="h-auto w-fit rounded-full border-neutral-200 bg-white px-4 py-2.5 text-sm text-stone-800 shadow-[0_2px_6px_rgba(87,83,78,0.08),0_10px_18px_-10px_rgba(87,83,78,0.22)] hover:bg-stone-50"
+          className="border-border bg-card text-foreground hover:bg-background h-auto w-fit rounded-full px-4 py-2.5 text-sm shadow-[0_2px_6px_rgba(87,83,78,0.08),0_10px_18px_-10px_rgba(87,83,78,0.22)]"
           onClick={addSection}
           disabled={disabled}
         >
@@ -217,7 +217,7 @@ function SectionItem({
   const [isFocused, setIsFocused] = useState(false);
 
   return (
-    <div className="group relative bg-white">
+    <div className="group bg-card relative">
       {!disabled && (
         <button
           type="button"
@@ -237,7 +237,7 @@ function SectionItem({
                 type="button"
                 size="icon"
                 variant="ghost"
-                className="h-7 w-7 text-neutral-400 hover:text-neutral-700"
+                className="text-muted-foreground hover:text-muted-foreground h-7 w-7"
                 aria-label="Section actions"
               >
                 <MoreHorizontalIcon className="size-4" />
@@ -303,7 +303,7 @@ function SectionItem({
             "min-h-[100px] w-full resize-y rounded-xl border p-3 font-mono text-sm transition-colors",
             "focus-visible:outline-hidden",
             disabled
-              ? "bg-neutral-50"
+              ? "bg-muted"
               : isFocused
                 ? "ring-primary/20 border-blue-500 ring-2"
                 : "border-input",

--- a/apps/desktop/src/templates/template-form.tsx
+++ b/apps/desktop/src/templates/template-form.tsx
@@ -108,7 +108,7 @@ function TemplateTargetsInput({
           type="text"
           autoFocus
           value={inputValue}
-          className="min-w-[84px] flex-1 bg-transparent py-0 text-xs leading-none text-neutral-500 outline-hidden"
+          className="text-muted-foreground min-w-[84px] flex-1 bg-transparent py-0 text-xs leading-none outline-hidden"
           onChange={(e) => setInputValue(e.target.value)}
           onBlur={submitTargets}
           onKeyDown={(e) => {
@@ -229,10 +229,8 @@ export function TemplateForm({
               onClick={setSelectedTemplateId}
               title={isDefault ? "Remove as default" : "Set as default"}
               className={cn([
-                "shrink-0 text-neutral-600 hover:text-black",
-                isDefault
-                  ? "bg-neutral-100 text-black hover:bg-neutral-100"
-                  : null,
+                "text-muted-foreground shrink-0 hover:text-black",
+                isDefault ? "bg-muted hover:bg-accent text-black" : null,
               ])}
             >
               {isDefault ? "Current default" : "Set as default"}
@@ -243,7 +241,7 @@ export function TemplateForm({
               variant="ghost"
               onClick={() => toggleTemplateFavorite(id)}
               className={cn([
-                "text-neutral-500 hover:text-neutral-800",
+                "text-muted-foreground hover:text-foreground",
                 template.pinned && "text-rose-500 hover:text-rose-600",
               ])}
               title={
@@ -265,9 +263,8 @@ export function TemplateForm({
                   size="icon"
                   variant="ghost"
                   className={cn([
-                    "text-neutral-500 hover:text-neutral-800",
-                    actionsOpen &&
-                      "bg-neutral-100 text-neutral-800 hover:bg-neutral-100",
+                    "text-muted-foreground hover:text-foreground",
+                    actionsOpen && "bg-muted text-foreground hover:bg-accent",
                   ])}
                   aria-label="Template actions"
                 >
@@ -311,7 +308,7 @@ export function TemplateForm({
                     className="absolute inset-0 h-auto w-full max-w-full min-w-0 border-0 px-0 py-0 text-lg font-semibold shadow-none focus-visible:ring-0 md:text-lg"
                   />
                 </div>
-                <span className="shrink-0 text-sm font-normal whitespace-nowrap text-neutral-400">
+                <span className="text-muted-foreground shrink-0 text-sm font-normal whitespace-nowrap">
                   {getTemplateCreatorLabel({
                     isUserTemplate: true,
                     creatorName,
@@ -327,7 +324,7 @@ export function TemplateForm({
                 value={field.state.value}
                 onChange={(e) => field.handleChange(e.target.value)}
                 placeholder="Describe the template purpose..."
-                className="mt-1 min-h-[24px] resize-none border-0 px-0 py-0 text-sm text-neutral-500 shadow-none focus-visible:ring-0"
+                className="text-muted-foreground mt-1 min-h-[24px] resize-none border-0 px-0 py-0 text-sm shadow-none focus-visible:ring-0"
                 rows={1}
               />
             )}

--- a/apps/desktop/src/templates/template-sidebar.tsx
+++ b/apps/desktop/src/templates/template-sidebar.tsx
@@ -300,7 +300,7 @@ export function TemplatesSidebarContent({
                 <Button
                   size="icon"
                   variant="ghost"
-                  className="relative z-[60] text-neutral-600 hover:text-black"
+                  className="text-muted-foreground relative z-[60] hover:text-black"
                 >
                   <ArrowDownUp size={16} />
                 </Button>
@@ -325,7 +325,7 @@ export function TemplatesSidebarContent({
           <Button
             size="icon"
             variant="ghost"
-            className="relative z-[60] text-neutral-600 hover:text-black"
+            className="text-muted-foreground relative z-[60] hover:text-black"
             onClick={createDefaultTemplate}
           >
             <Plus size={16} />
@@ -335,11 +335,11 @@ export function TemplatesSidebarContent({
         <div className="pb-2">
           <div
             className={cn([
-              "flex h-8 w-full shrink-0 items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-200/50 px-3",
-              "transition-colors focus-within:bg-neutral-200",
+              "border-border bg-accent/50 flex h-8 w-full shrink-0 items-center gap-2 rounded-lg border px-3",
+              "focus-within:bg-accent transition-colors",
             ])}
           >
-            <Search className="h-4 w-4 shrink-0 text-neutral-400" />
+            <Search className="text-muted-foreground h-4 w-4 shrink-0" />
             <input
               type="text"
               value={search}
@@ -350,14 +350,14 @@ export function TemplatesSidebarContent({
                 }
               }}
               placeholder="Search templates..."
-              className="min-w-0 flex-1 bg-transparent text-sm placeholder:text-sm placeholder:text-neutral-400 focus:outline-hidden"
+              className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-sm placeholder:text-sm focus:outline-hidden"
             />
             {search && (
               <button
                 onClick={() => setSearch("")}
                 className={cn([
                   "h-4 w-4 shrink-0",
-                  "text-neutral-400 hover:text-neutral-600",
+                  "text-muted-foreground hover:text-muted-foreground",
                   "transition-colors",
                 ])}
                 aria-label="Clear search"
@@ -374,15 +374,18 @@ export function TemplatesSidebarContent({
         className="scrollbar-hide flex-1 overflow-y-auto"
       >
         {isEmpty ? (
-          <div className="px-3 py-8 text-center text-neutral-500">
-            <BookText size={32} className="mx-auto mb-2 text-neutral-300" />
+          <div className="text-muted-foreground px-3 py-8 text-center">
+            <BookText
+              size={32}
+              className="text-muted-foreground/70 mx-auto mb-2"
+            />
             <p className="text-sm">
               {search ? "No templates found" : "No templates yet"}
             </p>
             {!search && (
               <button
                 onClick={createDefaultTemplate}
-                className="mt-3 text-sm text-neutral-600 underline hover:text-neutral-800"
+                className="text-muted-foreground hover:text-foreground mt-3 text-sm underline"
               >
                 Create my first template
               </button>
@@ -410,13 +413,11 @@ export function TemplatesSidebarContent({
                       data-template-selected={item.selected}
                       className={cn([
                         "w-full rounded-lg px-3 py-2 text-left text-sm transition-colors select-none",
-                        item.selected
-                          ? "bg-neutral-200"
-                          : "hover:bg-neutral-200/50",
+                        item.selected ? "bg-accent" : "hover:bg-accent/50",
                       ])}
                     >
                       <div className="flex items-center gap-2">
-                        <BookText className="h-4 w-4 shrink-0 text-neutral-500" />
+                        <BookText className="text-muted-foreground h-4 w-4 shrink-0" />
                         <div className="min-w-0 flex-1">
                           <div className="truncate font-medium">
                             {item.title}
@@ -437,8 +438,8 @@ export function TemplatesSidebarContent({
                       key={index}
                       className="animate-pulse rounded-lg px-3 py-2"
                     >
-                      <div className="h-4 w-3/4 rounded-xs bg-neutral-200" />
-                      <div className="mt-1.5 h-3 w-1/3 rounded-xs bg-neutral-100" />
+                      <div className="bg-accent h-4 w-3/4 rounded-xs" />
+                      <div className="bg-muted mt-1.5 h-3 w-1/3 rounded-xs" />
                     </div>
                   ))}
                 </div>
@@ -499,11 +500,11 @@ function TemplateListItem({
       data-template-selected={selected}
       className={cn([
         "w-full rounded-lg px-3 py-2 text-left text-sm transition-colors select-none",
-        selected ? "bg-neutral-200" : "hover:bg-neutral-200/50",
+        selected ? "bg-accent" : "hover:bg-accent/50",
       ])}
     >
       <div className="flex items-center gap-2">
-        <BookText className="h-4 w-4 shrink-0 text-neutral-500" />
+        <BookText className="text-muted-foreground h-4 w-4 shrink-0" />
         <div className="min-w-0 flex-1">
           <div className="truncate font-medium">
             {template.title?.trim() || "Untitled"}

--- a/packages/changelog/src/components.tsx
+++ b/packages/changelog/src/components.tsx
@@ -27,51 +27,62 @@ function flattenTextContent(node: React.ReactNode): string {
   return "";
 }
 
+const changelogLinkClassName =
+  "text-blue-600 underline decoration-blue-400/40 underline-offset-2 hover:text-blue-700 dark:text-blue-400 dark:decoration-blue-500/50 dark:hover:text-blue-300";
+
+const changelogBodyClassName = "text-foreground/85";
+
 const baseChangelogComponents = {
   h2: ({ children }: { children?: React.ReactNode }) => (
-    <h2 className="mt-6 mb-3 pt-6 text-base font-semibold text-amber-950 first:mt-0 first:pt-0">
+    <h2 className="text-foreground mt-6 mb-3 pt-6 text-base font-semibold first:mt-0 first:pt-0">
       {children}
     </h2>
   ),
   h3: ({ children }: { children?: React.ReactNode }) => (
-    <h3 className="mt-5 mb-2 text-sm font-semibold text-amber-950">
+    <h3 className="text-foreground mt-5 mb-2 text-sm font-semibold">
       {children}
     </h3>
   ),
   h4: ({ children }: { children?: React.ReactNode }) => (
-    <h4 className="mt-4 mb-2 text-sm font-medium text-amber-950">{children}</h4>
+    <h4 className="text-foreground mt-4 mb-2 text-sm font-medium">
+      {children}
+    </h4>
   ),
   p: ({ children }: { children?: React.ReactNode }) => (
-    <p className="my-2 text-stone-600">{children}</p>
+    <p className={cn(["my-2", changelogBodyClassName])}>{children}</p>
   ),
   strong: ({ children }: { children?: React.ReactNode }) => (
-    <strong className="font-semibold text-stone-800">{children}</strong>
+    <strong className="text-foreground font-semibold">{children}</strong>
   ),
   em: ({ children }: { children?: React.ReactNode }) => (
     <em className="italic">{children}</em>
   ),
   code: ({ children }: { children?: React.ReactNode }) => (
-    <code className="rounded bg-amber-50 px-1 py-0.5 text-[0.85em] text-amber-800">
+    <code className="bg-muted text-foreground rounded px-1 py-0.5 text-[0.85em]">
       {children}
     </code>
   ),
   ul: ({ children }: { children?: React.ReactNode }) => (
-    <ul className="my-2 list-disc pl-6 text-stone-600">{children}</ul>
+    <ul className={cn(["my-2 list-disc pl-6", changelogBodyClassName])}>
+      {children}
+    </ul>
   ),
   ol: ({ children }: { children?: React.ReactNode }) => (
-    <ol className="my-2 list-decimal pl-6 text-stone-600">{children}</ol>
+    <ol className={cn(["my-2 list-decimal pl-6", changelogBodyClassName])}>
+      {children}
+    </ol>
   ),
   li: ({ children }: { children?: React.ReactNode }) => (
     <li className="my-0.5">{children}</li>
   ),
   blockquote: ({ children }: { children?: React.ReactNode }) => (
-    <blockquote className="my-4 border-l-2 border-amber-200 pl-4 text-stone-500 italic">
+    <blockquote className="border-border text-muted-foreground my-4 border-l-2 pl-4 italic">
       {children}
     </blockquote>
   ),
   a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
     <a
-      className="text-amber-700 underline decoration-amber-300 underline-offset-2 hover:text-amber-900 hover:decoration-amber-500"
+      className={changelogLinkClassName}
       href={href}
       target="_blank"
       rel="noopener noreferrer"
@@ -80,11 +91,7 @@ const baseChangelogComponents = {
     </a>
   ),
   img: ({ src, alt }: { src?: string; alt?: string }) => (
-    <img
-      src={src}
-      alt={alt}
-      className="my-6 rounded-lg border border-stone-200"
-    />
+    <img src={src} alt={alt} className="border-border my-6 rounded-lg border" />
   ),
 };
 
@@ -103,10 +110,10 @@ export const changelogComponents = {
       className={cn([
         "mb-2 rounded-xl border px-5 pt-4 pb-4",
         variant === "warning"
-          ? "border-amber-300 bg-amber-50 text-amber-900"
+          ? "border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100"
           : variant === "info"
-            ? "border-blue-300 bg-blue-50 text-blue-900"
-            : "border-amber-200 bg-amber-50/60 text-stone-800",
+            ? "border-blue-300 bg-blue-50 text-blue-900 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-100"
+            : "border-border bg-muted text-foreground",
       ])}
     >
       {title && (
@@ -114,16 +121,21 @@ export const changelogComponents = {
           className={cn([
             "mb-1 text-sm font-semibold",
             variant === "warning"
-              ? "text-amber-900"
+              ? "text-amber-900 dark:text-amber-100"
               : variant === "info"
-                ? "text-blue-900"
-                : "text-amber-900",
+                ? "text-blue-900 dark:text-blue-100"
+                : "text-foreground",
           ])}
         >
           {title}
         </div>
       )}
-      <div className="text-sm text-stone-600 [&_p:last-child]:mb-0 [&_ul:last-child]:mb-0">
+      <div
+        className={cn([
+          "text-sm [&_p:last-child]:mb-0 [&_ul:last-child]:mb-0",
+          changelogBodyClassName,
+        ])}
+      >
         <Streamdown
           components={baseChangelogComponents}
           isAnimating={false}

--- a/packages/codemirror/src/template/theme.css
+++ b/packages/codemirror/src/template/theme.css
@@ -1,0 +1,21 @@
+:root {
+  --cm-placeholder: #999999;
+  --cm-syntax-brace: #d97706;
+  --cm-syntax-variable: #0369a1;
+  --cm-syntax-keyword: #7c3aed;
+  --cm-syntax-string: #059669;
+  --cm-syntax-operator: #64748b;
+  --cm-syntax-property: #0891b2;
+  --cm-syntax-comment: #9ca3af;
+}
+
+.dark {
+  --cm-placeholder: #78716c;
+  --cm-syntax-brace: #fbbf24;
+  --cm-syntax-variable: #38bdf8;
+  --cm-syntax-keyword: #c4b5fd;
+  --cm-syntax-string: #34d399;
+  --cm-syntax-operator: #a8a29e;
+  --cm-syntax-property: #67e8f9;
+  --cm-syntax-comment: #78716c;
+}

--- a/packages/codemirror/src/template/theme.ts
+++ b/packages/codemirror/src/template/theme.ts
@@ -1,3 +1,5 @@
+import "./theme.css";
+
 import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { EditorView } from "@codemirror/view";
 import { tags } from "@lezer/highlight";
@@ -28,19 +30,38 @@ const templateTheme = EditorView.theme({
     padding: "4px 8px",
   },
   ".cm-placeholder": {
-    color: "#999",
+    color: "var(--cm-placeholder)",
     fontStyle: "italic",
   },
 });
 
 const templateHighlightStyle = HighlightStyle.define([
-  { tag: tags.brace, color: "#d97706", fontWeight: "600" },
-  { tag: tags.variableName, color: "#0369a1", fontWeight: "500" },
-  { tag: tags.keyword, color: "#7c3aed", fontWeight: "500" },
-  { tag: tags.string, color: "#059669" },
-  { tag: tags.operator, color: "#64748b" },
-  { tag: tags.propertyName, color: "#0891b2" },
-  { tag: tags.comment, color: "#9ca3af", fontStyle: "italic" },
+  {
+    tag: tags.brace,
+    color: "var(--cm-syntax-brace)",
+    fontWeight: "600",
+  },
+  {
+    tag: tags.variableName,
+    color: "var(--cm-syntax-variable)",
+    fontWeight: "500",
+  },
+  {
+    tag: tags.keyword,
+    color: "var(--cm-syntax-keyword)",
+    fontWeight: "500",
+  },
+  { tag: tags.string, color: "var(--cm-syntax-string)" },
+  { tag: tags.operator, color: "var(--cm-syntax-operator)" },
+  {
+    tag: tags.propertyName,
+    color: "var(--cm-syntax-property)",
+  },
+  {
+    tag: tags.comment,
+    color: "var(--cm-syntax-comment)",
+    fontStyle: "italic",
+  },
 ]);
 
 export const templateExtensions = [

--- a/packages/editor/src/editor-error-boundary.tsx
+++ b/packages/editor/src/editor-error-boundary.tsx
@@ -63,7 +63,7 @@ export class EditorErrorBoundary extends Component<
       return (
         <div
           role="alert"
-          className="flex items-center justify-between gap-3 rounded-md border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-600"
+          className="border-border bg-muted text-muted-foreground flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-sm"
         >
           <span>
             The editor failed to render. Your recording is still running.
@@ -71,7 +71,7 @@ export class EditorErrorBoundary extends Component<
           <button
             type="button"
             onClick={this.retry}
-            className="shrink-0 rounded-md border border-neutral-200 bg-white px-2 py-1 text-xs font-medium text-neutral-700 hover:bg-neutral-100"
+            className="border-border bg-card text-muted-foreground hover:bg-accent shrink-0 rounded-md border px-2 py-1 text-xs font-medium"
           >
             Reload editor
           </button>

--- a/packages/editor/src/node-views/attachment-view.tsx
+++ b/packages/editor/src/node-views/attachment-view.tsx
@@ -72,7 +72,7 @@ export const AttachmentChipView = forwardRef<
       <span
         contentEditable={false}
         suppressContentEditableWarning
-        className="inline-flex items-center gap-1 rounded-md border border-neutral-200 bg-neutral-50 px-1.5 py-0.5 text-xs text-neutral-600"
+        className="border-border bg-muted text-muted-foreground inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs"
       >
         {isImage && url ? (
           <img
@@ -81,7 +81,7 @@ export const AttachmentChipView = forwardRef<
             className="h-4 w-4 shrink-0 rounded object-cover"
           />
         ) : (
-          <FileIcon size={12} className="shrink-0 text-neutral-400" />
+          <FileIcon size={12} className="text-muted-foreground shrink-0" />
         )}
         <span className="max-w-[120px] truncate">{displayName}</span>
         <button
@@ -91,7 +91,7 @@ export const AttachmentChipView = forwardRef<
             e.stopPropagation();
             handleRemove();
           }}
-          className="shrink-0 rounded p-0.5 hover:bg-neutral-200"
+          className="hover:bg-accent shrink-0 rounded p-0.5"
         >
           <XIcon size={10} />
         </button>

--- a/packages/editor/src/node-views/error-boundary.tsx
+++ b/packages/editor/src/node-views/error-boundary.tsx
@@ -66,7 +66,7 @@ class NodeViewErrorBoundary extends Component<
           suppressContentEditableWarning: true,
           "data-node-view-error": this.props.name,
           className: [
-            "rounded-md border border-neutral-200 bg-neutral-50 px-2 py-1 text-sm text-neutral-600",
+            "rounded-md border border-border bg-muted px-2 py-1 text-sm text-muted-foreground",
             typeof className === "string" ? className : "",
           ]
             .filter(Boolean)

--- a/packages/editor/src/node-views/file-attachment-view.tsx
+++ b/packages/editor/src/node-views/file-attachment-view.tsx
@@ -122,8 +122,8 @@ export const FileAttachmentView = forwardRef<
         contentEditable={false}
         suppressContentEditableWarning
         className={cn([
-          "group my-1 flex items-center gap-3 rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2.5",
-          "hover:border-neutral-300 hover:bg-neutral-100",
+          "group border-border bg-muted my-1 flex items-center gap-3 rounded-lg border px-3 py-2.5",
+          "hover:border-border hover:bg-accent",
           "transition-colors",
         ])}
       >
@@ -134,17 +134,17 @@ export const FileAttachmentView = forwardRef<
             className="h-10 w-10 shrink-0 rounded object-cover"
           />
         ) : (
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded bg-neutral-200/60">
-            <Icon size={20} className="text-neutral-500" />
+          <div className="bg-accent/60 flex h-10 w-10 shrink-0 items-center justify-center rounded">
+            <Icon size={20} className="text-muted-foreground" />
           </div>
         )}
 
         <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-medium text-neutral-700">
+          <div className="text-muted-foreground truncate text-sm font-medium">
             {displayName}
           </div>
           {sizeLabel && (
-            <div className="text-xs text-neutral-400">{sizeLabel}</div>
+            <div className="text-muted-foreground text-xs">{sizeLabel}</div>
           )}
         </div>
 
@@ -157,10 +157,10 @@ export const FileAttachmentView = forwardRef<
                 e.stopPropagation();
                 handleOpen();
               }}
-              className="rounded p-1 hover:bg-neutral-200"
+              className="hover:bg-accent rounded p-1"
               title="Open file"
             >
-              <ExternalLinkIcon size={14} className="text-neutral-500" />
+              <ExternalLinkIcon size={14} className="text-muted-foreground" />
             </button>
           )}
           <button
@@ -170,10 +170,10 @@ export const FileAttachmentView = forwardRef<
               e.stopPropagation();
               handleRemove();
             }}
-            className="rounded p-1 hover:bg-neutral-200"
+            className="hover:bg-accent rounded p-1"
             title="Remove attachment"
           >
-            <XIcon size={14} className="text-neutral-500" />
+            <XIcon size={14} className="text-muted-foreground" />
           </button>
         </div>
       </div>

--- a/packages/editor/src/node-views/image-view.tsx
+++ b/packages/editor/src/node-views/image-view.tsx
@@ -190,12 +190,12 @@ export const ResizableImageView = forwardRef<
           alt={node.attrs.alt || ""}
           title={parseImageMetadata(node.attrs.title).title ?? undefined}
           className={cn([
-            "tiptap-image max-w-full rounded-md bg-white transition-[box-shadow,border-color] select-none",
+            "tiptap-image bg-card max-w-full rounded-md transition-[box-shadow,border-color] select-none",
             isSelected
-              ? "ring-2 ring-blue-500 ring-offset-2 ring-offset-white"
+              ? "ring-offset-card ring-2 ring-blue-500 ring-offset-2"
               : "",
             isHovered && !isSelected
-              ? "ring-1 ring-neutral-300 ring-offset-2 ring-offset-white"
+              ? "ring-border ring-offset-card ring-1 ring-offset-2"
               : "",
             "w-full",
           ])}
@@ -215,17 +215,17 @@ export const ResizableImageView = forwardRef<
               type="button"
               aria-label="Resize image from left"
               onPointerDown={(event) => handleResizeStart("left", event)}
-              className="absolute top-1/2 left-1 z-20 flex h-14 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border border-neutral-300 bg-white/95 shadow-sm backdrop-blur-sm"
+              className="border-border bg-card/95 absolute top-1/2 left-1 z-20 flex h-14 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border shadow-sm backdrop-blur-sm"
             >
-              <span className="h-8 w-1 rounded-full bg-neutral-400" />
+              <span className="bg-muted-foreground h-8 w-1 rounded-full" />
             </button>
             <button
               type="button"
               aria-label="Resize image from right"
               onPointerDown={(event) => handleResizeStart("right", event)}
-              className="absolute top-1/2 right-1 z-20 flex h-14 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border border-neutral-300 bg-white/95 shadow-sm backdrop-blur-sm"
+              className="border-border bg-card/95 absolute top-1/2 right-1 z-20 flex h-14 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border shadow-sm backdrop-blur-sm"
             >
-              <span className="h-8 w-1 rounded-full bg-neutral-400" />
+              <span className="bg-muted-foreground h-8 w-1 rounded-full" />
             </button>
           </>
         )}

--- a/packages/editor/src/node-views/mention-view.tsx
+++ b/packages/editor/src/node-views/mention-view.tsx
@@ -47,16 +47,16 @@ export const mentionNodeSpec: NodeSpec = {
 const GLOBAL_NAVIGATE_FUNCTION = "__HYPR_NAVIGATE__";
 
 const FACEHASH_BG_CLASSES = [
-  "bg-amber-50",
-  "bg-rose-50",
-  "bg-violet-50",
-  "bg-blue-50",
-  "bg-teal-50",
-  "bg-green-50",
-  "bg-cyan-50",
-  "bg-fuchsia-50",
-  "bg-indigo-50",
-  "bg-yellow-50",
+  "bg-amber-50 dark:bg-amber-950",
+  "bg-rose-50 dark:bg-rose-950",
+  "bg-violet-50 dark:bg-violet-950",
+  "bg-blue-50 dark:bg-blue-950",
+  "bg-teal-50 dark:bg-teal-950",
+  "bg-green-50 dark:bg-green-950",
+  "bg-cyan-50 dark:bg-cyan-950",
+  "bg-fuchsia-50 dark:bg-fuchsia-950",
+  "bg-indigo-50 dark:bg-indigo-950",
+  "bg-yellow-50 dark:bg-yellow-950",
 ];
 
 function getMentionFacehashBgClass(name: string) {
@@ -83,6 +83,7 @@ function MentionAvatar({
           size={16}
           showInitial={true}
           interactive={false}
+          className="text-stone-950"
           colorClasses={[bgClass]}
         />
       </span>

--- a/packages/editor/src/widgets/format-toolbar.tsx
+++ b/packages/editor/src/widgets/format-toolbar.tsx
@@ -108,7 +108,7 @@ export function FormatToolbar() {
     <div
       ref={toolbarRef}
       className={cn([
-        "absolute z-[9999] flex items-center gap-0.5 rounded-lg border border-neutral-200 bg-white/95 p-1",
+        "border-border bg-card/95 absolute z-[9999] flex items-center gap-0.5 rounded-lg border p-1",
         "shadow-[0_2px_8px_rgba(0,0,0,0.08),0_18px_42px_-16px_rgba(0,0,0,0.34)] backdrop-blur-sm",
       ])}
       style={{ top: 0, left: 0 }}
@@ -123,8 +123,8 @@ export function FormatToolbar() {
               "flex size-8 items-center justify-center rounded-md",
               "cursor-pointer border-none transition-colors",
               active
-                ? "bg-neutral-200 text-neutral-900"
-                : "bg-transparent text-neutral-600 hover:bg-neutral-100",
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground hover:bg-accent bg-transparent",
             ])}
             onClick={() => toggle(button.markType)}
           >

--- a/packages/editor/src/widgets/slash-command.tsx
+++ b/packages/editor/src/widgets/slash-command.tsx
@@ -358,12 +358,12 @@ export function SlashCommandMenu() {
       data-editor-escape-consumer
       className={cn([
         "absolute z-[9999] max-h-64 w-[240px]",
-        "overflow-y-auto rounded-lg border border-neutral-200 bg-white/95 p-1",
+        "border-border bg-card/95 overflow-y-auto rounded-lg border p-1",
         "shadow-[0_2px_8px_rgba(0,0,0,0.08),0_18px_42px_-16px_rgba(0,0,0,0.34)] backdrop-blur-sm",
       ])}
       style={{ top: 0, left: 0 }}
     >
-      <div className="px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide text-neutral-400 uppercase select-none">
+      <div className="text-muted-foreground px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase select-none">
         Commands
       </div>
       {items.map((item, index) => (
@@ -372,19 +372,19 @@ export function SlashCommandMenu() {
           className={cn([
             "flex w-full items-center gap-1.5 rounded-md px-1.5 py-1 text-left",
             "cursor-pointer border-none bg-transparent transition-colors",
-            index === selectedIndex && "bg-neutral-100",
+            index === selectedIndex && "bg-muted",
           ])}
           onClick={() => executeCommand(item)}
           onMouseEnter={() => setSelectedIndex(index)}
         >
-          <span className="flex size-7 shrink-0 items-center justify-center rounded-md border border-neutral-200 bg-neutral-50">
-            <item.icon className="size-3.5 text-neutral-600" />
+          <span className="border-border bg-muted flex size-7 shrink-0 items-center justify-center rounded-md border">
+            <item.icon className="text-muted-foreground size-3.5" />
           </span>
           <span className="flex flex-col gap-px overflow-hidden">
-            <span className="truncate text-[0.8rem] font-medium text-neutral-900">
+            <span className="text-foreground truncate text-[0.8rem] font-medium">
               {item.label}
             </span>
-            <span className="truncate text-[0.7rem] text-neutral-400">
+            <span className="text-muted-foreground truncate text-[0.7rem]">
               {item.description}
             </span>
           </span>

--- a/packages/pricing/src/plan-feature-list.tsx
+++ b/packages/pricing/src/plan-feature-list.tsx
@@ -36,10 +36,10 @@ export function PlanFeatureList({
         const iconClassName = cn([
           dense ? "size-3.5" : "size-4.5",
           feature.included === true
-            ? "text-green-700"
+            ? "text-emerald-600 dark:text-emerald-400"
             : isPartial
-              ? "text-neutral-900"
-              : "text-red-500",
+              ? "text-foreground"
+              : "text-red-500 dark:text-red-400",
         ]);
         const featureContent = (
           <>
@@ -58,15 +58,15 @@ export function PlanFeatureList({
                   className={cn([
                     dense ? "text-xs" : "text-sm",
                     feature.included === false
-                      ? "text-neutral-700"
-                      : "text-neutral-900",
+                      ? "text-muted-foreground"
+                      : "text-foreground",
                   ])}
                 >
                   {feature.label}
                 </span>
               </div>
               {feature.tooltip && !dense && (
-                <div className="mt-0.5 text-xs text-neutral-500 italic">
+                <div className="text-muted-foreground mt-0.5 text-xs italic">
                   {feature.tooltip}
                 </div>
               )}
@@ -88,7 +88,7 @@ export function PlanFeatureList({
                 className={cn([
                   "flex w-full items-start border-0 bg-transparent p-0 text-left",
                   dense ? "gap-1.5" : "gap-3",
-                  "cursor-help rounded-sm focus-visible:ring-2 focus-visible:ring-stone-300 focus-visible:outline-none",
+                  "focus-visible:ring-ring cursor-help rounded-sm focus-visible:ring-2 focus-visible:outline-none",
                 ])}
                 aria-label={`${feature.label}: ${getPartialFeatureTooltip(feature)}`}
               >

--- a/packages/store/src/tinybase.ts
+++ b/packages/store/src/tinybase.ts
@@ -187,4 +187,5 @@ export const valueSchemaForTinybase = {
   current_stt_provider: { type: "string" },
   current_stt_model: { type: "string" },
   on_device_transcription_mode: { type: "string" },
+  theme: { type: "string" },
 } as const satisfies InferTinyBaseSchema<typeof generalSchema>;

--- a/packages/store/src/zod.ts
+++ b/packages/store/src/zod.ts
@@ -298,6 +298,7 @@ export const generalSchema = z.object({
   on_device_transcription_mode: z.string().default("realtime"),
   timezone: z.string().optional(),
   week_start: z.string().optional(),
+  theme: z.enum(["light", "dark", "system"]).default("system"),
 });
 
 export const aiProviderSchema = z

--- a/packages/tiptap/src/styles/dark.css
+++ b/packages/tiptap/src/styles/dark.css
@@ -1,0 +1,89 @@
+.dark .tiptap {
+  caret-color: #d6d3d1;
+}
+
+.dark .tiptap h1,
+.dark .tiptap h2,
+.dark .tiptap h3,
+.dark .tiptap h4,
+.dark .tiptap h5,
+.dark .tiptap h6,
+.dark .blog-editor .tiptap h3,
+.dark .blog-editor .tiptap h4,
+.dark .blog-editor .tiptap h5,
+.dark .blog-editor .tiptap h6 {
+  color: #e7e5e4;
+}
+
+.dark .tiptap blockquote {
+  border-left-color: #a8a29e;
+  caret-color: #e7e5e4;
+}
+
+.dark .tiptap a {
+  color: #60a5fa;
+}
+
+.dark .tiptap a:hover {
+  color: #93c5fd;
+}
+
+.dark .tiptap code {
+  border-color: #57534e;
+  color: #e7e5e4;
+}
+
+.dark .tiptap input.task-checkbox {
+  border-color: #78716c;
+}
+
+.dark .tiptap input.task-checkbox[data-interactive="true"]:hover:not(:checked) {
+  border-color: #a8a29e;
+}
+
+.dark .ProseMirror td,
+.dark .ProseMirror th {
+  border-color: #57534e;
+}
+
+.dark .ProseMirror th {
+  background-color: #292524;
+}
+
+.dark .tiptap mark {
+  background-color: rgb(113 63 18 / 0.45);
+  color: #fcd34d;
+}
+
+.dark .ProseMirror .ProseMirror-search-match {
+  background-color: rgb(113 63 18 / 0.45);
+}
+
+.dark .ProseMirror .ProseMirror-active-search-match {
+  background-color: rgb(202 138 4);
+}
+
+.dark .ProseMirror .is-editor-empty:first-child::before,
+.dark .ProseMirror .is-empty::before,
+.dark .ProseMirror .react-placeholder-widget {
+  color: #78716c;
+}
+
+.dark .mention-container {
+  background: #292524;
+  box-shadow:
+    0 0 0 1px rgb(255 255 255 / 0.08),
+    0 6px 12px -3px rgb(0 0 0 / 0.35);
+}
+
+.dark .mention-item.is-selected {
+  background-color: #44403c;
+}
+
+.dark .mention-item:hover {
+  background-color: #292524;
+}
+
+.dark .mention .mention-avatar-icon {
+  color: #a8a29e;
+}

--- a/packages/tiptap/src/styles/tiptap.css
+++ b/packages/tiptap/src/styles/tiptap.css
@@ -18,6 +18,8 @@
 /* Animation styles */
 @import "./animation.css";
 
+@import "./dark.css";
+
 .ProseMirror .is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   float: left;

--- a/packages/ui/src/components/ui/floating-content.tsx
+++ b/packages/ui/src/components/ui/floating-content.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@hypr/utils";
 
 export const appFloatingContentClassName =
-  "overflow-hidden rounded-2xl border border-neutral-200 bg-stone-50 p-1 shadow-lg";
+  "bg-popover text-popover-foreground overflow-hidden rounded-2xl border border-border p-1 shadow-lg";
 
 export type FloatingContentVariant = "default" | "app";
 
@@ -12,7 +12,7 @@ export function AppFloatingPanel({
   return (
     <div
       className={cn([
-        "rounded-2xl border border-neutral-200 bg-white",
+        "bg-popover text-popover-foreground border-border rounded-2xl border",
         className,
       ])}
       {...props}

--- a/packages/ui/src/components/ui/kbd.tsx
+++ b/packages/ui/src/components/ui/kbd.tsx
@@ -6,10 +6,8 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
       data-slot="kbd"
       className={cn([
         "pointer-events-none inline-flex h-5 w-fit min-w-5 shrink-0 items-center justify-center gap-1 rounded px-1 font-mono text-xs leading-none font-medium whitespace-nowrap select-none",
-        "border border-neutral-300",
-        "bg-linear-to-b from-white to-neutral-100",
-        "text-neutral-400",
-        "shadow-[0_1px_0_0_rgba(0,0,0,0.1),inset_0_1px_0_0_rgba(255,255,255,0.8)]",
+        "border-border bg-muted text-muted-foreground border",
+        "shadow-[0_1px_0_0_var(--kbd-shadow-outer),inset_0_1px_0_0_var(--kbd-shadow-inset)]",
         "[&_svg:not([class*='size-'])]:size-3",
         className,
       ])}

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -114,7 +114,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn([
-      "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center rounded-full py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+      "data-highlighted:bg-accent data-highlighted:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center rounded-full py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     ])}
     {...props}

--- a/packages/ui/src/components/ui/switch.tsx
+++ b/packages/ui/src/components/ui/switch.tsx
@@ -21,7 +21,7 @@ const switchVariants = cva(
 );
 
 const thumbVariants = cva(
-  "bg-background pointer-events-none block rounded-full shadow-lg ring-0 transition-transform",
+  "bg-background data-[state=checked]:bg-primary-foreground pointer-events-none block rounded-full shadow-lg ring-0 transition-transform",
   {
     variants: {
       size: {

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
   --animate-accordion-down: accordion-down 0.2s ease-out;
@@ -23,6 +23,10 @@
   --color-destructive: hsl(var(--destructive));
   --color-destructive-foreground: hsl(var(--destructive-foreground));
 
+  --color-alert: hsl(var(--alert));
+  --color-alert-foreground: hsl(var(--alert-foreground));
+  --color-alert-border: hsl(var(--alert-border));
+
   --color-muted: hsl(var(--muted));
   --color-muted-foreground: hsl(var(--muted-foreground));
 
@@ -43,6 +47,7 @@
   --color-sidebar-accent-foreground: hsl(var(--sidebar-accent-foreground));
   --color-sidebar-border: hsl(var(--sidebar-border));
   --color-sidebar-ring: hsl(var(--sidebar-ring));
+  --color-sidebar-accent: hsl(var(--sidebar-accent));
 
   --radius-xl: calc(var(--radius) + 4px);
   --radius-lg: var(--radius);
@@ -168,64 +173,78 @@
   ::before,
   ::backdrop,
   ::file-selector-button {
-    border-color: var(--color-gray-200, currentcolor);
+    border-color: var(--color-border, currentcolor);
   }
 }
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    --background: 60 9% 98%;
+    --foreground: 24 10% 10%;
     --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
+    --card-foreground: 24 10% 10%;
     --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
+    --popover-foreground: 24 10% 10%;
+    --primary: 24 10% 16%;
+    --primary-foreground: 60 9% 98%;
+    --secondary: 60 5% 96%;
+    --secondary-foreground: 24 10% 10%;
+    --muted: 60 5% 96%;
+    --muted-foreground: 25 5% 45%;
+    --accent: 60 5% 94%;
+    --accent-foreground: 24 10% 10%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
+    --alert: 0 86% 97%;
+    --alert-foreground: 0 72% 42%;
+    --alert-border: 0 90% 86%;
+    --border: 24 6% 90%;
+    --input: 24 6% 90%;
+    --ring: 24 10% 10%;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
+    --sidebar-accent: 60 5% 90%;
+    --kbd-shadow-outer: rgba(0, 0, 0, 0.1);
+    --kbd-shadow-inset: rgba(255, 255, 255, 0.8);
+    --kbd-shadow-outer-hover: rgba(0, 0, 0, 0.15);
   }
 
   .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
+    --background: 24 10% 11%;
+    --foreground: 60 9% 98%;
+    --card: 24 10% 16%;
+    --card-foreground: 60 9% 98%;
+    --popover: 24 10% 16%;
+    --popover-foreground: 60 9% 98%;
+    --primary: 24 10% 16%;
+    --primary-foreground: 60 9% 98%;
+    --secondary: 24 6% 20%;
+    --secondary-foreground: 60 9% 98%;
+    --muted: 24 6% 20%;
+    --muted-foreground: 25 5% 55%;
+    --accent: 24 6% 25%;
+    --accent-foreground: 60 9% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
+    --alert: 0 50% 14%;
+    --alert-foreground: 0 86% 72%;
+    --alert-border: 0 45% 24%;
+    --border: 24 6% 28%;
+    --input: 24 6% 28%;
+    --ring: 60 9% 75%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
+    --sidebar-accent: 24 6% 23%;
+    --kbd-shadow-outer: rgba(0, 0, 0, 0.35);
+    --kbd-shadow-inset: rgba(255, 255, 255, 0.08);
+    --kbd-shadow-outer-hover: rgba(0, 0, 0, 0.5);
   }
 
   .theme {


### PR DESCRIPTION
## Description

- Add light, dark, and system appearance preference in desktop settings with persisted theme state and flash-free startup
- Define warm stone semantic tokens in `@hypr/ui`, including alert and sidebar accent colors, with desktop dark-mode overrides
- Migrate desktop shell, settings, chat, session, calendar, onboarding, and shared packages from hardcoded neutral/stone colors to semantic tokens
- Theme TipTap and CodeMirror editors, provider icons, settings alerts, and sidebar nav hover/selected states for dark mode

## Test plan

- [ ] Toggle Appearance between Light, Dark, and System in Settings → App
- [ ] Verify settings sidebar hover and selected item highlights in both themes
- [ ] Spot-check session editor, chat panel, calendar, account page, and changelog in dark mode
- [ ] Confirm provider icons remain readable in dark mode while Anarlog logo stays full color
- [ ] Run `pnpm -F desktop typecheck` and `pnpm -F desktop test`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large cross-surface styling change with theme persistence and a chat exception path; low security impact but high visual regression risk if tokens mis-map in edge screens.
> 
> **Overview**
> Adds **light / dark / system** appearance with early `theme-boot.js` (toggles `dark` on `<html>` from `hypr-theme` before React) and `bootstrapThemeFromSettings` + `AppThemeProvider` syncing persisted settings and OS preference.
> 
> Replaces hardcoded **neutral/stone** Tailwind across desktop (calendar, contacts, onboarding, billing, timeline, composer, etc.) with **semantic tokens** (`background`, `foreground`, `card`, `muted`, `primary`, `destructive`, `border`, …) from `@hypr/ui` globals.
> 
> **Chat** is centralized in `chat/surface.ts` / `useChatAppearance`: floating and right-panel chrome stay on the **dark stone shell** (`bg-primary` / elevated `primary-foreground` surfaces) regardless of app theme, with new CSS for the elevated input and expanded tests.
> 
> Contacts gain **`ContactFacehash`** and **dark-aware avatar palette** classes; timeline selection moves from filled dark neutral to **`bg-accent` + `border-ring`**, with live sessions on **`destructive`** tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd819ce1e181b4892bb02524fb553d4b512ca569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->