### PR TITLE
simplify DeepWiki badge markup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 ![anarlog](https://repository-images.githubusercontent.com/900550981/a4267a9f-414b-4c36-965c-419313ce2417)
 
-<p align="center">
-  <p align="center">
-   <a href="https://deepwiki.com/fastrepl/anarlog"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
-  </p>
-</p>
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/fastrepl/anarlog)
 
 # anarlog
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> README-only formatting change with no runtime or behavioral impact.
> 
> **Overview**
> Replaces the nested `<p>` / `<a>` HTML block for the DeepWiki badge with a single standard Markdown image link (`[![Ask DeepWiki](...)](...)`), keeping the same badge image and destination URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d1de3821acff9ce6fbf4f8a57e96788476c53c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->