### PR TITLE
Improve dark speaker label contrast

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -3,7 +3,7 @@ import { useLayoutEffect, useMemo, useRef } from "react";
 
 import { cn } from "@hypr/utils";
 
-import { getSegmentColor } from "~/session/components/note-input/transcript/renderer/utils";
+import { useSegmentColorVars } from "~/session/components/note-input/transcript/renderer/utils";
 import * as main from "~/store/tinybase/store/main";
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
 import { useListener } from "~/stt/contexts";
@@ -344,16 +344,18 @@ function TranscriptSegmentRow({
   segment: Segment;
   label: string;
 }) {
-  const color = getSegmentColor(segment.key);
+  const colorVars = useSegmentColorVars(segment.key);
 
   return (
     <div className="grid min-w-0 grid-cols-[92px_minmax(0,1fr)] items-start gap-x-3">
       <span
-        className="sticky top-2.5 z-10 mt-0.5 flex min-h-5 max-w-full min-w-0 items-center justify-start rounded-full px-2 text-[11px] font-medium"
+        className="sticky top-2.5 z-10 mt-0.5 flex min-h-5 max-w-full min-w-0 items-center justify-start rounded-full px-2 text-[11px] font-medium [--segment-color:var(--segment-color-light)] dark:[--segment-color:var(--segment-color-dark)]"
         title={label}
         style={{
-          backgroundColor: `${color}1A`,
-          color,
+          ...colorVars,
+          backgroundColor:
+            "color-mix(in srgb, var(--segment-color) 10%, transparent)",
+          color: "var(--segment-color)",
         }}
       >
         <span className="min-w-0 truncate">{label}</span>

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { cn } from "@hypr/utils";
 
 import { SpeakerAssignPopover } from "./speaker-assign";
-import { getTimestampRange, useSegmentColor } from "./utils";
+import { getTimestampRange, useSegmentColorVars } from "./utils";
 
 import * as main from "~/store/tinybase/store/main";
 import type { Segment } from "~/stt/live-segment";
@@ -19,7 +19,7 @@ export function SegmentHeader({
   transcriptId: string;
   speakerLabelManager?: SpeakerLabelManager;
 }) {
-  const color = useSegmentColor(segment.key);
+  const colorVars = useSegmentColorVars(segment.key);
   const label = useSpeakerLabel(segment.key, speakerLabelManager);
   const timestamp = getTimestampRange(segment);
   const headerClassName = cn([
@@ -27,14 +27,16 @@ export function SegmentHeader({
     "-mx-3 px-3 py-1",
     "text-xs font-light",
     "flex items-center justify-between",
+    "[--segment-color:var(--segment-color-light)]",
+    "dark:[--segment-color:var(--segment-color-dark)]",
   ]);
 
   return (
-    <div className={headerClassName}>
+    <div className={headerClassName} style={colorVars}>
       <SpeakerAssignPopover
         segment={segment}
         transcriptId={transcriptId}
-        color={color}
+        color="var(--segment-color)"
         label={label}
       />
       <span className="text-muted-foreground font-mono">{timestamp}</span>

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/utils.test.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/utils.test.ts
@@ -1,0 +1,33 @@
+import chroma from "chroma-js";
+import { describe, expect, it } from "vitest";
+
+import { getSegmentColor, getSegmentColorVars } from "./utils";
+
+import type { SegmentKey } from "~/stt/live-segment";
+
+describe("transcript renderer utils", () => {
+  it("uses a brighter speaker color for dark mode", () => {
+    const key: SegmentKey = {
+      channel: "RemoteParty",
+      speaker_index: 1,
+      speaker_human_id: null,
+    };
+
+    expect(chroma(getSegmentColor(key, "dark")).luminance()).toBeGreaterThan(
+      chroma(getSegmentColor(key)).luminance(),
+    );
+  });
+
+  it("exposes light and dark speaker color variables", () => {
+    const key: SegmentKey = {
+      channel: "DirectMic",
+      speaker_index: 0,
+      speaker_human_id: null,
+    };
+
+    expect(getSegmentColorVars(key)).toEqual({
+      "--segment-color-light": getSegmentColor(key),
+      "--segment-color-dark": getSegmentColor(key, "dark"),
+    });
+  });
+});

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/utils.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/utils.ts
@@ -1,5 +1,5 @@
 import chroma from "chroma-js";
-import { useMemo } from "react";
+import { type CSSProperties, useMemo } from "react";
 
 import type { Segment, SegmentKey, SegmentWord } from "~/stt/live-segment";
 
@@ -9,6 +9,11 @@ export type SentenceLine = {
   words: SegmentWord[];
   startMs: number;
   endMs: number;
+};
+
+type SegmentColorVars = CSSProperties & {
+  "--segment-color-light": string;
+  "--segment-color-dark": string;
 };
 
 export function groupWordsIntoLines(words: SegmentWord[]): SentenceLine[] {
@@ -64,7 +69,10 @@ export function getTimestampRange(segment: Segment): string {
   return `${formatTimestamp(firstWord.start_ms)} - ${formatTimestamp(lastWord.end_ms)}`;
 }
 
-export function getSegmentColor(key: SegmentKey): string {
+export function getSegmentColor(
+  key: SegmentKey,
+  mode: "light" | "dark" = "light",
+): string {
   const speakerIndex = key.speaker_index ?? 0;
 
   const channelPalettes = [
@@ -76,9 +84,20 @@ export function getSegmentColor(key: SegmentKey): string {
   const hues = channelPalettes[paletteIndex]!;
   const hue = hues[speakerIndex % hues.length]!;
 
-  return chroma.oklch(0.55, 0.15, hue).hex();
+  return chroma.oklch(mode === "dark" ? 0.72 : 0.55, 0.15, hue).hex();
+}
+
+export function getSegmentColorVars(key: SegmentKey): SegmentColorVars {
+  return {
+    "--segment-color-light": getSegmentColor(key),
+    "--segment-color-dark": getSegmentColor(key, "dark"),
+  };
 }
 
 export function useSegmentColor(key: SegmentKey): string {
   return useMemo(() => getSegmentColor(key), [key]);
+}
+
+export function useSegmentColorVars(key: SegmentKey): SegmentColorVars {
+  return useMemo(() => getSegmentColorVars(key), [key]);
 }


### PR DESCRIPTION
Use brighter dark-mode speaker colors for transcript labels and live transcript chips.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only styling for transcript speaker labels with unit tests; no auth, data, or API changes.
> 
> **Overview**
> Speaker label colors in the **transcript segment header** and **live session footer chips** now pick a **brighter OKLCH lightness in dark mode** (`0.72` vs `0.55` for light) while keeping the same hue logic.
> 
> Rendering switches from a single hex to **CSS variables** (`--segment-color-light` / `--segment-color-dark`) with Tailwind `dark:` mapping to `--segment-color`, plus `color-mix` for chip backgrounds instead of hard-coded alpha hex. New **`getSegmentColorVars`** / **`useSegmentColorVars`** helpers centralize that; **`utils.test.ts`** asserts dark-mode luminance and variable shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dc4733e3819880be83112e838bc358963f71a52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->