### PR TITLE
Show sidebar calendar sync status

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -19,6 +19,12 @@ const mocks = vi.hoisted(() => ({
   smartCurrentTimeMs: undefined as number | undefined,
   timelineEventsTable: {} as Record<string, Record<string, unknown>>,
   timelineSessionsTable: {} as Record<string, Record<string, unknown>>,
+  scheduledTaskRunIds: undefined as string[] | undefined,
+  runningTaskRunIds: undefined as string[] | undefined,
+  taskRunInfo: {} as Record<
+    string,
+    { taskId: string; running: boolean; nextTimestamp: number } | undefined
+  >,
 }));
 
 vi.mock("~/shared/config", () => ({
@@ -65,6 +71,14 @@ vi.mock("~/store/tinybase/store/main", () => ({
         : mocks.timelineSessionsTable,
     useStore: () => null,
   },
+}));
+
+vi.mock("tinytick/ui-react", () => ({
+  useManager: () => ({
+    getTaskRunInfo: (taskRunId: string) => mocks.taskRunInfo[taskRunId],
+  }),
+  useRunningTaskRunIds: () => mocks.runningTaskRunIds,
+  useScheduledTaskRunIds: () => mocks.scheduledTaskRunIds,
 }));
 
 vi.mock("~/store/zustand/tabs", () => ({
@@ -137,6 +151,9 @@ describe("TimelineView", () => {
     mocks.smartCurrentTimeMs = undefined;
     mocks.timelineEventsTable = {};
     mocks.timelineSessionsTable = {};
+    mocks.scheduledTaskRunIds = undefined;
+    mocks.runningTaskRunIds = undefined;
+    mocks.taskRunInfo = {};
   });
 
   afterEach(() => {
@@ -157,6 +174,7 @@ describe("TimelineView", () => {
     expect(actionTabs.className).not.toContain("bg-neutral-100/80");
     expect(actionTabs.className).not.toContain("rounded-full");
     expect(newNoteButton.className).toContain("flex-1");
+    expect(newNoteButton.className).toContain("justify-center");
     expect(newNoteButton.className).toContain("rounded-full");
     expect(searchButton.className).toContain("w-8");
     expect(calendarButton.className).toContain("w-8");
@@ -165,6 +183,7 @@ describe("TimelineView", () => {
 
     expect(newNoteButton.className).toContain("w-8");
     expect(searchButton.className).toContain("flex-1");
+    expect(searchButton.className).toContain("justify-center");
 
     fireEvent.mouseLeave(actionTabs);
 
@@ -202,6 +221,133 @@ describe("TimelineView", () => {
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
     ).toContain("h-24");
+  });
+
+  it("shows a due calendar sync status in sidebar chrome", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.scheduledTaskRunIds = ["calendar-sync-run"];
+    mocks.taskRunInfo = {
+      "calendar-sync-run": {
+        taskId: "calendarSync",
+        running: false,
+        nextTimestamp: Date.now(),
+      },
+    };
+
+    const { container } = render(<TimelineView topChromeInset />);
+
+    expect(screen.getByRole("status").textContent).toBe(
+      "Starting calendar sync",
+    );
+    expect(
+      container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
+    ).toContain("h-28");
+  });
+
+  it("updates scheduled calendar sync status as the due window passes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.scheduledTaskRunIds = ["calendar-sync-run"];
+    mocks.taskRunInfo = {
+      "calendar-sync-run": {
+        taskId: "calendarSync",
+        running: false,
+        nextTimestamp: Date.now() + 2000,
+      },
+    };
+
+    const { rerender } = render(<TimelineView topChromeInset />);
+
+    expect(screen.queryByRole("status")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    mocks.currentTimeMs = Date.now();
+    rerender(<TimelineView topChromeInset />);
+
+    expect(screen.getByRole("status").textContent).toBe(
+      "Starting calendar sync",
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(2500);
+    });
+    mocks.currentTimeMs = Date.now();
+    rerender(<TimelineView topChromeInset />);
+
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("shows a running calendar sync status in sidebar chrome", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.runningTaskRunIds = ["calendar-sync-run"];
+    mocks.taskRunInfo = {
+      "calendar-sync-run": {
+        taskId: "calendarSync",
+        running: true,
+        nextTimestamp: Date.now() + 1000,
+      },
+    };
+
+    render(<TimelineView topChromeInset />);
+
+    expect(screen.getByRole("status").textContent).toBe("Syncing calendar");
+  });
+
+  it("keeps calendar sync status visible while action tabs hide on scroll", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.runningTaskRunIds = ["calendar-sync-run"];
+    mocks.taskRunInfo = {
+      "calendar-sync-run": {
+        taskId: "calendarSync",
+        running: true,
+        nextTimestamp: Date.now() + 1000,
+      },
+    };
+
+    const { container } = render(<TimelineView topChromeInset />);
+    const scroller = container.querySelector("[data-sidebar-timeline-scroll]");
+
+    expect(scroller).toBeInstanceOf(HTMLDivElement);
+
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 1200,
+    });
+    scroller!.scrollTop = 120;
+    fireEvent.scroll(scroller!);
+
+    expect(screen.getByRole("status").textContent).toBe("Syncing calendar");
+    expect(getSidebarActions().className).not.toContain("opacity-0");
+    expect(getSidebarActionTabs().className).toContain("opacity-0");
+    expect(
+      container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
+    ).toContain("h-28");
+  });
+
+  it("hides future repeated calendar sync schedules from sidebar chrome", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.scheduledTaskRunIds = ["calendar-sync-run"];
+    mocks.taskRunInfo = {
+      "calendar-sync-run": {
+        taskId: "calendarSync",
+        running: false,
+        nextTimestamp: Date.now() + 60_000,
+      },
+    };
+
+    render(<TimelineView topChromeInset />);
+
+    expect(screen.queryByRole("status")).toBeNull();
   });
 
   it("uses compact top spacing when top chrome has no hidden future items", () => {

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -15,8 +15,14 @@ import {
   useRef,
   useState,
 } from "react";
+import {
+  useManager,
+  useRunningTaskRunIds,
+  useScheduledTaskRunIds,
+} from "tinytick/ui-react";
 
 import { Button } from "@hypr/ui/components/ui/button";
+import { Spinner } from "@hypr/ui/components/ui/spinner";
 import { cn } from "@hypr/utils";
 
 import { useAnchor, useAutoScrollToAnchor } from "./anchor";
@@ -40,6 +46,7 @@ import {
   type TimelineSessionsTable,
 } from "./utils";
 
+import { CALENDAR_SYNC_TASK_ID } from "~/services/calendar";
 import { useConfigValue } from "~/shared/config";
 import { useNativeContextMenu } from "~/shared/hooks/useNativeContextMenu";
 import { useOpenNoteDialog } from "~/shared/open-note-dialog";
@@ -56,7 +63,10 @@ import { useTimelineSelection } from "~/store/zustand/timeline-selection";
 import { useUndoDelete } from "~/store/zustand/undo-delete";
 
 const SIDEBAR_ACTIONS_REVEAL_DELAY_MS = 900;
+const DUE_CALENDAR_SYNC_VISIBLE_WINDOW_MS = 1000;
+const CALENDAR_SYNC_STATUS_TICK_MS = 500;
 type SidebarTimelineActionId = "new-note" | "search" | "calendar";
+type SidebarCalendarSyncStatus = "idle" | "scheduled" | "syncing";
 
 export function TimelineView({
   showOpenCalendarButton = true,
@@ -123,6 +133,9 @@ export function TimelineView({
       }),
     [visibleTimelineEventsTable, timelineSessionsTable, timezone],
   );
+  const calendarSyncStatus = useCalendarSyncStatus();
+  const showCalendarSyncStatus =
+    topChromeInset && calendarSyncStatus !== "idle";
 
   const showOpenCalendarChip =
     !topChromeInset &&
@@ -130,9 +143,11 @@ export function TimelineView({
     isScrolledToTop &&
     hasMoreFutureItems;
   const topSpacerClassName = topChromeInset
-    ? hasMoreFutureItems
-      ? "h-24"
-      : "h-20"
+    ? showCalendarSyncStatus
+      ? "h-28"
+      : hasMoreFutureItems
+        ? "h-24"
+        : "h-20"
     : "h-10";
 
   const hasToday = useMemo(
@@ -483,11 +498,13 @@ export function TimelineView({
           data-sidebar-timeline-top-fade
           className={cn([
             "pointer-events-none absolute inset-x-0 top-0 z-[15]",
-            areSidebarActionsHidden
-              ? "h-20 bg-linear-to-b from-neutral-50 via-neutral-50/95 via-60% to-neutral-50/0"
-              : isScrolledToTop
-                ? "h-24 bg-neutral-50"
-                : "h-28 bg-linear-to-b from-neutral-50 via-neutral-50/95 via-55% to-neutral-50/0",
+            showCalendarSyncStatus
+              ? "h-28 bg-neutral-50"
+              : areSidebarActionsHidden
+                ? "h-20 bg-linear-to-b from-neutral-50 via-neutral-50/95 via-60% to-neutral-50/0"
+                : isScrolledToTop
+                  ? "h-24 bg-neutral-50"
+                  : "h-28 bg-linear-to-b from-neutral-50 via-neutral-50/95 via-55% to-neutral-50/0",
           ])}
         />
       )}
@@ -500,6 +517,7 @@ export function TimelineView({
           onOpenCalendar={handleOpenCalendar}
           onSearch={handleOpenNoteDialog}
           showCalendarAction={showOpenCalendarButton}
+          calendarSyncStatus={calendarSyncStatus}
         />
       )}
 
@@ -557,16 +575,20 @@ function SidebarTimelineActions({
   onOpenCalendar,
   onSearch,
   showCalendarAction,
+  calendarSyncStatus,
 }: {
   hidden: boolean;
   onNewNote: () => void;
   onOpenCalendar: () => void;
   onSearch: () => void;
   showCalendarAction: boolean;
+  calendarSyncStatus: SidebarCalendarSyncStatus;
 }) {
   const [expandedActionId, setExpandedActionId] =
     useState<SidebarTimelineActionId | null>(null);
   const activeActionId = expandedActionId ?? "new-note";
+  const showCalendarSyncStatus = calendarSyncStatus !== "idle";
+  const hideActionContainer = hidden && !showCalendarSyncStatus;
   const actionItems = useMemo(
     () => [
       {
@@ -605,7 +627,7 @@ function SidebarTimelineActions({
         "absolute inset-x-0 top-10 z-30 pt-1 pb-2",
         "bg-neutral-50",
         "transition-[opacity,transform] duration-150 ease-out",
-        hidden
+        hideActionContainer
           ? "pointer-events-none -translate-y-2 opacity-0"
           : "translate-y-0 opacity-100",
       ])}
@@ -614,7 +636,13 @@ function SidebarTimelineActions({
         data-sidebar-timeline-action-tabs
         role="toolbar"
         aria-label="Sidebar actions"
-        className="flex w-full items-center gap-1"
+        className={cn([
+          "flex w-full items-center gap-1",
+          "transition-[opacity,transform] duration-150 ease-out",
+          hidden
+            ? "pointer-events-none -translate-y-2 opacity-0"
+            : "translate-y-0 opacity-100",
+        ])}
         onMouseLeave={() => setExpandedActionId(null)}
         onBlur={(event) => {
           const nextFocusedNode = event.relatedTarget as Node | null;
@@ -636,6 +664,41 @@ function SidebarTimelineActions({
           />
         ))}
       </div>
+      <SidebarCalendarSyncStatus status={calendarSyncStatus} />
+    </div>
+  );
+}
+
+function SidebarCalendarSyncStatus({
+  status,
+}: {
+  status: SidebarCalendarSyncStatus;
+}) {
+  if (status === "idle") {
+    return null;
+  }
+
+  const label =
+    status === "scheduled" ? "Starting calendar sync" : "Syncing calendar";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-sidebar-calendar-sync-status
+      className={cn([
+        "mt-1.5 flex h-5 items-center gap-1.5 px-3",
+        "text-[11px] leading-none font-medium text-neutral-500",
+      ])}
+    >
+      <span className="flex size-3 shrink-0 items-center justify-center text-neutral-400">
+        {status === "syncing" ? (
+          <Spinner size={12} />
+        ) : (
+          <CalendarDaysIcon size={12} />
+        )}
+      </span>
+      <span className="truncate">{label}</span>
     </div>
   );
 }
@@ -668,7 +731,7 @@ function SidebarTimelineActionButton({
         "transition-[width,flex-grow,background-color,color] duration-150 ease-out",
         "focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:outline-hidden",
         active
-          ? "flex-1 bg-neutral-200/70 px-3 text-neutral-950"
+          ? "flex-1 justify-center bg-neutral-200/70 px-3 text-neutral-950"
           : "w-8 flex-none justify-center px-2 hover:bg-neutral-200/70 hover:text-neutral-950",
       ])}
       onClick={onClick}
@@ -924,6 +987,40 @@ function scrollTimelineItemIntoView(
     top: targetScrollTop,
     behavior: "smooth",
   });
+}
+
+function useCalendarSyncStatus(): SidebarCalendarSyncStatus {
+  const manager = useManager();
+  const scheduledTaskRunIds = useScheduledTaskRunIds();
+  const runningTaskRunIds = useRunningTaskRunIds();
+  const currentTimeMs = useCurrentTimeMs(CALENDAR_SYNC_STATUS_TICK_MS);
+
+  return useMemo(() => {
+    if (!manager) {
+      return "idle";
+    }
+
+    const hasRunningSync = runningTaskRunIds?.some(
+      (taskRunId) =>
+        manager.getTaskRunInfo(taskRunId)?.taskId === CALENDAR_SYNC_TASK_ID,
+    );
+    if (hasRunningSync) {
+      return "syncing";
+    }
+
+    const visibleFrom = currentTimeMs - DUE_CALENDAR_SYNC_VISIBLE_WINDOW_MS;
+    const visibleUntil = currentTimeMs + DUE_CALENDAR_SYNC_VISIBLE_WINDOW_MS;
+    const hasDueScheduledSync = scheduledTaskRunIds?.some((taskRunId) => {
+      const info = manager.getTaskRunInfo(taskRunId);
+      return (
+        info?.taskId === CALENDAR_SYNC_TASK_ID &&
+        info.nextTimestamp >= visibleFrom &&
+        info.nextTimestamp <= visibleUntil
+      );
+    });
+
+    return hasDueScheduledSync ? "scheduled" : "idle";
+  }, [manager, scheduledTaskRunIds, runningTaskRunIds, currentTimeMs]);
 }
 
 function useTimelineTables(): {

--- a/apps/desktop/src/sidebar/timeline/realtime.tsx
+++ b/apps/desktop/src/sidebar/timeline/realtime.tsx
@@ -49,7 +49,7 @@ export const CurrentTimeIndicator = forwardRef<
   );
 });
 
-export function useCurrentTimeMs() {
+export function useCurrentTimeMs(maxTickDelayMs = MINUTE_MS) {
   const [now, setNow] = useState(() => new Date().getTime());
 
   useMountEffect(() => {
@@ -64,7 +64,10 @@ export function useCurrentTimeMs() {
 
     const scheduleUpdate = () => {
       clearUpdate();
-      timeoutId = setTimeout(update, getCurrentTimeTickDelay(Date.now()));
+      timeoutId = setTimeout(
+        update,
+        getCurrentTimeTickDelay(Date.now(), maxTickDelayMs),
+      );
     };
 
     const update = () => {
@@ -96,9 +99,15 @@ export function useCurrentTimeMs() {
   return now;
 }
 
-function getCurrentTimeTickDelay(nowMs: number): number {
+function getCurrentTimeTickDelay(
+  nowMs: number,
+  maxTickDelayMs: number,
+): number {
   const msIntoMinute = nowMs % MINUTE_MS;
-  return MINUTE_MS - msIntoMinute + CURRENT_TIME_TICK_OFFSET_MS;
+  return Math.min(
+    MINUTE_MS - msIntoMinute + CURRENT_TIME_TICK_OFFSET_MS,
+    maxTickDelayMs,
+  );
 }
 
 export function useSmartCurrentTime(


### PR DESCRIPTION
Display calendar sync progress in the sidebar timeline chrome during due or running sync tasks.

Add coverage for scheduled, running, and future repeat states.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar feedback driven by existing task scheduler hooks; no auth, persistence, or sync logic changes.
> 
> **Overview**
> Adds **calendar sync progress** to the sidebar timeline top chrome when inset mode is on. Status comes from TinyTick scheduled/running task runs for `calendarSync`: **“Starting calendar sync”** only when a run is due within ±1s of now, **“Syncing calendar”** while running, and nothing for far-future repeats.
> 
> Layout updates reserve taller top spacing (`h-28`) and keep the status line visible when action tabs fade on scroll. `useCurrentTimeMs` now accepts an optional **max tick delay** (500ms) so the due window can refresh without waiting for the minute boundary. Tests mock TinyTick and cover scheduled, running, scroll, and hidden-future cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 378adaefbc16a2537e148706c7b500afe29af7cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->