### PR TITLE
Avoid Soniqo Parakeet batch crash

### DIFF
--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -8,12 +8,15 @@ use owhisper_client::{
 };
 use tracing::Instrument;
 
+use hypr_audio_chunking::AudioChunk;
 use hypr_audio_utils::Source;
 use hypr_transcribe_core::{
     TARGET_SAMPLE_RATE, channel_duration_sec, chunk_channel_audio, split_resampled_channels,
 };
 
 use super::{BatchParams, BatchRunMode, BatchRunOutput, format_user_friendly_error, session_span};
+
+const SONIQO_PARAKEET_MAX_CHUNK_SAMPLES: usize = TARGET_SAMPLE_RATE as usize * 39 / 2;
 
 macro_rules! dispatch_batch {
     ($ak:expr, $params:expr, $lp:expr,
@@ -266,6 +269,7 @@ fn transcribe_soniqo_channel(
     let duration_seconds = channel_duration_sec(samples);
     let chunks =
         chunk_channel_audio::<hypr_audio_chunking::Error>(samples).map_err(|e| e.to_string())?;
+    let chunks = split_soniqo_native_chunks(model, chunks);
     tracing::info!(
         hyprnote.stt.provider.name = "soniqo",
         hyprnote.stt.model = %model,
@@ -359,6 +363,47 @@ fn transcribe_soniqo_samples(
     hypr_transcribe_soniqo::transcribe_file(model, file.path(), language).map_err(|e| e.to_string())
 }
 
+fn split_soniqo_native_chunks(
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    chunks: Vec<AudioChunk>,
+) -> Vec<AudioChunk> {
+    let max_samples = match model {
+        hypr_transcribe_soniqo::SoniqoModel::ParakeetBatch => SONIQO_PARAKEET_MAX_CHUNK_SAMPLES,
+        _ => return chunks,
+    };
+
+    chunks
+        .into_iter()
+        .flat_map(|chunk| split_audio_chunk(chunk, max_samples))
+        .collect()
+}
+
+fn split_audio_chunk(chunk: AudioChunk, max_samples: usize) -> Vec<AudioChunk> {
+    if chunk.samples.len() <= max_samples {
+        return vec![chunk];
+    }
+
+    let AudioChunk {
+        samples,
+        sample_start,
+        ..
+    } = chunk;
+
+    samples
+        .chunks(max_samples)
+        .enumerate()
+        .map(|(index, window)| {
+            let sample_start = sample_start + index * max_samples;
+            let sample_end = sample_start + window.len();
+            AudioChunk {
+                samples: window.to_vec(),
+                sample_start,
+                sample_end,
+            }
+        })
+        .collect()
+}
+
 fn collapse_identical_channels(channels: Vec<Vec<f32>>) -> Vec<Vec<f32>> {
     if channels.len() != 2 || !channels_are_effectively_identical(&channels[0], &channels[1]) {
         return channels;
@@ -404,5 +449,44 @@ mod tests {
         let channels = collapse_identical_channels(vec![vec![0.1, 0.2], vec![0.9, 0.8]]);
 
         assert_eq!(channels, vec![vec![0.1, 0.2], vec![0.9, 0.8]]);
+    }
+
+    #[test]
+    fn splits_parakeet_chunks_below_largest_coreml_shape() {
+        let sample_start = TARGET_SAMPLE_RATE as usize * 4;
+        let oversized = SONIQO_PARAKEET_MAX_CHUNK_SAMPLES + TARGET_SAMPLE_RATE as usize;
+        let chunks = split_soniqo_native_chunks(
+            hypr_transcribe_soniqo::SoniqoModel::ParakeetBatch,
+            vec![AudioChunk {
+                samples: vec![0.0; oversized],
+                sample_start,
+                sample_end: sample_start + oversized,
+            }],
+        );
+
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].sample_start, sample_start);
+        assert_eq!(
+            chunks[0].sample_end,
+            sample_start + SONIQO_PARAKEET_MAX_CHUNK_SAMPLES
+        );
+        assert_eq!(chunks[1].sample_start, chunks[0].sample_end);
+        assert_eq!(chunks[1].samples.len(), TARGET_SAMPLE_RATE as usize);
+    }
+
+    #[test]
+    fn leaves_non_parakeet_chunks_unchanged() {
+        let oversized = SONIQO_PARAKEET_MAX_CHUNK_SAMPLES + TARGET_SAMPLE_RATE as usize;
+        let chunks = split_soniqo_native_chunks(
+            hypr_transcribe_soniqo::SoniqoModel::Omnilingual,
+            vec![AudioChunk {
+                samples: vec![0.0; oversized],
+                sample_start: 0,
+                sample_end: oversized,
+            }],
+        );
+
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].samples.len(), oversized);
     }
 }

--- a/crates/transcribe-soniqo/swift-lib/src/lib.swift
+++ b/crates/transcribe-soniqo/swift-lib/src/lib.swift
@@ -18,7 +18,7 @@ private enum SoniqoBridgeError: LocalizedError {
 
 private let soniqoFileTranscriptionSampleRate = 16_000
 private let parakeetBatchMinimumChunkSeconds = 5.0
-private let parakeetBatchMaximumChunkSeconds = 30.0
+private let parakeetBatchMaximumChunkSeconds = 19.5
 
 private enum SpeechModelKind: String, CaseIterable {
   case parakeetStreaming = "soniqo-parakeet-streaming"
@@ -70,7 +70,7 @@ private enum SpeechModelKind: String, CaseIterable {
     case .parakeetStreaming, .qwen3Small, .qwen3Large:
       return nil
     case .parakeetBatch:
-      return 25
+      return parakeetBatchMaximumChunkSeconds
     case .omnilingual:
       return 35
     }


### PR DESCRIPTION
## Summary
- Cap local Soniqo Parakeet chunks below the largest CoreML encoder shape
- Apply the same chunk limit to split-channel batches

## Verification
- cargo check -p listener2-core -p transcribe-soniqo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted chunk-size limits for one local STT model with tests; no auth, data, or API contract changes.
> 
> **Overview**
> Caps **Soniqo Parakeet batch** audio segments at **19.5 seconds** (~`TARGET_SAMPLE_RATE * 39 / 2` samples) so inference stays under the largest CoreML encoder shape and avoids batch crashes.
> 
> On the **Rust** multi-channel Soniqo path in `simple.rs`, chunks from `chunk_channel_audio` are further split via `split_soniqo_native_chunks` / `split_audio_chunk` for `ParakeetBatch` only; other Soniqo models are unchanged. Unit tests cover oversize Parakeet splits and non-Parakeet passthrough.
> 
> On the **Swift** bridge, `parakeetBatchMaximumChunkSeconds` drops from 30s to **19.5s**, and Parakeet batch file chunking now uses that constant instead of a hardcoded 25s preferred chunk size—keeping native file transcription aligned with the same limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65bb27c2741ee107c15e1ca5691abd660bad4982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->