### PR TITLE
Remove global nav history icons

### DIFF
--- a/apps/desktop/src/contacts/shared.tsx
+++ b/apps/desktop/src/contacts/shared.tsx
@@ -135,7 +135,7 @@ export function ColumnHeader({
 
   return (
     <div className="@container">
-      <CustomSidebarHeader title={title} showHistoryControls>
+      <CustomSidebarHeader title={title}>
         <div className="flex shrink-0 items-center">
           {sortOption && setSortOption && (
             <div className="hidden @[220px]:block">

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -2,7 +2,6 @@ import { isTauri } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   ArrowLeftIcon,
-  ArrowRightIcon,
   PanelLeftCloseIcon,
   PanelLeftOpenIcon,
 } from "lucide-react";
@@ -44,10 +43,6 @@ type MainAreaWindowDragStart = {
 export function ClassicMainBody() {
   const { leftsidebar } = useShell();
   const currentTab = useTabs((state) => state.currentTab);
-  const goBack = useTabs((state) => state.goBack);
-  const goNext = useTabs((state) => state.goNext);
-  const canGoBack = useTabs((state) => state.canGoBack);
-  const canGoNext = useTabs((state) => state.canGoNext);
   const sidebarTimelineEnabled = useConfigValue("sidebar_timeline_enabled");
   const { runEscapeShortcut } = useClassicMainTabsShortcuts();
 
@@ -95,10 +90,6 @@ export function ClassicMainBody() {
           >
             <SidebarTimelineChrome
               sidebarExpanded={leftsidebar.expanded}
-              canGoBack={canGoBack}
-              canGoNext={canGoNext}
-              onBack={goBack}
-              onForward={goNext}
               onToggleSidebar={leftsidebar.toggleExpanded}
               update={update}
             />
@@ -285,18 +276,10 @@ function isMainAreaWindowDrag(
 }
 
 function SidebarTimelineChrome({
-  canGoBack,
-  canGoNext,
-  onBack,
-  onForward,
   onToggleSidebar,
   sidebarExpanded,
   update,
 }: {
-  canGoBack: boolean;
-  canGoNext: boolean;
-  onBack: () => void;
-  onForward: () => void;
   onToggleSidebar: () => void;
   sidebarExpanded: boolean;
   update: DesktopUpdateControl;
@@ -316,20 +299,6 @@ function SidebarTimelineChrome({
           ) : (
             <PanelLeftOpenIcon size={14} />
           )}
-        </LeftSurfaceChromeButton>
-        <LeftSurfaceChromeButton
-          ariaLabel="Go back"
-          disabled={!canGoBack}
-          onClick={onBack}
-        >
-          <ArrowLeftIcon size={14} />
-        </LeftSurfaceChromeButton>
-        <LeftSurfaceChromeButton
-          ariaLabel="Go forward"
-          disabled={!canGoNext}
-          onClick={onForward}
-        >
-          <ArrowRightIcon size={14} />
         </LeftSurfaceChromeButton>
       </div>
       {sidebarExpanded ? <SidebarTimelineUpdateButton update={update} /> : null}

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -219,7 +219,6 @@ describe("ClassicMainBody", () => {
     expect(screen.queryByTestId("toast-area")).toBeNull();
     const sidebar = screen.getByTestId("main-sidebar");
     const sidebarToggle = screen.getByRole("button", { name: "Hide sidebar" });
-    const backButton = screen.getByRole("button", { name: "Go back" });
     const chrome = sidebarToggle.parentElement?.parentElement;
     const topArea = chrome?.parentElement?.parentElement;
 
@@ -227,13 +226,9 @@ describe("ClassicMainBody", () => {
     expect(sidebarToggle).toBeTruthy();
     expect(screen.queryByTestId("sidebar-update-button")).toBeNull();
     expect(screen.queryByRole("button", { name: "Open calendar" })).toBeNull();
-    expect(backButton.hasAttribute("disabled")).toBe(true);
-    expect(
-      screen
-        .getByRole("button", { name: "Go forward" })
-        .hasAttribute("disabled"),
-    ).toBe(true);
-    expect(backButton.parentElement?.className).toContain("gap-0");
+    expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();
+    expect(sidebarToggle.parentElement?.className).toContain("gap-0");
     expect(chrome?.className).toContain("justify-between");
     expect(chrome?.className).toContain("w-full");
     expect(topArea?.className).toContain("h-12");
@@ -246,25 +241,22 @@ describe("ClassicMainBody", () => {
   it("expands the main area to the full window when sidebar timeline mode is collapsed", () => {
     mocks.sidebarTimelineEnabled = true;
     mocks.leftSidebarExpanded = false;
-    mocks.canGoBack = true;
-    mocks.canGoNext = true;
 
     const { container } = render(<ClassicMainBody />);
     const body = container.firstElementChild;
     const contentRow = body?.lastElementChild;
     const sidebarToggle = screen.getByRole("button", { name: "Show sidebar" });
-    const backButton = screen.getByRole("button", { name: "Go back" });
     const chrome = sidebarToggle.parentElement?.parentElement;
     const topArea = chrome?.parentElement?.parentElement;
 
     fireEvent.click(sidebarToggle);
-    fireEvent.click(backButton);
-    fireEvent.click(screen.getByRole("button", { name: "Go forward" }));
 
     expect(screen.queryByTestId("top-meeting-timeline")).toBeNull();
     expect(screen.queryByTestId("timeline-update-banner")).toBeNull();
     expect(screen.queryByTestId("sidebar-update-button")).toBeNull();
-    expect(backButton.parentElement?.className).toContain("gap-0");
+    expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();
+    expect(sidebarToggle.parentElement?.className).toContain("gap-0");
     expect(topArea?.className).toContain("absolute");
     expect(topArea?.className).toContain("h-12");
     expect(topArea?.className).toContain("left-1");
@@ -273,8 +265,6 @@ describe("ClassicMainBody", () => {
     );
     expect(contentRow?.hasAttribute("data-tauri-drag-region")).toBe(false);
     expect(mocks.toggleLeftSidebar).toHaveBeenCalledTimes(1);
-    expect(mocks.goBack).toHaveBeenCalledTimes(1);
-    expect(mocks.goNext).toHaveBeenCalledTimes(1);
   });
 
   it("shows the update button at the far end of expanded sidebar timeline chrome", () => {
@@ -348,34 +338,20 @@ describe("ClassicMainBody", () => {
 
     render(<ClassicMainBody />);
 
-    const backButton = screen.getByRole("button", { name: "Go back" });
-    const chrome = backButton.parentElement?.parentElement;
+    const sidebarToggle = screen.getByRole("button", { name: "Hide sidebar" });
+    const chrome = sidebarToggle.parentElement?.parentElement;
     const topArea = chrome?.parentElement?.parentElement;
 
     expect(screen.queryByTestId("top-meeting-timeline")).toBeNull();
     expect(screen.queryByTestId("timeline-update-banner")).toBeNull();
-    expect(backButton.hasAttribute("disabled")).toBe(true);
-    expect(backButton.parentElement?.className).toContain("gap-0");
+    expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();
+    expect(sidebarToggle.parentElement?.className).toContain("gap-0");
     expect(topArea?.className).toContain("h-12");
     expect(topArea?.className).toContain("absolute");
     expect(screen.getByTestId("main-tab-content").textContent).toContain(
       "changelog",
     );
-  });
-
-  it("navigates history from the sidebar timeline chrome", () => {
-    mocks.sidebarTimelineEnabled = true;
-    mocks.canGoBack = true;
-    mocks.canGoNext = true;
-
-    render(<ClassicMainBody />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Go back" }));
-    fireEvent.click(screen.getByRole("button", { name: "Go forward" }));
-
-    expect(mocks.openNew).not.toHaveBeenCalled();
-    expect(mocks.goBack).toHaveBeenCalledTimes(1);
-    expect(mocks.goNext).toHaveBeenCalledTimes(1);
   });
 
   it.each(["calendar", "settings", "contacts", "templates"])(

--- a/apps/desktop/src/sidebar/calendar.tsx
+++ b/apps/desktop/src/sidebar/calendar.tsx
@@ -5,7 +5,7 @@ import { CalendarSidebarContent } from "~/calendar/components/sidebar";
 export function CalendarNav() {
   return (
     <div className="flex h-full flex-col overflow-hidden pb-2">
-      <CustomSidebarHeader title="Calendar" showHistoryControls />
+      <CustomSidebarHeader title="Calendar" />
       <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto px-3">
         <CalendarSidebarContent />
       </div>

--- a/apps/desktop/src/sidebar/custom-sidebar-header.test.tsx
+++ b/apps/desktop/src/sidebar/custom-sidebar-header.test.tsx
@@ -2,12 +2,8 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  canGoBack: false,
-  canGoNext: false,
   chatMode: "FloatingClosed",
   currentTab: { type: "settings" } as { type: string } | null,
-  goBack: vi.fn(),
-  goNext: vi.fn(),
   openCurrent: vi.fn(),
   select: vi.fn(),
   sendEvent: vi.fn(),
@@ -27,10 +23,6 @@ vi.mock("~/store/zustand/tabs", () => ({
   useTabs: (selector: (state: unknown) => unknown) =>
     selector({
       currentTab: mocks.currentTab,
-      canGoBack: mocks.canGoBack,
-      canGoNext: mocks.canGoNext,
-      goBack: mocks.goBack,
-      goNext: mocks.goNext,
       openCurrent: mocks.openCurrent,
       select: mocks.select,
       tabs: mocks.tabs,
@@ -45,12 +37,8 @@ describe("CustomSidebarHeader", () => {
   });
 
   beforeEach(() => {
-    mocks.canGoBack = false;
-    mocks.canGoNext = false;
     mocks.chatMode = "FloatingClosed";
     mocks.currentTab = { type: "settings" };
-    mocks.goBack.mockClear();
-    mocks.goNext.mockClear();
     mocks.openCurrent.mockClear();
     mocks.select.mockClear();
     mocks.sendEvent.mockClear();
@@ -99,20 +87,7 @@ describe("CustomSidebarHeader", () => {
     expect(mocks.openCurrent).not.toHaveBeenCalled();
   });
 
-  it("renders history controls when requested", () => {
-    mocks.canGoBack = true;
-    mocks.canGoNext = true;
-
-    render(<CustomSidebarHeader title="Contacts" showHistoryControls />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Go back" }));
-    fireEvent.click(screen.getByRole("button", { name: "Go forward" }));
-
-    expect(mocks.goBack).toHaveBeenCalledTimes(1);
-    expect(mocks.goNext).toHaveBeenCalledTimes(1);
-  });
-
-  it("hides history controls by default", () => {
+  it("does not render history controls", () => {
     render(<CustomSidebarHeader title="Settings" />);
 
     expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();

--- a/apps/desktop/src/sidebar/custom-sidebar-header.tsx
+++ b/apps/desktop/src/sidebar/custom-sidebar-header.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
+import { ArrowLeftIcon } from "lucide-react";
 import { useCallback } from "react";
 
 import { cn } from "@hypr/utils";
@@ -9,21 +9,15 @@ import { useTabs } from "~/store/zustand/tabs";
 export function CustomSidebarHeader({
   title,
   children,
-  showHistoryControls = false,
 }: {
   title: string;
   children?: React.ReactNode;
-  showHistoryControls?: boolean;
 }) {
   const { chat } = useShell();
   const currentTab = useTabs((state) => state.currentTab);
   const tabs = useTabs((state) => state.tabs);
   const select = useTabs((state) => state.select);
   const openCurrent = useTabs((state) => state.openCurrent);
-  const goBack = useTabs((state) => state.goBack);
-  const goNext = useTabs((state) => state.goNext);
-  const canGoBack = useTabs((state) => state.canGoBack);
-  const canGoNext = useTabs((state) => state.canGoNext);
 
   const handleBack = useCallback(() => {
     if (chat.mode !== "FloatingClosed") {
@@ -60,24 +54,6 @@ export function CustomSidebarHeader({
         >
           <ArrowLeftIcon size={14} />
         </CustomSidebarHeaderButton>
-        {showHistoryControls ? (
-          <>
-            <CustomSidebarHeaderButton
-              label="Go back"
-              disabled={!canGoBack}
-              onClick={goBack}
-            >
-              <ArrowLeftIcon size={14} />
-            </CustomSidebarHeaderButton>
-            <CustomSidebarHeaderButton
-              label="Go forward"
-              disabled={!canGoNext}
-              onClick={goNext}
-            >
-              <ArrowRightIcon size={14} />
-            </CustomSidebarHeaderButton>
-          </>
-        ) : null}
         <h3 className="truncate font-sans text-sm font-medium select-none">
           {title}
         </h3>


### PR DESCRIPTION
Keep special-view back buttons while dropping global sidebar history controls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only navigation chrome removal with tests updated; tab history APIs may remain unused elsewhere but behavior is intentionally simplified.
> 
> **Overview**
> Removes **global tab history** (back/forward) from the desktop shell while keeping contextual navigation.
> 
> **`CustomSidebarHeader`** no longer accepts `showHistoryControls` or renders history buttons; the **Go home** control remains. Calendar and contacts headers stop opting into history controls.
> 
> **Sidebar timeline chrome** (`ClassicMainBody`) drops back/forward buttons and tab-store wiring (`goBack` / `goNext` / `canGoBack` / `canGoNext`); the sidebar toggle and update affordances are unchanged.
> 
> **Left-surface back** for special views (calendar, settings, contacts, templates) still runs the escape shortcut—it is not part of this removal.
> 
> Tests are updated to assert history controls are absent and the dedicated history-navigation test is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a96e2d2f33c8603b4935aca61a4f60aafd4796c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->