### PR TITLE
Show audio player only when transcript is expanded

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -208,7 +208,7 @@ describe("useSessionBottomAccessory", () => {
     expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
   });
 
-  it("keeps the playback accessory mounted while the transcript panel is collapsed", () => {
+  it("hides the playback accessory while the transcript panel is collapsed", () => {
     const { result } = renderHook(() =>
       useSessionBottomAccessory({
         sessionId: "session-1",
@@ -222,7 +222,7 @@ describe("useSessionBottomAccessory", () => {
       mode: "playback",
       expanded: false,
     });
-    expect(result.current.bottomAccessory).not.toBeNull();
+    expect(result.current.bottomAccessory).toBeNull();
   });
 
   it("generates missing past note facts when the past notes tab opens", () => {

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -161,7 +161,7 @@ export function useSessionBottomAccessory({
   }
 
   if (showPostSession) {
-    const hasAccessoryContent = isExpanded || hasAudio || isRunningBatch;
+    const hasAccessoryContent = isExpanded || isRunningBatch;
     return {
       bottomAccessory: hasAccessoryContent ? (
         <PostSessionAccessory

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -63,8 +63,23 @@ vi.mock("@hypr/ui/components/ui/tooltip", () => ({
 
 vi.mock("~/audio-player", () => ({
   Timeline: () => <div data-testid="timeline" />,
-  TimelineShell: ({ children }: { children?: React.ReactNode }) => (
-    <div>{children}</div>
+  TimelineShell: ({
+    children,
+    leading,
+    main,
+    meta,
+  }: {
+    children?: React.ReactNode;
+    leading?: React.ReactNode;
+    main?: React.ReactNode;
+    meta?: React.ReactNode;
+  }) => (
+    <div>
+      {leading}
+      {main}
+      {meta}
+      {children}
+    </div>
   ),
   TimelineMeta: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
@@ -237,7 +252,7 @@ describe("PostSessionAccessory", () => {
     });
   });
 
-  it("keeps the audio timeline visible while the transcript panel is collapsed", () => {
+  it("hides the audio timeline while the transcript panel is collapsed", () => {
     render(
       <PostSessionAccessory
         sessionId="session-1"
@@ -247,12 +262,18 @@ describe("PostSessionAccessory", () => {
       />,
     );
 
-    expect(screen.getByTestId("timeline")).toBeTruthy();
+    expect(screen.queryByTestId("timeline")).toBeNull();
     expect(screen.queryByTestId("transcript")).toBeNull();
   });
 
-  it("keeps the audio timeline slot height stable between collapsed and expanded states", () => {
-    const { unmount } = render(
+  it("keeps batch progress visible while the transcript panel is collapsed", () => {
+    useTranscriptScreenMock.mockReturnValue({
+      kind: "running_batch",
+      percentage: 0.25,
+      phase: "transcribing",
+    });
+
+    render(
       <PostSessionAccessory
         sessionId="session-1"
         hasAudio
@@ -261,13 +282,12 @@ describe("PostSessionAccessory", () => {
       />,
     );
 
-    const collapsedSlotClassName =
-      screen.getByTestId("timeline").parentElement?.className;
-    expect(collapsedSlotClassName).toContain("h-10");
-    expect(collapsedSlotClassName).toContain("-mt-1.5");
+    expect(screen.getByText("25%")).toBeTruthy();
+    expect(screen.getByText("Transcribing")).toBeTruthy();
+    expect(screen.queryByTestId("transcript")).toBeNull();
+  });
 
-    unmount();
-
+  it("keeps the audio timeline slot height stable when expanded", () => {
     render(
       <PostSessionAccessory
         sessionId="session-1"
@@ -328,7 +348,7 @@ describe("PostSessionAccessory", () => {
 
     expect(screen.getByText("Transcript")).toBeTruthy();
     expect(screen.getAllByText("Transcribing...")).toHaveLength(1);
-    expect(screen.getAllByTestId("spinner")).toHaveLength(1);
+    expect(screen.getAllByTestId("spinner")).toHaveLength(2);
     expect(screen.getByTestId("transcript-skeleton")).toBeTruthy();
     expect(screen.queryByTestId("transcript")).toBeNull();
   });

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -63,7 +63,7 @@ export function PostSessionAccessory({
     (effectiveActiveTab === "past_notes" || hasTranscript || isBatching);
   const timeline = isBatching ? (
     <BatchProgressTimeline sessionId={sessionId} screen={screen} />
-  ) : hasAudio ? (
+  ) : hasAudio && isTranscriptExpanded ? (
     <AudioPlayer.Timeline />
   ) : null;
 


### PR DESCRIPTION
Hide saved-audio playback controls while the post-session transcript panel is collapsed, while preserving batch progress visibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop session UI visibility only; batch progress behavior is preserved and covered by tests.
> 
> **Overview**
> Saved-session **audio playback** no longer appears when the post-session transcript panel is **collapsed**. The bottom accessory mounts only when the panel is expanded or batch transcription is running; `hasAudio` alone no longer keeps it visible.
> 
> In `PostSessionAccessory`, the audio timeline renders only when **`hasAudio && isTranscriptExpanded`**. **Batch progress** (`BatchProgressTimeline`) still shows while collapsed. Tests were updated to match (including batch-progress visibility and spinner count during expanded batch UI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f16f43ab22cc72a9a79a350b67d18999d122b02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->