### PR TITLE
Add desktop changelog for 1.0.41

### DIFF
--- a/packages/changelog/content/1.0.41.md
+++ b/packages/changelog/content/1.0.41.md
@@ -1,0 +1,25 @@
+---
+date: "2026-06-08"
+summary: "Anarlog now supports dark mode, shows calendar sync progress more clearly, and polishes related meeting notes and local transcription."
+---
+
+## Appearance
+
+- Anarlog now supports light, dark, and system appearance settings
+- Dark mode has improved contrast across chat, notes, settings, calendars, contacts, templates, and task views
+
+## Meetings
+
+- The sidebar timeline now shows calendar sync progress when a sync is due or currently running
+- The floating listening button now stays revealed while you move the pointer across it
+- The related meetings panel now uses clearer labeling and no longer leaves extra empty space when a transcript is unavailable
+- Related meeting summaries now keep their bullet markers visible while staying compact
+
+## Local Transcription
+
+- Local transcription setup no longer makes unnecessary startup network calls
+- Local transcription status and model selection have been simplified for a cleaner settings experience
+
+## Reliability
+
+- Desktop builds are now more reliable on macOS 14.2


### PR DESCRIPTION
## Summary
- Add the 1.0.41 desktop changelog entry for the next stable release.
- Summarize dark mode, sidebar sync status, related meeting polish, local transcription cleanup, and macOS 14.2 build reliability.

## Verification
- pnpm exec dprint fmt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition of a changelog markdown file with no application or build logic changes.
> 
> **Overview**
> Adds the **1.0.41** desktop changelog at `packages/changelog/content/1.0.41.md` (dated 2026-06-08), using the same frontmatter `summary` plus sectioned bullets as prior release notes.
> 
> The entry documents user-facing changes for the next stable release: **Appearance** (light/dark/system and contrast polish), **Meetings** (sidebar calendar sync progress, listening button hover behavior, related meetings panel and summary bullets), **Local Transcription** (fewer startup network calls, simplified settings), and **Reliability** (macOS 14.2 desktop build fixes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1313693ad4c7e3ad9be143b5c26f9154c642370. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->