### PR TITLE
Restore past note bullets

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -362,9 +362,12 @@ describe("PostSessionAccessory", () => {
     );
     const factsList = screen.getByRole("list");
     expect(factsList.className).toContain("list-disc");
-    expect(factsList.className).toContain("list-inside");
+    expect(factsList.className).toContain("list-outside");
     expect(factsList.className).not.toContain("flex");
-    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    const facts = screen.getAllByRole("listitem");
+    expect(facts).toHaveLength(3);
+    expect(facts[0].className).not.toContain("line-clamp");
+    expect(facts[0].querySelector("span")?.className).toContain("line-clamp-2");
     expect(screen.getByText("Ship the transcript panel.")).toBeTruthy();
     expect(screen.getByText("Revisit visual polish next week.")).toBeTruthy();
     expect(screen.getByText("Confirm keyboard behavior.")).toBeTruthy();

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -180,13 +180,10 @@ function PastNotesPanel({
                   ) : null}
                 </div>
                 {note.summary ? (
-                  <ul className="min-w-0 list-inside list-disc space-y-1 overflow-hidden pr-1 pl-1 text-xs leading-5 text-neutral-500">
+                  <ul className="min-w-0 list-outside list-disc space-y-1 overflow-hidden pr-1 pl-4 text-xs leading-5 text-neutral-500">
                     {splitKeyFacts(note.summary).map((fact) => (
-                      <li
-                        key={fact}
-                        className="line-clamp-2 min-w-0 break-words"
-                      >
-                        {fact}
+                      <li key={fact} className="min-w-0 break-words">
+                        <span className="line-clamp-2">{fact}</span>
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
Keep list markers visible by moving line clamping from the list item onto the fact text span.

Assert the list marker layout in the bottom accessory test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS/markup change in the past-notes UI with matching test updates only.
> 
> **Overview**
> Fixes **past notes** key-fact bullets in the post-session bottom accessory so disc markers stay visible while long facts still truncate to two lines.
> 
> The facts `<ul>` switches from `list-inside` to `list-outside` with slightly more left padding (`pl-4`). **`line-clamp-2`** moves off the `<li>` onto an inner `<span>` so clamping no longer hides the bullet. The past-notes timeline test now expects `list-outside` and that clamping applies only on the inner span.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b38e4538ef91f9b69c5def821ce6ae50c1fd29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->