### PR TITLE
Fix sidebar timeline chrome

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -220,7 +220,7 @@ describe("TimelineView", () => {
     ).toBe(true);
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).toContain("h-24");
+    ).toContain("h-[5.25rem]");
   });
 
   it("shows a due calendar sync status in sidebar chrome", () => {
@@ -350,7 +350,7 @@ describe("TimelineView", () => {
     expect(screen.queryByRole("status")).toBeNull();
   });
 
-  it("uses compact top spacing when top chrome has no hidden future items", () => {
+  it("keeps the first bucket below the sidebar action chrome", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
     mocks.currentTimeMs = Date.now();
@@ -367,10 +367,11 @@ describe("TimelineView", () => {
     expect(getSidebarActions().className).not.toContain("opacity-0");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).toContain("h-20");
+    ).toContain("h-[5.25rem]");
     expect(
-      container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).not.toContain("h-24");
+      container.querySelector("[data-sidebar-timeline-bucket-header]")
+        ?.className,
+    ).toContain("top-[5.25rem]");
   });
 
   it("shows the open calendar chip without top chrome", () => {

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -142,13 +142,21 @@ export function TimelineView({
     showOpenCalendarButton &&
     isScrolledToTop &&
     hasMoreFutureItems;
+
   const topSpacerClassName = topChromeInset
     ? showCalendarSyncStatus
       ? "h-28"
-      : hasMoreFutureItems
-        ? "h-24"
-        : "h-20"
+      : "h-[5.25rem]"
     : "h-10";
+  const bucketHeaderTopClassName = topChromeInset
+    ? showCalendarSyncStatus
+      ? "top-28"
+      : areSidebarActionsHidden
+        ? "top-20"
+        : isScrolledToTop
+          ? "top-[5.25rem]"
+          : "top-28"
+    : "top-0";
 
   const hasToday = useMemo(
     () => buckets.some((bucket) => bucket.label === "Today"),
@@ -439,8 +447,10 @@ export function TimelineView({
                 />
               )}
               <div
+                data-sidebar-timeline-bucket-header
                 className={cn([
-                  "sticky top-0 z-10",
+                  "sticky z-10",
+                  bucketHeaderTopClassName,
                   "bg-background/95 py-1 pr-1 pl-3 backdrop-blur",
                 ])}
               >
@@ -503,7 +513,7 @@ export function TimelineView({
               : areSidebarActionsHidden
                 ? "from-background via-background/95 to-background/0 h-20 bg-linear-to-b via-60%"
                 : isScrolledToTop
-                  ? "bg-background h-24"
+                  ? "bg-background h-[5.25rem]"
                   : "from-background via-background/95 to-background/0 h-28 bg-linear-to-b via-55%",
           ])}
         />

--- a/apps/desktop/src/sidebar/timeline/realtime.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/realtime.test.tsx
@@ -29,6 +29,24 @@ describe("CurrentTimeIndicator", () => {
     );
   });
 
+  test("uses red current-time colors in light and dark mode", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 0, 15, 12, 0, 0));
+
+    const { container } = render(<CurrentTimeIndicator />);
+    const line = container.querySelector("[data-sidebar-current-time-line]");
+    const label = container.querySelector("[data-sidebar-current-time-label]");
+
+    expect(line?.className).toContain("bg-red-500/85");
+    expect(line?.className).toContain("dark:bg-red-400/70");
+    expect(label?.className).toContain("border-red-500");
+    expect(label?.className).toContain("bg-red-500");
+    expect(label?.className).toContain("text-white");
+    expect(label?.className).toContain("dark:border-red-500");
+    expect(label?.className).toContain("dark:bg-red-500");
+    expect(label?.className).toContain("dark:text-white");
+  });
+
   test("syncs the label at the next wall-clock minute", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2024, 0, 15, 12, 0, 45));

--- a/apps/desktop/src/sidebar/timeline/realtime.tsx
+++ b/apps/desktop/src/sidebar/timeline/realtime.tsx
@@ -38,9 +38,15 @@ export const CurrentTimeIndicator = forwardRef<
       style={variant === "inside" ? { top: insideOffset } : undefined}
     >
       <div className="absolute inset-x-0 top-0 -translate-y-1/2">
-        <div className="bg-border absolute top-1/2 right-0 left-0 h-px -translate-y-1/2" />
+        <div
+          data-sidebar-current-time-line
+          className="absolute top-1/2 right-0 left-0 h-px -translate-y-1/2 bg-red-500/85 dark:bg-red-400/70"
+        />
         <div className="relative flex h-5 items-center justify-center">
-          <div className="border-border bg-card text-foreground rounded-full border px-2 py-0.5 font-mono text-[11px] font-semibold opacity-0 shadow-xs transition-opacity group-hover:opacity-100">
+          <div
+            data-sidebar-current-time-label
+            className="rounded-full border border-red-500 bg-red-500 px-2 py-0.5 font-mono text-[11px] font-semibold text-white opacity-0 shadow-xs transition-opacity group-hover:opacity-100 dark:border-red-500 dark:bg-red-500 dark:text-white"
+          >
             {label}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- keep sticky sidebar timeline bucket headers below the action chrome
- restore the current-time indicator colors across themes with a red line and red pill
- update focused sidebar timeline tests

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop exec vitest run src/sidebar/timeline/realtime.test.tsx
- pnpm -F @hypr/desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized sidebar timeline layout and styling changes with no auth, data, or API impact.
> 
> **Overview**
> Fixes **sidebar timeline layout** when `topChromeInset` is on: top spacer and top fade use a fixed **`h-[5.25rem]`** instead of varying `h-20`/`h-24` based on future items, and **sticky bucket headers** no longer sit at `top-0`—they use **`bucketHeaderTopClassName`** (`top-[5.25rem]` at scroll top, `top-28` when scrolled or calendar sync shows, `top-20` when action tabs are hidden) so labels stay under the action chrome.
> 
> **Current-time indicator** styling switches from neutral border/card colors to a **red line** (`bg-red-500/85`, `dark:bg-red-400/70`) and **red hover pill** for the time label, with `data-sidebar-current-time-*` hooks. Tests assert the new spacing, sticky offset, and theme classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 622782802650206274e07f34d9494ad88ecb4a82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->