### PR TITLE
Add desktop 1.0.40 changelog

### DIFF
--- a/packages/changelog/content/1.0.40.md
+++ b/packages/changelog/content/1.0.40.md
@@ -1,0 +1,22 @@
+---
+date: "2026-06-06"
+summary: "Meeting controls and notifications are clearer, past note context is tighter, and note links open more reliably."
+---
+
+## Meetings
+
+- Join buttons for Zoom, Meet, Teams, Webex, and other meeting links now live in the session header alongside meeting details
+- The floating meeting status now shows an explicit error state when listening degrades or fails
+- The bottom accessory no longer shows a separate finalizing message after a meeting wraps up
+- The "Stop meeting" action in meeting-ended prompts is now styled as a destructive action with a stop icon and no ticking progress gauge
+- Upcoming event notifications now stay compact instead of expanding into full event details
+
+## Past Notes
+
+- Past notes now focus on related meetings from the same recurring series or matching meeting title
+- Past note summaries now show up to three concise key facts in a cleaner timeline layout
+- Individual past note summaries can now be regenerated from the Past notes timeline
+
+## Notes
+
+- Links clicked from notes now open more reliably through the desktop app


### PR DESCRIPTION
## Summary
- Add desktop 1.0.40 release notes for the next stable release.
- Cover user-facing meeting control, notification, past note, and note link updates.

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/changelog typecheck
- pnpm -F @hypr/web typecheck
- pnpm -F @hypr/web test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no application or build logic changes.
> 
> **Overview**
> Adds the **desktop 1.0.40** release notes at `packages/changelog/content/1.0.40.md` (dated 2026-06-06), documenting user-facing changes for the next stable desktop release.
> 
> **Meetings** — join actions in the session header, clearer floating status errors, no post-meeting finalizing accessory message, destructive “Stop meeting” styling, and compact upcoming notifications.
> 
> **Past notes** — related-meeting filtering, up to three key facts in the timeline, and per-summary regeneration.
> 
> **Notes** — more reliable link opening from the desktop app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f1247e827594bb0b977a871a95d204d5e757688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->