### PR TITLE
Deploy web on changelog changes

### DIFF
--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -3,7 +3,7 @@
 [build]
 command = "VITE_APP_VERSION=$COMMIT_REF pnpm -F @hypr/web build"
 publish = "apps/web/dist/client"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF apps/web packages/api-client packages/tiptap packages/ui packages/utils package.json pnpm-lock.yaml"
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF apps/web packages/api-client packages/changelog packages/tiptap packages/ui packages/utils package.json pnpm-lock.yaml"
 
 [build.environment]
 VITE_APP_URL = "https://anarlog.so"


### PR DESCRIPTION
## Summary
- Include `packages/changelog` in the Netlify auto-deploy ignore rule.
- Ensures desktop changelog releases publish their public changelog page.

## Context
- Desktop `1.0.40` released successfully.
- `https://anarlog.so/changelog/1.0.40` returned 404 because the changelog-only commit did not trigger a Netlify production deploy.
- Manual `web_cd.yaml` build passed but deploy failed because Netlify workflow secrets are not configured.

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/web typecheck
- Verified the updated ignore path list includes `packages/changelog/content/1.0.40.md` for the release commit range.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Netlify ignore-path tweak with no runtime or auth impact; may slightly increase deploy frequency when changelog content changes.
> 
> **Overview**
> Fixes changelog-only releases not appearing on production by treating **`packages/changelog`** as a deploy-triggering path in Netlify’s **`[build].ignore`** rule.
> 
> Previously, commits that only added release notes under that package could skip a web build, so routes like `/changelog/<version>` stayed 404 until an unrelated deploy ran.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46b69359491d0f70a678ee422d01eee344102d2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->