### PR TITLE
Hide now indicator during active meetings

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -11,11 +11,14 @@ const mocks = vi.hoisted(() => ({
   newNote: vi.fn(),
   openSearch: vi.fn(),
   openNew: vi.fn(),
+  registerAnchor: vi.fn(),
   invalidateResource: vi.fn(),
   clearSelection: vi.fn(),
   addDeletion: vi.fn(),
   configValue: undefined as string | undefined,
   currentTimeMs: undefined as number | undefined,
+  liveSessionId: null as string | null,
+  liveStatus: "inactive" as "inactive" | "active" | "finalizing",
   smartCurrentTimeMs: undefined as number | undefined,
   timelineEventsTable: {} as Record<string, Record<string, unknown>>,
   timelineSessionsTable: {} as Record<string, Record<string, unknown>>,
@@ -105,6 +108,23 @@ vi.mock("~/store/zustand/undo-delete", () => ({
     }),
 }));
 
+vi.mock("~/stt/contexts", () => ({
+  useListener: (
+    selector: (state: {
+      live: {
+        sessionId: string | null;
+        status: "inactive" | "active" | "finalizing";
+      };
+    }) => unknown,
+  ) =>
+    selector({
+      live: {
+        sessionId: mocks.liveSessionId,
+        status: mocks.liveStatus,
+      },
+    }),
+}));
+
 vi.mock("./anchor", async () => {
   const React = await vi.importActual<typeof import("react")>("react");
 
@@ -114,7 +134,7 @@ vi.mock("./anchor", async () => {
       containerRef: React.useRef<HTMLDivElement>(null),
       isAnchorVisible: true,
       isScrolledPastAnchor: false,
-      registerAnchor: vi.fn(),
+      registerAnchor: mocks.registerAnchor,
       scrollToAnchor: vi.fn(),
     }),
     useAutoScrollToAnchor: vi.fn(),
@@ -148,6 +168,8 @@ describe("TimelineView", () => {
     vi.clearAllMocks();
     mocks.configValue = undefined;
     mocks.currentTimeMs = undefined;
+    mocks.liveSessionId = null;
+    mocks.liveStatus = "inactive";
     mocks.smartCurrentTimeMs = undefined;
     mocks.timelineEventsTable = {};
     mocks.timelineSessionsTable = {};
@@ -517,6 +539,66 @@ describe("TimelineView", () => {
     expect(isBefore(tomorrowHeading, indicator)).toBe(true);
     expect(isBefore(indicator, yesterdayHeading)).toBe(true);
     expect(isBefore(indicator, twoDaysAgoHeading)).toBe(true);
+  });
+
+  it("hides the now indicator while an active meeting is visible", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T11:15:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.smartCurrentTimeMs = Date.now();
+    mocks.liveStatus = "active";
+    mocks.liveSessionId = "session-live";
+    mocks.timelineSessionsTable = {
+      "session-live": {
+        title: "kate <> john (char)",
+        created_at: "2024-01-15T11:00:00.000Z",
+        event_json: JSON.stringify({
+          started_at: "2024-01-15T11:00:00.000Z",
+          ended_at: "2024-01-15T12:00:00.000Z",
+        }),
+      },
+    };
+
+    const { container } = render(<TimelineView />);
+
+    expect(screen.getByText("Today")).toBeTruthy();
+    expect(screen.getByTestId("timeline-item-session-live")).toBeTruthy();
+    expect(screen.queryByTestId("current-time-indicator")).toBeNull();
+    const anchor = container.querySelector(
+      "[data-sidebar-current-time-anchor]",
+    );
+    expect(anchor).toBeTruthy();
+    expect(mocks.registerAnchor).toHaveBeenCalledWith(anchor);
+  });
+
+  it("hides the now indicator while a finalizing meeting is visible", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T11:15:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.smartCurrentTimeMs = Date.now();
+    mocks.liveStatus = "finalizing";
+    mocks.liveSessionId = "session-finalizing";
+    mocks.timelineSessionsTable = {
+      "session-finalizing": {
+        title: "kate <> john (char)",
+        created_at: "2024-01-15T11:00:00.000Z",
+        event_json: JSON.stringify({
+          started_at: "2024-01-15T11:00:00.000Z",
+          ended_at: "2024-01-15T12:00:00.000Z",
+        }),
+      },
+    };
+
+    const { container } = render(<TimelineView />);
+
+    expect(screen.getByText("Today")).toBeTruthy();
+    expect(screen.getByTestId("timeline-item-session-finalizing")).toBeTruthy();
+    expect(screen.queryByTestId("current-time-indicator")).toBeNull();
+    const anchor = container.querySelector(
+      "[data-sidebar-current-time-anchor]",
+    );
+    expect(anchor).toBeTruthy();
+    expect(mocks.registerAnchor).toHaveBeenCalledWith(anchor);
   });
 
   it("places the fallback now indicator with fresh time after data refreshes", () => {

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -61,6 +61,7 @@ import * as main from "~/store/tinybase/store/main";
 import { useTabs } from "~/store/zustand/tabs";
 import { useTimelineSelection } from "~/store/zustand/timeline-selection";
 import { useUndoDelete } from "~/store/zustand/undo-delete";
+import { useListener } from "~/stt/contexts";
 
 const SIDEBAR_ACTIONS_REVEAL_DELAY_MS = 900;
 const DUE_CALENDAR_SYNC_VISIBLE_WINDOW_MS = 1000;
@@ -163,6 +164,21 @@ export function TimelineView({
     [buckets],
   );
   const currentTimeMs = useCurrentTimeMs();
+  const activeSessionId = useListener((state) =>
+    state.live.status === "active" || state.live.status === "finalizing"
+      ? state.live.sessionId
+      : null,
+  );
+  const hasActiveVisibleSession = useMemo(
+    () =>
+      !!activeSessionId &&
+      buckets.some((bucket) =>
+        bucket.items.some(
+          (item) => item.type === "session" && item.id === activeSessionId,
+        ),
+      ),
+    [activeSessionId, buckets],
+  );
 
   const currentTab = useTabs((state) => state.currentTab);
 
@@ -434,8 +450,12 @@ export function TimelineView({
         )}
         {buckets.map((bucket, index) => {
           const isToday = bucket.label === "Today";
-          const shouldRenderIndicatorBefore =
+          const shouldPlaceIndicatorBefore =
             !hasToday && indicatorIndex === index;
+          const shouldRenderIndicatorBefore =
+            shouldPlaceIndicatorBefore && !hasActiveVisibleSession;
+          const shouldRenderIndicatorAnchorBefore =
+            shouldPlaceIndicatorBefore && hasActiveVisibleSession;
           const isTopIndicator = shouldRenderIndicatorBefore && index === 0;
 
           return (
@@ -444,6 +464,11 @@ export function TimelineView({
                 <CurrentTimeIndicator
                   ref={setCurrentTimeIndicatorRef}
                   timezone={timezone}
+                />
+              )}
+              {shouldRenderIndicatorAnchorBefore && (
+                <CurrentTimeAnchor
+                  registerIndicator={setCurrentTimeIndicatorRef}
                 />
               )}
               <div
@@ -465,6 +490,7 @@ export function TimelineView({
                   registerIndicator={setCurrentTimeIndicatorRef}
                   selectedSessionId={selectedSessionId}
                   selectedNodeRef={scrollSelectedSessionIntoView}
+                  suppressCurrentTimeIndicator={hasActiveVisibleSession}
                   timezone={timezone}
                   selectedIds={selectedIds}
                   flatItemKeys={flatItemKeys}
@@ -494,12 +520,15 @@ export function TimelineView({
           );
         })}
         {!hasToday &&
-          (indicatorIndex === -1 || indicatorIndex === buckets.length) && (
+          (indicatorIndex === -1 || indicatorIndex === buckets.length) &&
+          (hasActiveVisibleSession ? (
+            <CurrentTimeAnchor registerIndicator={setCurrentTimeIndicatorRef} />
+          ) : (
             <CurrentTimeIndicator
               ref={setCurrentTimeIndicatorRef}
               timezone={timezone}
             />
-          )}
+          ))}
       </div>
 
       {topChromeInset && (
@@ -836,12 +865,40 @@ function TimelineNowChip({
   );
 }
 
+function CurrentTimeAnchor({
+  progress = 0.5,
+  registerIndicator,
+  variant = "seam",
+}: {
+  progress?: number;
+  registerIndicator: (node: HTMLDivElement | null) => void;
+  variant?: "seam" | "inside";
+}) {
+  return (
+    <div
+      ref={registerIndicator}
+      aria-hidden
+      data-sidebar-current-time-anchor
+      className={cn([
+        "pointer-events-none opacity-0",
+        variant === "inside"
+          ? "absolute inset-x-0 z-20 h-px"
+          : "relative z-20 h-px",
+      ])}
+      style={
+        variant === "inside" ? { top: `${(1 - progress) * 100}%` } : undefined
+      }
+    />
+  );
+}
+
 function TodayBucket({
   items,
   precision,
   registerIndicator,
   selectedSessionId,
   selectedNodeRef,
+  suppressCurrentTimeIndicator,
   timezone,
   selectedIds,
   flatItemKeys,
@@ -851,6 +908,7 @@ function TodayBucket({
   registerIndicator: (node: HTMLDivElement | null) => void;
   selectedSessionId: string | undefined;
   selectedNodeRef: RefCallback<HTMLDivElement>;
+  suppressCurrentTimeIndicator: boolean;
   timezone?: string;
   selectedIds: string[];
   flatItemKeys: string[];
@@ -877,7 +935,11 @@ function TodayBucket({
     if (entries.length === 0) {
       return (
         <>
-          <CurrentTimeIndicator ref={registerIndicator} timezone={timezone} />
+          {suppressCurrentTimeIndicator ? (
+            <CurrentTimeAnchor registerIndicator={registerIndicator} />
+          ) : (
+            <CurrentTimeIndicator ref={registerIndicator} timezone={timezone} />
+          )}
           <div className="text-muted-foreground px-3 py-4 text-center text-sm">
             No items today
           </div>
@@ -893,11 +955,18 @@ function TodayBucket({
         index === indicatorPlacement.index
       ) {
         nodes.push(
-          <CurrentTimeIndicator
-            ref={registerIndicator}
-            key="current-time-indicator"
-            timezone={timezone}
-          />,
+          suppressCurrentTimeIndicator ? (
+            <CurrentTimeAnchor
+              key="current-time-anchor"
+              registerIndicator={registerIndicator}
+            />
+          ) : (
+            <CurrentTimeIndicator
+              ref={registerIndicator}
+              key="current-time-indicator"
+              timezone={timezone}
+            />
+          ),
         );
       }
 
@@ -924,13 +993,21 @@ function TodayBucket({
       ) {
         nodes.push(
           <div key={`${itemKey}-wrapper`} className="relative">
-            <CurrentTimeIndicator
-              ref={registerIndicator}
-              key="current-time-indicator-inside"
-              timezone={timezone}
-              variant="inside"
-              progress={indicatorPlacement.progress}
-            />
+            {suppressCurrentTimeIndicator ? (
+              <CurrentTimeAnchor
+                registerIndicator={registerIndicator}
+                variant="inside"
+                progress={indicatorPlacement.progress}
+              />
+            ) : (
+              <CurrentTimeIndicator
+                ref={registerIndicator}
+                key="current-time-indicator-inside"
+                timezone={timezone}
+                variant="inside"
+                progress={indicatorPlacement.progress}
+              />
+            )}
             {itemNode}
           </div>,
         );
@@ -942,11 +1019,18 @@ function TodayBucket({
 
     if (indicatorPlacement.type === "after") {
       nodes.push(
-        <CurrentTimeIndicator
-          ref={registerIndicator}
-          key="current-time-indicator-end"
-          timezone={timezone}
-        />,
+        suppressCurrentTimeIndicator ? (
+          <CurrentTimeAnchor
+            key="current-time-anchor-end"
+            registerIndicator={registerIndicator}
+          />
+        ) : (
+          <CurrentTimeIndicator
+            ref={registerIndicator}
+            key="current-time-indicator-end"
+            timezone={timezone}
+          />
+        ),
       );
     }
 
@@ -958,6 +1042,7 @@ function TodayBucket({
     registerIndicator,
     selectedSessionId,
     selectedNodeRef,
+    suppressCurrentTimeIndicator,
     timezone,
     selectedIds,
     flatItemKeys,


### PR DESCRIPTION
## Summary
- Suppress the sidebar current-time marker while the active meeting session is visible
- Add regression coverage for active meeting timeline rendering

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop exec vitest run src/sidebar/timeline/index.test.tsx
- pnpm -F @hypr/desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar timeline behavior with regression tests; no auth, data, or API changes.
> 
> **Overview**
> **Hides the sidebar “now” line while a live meeting session is on screen**, so the timeline doesn’t show a duplicate time marker next to the in-progress session.
> 
> `TimelineView` reads live listener state (`active` / `finalizing`) and, when that session appears in the current buckets, sets `hasActiveVisibleSession`. In that case it **does not render** `CurrentTimeIndicator`; it renders an invisible **`CurrentTimeAnchor`** (`data-sidebar-current-time-anchor`) at the same placement points (Today bucket, fallback between buckets, empty today) so **scroll-to-now / anchor registration** still works.
> 
> `TodayBucket` takes **`suppressCurrentTimeIndicator`** and swaps indicator vs anchor for all placement modes (before, inside, after).
> 
> Tests mock `~/stt/contexts` and assert no `current-time-indicator` plus anchor registration for **active** and **finalizing** visible sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d8340fb30830948770ef7105c3bdc0772c1f56a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->