### PR TITLE
Update desktop 1.0.42 changelog

### DIFF
--- a/packages/changelog/content/1.0.42.md
+++ b/packages/changelog/content/1.0.42.md
@@ -14,6 +14,7 @@ summary: "AI chat, timeline navigation, settings, and dark mode surfaces are mor
 - Sidebar timeline headers now stay pinned to the top of the sidebar while scrolling
 - The current-time indicator no longer appears on top of an active meeting card
 - The current-time label is no longer clipped in the sidebar timeline
+- The top timeline current-time marker is now a cleaner line-only indicator
 
 ## Settings
 


### PR DESCRIPTION
## Summary
- Mention the top timeline line-only current-time marker in the desktop 1.0.42 release notes

## Verification
- pnpm exec dprint fmt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edit with no application or build logic changes.
> 
> **Overview**
> Adds a **Timeline** release note for desktop **1.0.42**: the top timeline current-time marker is described as a cleaner **line-only** indicator, alongside the existing sidebar clipping and meeting-card overlap fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa480c3b0e8f7181c3de2bb2e879ebed750a506a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->