### PR TITLE
Left align note title field

### DIFF
--- a/apps/desktop/src/changelog/index.test.tsx
+++ b/apps/desktop/src/changelog/index.test.tsx
@@ -75,7 +75,18 @@ describe("TabContentChangelog", () => {
 
     render(<TabContentChangelog tab={buildChangelogTab()} />);
 
+    const heading = screen.getByRole("heading", {
+      name: "What's new in 1.0.36?",
+    });
+    const titleSlot = heading.parentElement;
+
     expect(getHeader().className).toContain("pl-[156px]");
+    expect(titleSlot?.className).toContain("left-[104px]");
+    expect(titleSlot?.className).not.toContain("-translate-y-1");
+    expect(titleSlot?.className).toContain("right-[70px]");
+    expect(titleSlot?.className).toContain("justify-start");
+    expect(titleSlot?.className).not.toContain("left-1/2");
+    expect(heading.className).toContain("text-left");
   });
 
   it("does not add the collapsed sidebar gutter while the left sidebar is expanded", () => {
@@ -85,6 +96,37 @@ describe("TabContentChangelog", () => {
 
     expect(getHeader().className).not.toContain("pl-[156px]");
   });
+
+  it("uses the left-edge title slot while sidebar timeline mode is expanded", () => {
+    mocks.sidebarTimelineEnabled = true;
+    mocks.leftsidebar.expanded = true;
+
+    render(<TabContentChangelog tab={buildChangelogTab()} />);
+
+    const heading = screen.getByRole("heading", {
+      name: "What's new in 1.0.36?",
+    });
+    const titleSlot = heading.parentElement;
+
+    expect(titleSlot?.className).toContain("left-0");
+    expect(titleSlot?.className).toContain("right-[70px]");
+    expect(titleSlot?.className).toContain("justify-start");
+    expect(titleSlot?.className).not.toContain("left-1/2");
+    expect(heading.className).toContain("text-left");
+  });
+
+  it("centers the changelog title independently from the close button", () => {
+    render(<TabContentChangelog tab={buildChangelogTab()} />);
+
+    const heading = screen.getByRole("heading", {
+      name: "What's new in 1.0.36?",
+    });
+    const titleSlot = heading.parentElement;
+
+    expect(titleSlot?.className).toContain("left-1/2");
+    expect(titleSlot?.className).toContain("-translate-x-1/2");
+    expect(heading.className).toContain("text-center");
+  });
 });
 
 function getHeader() {
@@ -92,7 +134,7 @@ function getHeader() {
     name: "What's new in 1.0.36?",
   });
 
