### PR TITLE
Fix chat overlay formatting layers

### DIFF
--- a/apps/desktop/src/chat/components/context-bar.tsx
+++ b/apps/desktop/src/chat/components/context-bar.tsx
@@ -19,7 +19,6 @@ import type { ContextRef } from "~/chat/context/entities";
 import { type ContextChipProps, renderChip } from "~/chat/context/registry";
 import type { DisplayEntity } from "~/chat/context/use-chat-context-pipeline";
 import { useChatAppearance } from "~/chat/hooks/use-chat-appearance";
-import { useShell } from "~/contexts/shell";
 import { useSearchEngine } from "~/search/contexts/engine";
 import { getSessionEvent } from "~/session/utils";
 import * as main from "~/store/tinybase/store/main";
@@ -354,9 +353,7 @@ export function ContextBar({
   onRemoveEntity?: (key: string) => void;
   onAddEntity?: (ref: ContextRef) => void;
 }) {
-  const { chat } = useShell();
   const { elevatedSurfaceClassName } = useChatAppearance();
-  const isRightPanel = chat.mode === "RightPanelOpen";
   const chips = useMemo(
     () =>
       entities
@@ -381,7 +378,7 @@ export function ContextBar({
       className={cn([
         "border-border shrink-0 rounded-t-xl border-t border-r border-l",
         elevatedSurfaceClassName,
-        isRightPanel ? "mx-3" : "mx-2",
+        "mx-3",
       ])}
     >
       <div className="flex items-start gap-1.5 px-2 py-2">

--- a/packages/editor/src/widgets/format-toolbar.tsx
+++ b/packages/editor/src/widgets/format-toolbar.tsx
@@ -88,6 +88,7 @@ export function FormatToolbar() {
     const update = () => {
       void computePosition(referenceEl, toolbar, {
         placement: "top",
+        strategy: "fixed",
         middleware: [offset(8), flip(), shift({ padding: 8 })],
       }).then(({ x, y }) => {
         Object.assign(toolbar.style, {
@@ -108,10 +109,10 @@ export function FormatToolbar() {
     <div
       ref={toolbarRef}
       className={cn([
-        "border-border bg-card/95 absolute z-[9999] flex items-center gap-0.5 rounded-lg border p-1",
+        "border-border bg-card/95 fixed flex items-center gap-0.5 rounded-lg border p-1",
         "shadow-[0_2px_8px_rgba(0,0,0,0.08),0_18px_42px_-16px_rgba(0,0,0,0.34)] backdrop-blur-sm",
       ])}
-      style={{ top: 0, left: 0 }}
+      style={{ top: 0, left: 0, zIndex: 10000 }}
       onMouseDown={(e) => e.preventDefault()}
     >
       {TOOLBAR_BUTTONS.map((button) => {


### PR DESCRIPTION
Keep the note formatting toolbar above floating chat and align the chat context bar with the input surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation-only changes to toolbar positioning and context bar spacing; no auth, data, or business logic.
> 
> **Overview**
> Fixes **layering and alignment** when notes and floating chat are shown together.
> 
> The note **format toolbar** now uses **`fixed`** positioning (including Floating UI `strategy: "fixed"`) and a higher **`zIndex`**, so it stays above the floating chat instead of sitting underneath it.
> 
> The chat **context bar** always uses **`mx-3`** horizontal margin and no longer branches on shell chat mode via `useShell`, so its width lines up with the chat input surface in every layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5370353e49c71abaac1e0e3d3dbbe7472fa96a6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->