### PR TITLE
Add web search to chat

### DIFF
--- a/apps/desktop/src/chat/tools/index.ts
+++ b/apps/desktop/src/chat/tools/index.ts
@@ -12,8 +12,10 @@ import { buildSearchSessionsTool } from "./search-sessions";
 import type {
   CalendarEventSearchResult,
   ContactSearchResult,
+  WebSearchResponse,
   ToolDependencies,
 } from "./types";
+import { buildWebSearchTool } from "./web-search";
 
 import type { SearchFilters } from "~/search/contexts/engine/types";
 
@@ -68,6 +70,7 @@ export const buildChatTools = (deps: ToolDependencies) => ({
     "search_calendar_events",
     buildSearchCalendarEventsTool(deps),
   ),
+  web_search: withToolLogging("web_search", buildWebSearchTool(deps)),
   edit_summary: withToolLogging("edit_summary", buildEditSummaryTool(deps)),
 });
 
@@ -172,6 +175,15 @@ type LocalTools = {
       query: string;
       results: CalendarEventSearchResult[];
     };
+  };
+  web_search: {
+    input: {
+      query: string;
+      includeDomains?: string[];
+      excludeDomains?: string[];
+      limit?: number;
+    };
+    output: WebSearchResponse;
   };
   edit_summary: {
     input: { sessionId?: string; enhancedNoteId?: string; content: string };

--- a/apps/desktop/src/chat/tools/types.ts
+++ b/apps/desktop/src/chat/tools/types.ts
@@ -26,6 +26,21 @@ export type CalendarEventSearchResult = {
   linkedSessionId: string | null;
 };
 
+export type WebSearchResult = {
+  title: string;
+  url: string;
+  snippet: string;
+  publishedDate?: string | null;
+  author?: string | null;
+};
+
+export type WebSearchResponse = {
+  status: "ok" | "error";
+  message?: string;
+  query: string;
+  results: WebSearchResult[];
+};
+
 export interface ToolDependencies {
   search: (
     query: string,
@@ -44,4 +59,6 @@ export interface ToolDependencies {
   getSessionId: () => string | undefined;
   getEnhancedNoteId: () => string | undefined;
   openEditTab: (requestId: string) => void;
+  getAuthHeaders: () => Record<string, string> | null | undefined;
+  fetch?: typeof fetch;
 }

--- a/apps/desktop/src/chat/tools/web-search.test.ts
+++ b/apps/desktop/src/chat/tools/web-search.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runWebSearch } from "./web-search";
+
+describe("web search chat tool", () => {
+  it("returns a tool error when auth headers are unavailable", async () => {
+    const fetch = vi.fn();
+
+    const result = await runWebSearch(
+      { query: "how can char.com help?" },
+      {
+        getAuthHeaders: () => null,
+        fetch: fetch as unknown as typeof globalThis.fetch,
+      },
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "error",
+      message: "Sign in to use web search.",
+      query: "how can char.com help?",
+      results: [],
+    });
+  });
+
+  it("posts search requests to the hosted research endpoint", async () => {
+    const fetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            query: "how can char.com help?",
+            results: [
+              {
+                title: "Char",
+                url: "https://char.com",
+                snippet: "Char helps teams turn meetings into useful notes.",
+                publishedDate: null,
+                author: null,
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const result = await runWebSearch(
+      {
+        query: "how can char.com help?",
+        includeDomains: ["char.com"],
+        limit: 3,
+      },
+      {
+        getAuthHeaders: () => ({
+          Authorization: "Bearer token",
+          "x-request-id": "request-1",
+        }),
+        fetch: fetch as unknown as typeof globalThis.fetch,
+      },
+    );
+
+    expect(fetch).toHaveBeenCalledOnce();
+    const [url, init] = fetch.mock.calls[0]!;
+    expect(url).toBe("http://localhost:3001/research/search");
+    expect(init?.method).toBe("POST");
+    expect((init?.headers as Headers).get("Authorization")).toBe(
+      "Bearer token",
+    );
+    expect((init?.headers as Headers).get("Content-Type")).toBe(
+      "application/json",
+    );
+    expect(JSON.parse(init?.body as string)).toEqual({
+      query: "how can char.com help?",
+      numResults: 3,
+      includeDomains: ["char.com"],
+    });
+    expect(result).toEqual({
+      status: "ok",
+      query: "how can char.com help?",
+      results: [
+        {
+          title: "Char",
+          url: "https://char.com",
+          snippet: "Char helps teams turn meetings into useful notes.",
+          publishedDate: null,
+          author: null,
+        },
+      ],
+    });
+  });
+});

--- a/apps/desktop/src/chat/tools/web-search.ts
+++ b/apps/desktop/src/chat/tools/web-search.ts
@@ -1,0 +1,90 @@
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import { tool } from "ai";
+import { z } from "zod";
+
+import type { ToolDependencies, WebSearchResponse } from "./types";
+
+import { env } from "~/env";
+
+const webSearchInputSchema = z.object({
+  query: z.string().min(1).describe("Search query for public web information."),
+  includeDomains: z
+    .array(z.string().min(1))
+    .max(5)
+    .optional()
+    .describe(
+      "Optional domains to search within, for example ['char.com']. Use only when the user names a specific site or domain.",
+    ),
+  excludeDomains: z
+    .array(z.string().min(1))
+    .max(5)
+    .optional()
+    .describe("Optional domains to exclude from the search results."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(10)
+    .optional()
+    .describe("Maximum number of web results to return."),
+});
+
+export type WebSearchInput = z.infer<typeof webSearchInputSchema>;
+
+export async function runWebSearch(
+  params: WebSearchInput,
+  deps: Pick<ToolDependencies, "getAuthHeaders" | "fetch">,
+): Promise<WebSearchResponse> {
+  const headers = deps.getAuthHeaders();
+  if (!headers) {
+    return {
+      status: "error",
+      message: "Sign in to use web search.",
+      query: params.query,
+      results: [],
+    };
+  }
+
+  const requestHeaders = new Headers(headers);
+  requestHeaders.set("Content-Type", "application/json");
+
+  const response = await (deps.fetch ?? tauriFetch)(
+    new URL("/research/search", env.VITE_API_URL).toString(),
+    {
+      method: "POST",
+      headers: requestHeaders,
+      body: JSON.stringify({
+        query: params.query,
+        numResults: params.limit,
+        includeDomains: params.includeDomains,
+        excludeDomains: params.excludeDomains,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    return {
+      status: "error",
+      message: `Web search failed with HTTP ${response.status}.`,
+      query: params.query,
+      results: [],
+    };
+  }
+
+  return {
+    status: "ok",
+    ...(await response.json()),
+  };
+}
+
+export const buildWebSearchTool = (deps: ToolDependencies) =>
+  tool({
+    description: `
+Search the public web for current or external information.
+Use this for questions about public websites, URLs, companies, products, people, news, or facts that may not be in local notes.
+Return source URLs in the final answer when web results are used.
+Do not use this when the user is asking only about local notes, meetings, contacts, or calendar events.
+`.trim(),
+    inputSchema: webSearchInputSchema,
+    execute: (params) => runWebSearch(params, deps),
+  });

--- a/apps/desktop/src/chat/transport/use-transport.ts
+++ b/apps/desktop/src/chat/transport/use-transport.ts
@@ -18,6 +18,11 @@ Context and local-note tool guidance:
 - When the user asks to find or search for something in notes, use grep_notes. If the answer needs the full source after a match, use read_note with the returned session id.
 - When the user asks about people from the current note or related meetings, use list_related_notes and then read_note as needed.
 - Do not assume note contents from chat history when a file-backed tool can read the current source of truth.
+
+Web search guidance:
+- Use web_search for public websites, URLs, companies, products, people, news, or current facts that may be outside local notes.
+- Include source URLs in the final answer when web_search results are used.
+- Do not use web_search for questions that only need local notes, contacts, or calendar events.
 `.trim();
 
 function appendFileContextToolGuidance(

--- a/apps/desktop/src/main/lifecycle.tsx
+++ b/apps/desktop/src/main/lifecycle.tsx
@@ -2,6 +2,7 @@ import { useRouteContext } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef } from "react";
 
 import { useLanguageModel, useLLMConnection } from "~/ai/hooks";
+import { useAuth } from "~/auth";
 import { useSessionTab } from "~/chat/components/use-session-tab";
 import { buildChatTools } from "~/chat/tools";
 import { useRegisterTools } from "~/contexts/tool";
@@ -40,6 +41,7 @@ export function ClassicMainServices() {
 }
 
 function ToolRegistration() {
+  const auth = useAuth();
   const { search } = useSearchEngine();
   const store = main.UI.useStore(main.STORE_ID);
   const indexes = main.UI.useIndexes(main.STORE_ID);
@@ -237,6 +239,7 @@ function ToolRegistration() {
   );
 
   const { getSessionId, getEnhancedNoteId } = useSessionTab();
+  const getAuthHeaders = useCallback(() => auth?.getHeaders(), [auth]);
   const openEditTab = useCallback((requestId: string) => {
     useTabs.getState().openNew({ type: "edit", requestId });
   }, []);
@@ -253,6 +256,7 @@ function ToolRegistration() {
         getSessionId,
         getEnhancedNoteId,
         openEditTab,
+        getAuthHeaders,
       }),
     [
       search,
@@ -261,6 +265,7 @@ function ToolRegistration() {
       getSessionId,
       getEnhancedNoteId,
       openEditTab,
+      getAuthHeaders,
     ],
   );
 

--- a/crates/api-research/src/routes.rs
+++ b/crates/api-research/src/routes.rs
@@ -1,4 +1,4 @@
-use axum::Router;
+use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
 
 use crate::config::ResearchConfig;
 use crate::mcp::mcp_service;
@@ -6,7 +6,209 @@ use crate::state::AppState;
 
 pub fn router(config: ResearchConfig) -> Router {
     let state = AppState::new(config);
-    let mcp = mcp_service(state);
+    let mcp = mcp_service(state.clone());
 
-    Router::new().nest("/research", Router::new().nest_service("/mcp", mcp))
+    Router::new().nest(
+        "/research",
+        Router::new()
+            .route("/search", post(web_search))
+            .nest_service("/mcp", mcp)
+            .with_state(state),
+    )
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebSearchRequest {
+    pub query: String,
+    pub num_results: Option<u32>,
+    pub include_domains: Option<Vec<String>>,
+    pub exclude_domains: Option<Vec<String>>,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebSearchResponse {
+    pub query: String,
+    pub results: Vec<WebSearchResult>,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebSearchResult {
+    pub title: String,
+    pub url: String,
+    pub snippet: String,
+    pub published_date: Option<String>,
+    pub author: Option<String>,
+}
+
+async fn web_search(
+    State(state): State<AppState>,
+    Json(request): Json<WebSearchRequest>,
+) -> Result<Json<WebSearchResponse>, (StatusCode, String)> {
+    let query = request.query.trim().to_string();
+    if query.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "query is required".to_string()));
+    }
+
+    let response = state
+        .exa
+        .search(hypr_exa::SearchRequest {
+            query: query.clone(),
+            additional_queries: None,
+            stream: None,
+            output_schema: None,
+            system_prompt: None,
+            r#type: Some(hypr_exa::SearchType::Auto),
+            category: None,
+            user_location: None,
+            num_results: Some(request.num_results.unwrap_or(5).clamp(1, 10)),
+            include_domains: normalize_domains(request.include_domains),
+            exclude_domains: normalize_domains(request.exclude_domains),
+            start_crawl_date: None,
+            end_crawl_date: None,
+            start_published_date: None,
+            end_published_date: None,
+            include_text: None,
+            exclude_text: None,
+            moderation: Some(true),
+            contents: Some(hypr_exa::ContentsRequest {
+                text: Some(hypr_exa::TextRequest::Options(hypr_exa::TextOptions {
+                    max_characters: Some(1200),
+                    include_html_tags: Some(false),
+                    verbosity: Some(hypr_exa::TextVerbosity::Compact),
+                    include_sections: None,
+                    exclude_sections: None,
+                })),
+                highlights: Some(hypr_exa::HighlightsRequest::Options(
+                    hypr_exa::HighlightsOptions {
+                        max_characters: Some(400),
+                        num_sentences: Some(2),
+                        highlights_per_url: Some(1),
+                        query: Some(query.clone()),
+                    },
+                )),
+                summary: Some(hypr_exa::SummaryRequest {
+                    query: Some(format!("Summarize the information relevant to: {query}")),
+                    schema: None,
+                }),
+                livecrawl: Some(hypr_exa::Livecrawl::Preferred),
+                livecrawl_timeout: None,
+                max_age_hours: None,
+                subpages: None,
+                subpage_target: None,
+                extras: None,
+                context: None,
+            }),
+        })
+        .await
+        .map_err(|error| (StatusCode::BAD_GATEWAY, error.to_string()))?;
+
+    Ok(Json(WebSearchResponse {
+        query,
+        results: response
+            .results
+            .into_iter()
+            .map(normalize_search_result)
+            .collect(),
+    }))
+}
+
+fn normalize_domains(domains: Option<Vec<String>>) -> Option<Vec<String>> {
+    domains
+        .map(|domains| {
+            domains
+                .into_iter()
+                .map(|domain| domain.trim().to_string())
+                .filter(|domain| !domain.is_empty())
+                .take(10)
+                .collect::<Vec<_>>()
+        })
+        .filter(|domains| !domains.is_empty())
+}
+
+fn normalize_search_result(result: hypr_exa::SearchResult) -> WebSearchResult {
+    let snippet = result
+        .summary
+        .as_deref()
+        .filter(|text| !text.trim().is_empty())
+        .or_else(|| {
+            result
+                .highlights
+                .as_ref()
+                .and_then(|highlights| highlights.iter().find(|text| !text.trim().is_empty()))
+                .map(String::as_str)
+        })
+        .or_else(|| {
+            result
+                .text
+                .as_deref()
+                .filter(|text| !text.trim().is_empty())
+        })
+        .map(|text| trim_to_chars(text.trim(), 600))
+        .unwrap_or_default();
+
+    WebSearchResult {
+        title: result
+            .title
+            .filter(|title| !title.trim().is_empty())
+            .unwrap_or_else(|| result.url.clone()),
+        url: result.url,
+        snippet,
+        published_date: result.published_date,
+        author: result.author,
+    }
+}
+
+fn trim_to_chars(text: &str, max_chars: usize) -> String {
+    let mut chars = text.chars();
+    let trimmed: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        format!("{trimmed}...")
+    } else {
+        trimmed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_domains_discards_empty_entries() {
+        assert_eq!(
+            normalize_domains(Some(vec![
+                " char.com ".to_string(),
+                "".to_string(),
+                "openai.com".to_string(),
+            ])),
+            Some(vec!["char.com".to_string(), "openai.com".to_string()])
+        );
+    }
+
+    #[test]
+    fn normalize_search_result_prefers_summary_over_highlights() {
+        let result = normalize_search_result(hypr_exa::SearchResult {
+            id: "result-1".to_string(),
+            url: "https://char.com".to_string(),
+            title: Some("Char".to_string()),
+            published_date: Some("2026-06-09".to_string()),
+            author: Some("Char".to_string()),
+            score: Some(0.9),
+            text: Some("Full page text".to_string()),
+            highlights: Some(vec!["Relevant highlight".to_string()]),
+            highlight_scores: None,
+            summary: Some("Relevant summary".to_string()),
+            image: None,
+            favicon: None,
+            subpages: None,
+            extras: None,
+        });
+
+        assert_eq!(result.title, "Char");
+        assert_eq!(result.url, "https://char.com");
+        assert_eq!(result.snippet, "Relevant summary");
+        assert_eq!(result.published_date.as_deref(), Some("2026-06-09"));
+    }
 }


### PR DESCRIPTION
## Summary
- Add a paid /research/search endpoint backed by the existing Exa research client
- Register a desktop web_search chat tool that calls the endpoint with auth headers
- Guide chat to use web_search for current public web facts and cite source URLs

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop exec vitest run src/chat/tools/web-search.test.ts
- pnpm -F @hypr/desktop typecheck
- cargo test -p api-research
- cargo check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new authenticated paid API path (Exa) and sends user queries off-device; failures are handled gracefully but billing and auth gating matter for production.
> 
> **Overview**
> Adds **web search** to desktop chat via a new `web_search` tool that POSTs authenticated requests to **`/research/search`** on the API (`VITE_API_URL`), with sign-in required and structured ok/error responses.
> 
> The **api-research** service gains a **`POST /research/search`** handler that runs Exa search (domain filters, result limits, moderation, compact snippets from summary/highlights/text) and returns normalized title/url/snippet metadata.
> 
> Chat wiring registers the tool in `buildChatTools`, extends `ToolDependencies` with `getAuthHeaders` (from `useAuth` in lifecycle), and updates transport system guidance so the model uses web search for public facts and cites URLs—not for purely local note/contact/calendar queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89ea9150df41a5d1e1abd3dcec808158d45dd412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->