### PR TITLE
Preserve chat stream across mode switches

### DIFF
--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -1,10 +1,10 @@
-import { useCallback } from "react";
+import { type ReactNode, useCallback } from "react";
 
 import { cn } from "@hypr/utils";
 
 import { ChatBody } from "./body";
 import { ChatContent } from "./content";
-import { ChatSession } from "./session-provider";
+import { ChatSession, type ChatSessionRenderProps } from "./session-provider";
 import { ChatToolbarControls } from "./toolbar-controls";
 import { useSessionTab } from "./use-session-tab";
 
@@ -23,15 +23,62 @@ export function ChatView({
   onOpenFloating?: () => void;
   onOpenRightPanel?: () => void;
 }) {
+  return (
+    <ChatSessionHost>
+      {(sessionProps) => (
+        <ChatPanelFrame
+          layout={layout}
+          onOpenFloating={onOpenFloating}
+          onOpenRightPanel={onOpenRightPanel}
+          sessionProps={sessionProps}
+        />
+      )}
+    </ChatSessionHost>
+  );
+}
+
+export function ChatSessionHost({
+  children,
+}: {
+  children: (sessionProps: ChatSessionRenderProps | null) => ReactNode;
+}) {
   const { chat } = useShell();
-  const { groupId, sessionId, setGroupId } = chat;
+  const { groupId, sessionId } = chat;
+  const { currentSessionId } = useSessionTab();
+  const { user_id } = main.UI.useValues(main.STORE_ID);
+
+  if (!user_id) {
+    return <>{children(null)}</>;
+  }
+
+  return (
+    <ChatSession
+      sessionId={sessionId}
+      chatGroupId={groupId}
+      currentSessionId={currentSessionId}
+      unstyled
+    >
+      {children}
+    </ChatSession>
+  );
+}
+
+export function ChatPanelFrame({
+  layout = "floating",
+  onOpenFloating,
+  onOpenRightPanel,
+  sessionProps,
+}: {
+  layout?: "floating" | "right-panel";
+  onOpenFloating?: () => void;
+  onOpenRightPanel?: () => void;
+  sessionProps: ChatSessionRenderProps | null;
+}) {
+  const { chat } = useShell();
+  const { groupId, setGroupId } = chat;
   const { panelClassName, toolbarSurface } = useChatAppearance();
   const isFloating = layout === "floating";
-
-  const { currentSessionId } = useSessionTab();
-
   const model = useLanguageModel("chat");
-  const { user_id } = main.UI.useValues(main.STORE_ID);
 
   const handleGroupCreated = useCallback(
     (newGroupId: string) => {
@@ -69,38 +116,29 @@ export function ChatView({
           surface={toolbarSurface}
         />
       </div>
-      {user_id && (
-        <ChatSession
-          key={sessionId}
-          sessionId={sessionId}
-          chatGroupId={groupId}
-          currentSessionId={currentSessionId}
+      {sessionProps && (
+        <ChatContent
+          {...sessionProps}
+          model={model}
+          handleSendMessage={handleSendMessage}
         >
-          {(sessionProps) => (
-            <ChatContent
-              {...sessionProps}
-              model={model}
-              handleSendMessage={handleSendMessage}
-            >
-              <ChatBody
-                messages={sessionProps.messages}
-                status={sessionProps.status}
-                error={sessionProps.error}
-                onReload={sessionProps.regenerate}
-                isModelConfigured={!!model}
-                hasContext={sessionProps.contextEntities.length > 0}
-                onSendMessage={(content, parts) => {
-                  handleSendMessage(
-                    content,
-                    parts,
-                    sessionProps.sendMessage,
-                    sessionProps.pendingRefs,
-                  );
-                }}
-              />
-            </ChatContent>
-          )}
-        </ChatSession>
+          <ChatBody
+            messages={sessionProps.messages}
+            status={sessionProps.status}
+            error={sessionProps.error}
+            onReload={sessionProps.regenerate}
+            isModelConfigured={!!model}
+            hasContext={sessionProps.contextEntities.length > 0}
+            onSendMessage={(content, parts) => {
+              handleSendMessage(
+                content,
+                parts,
+                sessionProps.sendMessage,
+                sessionProps.pendingRefs,
+              );
+            }}
+          />
+        </ChatContent>
       )}
     </div>
   );

--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -16,6 +16,21 @@ const mocks = vi.hoisted(() => ({
       | "RightPanelOpen",
   },
   sendEvent: vi.fn(),
+  sessionProps: {
+    contextEntities: [],
+    isSystemPromptReady: true,
+    messages: [],
+    onAddContextEntity: vi.fn(),
+    onDraftContextRefsChange: vi.fn(),
+    onRemoveContextEntity: vi.fn(),
+    pendingRefs: [],
+    regenerate: vi.fn(),
+    sendMessage: vi.fn(),
+    sessionId: "chat-session-1",
+    setMessages: vi.fn(),
+    status: "ready" as const,
+    stop: vi.fn(),
+  },
 }));
 
 vi.mock("react-hotkeys-hook", () => ({
@@ -32,15 +47,18 @@ vi.mock("~/contexts/shell", () => ({
 }));
 
 vi.mock("./chat-panel", () => ({
-  ChatView: ({
+  ChatPanelFrame: ({
     layout,
     onOpenRightPanel,
+    sessionProps,
   }: {
     layout?: "floating" | "right-panel";
     onOpenRightPanel?: () => void;
+    sessionProps: unknown;
   }) => (
     <>
       <button
+        data-has-session={String(sessionProps === mocks.sessionProps)}
         data-layout={layout}
         data-testid="open-right-panel"
         type="button"
@@ -61,7 +79,10 @@ function TestHost() {
   return (
     <div ref={containerRef} data-testid="full-panel-container">
       <div data-chat-floating-anchor />
-      <PersistentChatPanel floatingContainerRef={containerRef} />
+      <PersistentChatPanel
+        floatingContainerRef={containerRef}
+        sessionProps={mocks.sessionProps}
+      />
     </div>
   );
 }
@@ -83,6 +104,9 @@ describe("PersistentChatPanel", () => {
 
     await screen.findByTestId("chat-view");
 
+    expect(screen.getByTestId("open-right-panel").dataset.hasSession).toBe(
+      "true",
+    );
     const resizeFrame = document.querySelector("[data-chat-resize-frame]");
     const panel = document.querySelector<HTMLElement>("[data-chat-panel]");
 

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -11,8 +11,9 @@ import { useHotkeys } from "react-hotkeys-hook";
 
 import { cn } from "@hypr/utils";
 
-import { ChatView } from "./chat-panel";
+import { ChatPanelFrame } from "./chat-panel";
 
+import type { ChatSessionRenderProps } from "~/chat/components/session-provider";
 import { chatFloatingPanelShellClassNames } from "~/chat/surface";
 import { useShell } from "~/contexts/shell";
 
@@ -73,8 +74,10 @@ type ResizeState = {
 
 export function PersistentChatPanel({
   floatingContainerRef,
+  sessionProps,
 }: {
   floatingContainerRef: React.RefObject<HTMLDivElement | null>;
+  sessionProps: ChatSessionRenderProps | null;
 }) {
   const { chat } = useShell();
   const isVisible = chat.mode === "FloatingOpen";
@@ -315,11 +318,12 @@ export function PersistentChatPanel({
               exit={panelMotion.exit}
               transition={panelTransition}
             >
-              <ChatView
+              <ChatPanelFrame
                 layout="floating"
                 onOpenRightPanel={() =>
                   chat.sendEvent({ type: "OPEN_RIGHT_PANEL" })
                 }
+                sessionProps={sessionProps}
               />
               {RESIZE_HANDLES.map((handle) => (
                 <div

--- a/apps/desktop/src/chat/components/session-provider.tsx
+++ b/apps/desktop/src/chat/components/session-provider.tsx
@@ -24,6 +24,25 @@ import { useTransport } from "~/chat/transport/use-transport";
 import type { HyprUIMessage } from "~/chat/types";
 import * as main from "~/store/tinybase/store/main";
 
+export type ChatSessionRenderProps = {
+  sessionId: string;
+  messages: HyprUIMessage[];
+  setMessages: (
+    msgs: HyprUIMessage[] | ((prev: HyprUIMessage[]) => HyprUIMessage[]),
+  ) => void;
+  sendMessage: (message: HyprUIMessage) => void;
+  regenerate: () => void;
+  stop: () => void;
+  status: ChatStatus;
+  error?: Error;
+  contextEntities: DisplayEntity[];
+  pendingRefs: ContextRef[];
+  onRemoveContextEntity: (key: string) => void;
+  onAddContextEntity: (ref: ContextRef) => void;
+  onDraftContextRefsChange: (refs: ContextRef[]) => void;
+  isSystemPromptReady: boolean;
+};
+
 interface ChatSessionProps {
   sessionId: string;
   chatGroupId?: string;
@@ -31,24 +50,8 @@ interface ChatSessionProps {
   modelOverride?: LanguageModel;
   extraTools?: ToolSet;
   systemPromptOverride?: string;
-  children: (props: {
-    sessionId: string;
-    messages: HyprUIMessage[];
-    setMessages: (
-      msgs: HyprUIMessage[] | ((prev: HyprUIMessage[]) => HyprUIMessage[]),
-    ) => void;
-    sendMessage: (message: HyprUIMessage) => void;
-    regenerate: () => void;
-    stop: () => void;
-    status: ChatStatus;
-    error?: Error;
-    contextEntities: DisplayEntity[];
-    pendingRefs: ContextRef[];
-    onRemoveContextEntity: (key: string) => void;
-    onAddContextEntity: (ref: ContextRef) => void;
-    onDraftContextRefsChange: (refs: ContextRef[]) => void;
-    isSystemPromptReady: boolean;
-  }) => ReactNode;
+  unstyled?: boolean;
+  children: (props: ChatSessionRenderProps) => ReactNode;
 }
 
 export function ChatSession({
@@ -58,6 +61,7 @@ export function ChatSession({
   modelOverride,
   extraTools,
   systemPromptOverride,
+  unstyled = false,
   children,
 }: ChatSessionProps) {
   const store = main.UI.useStore(main.STORE_ID);
@@ -182,24 +186,26 @@ export function ChatSession({
     store,
   });
 
-  return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      {children({
-        sessionId,
-        messages,
-        setMessages,
-        sendMessage,
-        regenerate,
-        stop,
-        status,
-        error,
-        contextEntities,
-        pendingRefs,
-        onRemoveContextEntity,
-        onAddContextEntity,
-        onDraftContextRefsChange,
-        isSystemPromptReady,
-      })}
-    </div>
-  );
+  const content = children({
+    sessionId,
+    messages,
+    setMessages,
+    sendMessage,
+    regenerate,
+    stop,
+    status,
+    error,
+    contextEntities,
+    pendingRefs,
+    onRemoveContextEntity,
+    onAddContextEntity,
+    onDraftContextRefsChange,
+    isSystemPromptReady,
+  });
+
+  if (unstyled) {
+    return content;
+  }
+
+  return <div className="flex min-h-0 flex-1 flex-col">{content}</div>;
 }

--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
     | "RightPanelOpen",
   persistentChatPanel: vi.fn(),
   sendEvent: vi.fn(),
+  sessionProps: { sessionId: "chat-session-1" },
 }));
 
 vi.mock("@hypr/ui/components/ui/resizable", () => ({
@@ -63,14 +64,17 @@ vi.mock("~/contexts/shell", () => ({
 }));
 
 vi.mock("~/chat/components/chat-panel", () => ({
-  ChatView: ({
+  ChatPanelFrame: ({
     layout,
     onOpenFloating,
+    sessionProps,
   }: {
     layout?: "floating" | "right-panel";
     onOpenFloating?: () => void;
+    sessionProps: unknown;
   }) => (
     <button
+      data-has-session={String(sessionProps === mocks.sessionProps)}
       data-layout={layout}
       data-testid="chat-view"
       type="button"
@@ -79,15 +83,22 @@ vi.mock("~/chat/components/chat-panel", () => ({
       Chat
     </button>
   ),
+  ChatSessionHost: ({
+    children,
+  }: {
+    children: (sessionProps: unknown) => React.ReactNode;
+  }) => <>{children(mocks.sessionProps)}</>,
 }));
 
 vi.mock("~/chat/components/persistent-chat", () => ({
   PersistentChatPanel: ({
     floatingContainerRef,
+    sessionProps,
   }: {
     floatingContainerRef: { current: HTMLDivElement | null };
+    sessionProps: unknown;
   }) => {
-    mocks.persistentChatPanel(floatingContainerRef);
+    mocks.persistentChatPanel(floatingContainerRef, sessionProps);
     return <div data-testid="persistent-chat-panel" />;
   },
 }));
@@ -115,6 +126,9 @@ describe("MainChatPanels", () => {
     expect(mocks.persistentChatPanel.mock.calls[0]?.[0].current).toBeInstanceOf(
       HTMLDivElement,
     );
+    expect(mocks.persistentChatPanel.mock.calls[0]?.[1]).toBe(
+      mocks.sessionProps,
+    );
     expect(screen.getByTestId("panel-group").dataset.direction).toBe(
       "horizontal",
     );
@@ -135,6 +149,10 @@ describe("MainChatPanels", () => {
     expect(screen.getAllByTestId("panel")).toHaveLength(2);
     expect(screen.getByTestId("resize-handle")).toBeTruthy();
     expect(screen.getByTestId("chat-view").dataset.layout).toBe("right-panel");
+    expect(screen.getByTestId("chat-view").dataset.hasSession).toBe("true");
+    expect(mocks.persistentChatPanel.mock.calls[0]?.[1]).toBe(
+      mocks.sessionProps,
+    );
     const rightPanel = document.querySelector("[data-chat-right-panel]");
 
     expect(rightPanel).toBeInstanceOf(HTMLDivElement);

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -6,7 +6,7 @@ import {
   ResizablePanelGroup,
 } from "@hypr/ui/components/ui/resizable";
 
-import { ChatView } from "~/chat/components/chat-panel";
+import { ChatPanelFrame, ChatSessionHost } from "~/chat/components/chat-panel";
 import { PersistentChatPanel } from "~/chat/components/persistent-chat";
 import { useShell } from "~/contexts/shell";
 
@@ -18,45 +18,53 @@ export function MainChatPanels({ children }: { children: React.ReactNode }) {
   const isRightPanelOpen = chat.mode === "RightPanelOpen";
 
   return (
-    <>
-      <ResizablePanelGroup
-        autoSaveId="main-chat"
-        direction="horizontal"
-        className="flex min-h-0 flex-1 overflow-hidden"
-      >
-        <ResizablePanel className="min-h-0 flex-1 overflow-hidden">
-          <div
-            ref={bodyPanelContainerRef}
-            className="h-full min-h-0 min-w-0 flex-1 overflow-hidden"
+    <ChatSessionHost>
+      {(sessionProps) => (
+        <>
+          <ResizablePanelGroup
+            autoSaveId="main-chat"
+            direction="horizontal"
+            className="flex min-h-0 flex-1 overflow-hidden"
           >
-            {children}
-          </div>
-        </ResizablePanel>
-        {isRightPanelOpen ? (
-          <>
-            <ResizableHandle className="w-0" />
-            <ResizablePanel
-              defaultSize={30}
-              minSize={20}
-              maxSize={50}
-              className="min-h-0 overflow-hidden"
-              style={{ minWidth: RIGHT_CHAT_PANEL_MIN_WIDTH_PX }}
-            >
+            <ResizablePanel className="min-h-0 flex-1 overflow-hidden">
               <div
-                data-chat-right-panel
-                className="border-border bg-card -mb-1 h-[calc(100%+0.25rem)] min-h-0 overflow-hidden rounded-tr-xl border-x"
+                ref={bodyPanelContainerRef}
+                className="h-full min-h-0 min-w-0 flex-1 overflow-hidden"
               >
-                <ChatView
-                  layout="right-panel"
-                  onOpenFloating={() => chat.sendEvent({ type: "OPEN" })}
-                />
+                {children}
               </div>
             </ResizablePanel>
-          </>
-        ) : null}
-      </ResizablePanelGroup>
+            {isRightPanelOpen ? (
+              <>
+                <ResizableHandle className="w-0" />
+                <ResizablePanel
+                  defaultSize={30}
+                  minSize={20}
+                  maxSize={50}
+                  className="min-h-0 overflow-hidden"
+                  style={{ minWidth: RIGHT_CHAT_PANEL_MIN_WIDTH_PX }}
+                >
+                  <div
+                    data-chat-right-panel
+                    className="border-border bg-card -mb-1 h-[calc(100%+0.25rem)] min-h-0 overflow-hidden rounded-tr-xl border-x"
+                  >
+                    <ChatPanelFrame
+                      layout="right-panel"
+                      onOpenFloating={() => chat.sendEvent({ type: "OPEN" })}
+                      sessionProps={sessionProps}
+                    />
+                  </div>
+                </ResizablePanel>
+              </>
+            ) : null}
+          </ResizablePanelGroup>
 
-      <PersistentChatPanel floatingContainerRef={bodyPanelContainerRef} />
-    </>
+          <PersistentChatPanel
+            floatingContainerRef={bodyPanelContainerRef}
+            sessionProps={sessionProps}
+          />
+        </>
+      )}
+    </ChatSessionHost>
   );
 }


### PR DESCRIPTION
## Summary
- Keep one chat session host mounted while rendering modal or panel chat frames
- Preserve active streaming response state when switching chat between modal and right panel
- Update chat panel host tests for shared session props

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop exec vitest run src/chat/components/chat-panel.test.tsx src/chat/components/persistent-chat.test.tsx src/shared/main/chat-panels.test.tsx
- pnpm -F @hypr/desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors how chat session lifecycle is mounted across two UIs; incorrect sharing or null session handling could affect streaming, persistence, or logged-out behavior.
> 
> **Overview**
> **Hoists chat session state** so floating and docked panels share one `ChatSession` instead of each layout mounting its own.
> 
> `MainChatPanels` now wraps the resizable layout and `PersistentChatPanel` in **`ChatSessionHost`**, which owns `ChatSession` (with `unstyled` so the provider does not add an extra flex wrapper). **`ChatPanelFrame`** is the UI shell only: toolbar plus `ChatContent`/`ChatBody`, driven by injected **`ChatSessionRenderProps`** (new exported type from `session-provider`). Switching between floating and right-panel mode no longer tears down `useChat`, so **in-flight streams and session state stay alive** across mode changes.
> 
> `ChatView` remains a thin wrapper around `ChatSessionHost` + `ChatPanelFrame` for standalone entry points. Tests mock `ChatPanelFrame` / `ChatSessionHost` and assert the same `sessionProps` object is passed to both panel surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0af8b845ccf6e846d4d9352e1d88f692b345f3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->