### PR TITLE
Collapse empty transcript panel height

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -222,10 +222,12 @@ describe("PostSessionAccessory", () => {
     const noTranscript = screen.getByText("No transcript yet");
     const transcriptCard = noTranscript.parentElement?.parentElement;
     const transcriptSlot = transcriptCard?.parentElement;
+    const accessoryRoot = transcriptSlot?.parentElement;
     expect(transcriptCard?.className).not.toContain("min-h-[114px]");
     expect(transcriptCard?.className).not.toContain("min-h-[96px]");
     expect(transcriptSlot?.className).not.toContain("min-h-[114px]");
     expect(transcriptSlot?.className).toContain("shrink-0");
+    expect(accessoryRoot?.className).not.toContain("h-full");
     expect(screen.queryByRole("button", { name: "Upload audio" })).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: /Regenerate/ }));

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -75,7 +75,7 @@ export function PostSessionAccessory({
     <div
       className={cn([
         "flex min-h-0 flex-col",
-        fillHeight && "h-full overflow-hidden",
+        shouldFillExpandedPanel && "h-full overflow-hidden",
       ])}
     >
       {isTranscriptExpanded ? (


### PR DESCRIPTION
Avoid filling the post-session accessory when the expanded transcript panel has no transcript content.

Cover the empty state layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS class gating for post-session layout only; behavior is covered by an updated unit test.
> 
> **Overview**
> When the post-session bottom accessory is expanded with **`fillHeight`** but there is **no transcript content** (empty “No transcript yet” state, not batching), the root container no longer applies **`h-full overflow-hidden`**. Full-height stretching now follows **`shouldFillExpandedPanel`**, which is only true when there is actual transcript content, past notes, or an active batch—not for the empty expanded panel alone.
> 
> A test assertion was added so the accessory root must **not** include `h-full` in that empty expanded scenario, alongside existing checks that reserved min-heights stay off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d37f8c67bdfec42a98e7e2b5c20013aecb7d31a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->