### PR TITLE
Add modal chat close button

### DIFF
--- a/apps/desktop/src/chat/components/body/index.test.tsx
+++ b/apps/desktop/src/chat/components/body/index.test.tsx
@@ -51,7 +51,8 @@ describe("ChatBody", () => {
 
     const content = screen.getByTestId("chat-body-empty").parentElement;
 
-    expect(content?.className).toContain("px-2");
+    expect(content?.className).toContain("px-3");
+    expect(content?.className).not.toContain("px-2");
     expect(content?.className).not.toContain("pr-0");
   });
 

--- a/apps/desktop/src/chat/components/body/index.tsx
+++ b/apps/desktop/src/chat/components/body/index.tsx
@@ -58,7 +58,7 @@ export function ChatBody({
           ref={contentRef}
           className={cn([
             "flex min-h-full flex-1 flex-col",
-            isRightPanel ? "px-3 py-5" : "px-2 py-3",
+            isRightPanel ? "px-3 py-5" : "px-3 py-3",
           ])}
         >
           <div className="flex-1" />

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -153,6 +153,22 @@ describe("ChatMessageInput", () => {
     expect(surface?.className).toContain("text-accent-foreground");
   });
 
+  it("uses shared horizontal outer padding while floating", () => {
+    render(
+      <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
+    );
+
+    const messageInput = screen
+      .getByTestId("chat-editor")
+      .closest("[data-chat-message-input]");
+    const outerContainer = messageInput?.parentElement?.parentElement;
+
+    expect(outerContainer?.className).toContain("px-3");
+    expect(outerContainer?.className).toContain("pb-2");
+    expect(outerContainer?.className).not.toContain("px-2");
+    expect(outerContainer?.className).not.toContain("pr-0");
+  });
+
   it("uses balanced outer padding in the right panel", () => {
     shellState.mode = "RightPanelOpen";
 

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -139,7 +139,7 @@ function Container({
     <div
       className={cn([
         "relative min-w-0 shrink-0",
-        isRightPanel ? "px-3 pb-4" : "px-2 pb-2",
+        isRightPanel ? "px-3 pb-4" : "px-3 pb-2",
       ])}
     >
       <div

--- a/apps/desktop/src/chat/components/toolbar-controls.test.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.test.tsx
@@ -73,8 +73,9 @@ describe("ChatToolbarControls", () => {
 
     const title = screen.getByText("Ask Anarlog AI anything");
     const titleButton = title.closest("button");
-    expect(container.firstElementChild?.className).toContain("pl-2");
-    expect(container.firstElementChild?.className).toContain("pr-2");
+    expect(container.firstElementChild?.className).toContain("px-3");
+    expect(container.firstElementChild?.className).not.toContain("pl-2");
+    expect(container.firstElementChild?.className).not.toContain("pr-2");
     expect(titleButton?.className).toContain("-ml-2");
     expect(titleButton?.className).toContain("px-2");
     expect(title.className).toContain("text-foreground");
@@ -86,6 +87,7 @@ describe("ChatToolbarControls", () => {
     render(
       <ChatToolbarControls
         currentChatGroupId={undefined}
+        onClose={vi.fn()}
         onNewChat={vi.fn()}
         onOpenRightPanel={vi.fn()}
         onSelectChat={vi.fn()}
@@ -97,6 +99,7 @@ describe("ChatToolbarControls", () => {
     const rightPanelButton = screen.getByRole("button", {
       name: "Open in right panel",
     });
+    const closeButton = screen.getByRole("button", { name: "Close chat" });
 
     expect(newChatButton.className).toContain("rounded-full");
     expect(newChatButton.className).toContain("hover:!bg-primary-foreground/7");
@@ -106,9 +109,43 @@ describe("ChatToolbarControls", () => {
       "hover:!bg-primary-foreground/7",
     );
     expect(rightPanelButton.getAttribute("title")).toBeNull();
+    expect(closeButton.className).toContain("rounded-full");
+    expect(closeButton.className).toContain("hover:!bg-primary-foreground/7");
+    expect(closeButton.getAttribute("title")).toBeNull();
   });
 
-  it("uses tighter toolbar right padding in the right panel", () => {
+  it("renders and wires close in the floating toolbar", () => {
+    const onClose = vi.fn();
+    const onOpenRightPanel = vi.fn();
+
+    const { container } = render(
+      <ChatToolbarControls
+        currentChatGroupId={undefined}
+        layout="floating"
+        onClose={onClose}
+        onNewChat={vi.fn()}
+        onOpenRightPanel={onOpenRightPanel}
+        onSelectChat={vi.fn()}
+        surface="light"
+      />,
+    );
+
+    const rightPanelButton = screen.getByRole("button", {
+      name: "Open in right panel",
+    });
+    const closeButton = screen.getByRole("button", { name: "Close chat" });
+    const actions = container.querySelector("[data-chat-toolbar-actions]");
+
+    fireEvent.click(rightPanelButton);
+    fireEvent.click(closeButton);
+
+    expect(actions?.className).toContain("gap-0");
+    expect(actions?.className).not.toContain("gap-1");
+    expect(onOpenRightPanel).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("uses the shared toolbar padding in the right panel", () => {
     const onClose = vi.fn();
     const onOpenFloating = vi.fn();
     const { container } = render(
@@ -127,11 +164,14 @@ describe("ChatToolbarControls", () => {
       .getByText("Ask Anarlog AI anything")
       .closest("button");
 
-    expect(container.firstElementChild?.className).toContain("pl-3");
-    expect(container.firstElementChild?.className).toContain("pr-1");
+    expect(container.firstElementChild?.className).toContain("px-3");
     expect(container.firstElementChild?.className).not.toContain("px-5");
     expect(container.firstElementChild?.className).not.toContain("px-2");
     expect(container.firstElementChild?.className).not.toContain("pr-0");
+    expect(container.firstElementChild?.className).not.toContain("pr-1");
+    const actions = container.querySelector("[data-chat-toolbar-actions]");
+    expect(actions?.className).toContain("gap-0");
+    expect(actions?.className).not.toContain("gap-1");
     expect(titleButton?.className).toContain("-ml-2");
     expect(titleButton?.className).toContain("px-2");
     const floatButton = screen.getByRole("button", { name: "Float chat" });

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -43,10 +43,7 @@ export function ChatToolbarControls({
 
   return (
     <div
-      className={cn([
-        "flex h-full w-full min-w-0 items-center gap-2",
-        isRightPanel ? "pr-1 pl-3" : isDark ? "px-2" : "pr-2 pl-2",
-      ])}
+      className={cn(["flex h-full w-full min-w-0 items-center gap-2", "px-3"])}
     >
       <div className="flex min-w-0 flex-1 items-center gap-1">
         <ChatGroups
@@ -55,7 +52,10 @@ export function ChatToolbarControls({
           surface={surface}
         />
       </div>
-      <div className="flex shrink-0 items-center gap-1">
+      <div
+        data-chat-toolbar-actions
+        className="flex shrink-0 items-center gap-0"
+      >
         <ChatActionButton
           icon={<Plus size={16} />}
           label="New chat"
@@ -78,12 +78,20 @@ export function ChatToolbarControls({
             />
           </>
         ) : (
-          <ChatActionButton
-            icon={<PanelRight size={16} />}
-            label="Open in right panel"
-            onClick={onOpenRightPanel ?? (() => {})}
-            className={isDark ? darkToolbarButtonClassName : undefined}
-          />
+          <>
+            <ChatActionButton
+              icon={<PanelRight size={16} />}
+              label="Open in right panel"
+              onClick={onOpenRightPanel ?? (() => {})}
+              className={isDark ? darkToolbarButtonClassName : undefined}
+            />
+            <ChatActionButton
+              icon={<X size={16} />}
+              label="Close chat"
+              onClick={onClose ?? (() => {})}
+              className={isDark ? darkToolbarButtonClassName : undefined}
+            />
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Render a close action in the floating chat toolbar
- Cover modal and panel toolbar actions in tests

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop exec vitest run src/chat/components/chat-panel.test.tsx src/chat/components/persistent-chat.test.tsx
- pnpm -F @hypr/desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only toolbar and Tailwind class changes with expanded component tests; no auth, data, or API impact.
> 
> **Overview**
> Adds a **Close chat** control to the **floating** toolbar (next to open-in-right-panel), matching the right-panel toolbar, wired through `onClose`.
> 
> **Layout polish:** floating chat uses consistent **`px-3`** horizontal padding on the toolbar, message body, and input outer shell (replacing mixed `px-2` / asymmetric padding). Toolbar actions sit in a **`gap-0`** group marked with `data-chat-toolbar-actions`.
> 
> Tests cover floating close wiring, dark-surface close styling, and updated padding expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80944fbc6ce51eeb396afa9229b98ce0e3961a13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->