### PR TITLE
Keep floating FAB hover zone expanded

### DIFF
--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -168,6 +168,10 @@ describe("FloatingActionButton", () => {
 
     expect(hoverZone?.className).toContain("group");
     expect(hoverZone?.className).toContain("pointer-events-auto");
+    expect(hoverZone?.className).toContain("bottom-0");
+    expect(hoverZone?.className).not.toContain("-bottom-4");
+    expect(hoverZone?.className).toContain("h-24");
+    expect(hoverZone?.className).toContain("pb-4");
     expect(hoverZone?.className).toContain("max-w-[calc(100%-2rem)]");
     expect(hoverZone?.className).not.toContain("w-96");
     expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
@@ -194,6 +198,10 @@ describe("FloatingActionButton", () => {
 
     expect(hoverZone?.className).toContain("group");
     expect(hoverZone?.className).toContain("pointer-events-auto");
+    expect(hoverZone?.className).toContain("bottom-0");
+    expect(hoverZone?.className).not.toContain("-bottom-4");
+    expect(hoverZone?.className).toContain("h-24");
+    expect(hoverZone?.className).toContain("pb-4");
     expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
     expect(wrapper?.style.getPropertyValue("--floating-fab-tuck-offset")).toBe(
       "calc(100% - 0.5rem + 18px)",
@@ -214,6 +222,10 @@ describe("FloatingActionButton", () => {
 
     expect(hoverZone?.className).toContain("group");
     expect(hoverZone?.className).toContain("pointer-events-auto");
+    expect(hoverZone?.className).toContain("bottom-0");
+    expect(hoverZone?.className).not.toContain("-bottom-4");
+    expect(hoverZone?.className).toContain("h-24");
+    expect(hoverZone?.className).toContain("pb-4");
     expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
     expect(wrapper?.style.getPropertyValue("--floating-fab-tuck-offset")).toBe(
       "calc(100% - 0.5rem + 18px)",

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -46,8 +46,10 @@ export function FloatingActionButton({
   return (
     <div
       className={cn([
-        "absolute bottom-0 left-1/2 z-20 flex h-14 max-w-[calc(100%-2rem)] -translate-x-1/2 items-end justify-center pb-4",
-        tuckAction ? "group pointer-events-auto" : "pointer-events-none",
+        "absolute left-1/2 z-20 flex max-w-[calc(100%-2rem)] -translate-x-1/2 items-end justify-center",
+        tuckAction
+          ? "group pointer-events-auto bottom-0 h-24 pb-4"
+          : "pointer-events-none bottom-0 h-14 pb-4",
       ])}
     >
       <AnimatePresence mode="wait" initial={false}>

--- a/apps/desktop/src/shared/floating-action-surface.ts
+++ b/apps/desktop/src/shared/floating-action-surface.ts
@@ -1,2 +1,2 @@
 export const floatingActionSurfaceClassName =
-  "border-primary/80 bg-primary text-primary-foreground hover:bg-primary/90 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.22),0_10px_28px_rgba(0,0,0,0.28)] dark:border-black/15 dark:bg-white/92 dark:text-primary dark:hover:bg-white dark:shadow-[inset_0_0_0_1px_rgba(0,0,0,0.18),0_16px_40px_rgba(0,0,0,0.52),0_0_0_1px_rgba(255,255,255,0.14)]";
+  "border-primary/80 bg-primary text-primary-foreground hover:bg-primary shadow-[inset_0_0_0_1px_rgba(255,255,255,0.22),0_10px_28px_rgba(0,0,0,0.28)] dark:border-black/15 dark:bg-white/92 dark:text-primary dark:hover:bg-white/92 dark:shadow-[inset_0_0_0_1px_rgba(0,0,0,0.18),0_16px_40px_rgba(0,0,0,0.52),0_0_0_1px_rgba(255,255,255,0.14)]";


### PR DESCRIPTION
Expand the tucked FAB hit area so pointer movement through the bottom gap does not collapse it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and styling for the session floating action button; no auth, data, or API changes.
> 
> **Overview**
> Expands the **tucked chat FAB** hover hit area so moving the pointer through the bottom gap no longer drops hover and collapses the peek.
> 
> The outer wrapper in `FloatingActionButton` now uses **`h-24`** (with `bottom-0` and `pb-4`) when the action is tucked, instead of a shorter fixed height, while the non-tucked state stays **`h-14`**. Tests assert the tucked hover zone includes `bottom-0`, `h-24`, and `pb-4`, and no longer uses `-bottom-4`.
> 
> Also tweaks **`floatingActionSurfaceClassName`**: light-mode hover uses solid `hover:bg-primary`, and dark mode uses `dark:hover:bg-white/92` instead of full white on hover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22cb93ecfc17ef53a59fc13bbc9b5d874c452916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->