-  return heading.parentElement?.parentElement?.parentElement as HTMLElement;
+  return heading.parentElement?.parentElement as HTMLElement;
 }
 
 function buildChangelogTab(): Extract<Tab, { type: "changelog" }> {

--- a/apps/desktop/src/changelog/index.tsx
+++ b/apps/desktop/src/changelog/index.tsx
@@ -26,6 +26,8 @@ export function TabContentChangelog({
   const sidebarTimelineEnabled = useConfigValue("sidebar_timeline_enabled");
   const showSidebarTimelineHeaderGutter =
     sidebarTimelineEnabled && !leftsidebar.expanded;
+  const showExpandedSidebarTimelineHeader =
+    sidebarTimelineEnabled && leftsidebar.expanded;
 
   useMountEffect(() => {
     if (chat.mode !== "FloatingClosed") {
@@ -42,6 +44,9 @@ export function TabContentChangelog({
           <ChangelogHeader
             version={current}
             showSidebarTimelineHeaderGutter={showSidebarTimelineHeaderGutter}
+            showExpandedSidebarTimelineHeader={
+              showExpandedSidebarTimelineHeader
+            }
             onClose={() => close(tab)}
           />
         </div>
@@ -118,10 +123,12 @@ function ChangelogBody({
 }
 
 function ChangelogHeader({
+  showExpandedSidebarTimelineHeader,
   showSidebarTimelineHeaderGutter,
   version,
   onClose,
 }: {
+  showExpandedSidebarTimelineHeader: boolean;
   showSidebarTimelineHeaderGutter: boolean;
   version: string;
   onClose: () => void;
@@ -129,29 +136,43 @@ function ChangelogHeader({
   return (
     <div
       className={cn([
-        "flex h-12 w-full items-center",
+        "relative flex h-12 w-full items-center",
         showSidebarTimelineHeaderGutter && "pl-[156px]",
       ])}
     >
-      <div className="flex w-full min-w-0 items-center justify-between gap-0">
-        <div className="min-w-0 flex-1">
-          <h1 className="text-foreground truncate text-xl font-semibold">
-            What's new in {version}?
-          </h1>
-        </div>
+      <div
+        className={cn([
+          "pointer-events-none absolute inset-y-0 flex items-center",
+          showExpandedSidebarTimelineHeader
+            ? "right-[70px] left-0 justify-start"
+            : showSidebarTimelineHeaderGutter
+              ? "right-[70px] left-[104px] justify-start"
+              : "left-1/2 w-[min(640px,calc(100%_-_160px))] -translate-x-1/2 justify-center",
+        ])}
+      >
+        <h1
+          className={cn([
+            "text-foreground truncate text-xl font-semibold",
+            showExpandedSidebarTimelineHeader || showSidebarTimelineHeaderGutter
+              ? "text-left"
+              : "text-center",
+          ])}
+        >
+          What's new in {version}?
+        </h1>
+      </div>
 
-        <div className="flex shrink-0 items-center gap-0 pr-1">
-          <Button
-            size="icon"
-            variant="ghost"
-            className="text-muted-foreground hover:text-foreground"
-            aria-label="Close changelog"
-            title="Close"
-            onClick={onClose}
-          >
-            <XIcon size={15} />
-          </Button>
-        </div>
+      <div className="relative z-10 ml-auto flex shrink-0 items-center gap-0 pr-1">
+        <Button
+          size="icon"
+          variant="ghost"
+          className="text-muted-foreground hover:text-foreground"
+          aria-label="Close changelog"
+          title="Close"
+          onClick={onClose}
+        >
+          <XIcon size={16} />
+        </Button>
       </div>
     </div>
   );

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -82,6 +82,7 @@ export function ClassicMainBody() {
           className={cn([
             "absolute top-0 z-40 h-12 w-[200px]",
             leftsidebar.expanded ? "left-0" : "left-1",
+            !leftsidebar.expanded && "pointer-events-none",
           ])}
         >
           <div
@@ -133,7 +134,7 @@ export function ClassicMainBody() {
               ariaLabel="Go back"
               onClick={runEscapeShortcut}
             >
-              <ArrowLeftIcon size={14} />
+              <ArrowLeftIcon size={16} />
             </LeftSurfaceChromeButton>
           </div>
         </div>
@@ -177,6 +178,7 @@ function useMainAreaTopWindowDrag(enabled: boolean) {
       if (
         !enabled ||
         event.button !== 0 ||
+        isInteractiveMainAreaDragTarget(event.target) ||
         !isWithinMainAreaTopDragRegion(event)
       ) {
         windowDragStartRef.current = null;
@@ -262,6 +264,27 @@ function isWithinMainAreaTopDragRegion(
   return offsetY >= 0 && offsetY < MAIN_AREA_TOP_DRAG_HEIGHT_PX;
 }
 
+function isInteractiveMainAreaDragTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  return Boolean(
+    target.closest(
+      [
+        "a",
+        "button",
+        "input",
+        "select",
+        "textarea",
+        "[contenteditable='true']",
+        "[role='button']",
+        "[role='textbox']",
+      ].join(","),
+    ),
+  );
+}
+
 function isMainAreaWindowDrag(
   start: { clientX: number; clientY: number },
   current: { clientX: number; clientY: number },
@@ -295,9 +318,9 @@ function SidebarTimelineChrome({
           onClick={onToggleSidebar}
         >
           {sidebarExpanded ? (
-            <PanelLeftCloseIcon size={14} />
+            <PanelLeftCloseIcon size={16} />
           ) : (
-            <PanelLeftOpenIcon size={14} />
+            <PanelLeftOpenIcon size={16} />
           )}
         </LeftSurfaceChromeButton>
       </div>
@@ -326,7 +349,7 @@ function LeftSurfaceChromeButton({
       data-tauri-drag-region="false"
       disabled={disabled}
       className={cn([
-        "relative flex size-7 items-center justify-center rounded-full",
+        "pointer-events-auto relative flex size-7 items-center justify-center rounded-full",
         "text-muted-foreground hover:bg-accent hover:text-foreground transition-colors",
         "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
         "disabled:text-muted-foreground/70 disabled:hover:text-muted-foreground/70 disabled:hover:bg-transparent",

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -147,7 +147,7 @@ describe("OuterHeader", () => {
     expect(mocks.stopListening).toHaveBeenCalledTimes(1);
   });
 
-  it("adds a left gutter for anchored sidebar chrome when collapsed", () => {
+  it("raises the tightened title field when sidebar timeline mode is collapsed", () => {
     mocks.sidebarTimelineEnabled = true;
     mocks.leftsidebar.expanded = false;
 
@@ -160,15 +160,40 @@ describe("OuterHeader", () => {
     );
 
     const title = screen.getByText("Session title");
-    const header =
-      title.parentElement?.parentElement?.parentElement?.parentElement;
-    const titleRow = title.parentElement?.parentElement;
+    const titleWrapper = title.parentElement;
+    const titleSlot = titleWrapper?.parentElement;
+    const header = titleSlot?.parentElement;
 
     expect(header?.className).toContain("pl-[156px]");
-    expect(titleRow?.className).toContain("items-center");
+    expect(header?.className).toContain("h-[52px]");
+    expect(header?.className).toContain("pb-1");
+    expect(titleWrapper?.className).toContain("w-full");
+    expect(titleWrapper?.className).not.toContain("max-w-[680px]");
+    expect(titleSlot?.className).toContain("left-[104px]");
+    expect(titleSlot?.className).toContain("-translate-y-1");
+    expect(titleSlot?.className).toContain("right-[70px]");
     expect(screen.queryByRole("button", { name: "Show sidebar" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();
+  });
+
+  it("uses a compact title offset while the sidebar timeline is expanded", () => {
+    mocks.sidebarTimelineEnabled = true;
+    mocks.leftsidebar.expanded = true;
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    const title = screen.getByText("Session title");
+    const titleSlot = title.parentElement?.parentElement;
+
+    expect(titleSlot?.className).toContain("left-0");
+    expect(titleSlot?.className).toContain("right-[70px]");
   });
 
   it("keeps sidebar timeline header controls hidden while the sidebar is expanded", () => {
@@ -202,8 +227,8 @@ describe("OuterHeader", () => {
     expect(container.firstElementChild?.className).toContain("h-12");
   });
 
-  it("keeps the header content row full width", () => {
-    const { container } = render(
+  it("uses the note-surface title offset while reserving room for header controls", () => {
+    render(
       <OuterHeader
         sessionId="session-1"
         currentView={{ type: "raw" } as EditorView}
@@ -211,9 +236,11 @@ describe("OuterHeader", () => {
       />,
     );
 
-    expect(container.firstElementChild?.firstElementChild?.className).toContain(
-      "w-full",
-    );
+    const title = screen.getByText("Session title");
+    const titleSlot = title.parentElement?.parentElement;
+
+    expect(titleSlot?.className).toContain("left-[114px]");
+    expect(titleSlot?.className).toContain("right-[70px]");
   });
 
   it("keeps the dedicated stop button hidden outside sidebar timeline mode", () => {

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -31,23 +31,35 @@ export function OuterHeader({
   const sidebarTimelineEnabled = useConfigValue("sidebar_timeline_enabled");
   const showSidebarTimelineHeaderGutter =
     sidebarTimelineEnabled && !leftsidebar.expanded;
+  const showExpandedSidebarTimelineHeader =
+    sidebarTimelineEnabled && leftsidebar.expanded;
 
   return (
     <div
       className={cn([
-        "flex h-12 w-full items-center",
+        "relative flex w-full items-center",
+        showSidebarTimelineHeaderGutter ? "h-[52px] pb-1" : "h-12",
         showSidebarTimelineHeaderGutter && "pl-[156px]",
       ])}
     >
-      <div className="flex w-full min-w-0 items-center justify-between gap-0">
-        <div className="flex min-w-0 flex-1 items-center gap-1">
-          {title ? <div className="min-w-0 flex-1">{title}</div> : null}
+      {title ? (
+        <div
+          className={cn([
+            "pointer-events-none absolute inset-y-0 right-[70px] flex items-center",
+            showSidebarTimelineHeaderGutter
+              ? "left-[104px] -translate-y-1"
+              : showExpandedSidebarTimelineHeader
+                ? "left-0"
+                : "left-[114px]",
+          ])}
+        >
+          <div className="pointer-events-auto w-full min-w-0">{title}</div>
         </div>
-        <div className="flex shrink-0 items-center gap-0 pr-1">
-          <SidebarModeStopButton sessionId={sessionId} />
-          <HeaderMeetingControl sessionId={sessionId} />
-          <OverflowButton sessionId={sessionId} currentView={currentView} />
-        </div>
+      ) : null}
+      <div className="relative z-10 ml-auto flex shrink-0 items-center gap-0 pr-1">
+        <SidebarModeStopButton sessionId={sessionId} />
+        <HeaderMeetingControl sessionId={sessionId} />
+        <OverflowButton sessionId={sessionId} currentView={currentView} />
       </div>
     </div>
   );

--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -84,21 +84,23 @@ describe("TitleInput", () => {
     expect(hoisted.clearLiveTitle).not.toHaveBeenCalled();
   });
 
-  it("positions the empty title generate button next to the placeholder", () => {
+  it("left-aligns the empty title field without a generate button", () => {
     hoisted.store.getCell.mockReturnValueOnce("");
 
-    renderTitleInput({ onGenerateTitle: vi.fn() });
+    renderTitleInput();
 
     const input = screen.getByPlaceholderText("Untitled");
-    const button = screen.getByRole("button", { name: "Regenerate title" });
     expect(input.parentElement?.className).toContain("relative");
-    expect(button.className).toContain("left-[84px]");
+    expect(input.className).toContain("text-left");
+    expect(
+      screen.queryByRole("button", { name: "Regenerate title" }),
+    ).toBeNull();
   });
 
   it("uses the flexible title layout for whitespace-only titles", () => {
     hoisted.store.getCell.mockReturnValueOnce("          ");
 
-    renderTitleInput({ onGenerateTitle: vi.fn() });
+    renderTitleInput();
 
     const input = screen.getByPlaceholderText("Untitled");
     expect(input.className).toContain("w-full");
@@ -126,12 +128,57 @@ describe("TitleInput", () => {
     fireEvent.change(input, { target: { value: title } });
 
     const hoverTitle = screen.getByText(title);
+    const overlay = hoverTitle.parentElement;
     expect(input.className).toContain("text-transparent");
+    expect(input.parentElement?.style.maskImage).toBe(
+      "linear-gradient(to right, black 0, black calc(100% - 28px), transparent 100%)",
+    );
+    expect(overlay?.className).toContain("justify-start");
     expect(hoverTitle.className).toContain(
       "group-hover/title-input:animate-title-hover-scroll",
     );
     expect(
       hoverTitle.style.getPropertyValue("--title-hover-scroll-distance"),
     ).toBe("-260px");
+  });
+
+  it("updates title fades based on horizontal scroll position", () => {
+    renderTitleInput();
+
+    const input = screen.getByPlaceholderText("Untitled");
+    Object.defineProperty(input, "clientWidth", {
+      configurable: true,
+      value: 160,
+    });
+    Object.defineProperty(input, "scrollWidth", {
+      configurable: true,
+      value: 420,
+    });
+
+    fireEvent.change(input, {
+      target: {
+        value:
+          "Product Discovery Pace and Headless Agent Usage Strategy Review",
+      },
+    });
+
+    const titleInputShell = input.parentElement;
+    expect(titleInputShell?.style.maskImage).toBe(
+      "linear-gradient(to right, black 0, black calc(100% - 28px), transparent 100%)",
+    );
+
+    input.scrollLeft = 130;
+    fireEvent.scroll(input);
+
+    expect(titleInputShell?.style.maskImage).toBe(
+      "linear-gradient(to right, transparent 0, black 28px, black calc(100% - 28px), transparent 100%)",
+    );
+
+    input.scrollLeft = 260;
+    fireEvent.scroll(input);
+
+    expect(titleInputShell?.style.maskImage).toBe(
+      "linear-gradient(to right, transparent 0, black 28px, black 100%)",
+    );
   });
 });

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -1,5 +1,4 @@
 import { usePrevious } from "@uidotdev/usehooks";
-import { SparklesIcon } from "lucide-react";
 import {
   type CSSProperties,
   forwardRef,
@@ -12,11 +11,6 @@ import {
 } from "react";
 import { useResizeObserver } from "usehooks-ts";
 
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@hypr/ui/components/ui/tooltip";
 import { cn } from "@hypr/utils";
 
 import { useTitleGenerating } from "~/ai/hooks";
@@ -37,7 +31,6 @@ export const TitleInput = forwardRef<
     onTransferContentToEditor?: (content: string) => void;
     onFocusEditorAtStart?: () => void;
     onFocusEditorAtPixelWidth?: (pixelWidth: number) => void;
-    onGenerateTitle?: () => void;
   }
 >(
   (
@@ -46,7 +39,6 @@ export const TitleInput = forwardRef<
       onTransferContentToEditor,
       onFocusEditorAtStart,
       onFocusEditorAtPixelWidth,
-      onGenerateTitle,
     },
     ref,
   ) => {
@@ -85,7 +77,7 @@ export const TitleInput = forwardRef<
 
     if (isGenerating) {
       return (
-        <div className="flex h-8 w-full items-center">
+        <div className="flex h-8 w-full items-center justify-start">
           <span className="text-muted-foreground animate-pulse text-xl font-semibold">
             Generating title...
           </span>
@@ -95,7 +87,7 @@ export const TitleInput = forwardRef<
 
     if (showRevealAnimation && generatedTitle) {
       return (
-        <div className="flex h-8 w-full items-center overflow-hidden">
+        <div className="flex h-8 w-full items-center justify-start overflow-hidden">
           <span className="animate-reveal-left text-xl font-semibold whitespace-nowrap">
             {generatedTitle}
           </span>
@@ -112,7 +104,6 @@ export const TitleInput = forwardRef<
         onTransferContentToEditor={onTransferContentToEditor}
         onFocusEditorAtStart={onFocusEditorAtStart}
         onFocusEditorAtPixelWidth={onFocusEditorAtPixelWidth}
-        onGenerateTitle={onGenerateTitle}
       />
     );
   },
@@ -128,7 +119,6 @@ const TitleInputInner = memo(
       onTransferContentToEditor?: (content: string) => void;
       onFocusEditorAtStart?: () => void;
       onFocusEditorAtPixelWidth?: (pixelWidth: number) => void;
-      onGenerateTitle?: () => void;
     }
   >(
     (
@@ -139,13 +129,14 @@ const TitleInputInner = memo(
         onTransferContentToEditor,
         onFocusEditorAtStart,
         onFocusEditorAtPixelWidth,
-        onGenerateTitle,
       },
       ref,
     ) => {
       const [localTitle, setLocalTitle] = useState(() => getInitialTitle());
       const [isOverflowing, setIsOverflowing] = useState(false);
       const [overflowDistance, setOverflowDistance] = useState(0);
+      const [showStartFade, setShowStartFade] = useState(false);
+      const [showEndFade, setShowEndFade] = useState(false);
       const [isTitleFocused, setIsTitleFocused] = useState(false);
       const isFocused = useRef(false);
       const internalRef = useRef<HTMLInputElement>(null);
@@ -159,11 +150,17 @@ const TitleInputInner = memo(
           if (!input) {
             setIsOverflowing(false);
             setOverflowDistance(0);
+            setShowStartFade(false);
+            setShowEndFade(false);
             return;
           }
           const distance = Math.max(input.scrollWidth - input.clientWidth, 0);
+          const overflowing = distance > 1;
+          const scrollLeft = Math.max(input.scrollLeft, 0);
           setIsOverflowing(distance > 1);
           setOverflowDistance(distance);
+          setShowStartFade(overflowing && scrollLeft > 1);
+          setShowEndFade(overflowing && scrollLeft < distance - 1);
         },
         [],
       );
@@ -176,6 +173,8 @@ const TitleInputInner = memo(
           } else {
             setIsOverflowing(false);
             setOverflowDistance(0);
+            setShowStartFade(false);
+            setShowEndFade(false);
           }
         },
         [updateOverflowState],
@@ -186,13 +185,14 @@ const TitleInputInner = memo(
         onResize: () => updateOverflowState(),
       });
 
-      const overflowFadeStyle =
-        isOverflowing && !isTitleFocused
+      const titleFadeStyle =
+        showStartFade || showEndFade
           ? {
-              WebkitMaskImage:
-                "linear-gradient(to right, black, black calc(100% - 28px), transparent)",
-              maskImage:
-                "linear-gradient(to right, black, black calc(100% - 28px), transparent)",
+              WebkitMaskImage: getTitleFadeMask({
+                showStartFade,
+                showEndFade,
+              }),
+              maskImage: getTitleFadeMask({ showStartFade, showEndFade }),
               WebkitMaskRepeat: "no-repeat",
               maskRepeat: "no-repeat",
               WebkitMaskSize: "100% 100%",
@@ -338,11 +338,12 @@ const TitleInputInner = memo(
           }
         }
       };
-      const generateTitleHandler =
-        localTitle.length === 0 ? onGenerateTitle : undefined;
 
       return (
-        <div className="group/title-input relative flex h-8 w-full items-center overflow-hidden">
+        <div
+          style={titleFadeStyle}
+          className="group/title-input relative flex h-8 w-full items-center overflow-hidden"
+        >
           <input
             ref={setInputRef}
             id={`title-input-${sessionId}-${editorId}`}
@@ -354,10 +355,13 @@ const TitleInputInner = memo(
               setLiveTitle(sessionId, value);
               updateOverflowState(e.target);
             }}
+            onClick={(e) => updateOverflowState(e.currentTarget)}
             onKeyDown={handleKeyDown}
+            onKeyUp={(e) => updateOverflowState(e.currentTarget)}
             onFocus={() => {
               isFocused.current = true;
               setIsTitleFocused(true);
+              updateOverflowState();
             }}
             onBlur={(e) => {
               isFocused.current = false;
@@ -366,19 +370,20 @@ const TitleInputInner = memo(
               clearLiveTitle(sessionId);
               updateOverflowState(e.target);
             }}
+            onScroll={(e) => updateOverflowState(e.currentTarget)}
+            onSelect={(e) => updateOverflowState(e.currentTarget)}
             value={localTitle}
-            style={showHoverReveal ? undefined : overflowFadeStyle}
             className={cn([
               "w-full min-w-0 transition-opacity duration-200",
               "border-none bg-transparent focus:outline-hidden",
-              "placeholder:text-muted-foreground text-xl font-semibold",
+              "placeholder:text-muted-foreground text-left text-xl font-semibold",
               showHoverReveal && "text-transparent caret-transparent",
             ])}
           />
           {showHoverReveal ? (
             <div
               aria-hidden="true"
-              className="pointer-events-none absolute inset-0 flex items-center overflow-hidden"
+              className="pointer-events-none absolute inset-0 flex items-center justify-start overflow-hidden"
             >
               <span
                 style={titleHoverScrollStyle}
@@ -388,47 +393,26 @@ const TitleInputInner = memo(
               </span>
             </div>
           ) : null}
-          {generateTitleHandler && (
-            <GenerateButton
-              className="absolute top-1/2 left-[84px] -translate-y-1/2"
-              onGenerateTitle={generateTitleHandler}
-            />
-          )}
         </div>
       );
     },
   ),
 );
 
-const GenerateButton = memo(function GenerateButton({
-  className,
-  onGenerateTitle,
+function getTitleFadeMask({
+  showStartFade,
+  showEndFade,
 }: {
-  className?: string;
-  onGenerateTitle: () => void;
+  showStartFade: boolean;
+  showEndFade: boolean;
 }) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          aria-label="Regenerate title"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onGenerateTitle();
-          }}
-          onMouseDown={(e) => e.preventDefault()}
-          className={cn([
-            "shrink-0",
-            "text-muted-foreground hover:text-foreground",
-            "opacity-50 transition-opacity hover:opacity-100",
-            className,
-          ])}
-        >
-          <SparklesIcon className="h-4 w-4" />
-        </button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">Regenerate title</TooltipContent>
-    </Tooltip>
-  );
-});
+  if (showStartFade && showEndFade) {
+    return "linear-gradient(to right, transparent 0, black 28px, black calc(100% - 28px), transparent 100%)";
+  }
+
+  if (showStartFade) {
+    return "linear-gradient(to right, transparent 0, black 28px, black 100%)";
+  }
+
+  return "linear-gradient(to right, black 0, black calc(100% - 28px), transparent 100%)";
+}

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -16,7 +16,6 @@ import { TitleInput, type TitleInputHandle } from "./components/title-input";
 import { getNextFloatingButtonHidden } from "./floating-scroll-state";
 import { useAutoEnhance } from "./hooks/useAutoEnhance";
 
-import { useTitleGeneration } from "~/ai/hooks";
 import * as AudioPlayer from "~/audio-player";
 import * as main from "~/store/tinybase/store/main";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
@@ -113,7 +112,6 @@ function TabContentNoteInner({
     currentView.type === "enhanced"
       ? `enhanced-${currentView.id}`
       : currentView.type;
-  const { generateTitle } = useTitleGeneration(tab);
   const hasTranscript = useHasTranscript(tab.id);
   const [floatingButtonScrollState, setFloatingButtonScrollState] =
     React.useState({
@@ -227,7 +225,6 @@ function TabContentNoteInner({
               onTransferContentToEditor={handleTransferContentToEditor}
               onFocusEditorAtStart={handleFocusEditorAtStart}
               onFocusEditorAtPixelWidth={handleFocusEditorAtPixelWidth}
-              onGenerateTitle={hasTranscript ? generateTitle : undefined}
             />
           }
         />

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -54,9 +54,14 @@ vi.mock("~/main/useTabsShortcuts", () => ({
 }));
 
 vi.mock("~/main/tab-content", () => ({
-  ClassicMainTabContent: ({ tab }: { tab: { type: string } }) => (
-    <div data-testid="main-tab-content">{tab.type}</div>
-  ),
+  ClassicMainTabContent: ({ tab }: { tab: { type: string } }) =>
+    tab.type === "sessions" ? (
+      <div data-testid="main-tab-content">
+        <input aria-label="Session title" />
+      </div>
+    ) : (
+      <div data-testid="main-tab-content">{tab.type}</div>
+    ),
 }));
 
 vi.mock("~/main/top-meeting-timeline", () => ({
@@ -257,9 +262,11 @@ describe("ClassicMainBody", () => {
     expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();
     expect(sidebarToggle.parentElement?.className).toContain("gap-0");
+    expect(sidebarToggle.className).toContain("pointer-events-auto");
     expect(topArea?.className).toContain("absolute");
     expect(topArea?.className).toContain("h-12");
     expect(topArea?.className).toContain("left-1");
+    expect(topArea?.className).toContain("pointer-events-none");
     expect(contentRow?.className).toContain(
       "flex min-h-0 min-w-0 flex-1 gap-1",
     );
@@ -402,6 +409,34 @@ describe("ClassicMainBody", () => {
     });
 
     expect(mocks.startDragging).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start window dragging from an input in the top drag strip", () => {
+    mocks.sidebarTimelineEnabled = true;
+    mocks.currentTab = {
+      active: true,
+      pinned: false,
+      slotId: "slot-1",
+      type: "sessions",
+    };
+
+    render(<ClassicMainBody />);
+
+    const titleInput = screen.getByRole("textbox", { name: "Session title" });
+
+    fireEvent.pointerDown(titleInput, {
+      button: 0,
+      clientX: 240,
+      clientY: 12,
+      pointerId: 1,
+    });
+    fireEvent.pointerMove(titleInput, {
+      clientX: 248,
+      clientY: 12,
+      pointerId: 1,
+    });
+
+    expect(mocks.startDragging).not.toHaveBeenCalled();
   });
 
   it("does not start window dragging below the main area drag strip", () => {

--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -492,6 +492,7 @@ describe("TimelineView", () => {
 
     expect(getSidebarActions().className).toContain("opacity-0");
     expect(getTopFade(container).className).toContain("h-20");
+    expect(getTopFade(container).className).toContain("from-60%");
 
     act(() => {
       vi.advanceTimersByTime(900);
@@ -506,6 +507,7 @@ describe("TimelineView", () => {
     expect(revealedNewNoteButton.className).toContain("flex-1");
     expect(revealedSearchButton.className).toContain("w-8");
     expect(getTopFade(container).className).toContain("h-28");
+    expect(getTopFade(container).className).toContain("from-75%");
   });
 
   it("keeps sidebar actions hidden during timeline data refreshes", () => {

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -540,10 +540,10 @@ export function TimelineView({
             showCalendarSyncStatus
               ? "bg-background h-28"
               : areSidebarActionsHidden
-                ? "from-background via-background/95 to-background/0 h-20 bg-linear-to-b via-60%"
+                ? "from-background via-background/95 to-background/0 h-20 bg-linear-to-b from-60% via-80%"
                 : isScrolledToTop
                   ? "bg-background h-[5.25rem]"
-                  : "from-background via-background/95 to-background/0 h-28 bg-linear-to-b via-55%",
+                  : "from-background via-background/95 to-background/0 h-28 bg-linear-to-b from-75% via-85%",
           ])}
         />
       )}


### PR DESCRIPTION
Anchor note titles from the left header gutter and remove the manual title generation button.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly layout, styling, and input/drag hit-testing; removing the in-title generate button is a small UX change with no auth or data-path impact.
> 
> **Overview**
> **Note titles** are left-aligned in the header gutter: `OuterHeader` and `ChangelogHeader` use an absolutely positioned title slot (offsets for collapsed/expanded sidebar timeline vs default) with header actions on the right, instead of a single flex row.
> 
> **`TitleInput`** drops the empty-state **Regenerate title** control and `onGenerateTitle` wiring from the session tab; text is **left-aligned**, and overflow uses **scroll-aware** edge fades (start/end) on the input shell plus the existing hover-scroll reveal.
> 
> **Main chrome / dragging:** collapsed sidebar timeline drag region is `pointer-events-none` with clickable chrome buttons restored via `pointer-events-auto`; top-strip window drag ignores interactive targets (e.g. the title field). Sidebar timeline top-fade gradient stops are tweaked.
> 
> Tests cover the new layout classes, title fades, and drag behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62659669a3d47f701c621a3513cd15332f02b775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5535 
- <kbd>&nbsp;2&nbsp;</kbd> #5533 
- <kbd>&nbsp;1&nbsp;</kbd> #5531 👈 
<!-- GitButler Footer Boundary Bottom -->

