### PR TITLE
Pin sidebar timeline headers to chrome

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -374,6 +374,46 @@ describe("TimelineView", () => {
     ).toContain("top-[5.25rem]");
   });
 
+  it("pins bucket headers to the sidebar chrome while scrolled", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.smartCurrentTimeMs = Date.now();
+    mocks.timelineSessionsTable = {
+      tomorrow: {
+        title: "Founder sync",
+        created_at: "2024-01-16T10:00:00.000Z",
+      },
+      today: {
+        title: "Design sync",
+        created_at: "2024-01-15T17:30:00.000Z",
+      },
+    };
+
+    const { container } = render(<TimelineView topChromeInset />);
+    const scroller = container.querySelector("[data-sidebar-timeline-scroll]");
+    const header = container.querySelector(
+      "[data-sidebar-timeline-bucket-header]",
+    );
+
+    expect(scroller).toBeInstanceOf(HTMLDivElement);
+    expect(header?.className).toContain("top-[5.25rem]");
+
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 1200,
+    });
+    scroller!.scrollTop = 120;
+    fireEvent.scroll(scroller!);
+
+    expect(header?.className).toContain("top-12");
+    expect(header?.className).toContain("z-20");
+  });
+
   it("shows the open calendar chip without top chrome", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -151,11 +151,9 @@ export function TimelineView({
   const bucketHeaderTopClassName = topChromeInset
     ? showCalendarSyncStatus
       ? "top-28"
-      : areSidebarActionsHidden
-        ? "top-20"
-        : isScrolledToTop
-          ? "top-[5.25rem]"
-          : "top-28"
+      : isScrolledToTop
+        ? "top-[5.25rem]"
+        : "top-12"
     : "top-0";
 
   const hasToday = useMemo(
@@ -449,7 +447,7 @@ export function TimelineView({
               <div
                 data-sidebar-timeline-bucket-header
                 className={cn([
-                  "sticky z-10",
+                  "sticky z-20",
                   bucketHeaderTopClassName,
                   "bg-background/95 py-1 pr-1 pl-3 backdrop-blur",
                 ])}


### PR DESCRIPTION
## Summary
- Keep sidebar timeline bucket headers pinned to the sidebar chrome edge while scrolling
- Preserve the initial top spacer below the action chrome
- Add regression coverage for the scrolled sticky header offset

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop exec vitest run src/sidebar/timeline/index.test.tsx
- pnpm -F @hypr/desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized sidebar timeline layout/CSS behavior with test coverage; no data or auth changes.
> 
> **Overview**
> Adjusts **sticky timeline bucket headers** when the sidebar uses `topChromeInset`: at scroll top they still sit at `top-[5.25rem]` under the action chrome, but once the user scrolls down they stick at **`top-12`** (chrome edge) instead of jumping to `top-28` or varying with hidden action tabs. Sticky headers also use **`z-20`** so they layer above adjacent timeline content.
> 
> Adds a regression test that simulates scroll on the timeline scroller and asserts the header classes switch to `top-12` and `z-20`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3162a3d57ce4eef984dcfe2f5df8bf5f0b9305b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->