### PR TITLE
Polish dark mode UI surfaces

### DIFF
--- a/apps/desktop/src/audio-player/timeline-shell.tsx
+++ b/apps/desktop/src/audio-player/timeline-shell.tsx
@@ -23,7 +23,7 @@ export function TimelineShell({
 }) {
   return (
     <div
-      className="bg-muted w-full rounded-xl select-none"
+      className="w-full rounded-xl bg-transparent select-none"
       onContextMenu={onContextMenu}
     >
       <div

--- a/apps/desktop/src/main/top-meeting-timeline.test.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.test.tsx
@@ -369,9 +369,12 @@ describe("TopMeetingTimeline", () => {
 
     render(<TopMeetingTimeline currentTab={null} />);
 
-    expect(screen.getByTestId("top-timeline-now-indicator").style.left).toBe(
-      "80px",
-    );
+    const indicator = screen.getByTestId("top-timeline-now-indicator");
+
+    expect(indicator.style.left).toBe("80px");
+    expect(indicator.children).toHaveLength(2);
+    expect(indicator.children[0]?.className).toContain("top-0");
+    expect(indicator.children[0]?.className).toContain("bottom-1");
   });
 
   it("uses the recording end for completed sessions linked to calendar events", () => {

--- a/apps/desktop/src/main/top-meeting-timeline.tsx
+++ b/apps/desktop/src/main/top-meeting-timeline.tsx
@@ -519,8 +519,11 @@ function TopCurrentTimeIndicator({
       className="pointer-events-none absolute top-0 bottom-0 z-40 w-0"
       style={{ left }}
     >
-      <div className="absolute top-0 bottom-1 left-0 w-px -translate-x-1/2 bg-red-500/90 shadow-[0_0_0_1px_rgba(255,255,255,0.85)]" />
-      <div className="absolute top-0 left-0 size-1.5 -translate-x-1/2 rounded-full bg-red-500 shadow-[0_0_0_1px_rgba(255,255,255,0.95)]" />
+      <div
+        className={cn([
+          "absolute top-0 bottom-1 left-0 w-px -translate-x-1/2 bg-red-500/90 shadow-[0_0_0_1px_rgba(255,255,255,0.85)]",
+        ])}
+      />
       <div className="bg-destructive text-destructive-foreground absolute top-1/2 left-0 -translate-x-1/2 -translate-y-1/2 rounded-full px-2 py-1 font-mono text-[10px] leading-none font-semibold whitespace-nowrap opacity-0 shadow-xs transition-opacity group-hover/timeline-strip:opacity-100">
         {label}
       </div>

--- a/apps/desktop/src/session/components/floating/options-menu.tsx
+++ b/apps/desktop/src/session/components/floating/options-menu.tsx
@@ -52,7 +52,7 @@ export function OptionsMenu({
 
   const moreButton = (
     <button
-      className="text-primary-foreground/70 hover:text-primary-foreground absolute top-1/2 right-2 z-10 -translate-y-1/2 cursor-pointer transition-colors disabled:opacity-50"
+      className="text-primary-foreground/70 hover:text-primary-foreground dark:text-primary/65 dark:hover:text-primary absolute top-1/2 right-2 z-10 -translate-y-1/2 cursor-pointer transition-colors disabled:opacity-50"
       disabled={disabled}
       onClick={(e) => {
         e.stopPropagation();

--- a/apps/desktop/src/session/components/floating/shared.tsx
+++ b/apps/desktop/src/session/components/floating/shared.tsx
@@ -8,6 +8,8 @@ import {
 } from "@hypr/ui/components/ui/tooltip";
 import { cn } from "@hypr/utils";
 
+import { floatingActionSurfaceClassName } from "~/shared/floating-action-surface";
+
 export { ActionableTooltipContent } from "~/session/components/shared";
 
 export function FloatingButton({
@@ -42,9 +44,9 @@ export function FloatingButton({
     <Button
       size="lg"
       className={cn([
-        "rounded-full border-2 transition-[border-color,opacity] duration-200 focus-visible:ring-0",
+        "rounded-full border-2 transition-[background-color,border-color,color,opacity,box-shadow] duration-200 focus-visible:ring-0",
+        floatingActionSurfaceClassName,
         error && "border-red-500",
-        !error && "border-border",
         subtle && "opacity-40 hover:opacity-100",
         className,
       ])}

--- a/apps/desktop/src/session/components/listen-action.tsx
+++ b/apps/desktop/src/session/components/listen-action.tsx
@@ -48,7 +48,7 @@ export function ListenActionButton({ sessionId }: { sessionId: string }) {
         <FloatingButton
           onClick={startListening}
           disabled={isDisabled}
-          className="border-primary bg-primary text-primary-foreground hover:bg-primary/90 dark:border-border dark:bg-accent dark:text-accent-foreground dark:hover:bg-accent/90 dark:ring-border/70 w-[148px] justify-start gap-2 pr-7 pl-3 shadow-[0_4px_14px_rgba(87,83,78,0.4)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.45)] dark:ring-1"
+          className="w-[148px] justify-start gap-2 pr-7 pl-3"
           tooltip={
             warningMessage
               ? {

--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -65,8 +65,8 @@ const TriggerInner = forwardRef<
       title={label}
       className={cn([
         "rounded-full",
-        "text-muted-foreground hover:bg-accent hover:text-black",
-        open && "bg-muted",
+        "text-muted-foreground hover:bg-accent hover:text-foreground",
+        open && "bg-muted text-foreground",
       ])}
     >
       <CalendarIcon size={16} />

--- a/apps/desktop/src/settings/general/permissions.tsx
+++ b/apps/desktop/src/settings/general/permissions.tsx
@@ -146,12 +146,9 @@ function PermissionGroup({
 
 export function Permissions() {
   const calendar = usePermission("calendar");
-  const reminders = usePermission("reminders");
   const mic = usePermission("microphone");
   const systemAudio = usePermission("systemAudio");
-  const screenRecording = usePermission("screenRecording");
   const accessibility = usePermission("accessibility");
-  const inputMonitoring = usePermission("inputMonitoring");
 
   return (
     <div className="flex flex-col gap-8">
@@ -186,15 +183,6 @@ export function Permissions() {
           onReset={accessibility.reset}
           onOpen={accessibility.open}
         />
-        <PermissionRow
-          title="Screen recording"
-          description="Required to capture screenshots and on-screen context for vision and activity features"
-          status={screenRecording.status}
-          isPending={screenRecording.isPending}
-          onRequest={screenRecording.request}
-          onReset={screenRecording.reset}
-          onOpen={screenRecording.open}
-        />
       </PermissionGroup>
 
       <PermissionGroup title="Others">
@@ -206,24 +194,6 @@ export function Permissions() {
           onRequest={calendar.request}
           onReset={calendar.reset}
           onOpen={calendar.open}
-        />
-        <PermissionRow
-          title="Reminders"
-          description="Required to sync Apple Reminders into Anarlog"
-          status={reminders.status}
-          isPending={reminders.isPending}
-          onRequest={reminders.request}
-          onReset={reminders.reset}
-          onOpen={reminders.open}
-        />
-        <PermissionRow
-          title="Input monitoring"
-          description="Required to listen for global dictation hotkeys"
-          status={inputMonitoring.status}
-          isPending={inputMonitoring.isPending}
-          onRequest={inputMonitoring.request}
-          onReset={inputMonitoring.reset}
-          onOpen={inputMonitoring.open}
         />
       </PermissionGroup>
     </div>

--- a/apps/desktop/src/settings/general/searchable-select.tsx
+++ b/apps/desktop/src/settings/general/searchable-select.tsx
@@ -107,7 +107,7 @@ export function SearchableSelect({
             : "var(--radix-popover-trigger-width)",
         }}
       >
-        <AppFloatingPanel className="bg-background overflow-hidden">
+        <AppFloatingPanel className="overflow-hidden">
           <Command
             filter={filterFunction}
             className="rounded-[inherit] border-0 bg-transparent"

--- a/apps/desktop/src/settings/index.tsx
+++ b/apps/desktop/src/settings/index.tsx
@@ -51,7 +51,10 @@ function SettingsView({ tab }: { tab: Extract<Tab, { type: "settings" }> }) {
   };
 
   return (
-    <div className="flex w-full flex-1 flex-col overflow-hidden">
+    <div
+      data-settings-content
+      className="bg-card dark:bg-accent flex w-full flex-1 flex-col overflow-hidden"
+    >
       <div className="relative w-full flex-1 overflow-hidden">
         <div
           className={cn([

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -3,6 +3,7 @@ import { MessageCircle } from "lucide-react";
 import { cn } from "@hypr/utils";
 
 import { useShell } from "~/contexts/shell";
+import { floatingActionSurfaceClassName } from "~/shared/floating-action-surface";
 
 export function ChatCTA({
   label = "Ask Anarlog anything",
@@ -25,9 +26,9 @@ export function ChatCTA({
       type="button"
       onClick={handleClick}
       className={cn([
-        "border-primary bg-primary inline-flex max-w-full items-center gap-2 rounded-full border-2",
-        "text-primary-foreground px-4 py-2 text-sm shadow-[0_6px_20px_rgba(0,0,0,0.45)]",
-        "hover:bg-primary/90 transition-colors",
+        "inline-flex h-10 max-w-full items-center gap-2 rounded-full border-2",
+        "px-4 text-sm transition-colors",
+        floatingActionSurfaceClassName,
       ])}
     >
       <MessageCircle className="size-4 shrink-0" aria-hidden="true" />

--- a/apps/desktop/src/shared/floating-action-surface.ts
+++ b/apps/desktop/src/shared/floating-action-surface.ts
@@ -1,0 +1,2 @@
+export const floatingActionSurfaceClassName =
+  "border-primary/80 bg-primary text-primary-foreground hover:bg-primary/90 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.22),0_10px_28px_rgba(0,0,0,0.28)] dark:border-black/15 dark:bg-white/92 dark:text-primary dark:hover:bg-white dark:shadow-[inset_0_0_0_1px_rgba(0,0,0,0.18),0_16px_40px_rgba(0,0,0,0.52),0_0_0_1px_rgba(255,255,255,0.14)]";

--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -579,6 +579,9 @@ describe("TimelineView", () => {
     expect(isBefore(tomorrowHeading, indicator)).toBe(true);
     expect(isBefore(indicator, yesterdayHeading)).toBe(true);
     expect(isBefore(indicator, twoDaysAgoHeading)).toBe(true);
+    expect(
+      indicator.closest("[data-sidebar-current-time-header-gap]")?.className,
+    ).toContain("pb-3");
   });
 
   it("hides the now indicator while an active meeting is visible", () => {

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -459,10 +459,12 @@ export function TimelineView({
           return (
             <div key={bucket.label} className={cn([isTopIndicator && "pt-3"])}>
               {shouldRenderIndicatorBefore && (
-                <CurrentTimeIndicator
-                  ref={setCurrentTimeIndicatorRef}
-                  timezone={timezone}
-                />
+                <div data-sidebar-current-time-header-gap className="pb-3">
+                  <CurrentTimeIndicator
+                    ref={setCurrentTimeIndicatorRef}
+                    timezone={timezone}
+                  />
+                </div>
               )}
               {shouldRenderIndicatorAnchorBefore && (
                 <CurrentTimeAnchor

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -230,6 +230,17 @@
   }
 }
 
+@layer components {
+  [data-settings-content] button,
+  [data-settings-content] button:hover,
+  [data-settings-content] [role="combobox"],
+  [data-settings-content] [role="combobox"]:hover,
+  [data-settings-content] [data-slot="select-trigger"],
+  [data-settings-content] [data-slot="select-trigger"]:hover {
+    box-shadow: none !important;
+  }
+}
+
 /* Search result highlighting styles — matches transcript's bg-yellow-200/50 and bg-yellow-500 */
 .ProseMirror-search-match {
   background-color: rgb(254 240 138 / 0.5);

--- a/packages/changelog/content/1.0.42.md
+++ b/packages/changelog/content/1.0.42.md
@@ -1,0 +1,28 @@
+---
+date: "2026-06-09"
+summary: "AI chat, timeline navigation, settings, and dark mode surfaces are more polished and easier to use."
+---
+
+## AI Chat
+
+- Anarlog AI can now use web search when your question needs current outside information
+- AI responses now keep streaming when you switch chat between modal and side panel views
+- The chat panel and modal now use cleaner spacing, clearer controls, and surfaces that better match the rest of the app in light and dark mode
+
+## Timeline
+
+- Sidebar timeline headers now stay pinned to the top of the sidebar while scrolling
+- The current-time indicator no longer appears on top of an active meeting card
+- The current-time label is no longer clipped in the sidebar timeline
+
+## Settings
+
+- Settings now use localized labels consistently in the app section
+- Appearance, language, timezone, and week-start selectors are simpler and no longer show unnecessary search fields
+- Dark mode settings surfaces are lighter and make switches easier to see
+- Settings buttons and selectors now use flatter styling without extra shadows
+
+## Appearance
+
+- Floating controls, menus, popovers, and metadata buttons now have clearer contrast in dark mode
+- Meeting controls, chat buttons, and audio playback now blend more naturally with the session background

--- a/packages/ui/src/components/ui/floating-content.tsx
+++ b/packages/ui/src/components/ui/floating-content.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@hypr/utils";
 
 export const appFloatingContentClassName =
-  "bg-popover text-popover-foreground overflow-hidden rounded-2xl border border-border p-1 shadow-lg";
+  "bg-app-floating-chrome text-popover-foreground border-app-floating-border overflow-hidden rounded-2xl border p-1 shadow-lg";
 
 export type FloatingContentVariant = "default" | "app";
 
@@ -12,7 +12,7 @@ export function AppFloatingPanel({
   return (
     <div
       className={cn([
-        "bg-popover text-popover-foreground border-border rounded-2xl border",
+        "bg-app-floating-panel text-popover-foreground border-app-floating-border rounded-2xl border",
         className,
       ])}
       {...props}

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -35,6 +35,9 @@
 
   --color-popover: hsl(var(--popover));
   --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-app-floating-chrome: hsl(var(--app-floating-chrome));
+  --color-app-floating-panel: hsl(var(--app-floating-panel));
+  --color-app-floating-border: hsl(var(--app-floating-border));
 
   --color-card: hsl(var(--card));
   --color-card-foreground: hsl(var(--card-foreground));
@@ -201,6 +204,9 @@
     --border: 24 6% 90%;
     --input: 24 6% 90%;
     --ring: 24 10% 10%;
+    --app-floating-chrome: 60 5% 94%;
+    --app-floating-panel: 60 9% 98%;
+    --app-floating-border: 24 6% 86%;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
@@ -236,6 +242,9 @@
     --border: 24 6% 28%;
     --input: 24 6% 28%;
     --ring: 60 9% 75%;
+    --app-floating-chrome: 24 7% 21%;
+    --app-floating-panel: 24 8% 14%;
+    --app-floating-border: 24 6% 33%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;


### PR DESCRIPTION
Summary:
- improve contrast for settings, floating buttons, chat panel, and app popovers
- reduce visual clutter in settings permissions and controls
- fix sidebar timeline spacing and now indicator clipping

Verification:
- pnpm exec dprint fmt
- pnpm -F @hypr/ui build
- pnpm -F @hypr/ui typecheck
- pnpm -F @hypr/desktop typecheck
- targeted desktop component tests for changed areas

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly visual/CSS and settings UI simplification; permission rows removed from one screen only (other flows like todo may still request those permissions).
> 
> **Overview**
> This PR polishes **dark mode and floating UI** across desktop and shared UI tokens, with smaller timeline and settings tweaks.
> 
> **Shared styling:** New `--app-floating-chrome`, `--app-floating-panel`, and `--app-floating-border` theme variables drive `AppFloatingPanel` / app popover chrome. A shared `floatingActionSurfaceClassName` unifies **Listen**, **Chat CTA**, and other floating actions (light primary pill; dark high-contrast white surface). Settings get `data-settings-content` with a darker panel in dark mode and a global rule that strips box shadows from buttons and comboboxes inside settings.
> 
> **Session & chrome:** Floating listen/chat buttons drop one-off shadow classes in favor of the shared surface. Metadata calendar trigger uses `text-foreground` instead of hard-coded black on hover. Options menu ellipsis gets explicit dark-mode text colors. Audio timeline shell loses `bg-muted` for a transparent track.
> 
> **Timeline:** Top “now” indicator removes the top red dot (line + hover time chip only). Sidebar now indicator is wrapped in `data-sidebar-current-time-header-gap` with `pb-3` to fix label clipping. Tests updated for the new structure.
> 
> **Settings permissions:** The general Permissions screen no longer lists **Reminders**, **Screen recording**, or **Input monitoring** (calendar, mic, system audio, accessibility remain).
> 
> Changelog **1.0.42** documents broader release notes including items outside this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed802d6aff48d668d89ac41178569ef8857941c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->