### PR TITLE
Remove live transcript panel background

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -102,9 +102,7 @@ function LiveTranscriptFooterContent({
 
   return (
     <div className={cn(["w-full select-none", fillHeight && "h-full min-h-0"])}>
-      <div
-        className={cn(["bg-muted rounded-xl", fillHeight && "h-full min-h-0"])}
-      >
+      <div className={cn(["rounded-xl", fillHeight && "h-full min-h-0"])}>
         <LiveTranscriptContent
           fillHeight={fillHeight}
           isExpanded={isExpanded}


### PR DESCRIPTION
Drop the muted fill from the live transcript footer so it renders without a panel background.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class change on the session live transcript footer with no logic or data impact.
> 
> **Overview**
> Removes the **muted background** from the live transcript footer content wrapper in `during-session.tsx` so the transcript area no longer reads as a filled panel.
> 
> The outer wrapper keeps **`rounded-xl`** and height behavior (`h-full min-h-0` when `fillHeight`); only the `bg-muted` class is dropped. Expand/collapse chrome elsewhere (e.g. `ExpandToggle` with `bg-muted`) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f73384f76ddc1a0530f77ca15bd9a3838109ae42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->