### PR TITLE
Match chat panel to sidebar surface

### DIFF
--- a/apps/desktop/src/chat/components/chat-panel.test.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.test.tsx
@@ -82,30 +82,33 @@ describe("ChatView", () => {
     mocks.toolbarControls.mockClear();
   });
 
-  it("uses the dark stone shell in the right panel layout", () => {
+  it("uses the sidebar card shell in the right panel layout", () => {
     const { container } = render(<ChatView layout="right-panel" />);
     const root = container.firstElementChild;
 
-    expect(root?.className).toContain("bg-primary");
-    expect(root?.className).toContain("text-primary-foreground");
-    expect(root?.className).not.toContain("bg-card");
+    expect(root?.className).toContain("bg-card");
+    expect(root?.className).toContain("text-card-foreground");
+    expect(root?.className).not.toContain("bg-primary");
     expect(root?.firstElementChild?.className).toContain("h-12");
-    expect(screen.getByTestId("chat-toolbar").dataset.surface).toBe("dark");
+    expect(root?.firstElementChild?.className).not.toContain("border-b");
+    expect(screen.getByTestId("chat-toolbar").dataset.surface).toBe("light");
     expect(mocks.toolbarControls).toHaveBeenCalledWith(
       expect.objectContaining({
         layout: "right-panel",
-        surface: "dark",
+        onClose: expect.any(Function),
+        surface: "light",
       }),
     );
   });
 
-  it("uses the dark stone shell in the floating layout", () => {
+  it("uses the sidebar card shell in the floating layout", () => {
     const { container } = render(<ChatView layout="floating" />);
     const root = container.firstElementChild;
 
-    expect(root?.className).toContain("bg-primary");
-    expect(root?.className).toContain("text-primary-foreground");
+    expect(root?.className).toContain("bg-card");
+    expect(root?.className).toContain("text-card-foreground");
     expect(root?.firstElementChild?.className).toContain("h-11");
-    expect(screen.getByTestId("chat-toolbar").dataset.surface).toBe("dark");
+    expect(root?.firstElementChild?.className).not.toContain("border-b");
+    expect(screen.getByTestId("chat-toolbar").dataset.surface).toBe("light");
   });
 });

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -25,8 +25,7 @@ export function ChatView({
 }) {
   const { chat } = useShell();
   const { groupId, sessionId, setGroupId } = chat;
-  const { panelClassName, panelBorderClassName, toolbarSurface } =
-    useChatAppearance();
+  const { panelClassName, toolbarSurface } = useChatAppearance();
   const isFloating = layout === "floating";
 
   const { currentSessionId } = useSessionTab();
@@ -57,13 +56,12 @@ export function ChatView({
         className={cn([
           "flex shrink-0 items-center pr-0 pl-0",
           isFloating ? "h-11" : "h-12",
-          panelBorderClassName,
-          "border-b",
         ])}
       >
         <ChatToolbarControls
           currentChatGroupId={groupId}
           layout={layout}
+          onClose={() => chat.sendEvent({ type: "CLOSE" })}
           onNewChat={chat.startNewChat}
           onOpenFloating={onOpenFloating}
           onOpenRightPanel={onOpenRightPanel}

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -166,7 +166,7 @@ describe("ChatMessageInput", () => {
     const outerContainer = messageInput?.parentElement?.parentElement;
 
     expect(outerContainer?.className).toContain("px-3");
-    expect(outerContainer?.className).toContain("pb-5");
+    expect(outerContainer?.className).toContain("pb-4");
     expect(outerContainer?.className).not.toContain("px-5");
     expect(outerContainer?.className).not.toContain("px-2");
     expect(outerContainer?.className).not.toContain("pr-0");

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -139,7 +139,7 @@ function Container({
     <div
       className={cn([
         "relative min-w-0 shrink-0",
-        isRightPanel ? "px-3 pb-5" : "px-2 pb-2",
+        isRightPanel ? "px-3 pb-4" : "px-2 pb-2",
       ])}
     >
       <div

--- a/apps/desktop/src/chat/components/toolbar-controls.test.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -60,6 +60,28 @@ describe("ChatToolbarControls", () => {
     expect(title.closest("button")?.className).toContain("rounded-full");
   });
 
+  it("keeps the light chat title readable on the card shell", () => {
+    const { container } = render(
+      <ChatToolbarControls
+        currentChatGroupId={undefined}
+        onNewChat={vi.fn()}
+        onOpenRightPanel={vi.fn()}
+        onSelectChat={vi.fn()}
+        surface="light"
+      />,
+    );
+
+    const title = screen.getByText("Ask Anarlog AI anything");
+    const titleButton = title.closest("button");
+    expect(container.firstElementChild?.className).toContain("pl-2");
+    expect(container.firstElementChild?.className).toContain("pr-2");
+    expect(titleButton?.className).toContain("-ml-2");
+    expect(titleButton?.className).toContain("px-2");
+    expect(title.className).toContain("text-foreground");
+    expect(title.className).toContain("text-[15px]");
+    expect(title.className).not.toContain("text-muted-foreground");
+  });
+
   it("renders dark toolbar action buttons as circles without tooltips", () => {
     render(
       <ChatToolbarControls
@@ -86,24 +108,46 @@ describe("ChatToolbarControls", () => {
     expect(rightPanelButton.getAttribute("title")).toBeNull();
   });
 
-  it("uses balanced toolbar horizontal padding in the right panel", () => {
+  it("uses tighter toolbar right padding in the right panel", () => {
+    const onClose = vi.fn();
+    const onOpenFloating = vi.fn();
     const { container } = render(
       <ChatToolbarControls
         currentChatGroupId={undefined}
         layout="right-panel"
+        onClose={onClose}
         onNewChat={vi.fn()}
-        onOpenFloating={vi.fn()}
+        onOpenFloating={onOpenFloating}
         onSelectChat={vi.fn()}
-        surface="dark"
+        surface="light"
       />,
     );
 
-    expect(container.firstElementChild?.className).toContain("px-3");
+    const titleButton = screen
+      .getByText("Ask Anarlog AI anything")
+      .closest("button");
+
+    expect(container.firstElementChild?.className).toContain("pl-3");
+    expect(container.firstElementChild?.className).toContain("pr-1");
     expect(container.firstElementChild?.className).not.toContain("px-5");
     expect(container.firstElementChild?.className).not.toContain("px-2");
     expect(container.firstElementChild?.className).not.toContain("pr-0");
+    expect(titleButton?.className).toContain("-ml-2");
+    expect(titleButton?.className).toContain("px-2");
+    const floatButton = screen.getByRole("button", { name: "Float chat" });
+    const closeButton = screen.getByRole("button", { name: "Close chat" });
+    expect(floatButton.className).not.toContain("bg-muted");
+    expect(floatButton.className).not.toContain("text-foreground");
+    expect(floatButton.className).not.toContain("mr-1");
+    expect(closeButton.className).not.toContain("bg-muted");
     expect(
-      screen.getByRole("button", { name: "Float chat" }).className,
-    ).toContain("mr-1");
+      screen.queryByRole("button", { name: "Open in right panel" }),
+    ).toBeNull();
+
+    fireEvent.click(floatButton);
+    fireEvent.click(closeButton);
+
+    expect(onOpenFloating).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -1,9 +1,10 @@
 import {
   ChevronDown,
   MessageCircle,
-  PanelRightClose,
-  PanelRightOpen,
+  PanelRight,
+  PictureInPicture2,
   Plus,
+  X,
 } from "lucide-react";
 import { useState } from "react";
 
@@ -21,6 +22,7 @@ import * as main from "~/store/tinybase/store/main";
 export function ChatToolbarControls({
   currentChatGroupId,
   layout = "floating",
+  onClose,
   onNewChat,
   onOpenFloating,
   onOpenRightPanel,
@@ -29,6 +31,7 @@ export function ChatToolbarControls({
 }: {
   currentChatGroupId: string | undefined;
   layout?: "floating" | "right-panel";
+  onClose?: () => void;
   onNewChat: () => void;
   onOpenFloating?: () => void;
   onOpenRightPanel?: () => void;
@@ -42,7 +45,7 @@ export function ChatToolbarControls({
     <div
       className={cn([
         "flex h-full w-full min-w-0 items-center gap-2",
-        isRightPanel ? "px-3" : isDark ? "px-2" : "px-0",
+        isRightPanel ? "pr-1 pl-3" : isDark ? "px-2" : "pr-2 pl-2",
       ])}
     >
       <div className="flex min-w-0 flex-1 items-center gap-1">
@@ -59,27 +62,29 @@ export function ChatToolbarControls({
           onClick={onNewChat}
           className={isDark ? darkToolbarButtonClassName : undefined}
         />
-        <ChatActionButton
-          icon={
-            isRightPanel ? (
-              <PanelRightClose size={16} />
-            ) : (
-              <PanelRightOpen size={16} />
-            )
-          }
-          onClick={
-            isRightPanel
-              ? (onOpenFloating ?? (() => {}))
-              : (onOpenRightPanel ?? (() => {}))
-          }
-          label={isRightPanel ? "Float chat" : "Open in right panel"}
-          className={cn([
-            isDark
-              ? darkToolbarButtonClassName
-              : isRightPanel && "bg-muted text-foreground hover:bg-accent",
-            isRightPanel && "mr-1",
-          ])}
-        />
+        {isRightPanel ? (
+          <>
+            <ChatActionButton
+              icon={<PictureInPicture2 size={16} />}
+              label="Float chat"
+              onClick={onOpenFloating ?? (() => {})}
+              className={isDark ? darkToolbarButtonClassName : undefined}
+            />
+            <ChatActionButton
+              icon={<X size={16} />}
+              label="Close chat"
+              onClick={onClose ?? (() => {})}
+              className={isDark ? darkToolbarButtonClassName : undefined}
+            />
+          </>
+        ) : (
+          <ChatActionButton
+            icon={<PanelRight size={16} />}
+            label="Open in right panel"
+            onClick={onOpenRightPanel ?? (() => {})}
+            className={isDark ? darkToolbarButtonClassName : undefined}
+          />
+        )}
       </div>
     </div>
   );
@@ -145,10 +150,11 @@ function ChatGroups({
         <Button
           variant="ghost"
           className={cn([
-            "group flex h-8 max-w-full min-w-0 justify-start gap-1.5 px-2 py-0 text-left",
+            "group flex h-8 max-w-full min-w-0 justify-start gap-1.5 py-0 text-left",
+            "-ml-2 px-2",
             isDark
               ? "text-primary-foreground hover:bg-primary-foreground/7 hover:text-primary-foreground data-[state=open]:bg-primary-foreground/7 w-fit rounded-full"
-              : "text-muted-foreground",
+              : "text-foreground hover:bg-accent hover:text-foreground data-[state=open]:bg-accent w-fit rounded-full",
           ])}
         >
           <h3
@@ -156,7 +162,7 @@ function ChatGroups({
               "max-w-64 min-w-0 truncate text-left font-medium",
               isDark
                 ? "text-primary-foreground text-[15px]"
-                : "text-muted-foreground text-xs",
+                : "text-foreground text-[15px]",
             ])}
           >
             {currentChatTitle || "Ask Anarlog AI anything"}

--- a/apps/desktop/src/chat/surface.test.ts
+++ b/apps/desktop/src/chat/surface.test.ts
@@ -5,6 +5,7 @@ import {
   chatFloatingControlClassNames,
   chatFloatingPanelShellClassNames,
   chatInputEditorClassNames,
+  chatPanelBorderClassNames,
   chatPanelClassNames,
   chatSendButtonDisabledClassNames,
   chatToolbarSurface,
@@ -12,15 +13,16 @@ import {
 } from "./surface";
 
 describe("chat surface tokens", () => {
-  it("always uses the dark stone chat chrome regardless of app theme", () => {
-    expect(isChatDarkAppearance()).toBe(true);
-    expect(chatToolbarSurface()).toBe("dark");
+  it("uses the app chrome appearance instead of the forced dark chat chrome", () => {
+    expect(isChatDarkAppearance()).toBe(false);
+    expect(chatToolbarSurface()).toBe("light");
   });
 
-  it("maps the original stone-800 shell to primary tokens", () => {
-    expect(chatPanelClassNames()).toContain("bg-primary");
-    expect(chatPanelClassNames()).toContain("text-primary-foreground");
-    expect(chatPanelClassNames()).not.toContain("bg-card");
+  it("matches the main sidebar card surface", () => {
+    expect(chatPanelClassNames()).toContain("bg-card");
+    expect(chatPanelClassNames()).toContain("text-card-foreground");
+    expect(chatPanelClassNames()).not.toContain("bg-primary");
+    expect(chatPanelBorderClassNames()).toContain("border-border");
   });
 
   it("maps elevated chat surfaces to dark accent tokens", () => {
@@ -31,17 +33,20 @@ describe("chat surface tokens", () => {
     expect(chatInputEditorClassNames()).toContain("chat-input-editor");
   });
 
-  it("uses elevated controls on the dark chat panel", () => {
+  it("uses elevated controls on the chat panel", () => {
     expect(chatFloatingControlClassNames()).toContain("bg-accent");
     expect(chatFloatingControlClassNames()).toContain("text-accent-foreground");
   });
 
-  it("uses a dark drop shadow on the floating shell", () => {
+  it("uses the card surface on the floating shell", () => {
     expect(chatFloatingPanelShellClassNames()).toContain(
-      "shadow-[0_16px_48px_rgba(0,0,0,0.55)]",
+      "shadow-[0_16px_48px_rgba(0,0,0,0.18)]",
     );
-    expect(chatFloatingPanelShellClassNames()).toContain("border-stone-600");
-    expect(chatFloatingPanelShellClassNames()).toContain("bg-primary");
+    expect(chatFloatingPanelShellClassNames()).toContain(
+      "dark:shadow-[0_16px_48px_rgba(0,0,0,0.55)]",
+    );
+    expect(chatFloatingPanelShellClassNames()).toContain("border-border");
+    expect(chatFloatingPanelShellClassNames()).toContain("bg-card");
   });
 
   it("styles disabled send controls on the elevated input surface", () => {

--- a/apps/desktop/src/chat/surface.ts
+++ b/apps/desktop/src/chat/surface.ts
@@ -1,20 +1,19 @@
 export type ChatToolbarSurface = "light" | "dark";
 
-// Chat chrome always uses the original stone-800 shell, independent of app theme.
 export function isChatDarkAppearance(): boolean {
-  return true;
+  return false;
 }
 
 export function chatPanelClassNames(): string {
-  return "bg-primary text-primary-foreground";
+  return "bg-card text-card-foreground";
 }
 
 export function chatPanelBorderClassNames(): string {
-  return "border-stone-700/80";
+  return "border-border";
 }
 
 export function chatFloatingPanelShellClassNames(): string {
-  return "bg-primary text-primary-foreground rounded-2xl border-2 border-stone-600 shadow-[0_16px_48px_rgba(0,0,0,0.55)]";
+  return "bg-card text-card-foreground rounded-2xl border-2 border-border shadow-[0_16px_48px_rgba(0,0,0,0.18)] dark:shadow-[0_16px_48px_rgba(0,0,0,0.55)]";
 }
 
 export function chatElevatedSurfaceClassNames(): string {
@@ -34,7 +33,7 @@ export function chatSendButtonShortcutDisabledClassNames(): string {
 }
 
 export function chatToolbarSurface(): ChatToolbarSurface {
-  return "dark";
+  return "light";
 }
 
 export function chatFloatingControlClassNames(): string {

--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -138,9 +138,9 @@ describe("MainChatPanels", () => {
     const rightPanel = document.querySelector("[data-chat-right-panel]");
 
     expect(rightPanel).toBeInstanceOf(HTMLDivElement);
-    expect(rightPanel?.className).toContain("bg-primary");
+    expect(rightPanel?.className).toContain("bg-card");
     expect(rightPanel?.className).toContain("border-x");
-    expect(rightPanel?.className).toContain("border-primary");
+    expect(rightPanel?.className).toContain("border-border");
     expect(rightPanel?.className).not.toContain("border-b-0");
     expect(rightPanel?.className).toContain("rounded-tr-xl");
     expect(rightPanel?.className).not.toContain("rounded-t-xl");

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -44,7 +44,7 @@ export function MainChatPanels({ children }: { children: React.ReactNode }) {
             >
               <div
                 data-chat-right-panel
-                className="border-primary bg-primary -mb-1 h-[calc(100%+0.25rem)] min-h-0 overflow-hidden rounded-tr-xl border-x"
+                className="border-border bg-card -mb-1 h-[calc(100%+0.25rem)] min-h-0 overflow-hidden rounded-tr-xl border-x"
               >
                 <ChatView
                   layout="right-panel"


### PR DESCRIPTION
## Summary
- use the sidebar card surface and border tokens for chat panel chrome
- refine docked and modal chat toolbar spacing, actions, and close/float controls
- reduce chat input bottom padding and update focused tests

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop exec vitest run src/chat/components/toolbar-controls.test.tsx
- pnpm -F @hypr/desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and toolbar interaction changes only; close uses existing shell chat events with no auth or data-path changes.
> 
> **Overview**
> **Aligns chat chrome with the main sidebar card surface** instead of the previous always-on dark `bg-primary` shell. `surface.ts` now returns `bg-card` / `text-card-foreground`, `border-border`, a lighter floating shadow (with a dark-mode variant), and a **light** toolbar surface.
> 
> **Docked right-panel UX** updates: the outer shell and resizable host use card/border tokens; the panel header **drops** the bottom border. The toolbar gets **Float** (`PictureInPicture2`) and **Close** (`X`) actions (close dispatches `chat.sendEvent({ type: "CLOSE" })` from `ChatView`), tighter `pl-3` / `pr-1` padding, and light-surface title styling (`text-foreground`, 15px). Floating layout still exposes **Open in right panel** via `PanelRight`.
> 
> **Minor layout tweak:** right-panel message input outer padding goes from `pb-5` to `pb-4`. Tests are updated to match the new classes, actions, and behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16faf4e07f886f95377028f674e80aecc3c2ea56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->