### PR TITLE
Keep floating FAB revealed on hover

### DIFF
--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -180,6 +180,8 @@ describe("FloatingActionButton", () => {
     );
     expect(wrapper?.className).toContain("group-hover:pointer-events-auto");
     expect(wrapper?.className).toContain("group-hover:translate-y-0");
+    expect(wrapper?.className).toContain("hover:pointer-events-auto");
+    expect(wrapper?.className).toContain("hover:translate-y-0");
   });
 
   it("tucks the chat FAB near the editor caret and reveals it from the hover zone", () => {
@@ -198,6 +200,8 @@ describe("FloatingActionButton", () => {
     );
     expect(wrapper?.className).toContain("group-hover:pointer-events-auto");
     expect(wrapper?.className).toContain("group-hover:translate-y-0");
+    expect(wrapper?.className).toContain("hover:pointer-events-auto");
+    expect(wrapper?.className).toContain("hover:translate-y-0");
   });
 
   it("keeps the chat FAB tucked during active meetings", () => {
@@ -217,6 +221,8 @@ describe("FloatingActionButton", () => {
     expect(wrapper?.className).toContain("pointer-events-none");
     expect(wrapper?.className).toContain("group-hover:pointer-events-auto");
     expect(wrapper?.className).toContain("group-hover:translate-y-0");
+    expect(wrapper?.className).toContain("hover:pointer-events-auto");
+    expect(wrapper?.className).toContain("hover:translate-y-0");
   });
 
   it("shows the tucked chat FAB during active meetings before transcript exists", () => {

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -81,7 +81,7 @@ export function FloatingActionButton({
             className={cn([
               "max-w-full translate-y-[var(--floating-fab-tuck-offset)] transition-transform duration-200 ease-out",
               tuckAction
-                ? "pointer-events-none visible group-hover:pointer-events-auto group-hover:translate-y-0"
+                ? "pointer-events-none visible group-hover:pointer-events-auto group-hover:translate-y-0 hover:pointer-events-auto hover:translate-y-0"
                 : "pointer-events-auto visible",
             ])}
           >


### PR DESCRIPTION
## Summary
- keep the tucked floating action button revealed when the pointer moves onto the expanded button
- cover the hover persistence classes in the floating FAB tests

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop test -- src/session/components/floating/index.test.tsx
- pnpm -F @hypr/desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Tailwind class change on floating FAB tuck/reveal behavior only; no auth, data, or API impact.
> 
> **Overview**
> When the session **floating action button** is tucked, it now stays **un-tucked and clickable** if the pointer moves directly onto the button, not only while hovering the parent hover zone.
> 
> The tucked-state wrapper adds **`hover:pointer-events-auto`** and **`hover:translate-y-0`** alongside the existing **`group-hover:*`** classes in `FloatingActionButton`. Tests for hidden, caret-near-bottom, and active-meeting tuck cases now assert those hover classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d24227cbbc0911f3b4363580c3fc5dc93f0923b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->