### PR TITLE
Hide uploads for filled notes

### DIFF
--- a/apps/desktop/src/session/components/floating/options-menu.tsx
+++ b/apps/desktop/src/session/components/floating/options-menu.tsx
@@ -22,12 +22,14 @@ export function OptionsMenu({
   sessionId,
   disabled,
   warningMessage,
+  hideUploadActions = false,
   onConfigure,
   children,
 }: {
   sessionId: string;
   disabled: boolean;
   warningMessage: string;
+  hideUploadActions?: boolean;
   onConfigure?: () => void;
   children: React.ReactNode;
 }) {
@@ -63,6 +65,10 @@ export function OptionsMenu({
       <span className="sr-only">More options</span>
     </button>
   );
+
+  if (hideUploadActions) {
+    return <div className="relative flex items-center">{children}</div>;
+  }
 
   if (disabled && warningMessage) {
     return (

--- a/apps/desktop/src/session/components/listen-action.tsx
+++ b/apps/desktop/src/session/components/listen-action.tsx
@@ -4,7 +4,11 @@ import { Spinner } from "@hypr/ui/components/ui/spinner";
 
 import { OptionsMenu } from "./floating/options-menu";
 import { ActionableTooltipContent, FloatingButton } from "./floating/shared";
-import { RecordingIcon, useListenButtonState } from "./shared";
+import {
+  RecordingIcon,
+  useCurrentNoteHasContent,
+  useListenButtonState,
+} from "./shared";
 
 import { useTabs } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
@@ -19,6 +23,7 @@ export function ListenActionButton({ sessionId }: { sessionId: string }) {
   }));
   const startListening = useStartListening(sessionId);
   const openNew = useTabs((state) => state.openNew);
+  const noteHasContent = useCurrentNoteHasContent(sessionId, { type: "raw" });
 
   const handleConfigure = useCallback(() => {
     startListening();
@@ -43,6 +48,7 @@ export function ListenActionButton({ sessionId }: { sessionId: string }) {
         sessionId={sessionId}
         disabled={isDisabled}
         warningMessage={warningMessage}
+        hideUploadActions={noteHasContent}
         onConfigure={handleConfigure}
       >
         <FloatingButton

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OverflowButton } from "./index";
 
@@ -8,12 +8,14 @@ import type { EditorView } from "~/store/zustand/tabs/schema";
 const {
   uploadAudioMock,
   uploadTranscriptMock,
+  useCurrentNoteHasContentMock,
   useHasTranscriptMock,
   useListenerMock,
   useConfigValueMock,
 } = vi.hoisted(() => ({
   uploadAudioMock: vi.fn(),
   uploadTranscriptMock: vi.fn(),
+  useCurrentNoteHasContentMock: vi.fn(),
   useHasTranscriptMock: vi.fn(),
   useListenerMock: vi.fn(),
   useConfigValueMock: vi.fn(),
@@ -80,6 +82,7 @@ vi.mock("~/meeting-float/host", () => ({
 }));
 
 vi.mock("~/session/components/shared", () => ({
+  useCurrentNoteHasContent: useCurrentNoteHasContentMock,
   useHasTranscript: useHasTranscriptMock,
 }));
 
@@ -99,8 +102,13 @@ vi.mock("~/stt/useUploadFile", () => ({
 }));
 
 describe("OverflowButton", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    useCurrentNoteHasContentMock.mockReturnValue(false);
     useHasTranscriptMock.mockReturnValue(true);
     useConfigValueMock.mockReturnValue(false);
     useListenerMock.mockImplementation((selector) =>
@@ -110,7 +118,7 @@ describe("OverflowButton", () => {
     );
   });
 
-  it("keeps upload actions available when a transcript already exists", () => {
+  it("keeps upload actions available when the current note is empty", () => {
     render(
       <OverflowButton
         sessionId="session-1"
@@ -123,5 +131,21 @@ describe("OverflowButton", () => {
 
     expect(uploadAudioMock).toHaveBeenCalledTimes(1);
     expect(uploadTranscriptMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides upload actions when the current note has content", () => {
+    useCurrentNoteHasContentMock.mockReturnValue(true);
+
+    render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Upload audio" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Upload transcript" }),
+    ).toBeNull();
   });
 });

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -24,7 +24,10 @@ import { ShowInFinder } from "./misc";
 
 import { useAudioPlayer } from "~/audio-player";
 import { openFloatingMeetingPanel } from "~/meeting-float/host";
-import { useHasTranscript } from "~/session/components/shared";
+import {
+  useCurrentNoteHasContent,
+  useHasTranscript,
+} from "~/session/components/shared";
 import { useConfigValue } from "~/shared/config";
 import type { EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
@@ -40,6 +43,10 @@ export function OverflowButton({
   const [open, setOpen] = useState(false);
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
   const hasTranscript = useHasTranscript(sessionId);
+  const currentNoteHasContent = useCurrentNoteHasContent(
+    sessionId,
+    currentView,
+  );
   const { uploadAudio, uploadTranscript } = useUploadFile(sessionId);
   const { audioExists } = useAudioPlayer();
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
@@ -90,20 +97,24 @@ export function OverflowButton({
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <Listening sessionId={sessionId} hasTranscript={hasTranscript} />
-            <DropdownMenuItem
-              onClick={handleUploadAudio}
-              className="cursor-pointer"
-            >
-              <AudioLinesIcon />
-              <span>Upload audio</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={handleUploadTranscript}
-              className="cursor-pointer"
-            >
-              <FileTextIcon />
-              <span>Upload transcript</span>
-            </DropdownMenuItem>
+            {!currentNoteHasContent && (
+              <>
+                <DropdownMenuItem
+                  onClick={handleUploadAudio}
+                  className="cursor-pointer"
+                >
+                  <AudioLinesIcon />
+                  <span>Upload audio</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={handleUploadTranscript}
+                  className="cursor-pointer"
+                >
+                  <FileTextIcon />
+                  <span>Upload transcript</span>
+                </DropdownMenuItem>
+              </>
+            )}
             {canOpenFloatingPanel && (
               <DropdownMenuItem
                 onClick={handleOpenFloatingPanel}

--- a/apps/desktop/src/session/components/shared.test.ts
+++ b/apps/desktop/src/session/components/shared.test.ts
@@ -1,6 +1,38 @@
 import { describe, expect, it } from "vitest";
 
 import { computeCurrentNoteTab } from "./compute-note-tab";
+import { hasStoredNoteContent } from "./shared";
+
+describe("hasStoredNoteContent", () => {
+  it("returns false for empty stored note values", () => {
+    expect(hasStoredNoteContent("")).toBe(false);
+    expect(
+      hasStoredNoteContent(
+        JSON.stringify({
+          type: "doc",
+          content: [{ type: "paragraph" }],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for markdown and tiptap text content", () => {
+    expect(hasStoredNoteContent("Meeting notes")).toBe(true);
+    expect(
+      hasStoredNoteContent(
+        JSON.stringify({
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Meeting notes" }],
+            },
+          ],
+        }),
+      ),
+    ).toBe(true);
+  });
+});
 
 describe("computeCurrentNoteTab", () => {
   describe("when listening is active", () => {

--- a/apps/desktop/src/session/components/shared.tsx
+++ b/apps/desktop/src/session/components/shared.tsx
@@ -4,6 +4,7 @@ import { Button } from "@hypr/ui/components/ui/button";
 
 import { computeCurrentNoteTab } from "./compute-note-tab";
 
+import { extractPlainText } from "~/search/contexts/engine/utils";
 import * as main from "~/store/tinybase/store/main";
 import type { Tab } from "~/store/zustand/tabs/schema";
 import { type EditorView } from "~/store/zustand/tabs/schema";
@@ -19,6 +20,30 @@ export function useHasTranscript(sessionId: string): boolean {
   );
 
   return !!transcriptIds && transcriptIds.length > 0;
+}
+
+export function hasStoredNoteContent(value: unknown): boolean {
+  return extractPlainText(value).trim().length > 0;
+}
+
+export function useCurrentNoteHasContent(
+  sessionId: string,
+  currentView: EditorView,
+): boolean {
+  const rawMd = main.UI.useCell("sessions", sessionId, "raw_md", main.STORE_ID);
+  const enhancedNoteId = currentView.type === "enhanced" ? currentView.id : "";
+  const enhancedContent = main.UI.useCell(
+    "enhanced_notes",
+    enhancedNoteId,
+    "content",
+    main.STORE_ID,
+  );
+
+  if (currentView.type === "enhanced") {
+    return hasStoredNoteContent(enhancedContent);
+  }
+
+  return hasStoredNoteContent(rawMd);
 }
 
 export function useCurrentNoteTab(


### PR DESCRIPTION
Hide upload audio and transcript actions when the active note already contains content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only visibility changes; upload handlers are unchanged and existing flows still work when notes are empty.
> 
> **Overview**
> **Upload audio** and **upload transcript** are now hidden when the **active note already has text**, so users are less likely to overwrite or conflict with existing notes.
> 
> Shared helpers **`hasStoredNoteContent`** and **`useCurrentNoteHasContent`** read raw markdown or enhanced note content from the store and treat empty TipTap docs as empty. The **overflow menu** omits upload items when content is present; the floating **listen** flow passes **`hideUploadActions`** into **`OptionsMenu`**, which skips the upload popover and only shows the listen button. Tests cover empty vs filled notes for overflow and the content-detection helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52f00d7cf8c5bf41c6ba3d001d46100de76bcecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->