### PR TITLE
Remove calendar nav shadow

### DIFF
--- a/apps/desktop/src/calendar/components/calendar-view.tsx
+++ b/apps/desktop/src/calendar/components/calendar-view.tsx
@@ -236,7 +236,7 @@ export function CalendarView() {
           data-tauri-drag-region="false"
           className={cn([
             "border-border h-8 overflow-hidden rounded-full border",
-            "bg-card shadow-xs",
+            "bg-card",
           ])}
         >
           <Button


### PR DESCRIPTION
## Summary
- Drop the shadow from the calendar Today navigation pill so it stays visually flat against the header

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class removal on calendar header UI with no logic or data impact.
> 
> **Overview**
> Removes the **`shadow-xs`** utility from the calendar header **Today** navigation pill (`ButtonGroup` wrapping prev / Today / next) so the control reads flat against the header instead of elevated.
> 
> No behavior or layout changes—only the dropped shadow class on that pill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 843cf150fbc098cfc3811e1c90233977d29dadef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->