### PR TITLE
Fix sidebar live suffix color

### DIFF
--- a/apps/desktop/src/sidebar/timeline/item.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.test.tsx
@@ -185,7 +185,11 @@ describe("TimelineItemComponent", () => {
     expect(rowButton?.className).not.toContain("bg-accent");
     expect(screen.getByTestId("dancing-sticks").dataset.amplitude).toBe("0.5");
 
-    fireEvent.click(screen.getByRole("button", { name: "Stop listening" }));
+    const stopButton = screen.getByRole("button", { name: "Stop listening" });
+    expect(stopButton.className).toContain("text-white/80");
+    expect(stopButton.className).toContain("hover:text-white");
+
+    fireEvent.click(stopButton);
 
     expect(mocks.stop).toHaveBeenCalledOnce();
     expect(mocks.openCurrent).not.toHaveBeenCalled();

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -201,8 +201,8 @@ function ItemBase({
           }}
           className={cn([
             "absolute top-1/2 right-3 flex size-5 -translate-y-1/2 items-center justify-center rounded-sm",
-            "text-destructive-foreground/80 hover:bg-destructive-foreground/15 hover:text-destructive-foreground transition-colors",
-            "focus-visible:ring-destructive-foreground/70 focus-visible:ring-2 focus-visible:outline-hidden",
+            "text-white/80 transition-colors hover:bg-white/15 hover:text-white",
+            "focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:outline-hidden",
           ])}
         >
           <span


### PR DESCRIPTION
Keep the active sidebar timeline live control white on destructive rows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only change on the sidebar timeline live stop button plus test updates; no logic or data paths affected.
> 
> **Overview**
> Updates the **Stop listening** control on active (red) sidebar timeline rows so the live suffix uses **white** text and hover/focus rings instead of `destructive-foreground` tokens, keeping the dancing-sticks/stop affordance readable on the destructive background.
> 
> The sidebar timeline test now asserts those white utility classes on the stop button before clicking it; stop behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8253c950ff02c2ece3b32e17539e8d11b8d5b2ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->