### PR TITLE
Enable live speaker label assignment

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
@@ -1,30 +1,69 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DuringSessionAccessory } from "./during-session";
 
 import type { Segment } from "~/stt/live-segment";
 
-const { useListenerMock, useQueryMock, useStoreMock } = vi.hoisted(() => ({
+const {
+  useCellMock,
+  useListenerMock,
+  useQueriesMock,
+  useQueryMock,
+  useRowIdsMock,
+  useSliceRowIdsMock,
+  useStoreMock,
+  useTableMock,
+  useValueMock,
+} = vi.hoisted(() => ({
+  useCellMock: vi.fn(),
   useListenerMock: vi.fn(),
+  useQueriesMock: vi.fn(),
   useQueryMock: vi.fn(),
+  useRowIdsMock: vi.fn(),
+  useSliceRowIdsMock: vi.fn(),
   useStoreMock: vi.fn(),
+  useTableMock: vi.fn(),
+  useValueMock: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-query", () => ({
   useQuery: useQueryMock,
 }));
 
+vi.mock("@hypr/ui/components/ui/popover", () => ({
+  AppFloatingPanel: ({
+    children,
+    className,
+  }: {
+    children: ReactNode;
+    className?: string;
+  }) => <div className={className}>{children}</div>,
+  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
 vi.mock("~/store/tinybase/store/main", () => ({
   STORE_ID: "main",
   INDEXES: {
+    sessionParticipantsBySession: "sessionParticipantsBySession",
     transcriptBySession: "transcriptBySession",
   },
+  QUERIES: {
+    sessionParticipantsWithDetails: "sessionParticipantsWithDetails",
+  },
   UI: {
-    useSliceRowIds: vi.fn(() => []),
+    useCell: useCellMock,
+    useQueries: useQueriesMock,
+    useRowIds: useRowIdsMock,
+    useSliceRowIds: useSliceRowIdsMock,
     useStore: useStoreMock,
-    useTable: vi.fn(() => ({})),
-    useValue: vi.fn(() => undefined),
+    useTable: useTableMock,
+    useValue: useValueMock,
   },
 }));
 
@@ -45,7 +84,13 @@ describe("DuringSessionAccessory", () => {
     scrollHeight = 480;
 
     useQueryMock.mockReturnValue({ data: [] });
+    useCellMock.mockReturnValue(undefined);
+    useQueriesMock.mockReturnValue(null);
+    useRowIdsMock.mockReturnValue([]);
+    useSliceRowIdsMock.mockReturnValue([]);
     useStoreMock.mockReturnValue(null);
+    useTableMock.mockReturnValue({});
+    useValueMock.mockReturnValue(undefined);
     useListenerMock.mockImplementation((selector) =>
       selector({
         live: {
@@ -214,6 +259,95 @@ describe("DuringSessionAccessory", () => {
     const chip = screen.getByTitle(label);
     expect(chip.className).toContain("sticky");
     expect(chip.className).toContain("top-2.5");
+  });
+
+  it("assigns live transcript speaker labels to session participants", () => {
+    const setCell = vi.fn();
+    const store = {
+      forEachRow: vi.fn(
+        (tableId: string, callback: (rowId: string) => void) => {
+          if (tableId === "humans") {
+            callback("human-1");
+          }
+          if (tableId === "mapping_session_participant") {
+            callback("mapping-1");
+          }
+        },
+      ),
+      getCell: vi.fn((tableId: string, rowId: string, cellId: string) => {
+        if (tableId === "transcripts" && rowId === "transcript-1") {
+          if (cellId === "session_id") return "session-1";
+          if (cellId === "started_at") return 0;
+          if (cellId === "words") {
+            return JSON.stringify([
+              {
+                id: "word-0",
+                text: "Remote words.",
+                start_ms: 0,
+                end_ms: 300,
+                channel: 1,
+              },
+            ]);
+          }
+          if (cellId === "speaker_hints") return "[]";
+        }
+        if (tableId === "mapping_session_participant") {
+          if (cellId === "session_id") return "session-1";
+          if (cellId === "human_id") return "human-1";
+        }
+        return undefined;
+      }),
+      getRow: vi.fn((tableId: string, rowId: string) =>
+        tableId === "humans" && rowId === "human-1"
+          ? { name: "Alex", email: "alex@example.com" }
+          : {},
+      ),
+      getValue: vi.fn(() => "user-1"),
+      setCell,
+      setRow: vi.fn(),
+    };
+
+    useStoreMock.mockReturnValue(store);
+    useCellMock.mockReturnValue("session-1");
+    useQueriesMock.mockReturnValue({
+      getResultRow: vi.fn(() => ({
+        human_id: "human-1",
+        human_name: "Alex",
+        human_email: "alex@example.com",
+      })),
+    });
+    useRowIdsMock.mockReturnValue(["human-1"]);
+    useSliceRowIdsMock.mockImplementation((indexId: string) =>
+      indexId === "transcriptBySession" ? ["transcript-1"] : ["mapping-1"],
+    );
+    useValueMock.mockReturnValue("user-1");
+    liveSegments = [
+      segment("Remote words.", 0, {
+        channel: "RemoteParty",
+        speaker_index: 0,
+      }),
+    ];
+
+    render(<DuringSessionAccessory sessionId="session-1" isExpanded />);
+
+    expect(screen.getByRole("button", { name: "Speaker 1" })).toBeTruthy();
+    fireEvent.click(screen.getByText("Alex"));
+
+    expect(setCell).toHaveBeenCalledWith(
+      "transcripts",
+      "transcript-1",
+      "speaker_hints",
+      expect.any(String),
+    );
+    const hints = JSON.parse(setCell.mock.calls[0]?.[3] as string);
+    expect(hints).toEqual([
+      {
+        id: "word-0:user_speaker_assignment",
+        word_id: "word-0",
+        type: "user_speaker_assignment",
+        value: JSON.stringify({ human_id: "human-1" }),
+      },
+    ]);
   });
 });
 

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -3,6 +3,8 @@ import { useLayoutEffect, useMemo, useRef } from "react";
 
 import { cn } from "@hypr/utils";
 
+import { SpeakerAssignPopover } from "../note-input/transcript/renderer/speaker-assign";
+
 import { useSegmentColorVars } from "~/session/components/note-input/transcript/renderer/utils";
 import * as main from "~/store/tinybase/store/main";
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
@@ -21,6 +23,7 @@ import {
   SpeakerLabelManager,
   defaultRenderLabelContext,
 } from "~/stt/segment/shared";
+import { parseTranscriptWords } from "~/stt/utils";
 
 export function DuringSessionAccessory({
   sessionId,
@@ -83,7 +86,7 @@ function LiveTranscriptFooterContent({
   isExpanded?: boolean;
 }) {
   const store = main.UI.useStore(main.STORE_ID);
-  const segments = useLiveTranscriptSegments(sessionId);
+  const { segments, transcriptIdByWordId } = useLiveTranscriptData(sessionId);
   const labelContext = useMemo(
     () => (store ? defaultRenderLabelContext(store) : undefined),
     [store],
@@ -109,6 +112,7 @@ function LiveTranscriptFooterContent({
           previewText={previewText}
           scrollRef={scrollRef}
           segments={segments}
+          transcriptIdByWordId={transcriptIdByWordId}
           labelContext={labelContext}
           speakerLabelManager={speakerLabelManager}
         />
@@ -123,6 +127,7 @@ function LiveTranscriptContent({
   previewText,
   scrollRef,
   segments,
+  transcriptIdByWordId,
   labelContext,
   speakerLabelManager,
 }: {
@@ -131,6 +136,7 @@ function LiveTranscriptContent({
   previewText: string | null;
   scrollRef: React.RefObject<HTMLDivElement | null>;
   segments: Segment[];
+  transcriptIdByWordId: Map<string, string>;
   labelContext: ReturnType<typeof defaultRenderLabelContext> | undefined;
   speakerLabelManager: SpeakerLabelManager;
 }) {
@@ -178,6 +184,7 @@ function LiveTranscriptContent({
           <TranscriptSegmentRow
             key={getSegmentIdentity(segment, index)}
             segment={segment}
+            transcriptId={getSegmentTranscriptId(segment, transcriptIdByWordId)}
             label={SegmentKeyUtils.renderLabel(
               segment.key,
               labelContext,
@@ -227,7 +234,10 @@ function CollapsedFooterMessage({ message }: { message: string }) {
   );
 }
 
-function useLiveTranscriptSegments(sessionId: string): Segment[] {
+function useLiveTranscriptData(sessionId: string): {
+  segments: Segment[];
+  transcriptIdByWordId: Map<string, string>;
+} {
   const store = main.UI.useStore(main.STORE_ID);
   const transcriptIds =
     main.UI.useSliceRowIds(
@@ -277,8 +287,24 @@ function useLiveTranscriptSegments(sessionId: string): Segment[] {
   });
 
   return useMemo(() => {
-    return mergeRenderedAndLiveSegments(renderedSegments, liveSegments);
-  }, [liveSegments, renderedSegments]);
+    const segments = mergeRenderedAndLiveSegments(
+      renderedSegments,
+      liveSegments,
+    );
+    const transcriptIdByWordId = new Map<string, string>();
+
+    if (store) {
+      for (const transcriptId of transcriptIds) {
+        for (const word of parseTranscriptWords(store, transcriptId)) {
+          if (typeof word.id === "string" && word.id) {
+            transcriptIdByWordId.set(word.id, transcriptId);
+          }
+        }
+      }
+    }
+
+    return { segments, transcriptIdByWordId };
+  }, [liveSegments, renderedSegments, store, transcriptIds, transcriptsTable]);
 }
 
 function getLiveTranscriptScrollKey(segments: Segment[]): string {
@@ -339,9 +365,11 @@ function getTranscriptPreview(segments: Segment[]): string | null {
 
 function TranscriptSegmentRow({
   segment,
+  transcriptId,
   label,
 }: {
   segment: Segment;
+  transcriptId: string | undefined;
   label: string;
 }) {
   const colorVars = useSegmentColorVars(segment.key);
@@ -358,11 +386,37 @@ function TranscriptSegmentRow({
           color: "var(--segment-color)",
         }}
       >
-        <span className="min-w-0 truncate">{label}</span>
+        {transcriptId ? (
+          <SpeakerAssignPopover
+            segment={segment}
+            transcriptId={transcriptId}
+            color="var(--segment-color)"
+            label={label}
+            className="max-w-full min-w-0 truncate text-left"
+          />
+        ) : (
+          <span className="min-w-0 truncate">{label}</span>
+        )}
       </span>
       <span className="text-muted-foreground min-w-0 text-xs leading-5">
         {getSegmentText(segment)}
       </span>
     </div>
   );
+}
+
+function getSegmentTranscriptId(
+  segment: Segment,
+  transcriptIdByWordId: Map<string, string>,
+): string | undefined {
+  for (const word of segment.words) {
+    if (word.id) {
+      const transcriptId = transcriptIdByWordId.get(word.id);
+      if (transcriptId) {
+        return transcriptId;
+      }
+    }
+  }
+
+  return undefined;
 }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -17,11 +17,13 @@ export function SpeakerAssignPopover({
   transcriptId,
   color,
   label,
+  className,
 }: {
   segment: Segment;
   transcriptId: string;
   color: string;
   label: string;
+  className?: string;
 }) {
   const [open, setOpen] = useState(false);
   const store = main.UI.useStore(main.STORE_ID);
@@ -52,7 +54,11 @@ export function SpeakerAssignPopover({
   );
 
   if (isSelf) {
-    return <span style={{ color }}>{label}</span>;
+    return (
+      <span className={className} style={{ color }}>
+        {label}
+      </span>
+    );
   }
 
   return (
@@ -63,6 +69,7 @@ export function SpeakerAssignPopover({
           className={cn([
             "-ml-1 cursor-pointer rounded-xs px-1",
             "hover:bg-accent transition-colors",
+            className,
           ])}
           style={{ color }}
         >


### PR DESCRIPTION
Reuse the speaker assignment popover in the live transcript footer and persist selected names to transcript hints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes transcript speaker_hints during live capture via shared assignment logic; limited to desktop session UI but affects persisted transcript metadata.
> 
> **Overview**
> **Live session footer speaker chips are now assignable** when the segment’s words map to a stored transcript row. The live transcript hook builds a **word id → transcript id** index and passes it into each row; remote-party labels render **`SpeakerAssignPopover`** instead of plain text (direct mic stays read-only).
> 
> Choosing a participant reuses **`upsertSpeakerAssignment`**, persisting **`user_speaker_assignment`** hints on the transcript. **`SpeakerAssignPopover`** accepts an optional **`className`** so labels truncate correctly inside the sticky chip. Tests mock Tinybase/popover UI and assert assignment updates **`speaker_hints`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44593cc82ccb4212084b1efe406adb7f94e0996a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->