### PR TITLE
Remove sidebar timeline from update notes

### DIFF
--- a/packages/changelog/content/1.0.42.md
+++ b/packages/changelog/content/1.0.42.md
@@ -1,6 +1,6 @@
 ---
 date: "2026-06-09"
-summary: "AI chat, timeline navigation, settings, and dark mode surfaces are more polished and easier to use."
+summary: "AI chat, settings, and dark mode surfaces are more polished and easier to use."
 ---
 
 ## AI Chat
@@ -11,9 +11,6 @@ summary: "AI chat, timeline navigation, settings, and dark mode surfaces are mor
 
 ## Timeline
 
-- Sidebar timeline headers now stay pinned to the top of the sidebar while scrolling
-- The current-time indicator no longer appears on top of an active meeting card
-- The current-time label is no longer clipped in the sidebar timeline
 - The top timeline current-time marker is now a cleaner line-only indicator
 
 ## Settings


### PR DESCRIPTION
Drop left-sidebar timeline claims from the 1.0.42 changelog while keeping the top timeline note.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or product behavior changes.
> 
> **Overview**
> Updates the **1.0.42** changelog so it no longer calls out **left-sidebar timeline** work.
> 
> The release **summary** drops “timeline navigation,” and the **Timeline** section removes three bullets about pinned sidebar headers, current-time layering/clipping in the sidebar, and related polish. The remaining bullet still documents the **top** timeline’s cleaner line-only current-time marker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f81d66cb119550ed23ee13738b37743fde25c36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5536 
- <kbd>&nbsp;2&nbsp;</kbd> #5535 
- <kbd>&nbsp;1&nbsp;</kbd> #5533 👈 
<!-- GitButler Footer Boundary Bottom -->

