### PR TITLE
Auto collapse sidebar on meeting start

### DIFF
--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -15,6 +15,7 @@ const {
   useConfigValueMock,
   useSTTConnectionMock,
   isSupportedLanguagesLiveMock,
+  setLeftSidebarExpandedMock,
 } = vi.hoisted(() => ({
   queueAutoEnhanceIfSummaryEmptyMock: vi.fn(),
   startMock: vi.fn(),
@@ -26,6 +27,7 @@ const {
   useConfigValueMock: vi.fn(),
   useSTTConnectionMock: vi.fn(),
   isSupportedLanguagesLiveMock: vi.fn(),
+  setLeftSidebarExpandedMock: vi.fn(),
 }));
 
 vi.mock("@hypr/plugin-transcription", () => ({
@@ -60,6 +62,14 @@ vi.mock("./useSTTConnection", () => ({
 vi.mock("~/services/enhancer", () => ({
   getEnhancerService: vi.fn(() => ({
     queueAutoEnhanceIfSummaryEmpty: queueAutoEnhanceIfSummaryEmptyMock,
+  })),
+}));
+
+vi.mock("~/contexts/shell", () => ({
+  useShell: vi.fn(() => ({
+    leftsidebar: {
+      setExpanded: setLeftSidebarExpandedMock,
+    },
   })),
 }));
 
@@ -172,6 +182,28 @@ describe("useStartListening", () => {
       status: "ok",
       data: true,
     });
+  });
+
+  test("collapses the left sidebar after listening starts", async () => {
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(setLeftSidebarExpandedMock).toHaveBeenCalledWith(false);
+  });
+
+  test("keeps the left sidebar state when listening fails to start", async () => {
+    startMock.mockResolvedValue(false);
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(setLeftSidebarExpandedMock).not.toHaveBeenCalled();
   });
 
   test("runs batch transcription after record-only capture stops", async () => {

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -12,6 +12,7 @@ import {
 } from "./useRunBatch";
 import { useSTTConnection } from "./useSTTConnection";
 
+import { useShell } from "~/contexts/shell";
 import { getEnhancerService } from "~/services/enhancer";
 import { getSessionEventById } from "~/session/utils";
 import { useConfigValue } from "~/shared/config";
@@ -56,6 +57,8 @@ export function useStartListening(sessionId: string) {
   const start = useListener((state) => state.start);
   const { conn } = useSTTConnection();
   const runBatch = useRunBatch(sessionId);
+  const { leftsidebar } = useShell();
+  const setLeftSidebarExpanded = leftsidebar.setExpanded;
 
   const keywords = useKeywords(sessionId);
   const runBatchRef = useRef(runBatch);
@@ -180,6 +183,8 @@ export function useStartListening(sessionId: string) {
       return;
     }
 
+    setLeftSidebarExpanded(false);
+
     void analyticsCommands.event({
       event: "session_started",
       has_calendar_event: !!getSessionEventById(store, sessionId),
@@ -200,6 +205,7 @@ export function useStartListening(sessionId: string) {
     keywords,
     user_id,
     spokenLanguages,
+    setLeftSidebarExpanded,
   ]);
 
   return startListening;


### PR DESCRIPTION
Collapse the left sidebar after listener startup succeeds and cover success/failure behavior in hook tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI shell tweak gated on successful STT start; no auth, data, or transcription logic changes.
> 
> **Overview**
> When a meeting/listening session **starts successfully**, the left sidebar is **collapsed automatically** via `useShell`’s `leftsidebar.setExpanded(false)` in `useStartListening`.
> 
> If listener startup **fails** (`start` returns false), the sidebar is **left unchanged**—collapse runs only after a successful start, alongside the existing analytics event.
> 
> Hook tests mock the shell context and assert collapse on success and no call on failed start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dd68b6570e8553046fb82224453318c912daf2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->