### PR TITLE
Rename past notes label

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -221,7 +221,7 @@ function PostSessionTabHandle({
         className="rounded-t-[10px] border-x"
       />
       <PostSessionTabButton
-        label="Past notes"
+        label="Related meetings"
         tab="past_notes"
         activeTab={activeTab}
         isExpanded={isExpanded}

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -352,7 +352,7 @@ describe("PostSessionAccessory", () => {
       />,
     );
 
-    expect(screen.getByText("Past notes")).toBeTruthy();
+    expect(screen.getByText("Related meetings")).toBeTruthy();
     const title = screen.getByText("Weekly Product Sync");
     const date = screen.getByText("May 28, 2026");
     expect(title).toBeTruthy();

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -142,7 +142,9 @@ function PastNotesPanel({
   return (
     <TranscriptCard fillHeight={fillHeight}>
       <div className="flex shrink-0 items-center justify-between px-3 py-1.5">
-        <span className="text-xs font-medium text-neutral-500">Past notes</span>
+        <span className="text-xs font-medium text-neutral-500">
+          Related meetings
+        </span>
       </div>
 
       <div


### PR DESCRIPTION
Update the bottom accessory tab and panel heading to say Related meetings.

Update the matching test expectation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UI label changes with no logic, routing, or data handling changes.
> 
> **Overview**
> Renames the post-session bottom accessory UI copy from **Past notes** to **Related meetings** so the tab and expanded panel heading match how that content is presented (related prior sessions, not generic notes).
> 
> The internal tab id (`past_notes`) and behavior are unchanged. The test that asserts the past-notes timeline now expects **Related meetings** instead of **Past notes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54b6ac8f0bb5e75cd4f2dedca5d8fd418e210f5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->