### PR TITLE
Move sidebar actions into chrome row

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -4,6 +4,8 @@ import {
   ArrowLeftIcon,
   PanelLeftCloseIcon,
   PanelLeftOpenIcon,
+  SearchIcon,
+  SquarePenIcon,
 } from "lucide-react";
 import { type MouseEvent, type PointerEvent, useCallback, useRef } from "react";
 
@@ -21,6 +23,8 @@ import { useClassicMainTabsShortcuts } from "./useTabsShortcuts";
 
 import { useShell } from "~/contexts/shell";
 import { GlobalLiveTranscriptAccessory } from "~/session/components/bottom-accessory/global-live";
+import { useOpenNoteDialog } from "~/shared/open-note-dialog";
+import { useNewNote } from "~/shared/useNewNote";
 import {
   hasCustomSidebarTab,
   hasLeftSurfaceCustomSidebarTab,
@@ -61,6 +65,11 @@ export function ClassicMainBody() {
   });
   const mainAreaTopDrag = useMainAreaTopWindowDrag(enableMainAreaTopDrag);
   const update = useDesktopUpdateControl();
+  const createNewNote = useNewNote();
+  const openNoteDialog = useOpenNoteDialog();
+  const handleOpenNoteDialog = useCallback(() => {
+    openNoteDialog.open();
+  }, [openNoteDialog]);
 
   return (
     <div className="relative flex h-full min-w-0 flex-1 flex-col">
@@ -75,10 +84,12 @@ export function ClassicMainBody() {
         >
           <div
             data-tauri-drag-region
-            className="flex h-full min-w-0 items-start pt-[9px] pr-3 pl-[76px]"
+            className="flex h-full min-w-0 items-start pt-[9px] pr-1 pl-[76px]"
           >
             <SidebarTimelineChrome
               sidebarExpanded={leftsidebar.expanded}
+              onNewNote={createNewNote}
+              onSearch={handleOpenNoteDialog}
               onToggleSidebar={leftsidebar.toggleExpanded}
               update={update}
             />
@@ -274,15 +285,20 @@ function isMainAreaWindowDrag(
 }
 
 function SidebarTimelineChrome({
+  onNewNote,
+  onSearch,
   onToggleSidebar,
   sidebarExpanded,
   update,
 }: {
+  onNewNote: () => void;
+  onSearch: () => void;
   onToggleSidebar: () => void;
   sidebarExpanded: boolean;
   update: DesktopUpdateControl;
 }) {
   const updateVisible = Boolean(update.status && update.version);
+  const showDownloadButton = sidebarExpanded && update.status === "available";
 
   return (
     <div className="flex w-full items-center justify-between">
@@ -298,8 +314,20 @@ function SidebarTimelineChrome({
             <PanelLeftOpenIcon size={16} />
           )}
         </LeftSurfaceChromeButton>
+        {sidebarExpanded ? (
+          <>
+            <LeftSurfaceChromeButton ariaLabel="Search" onClick={onSearch}>
+              <SearchIcon size={15} />
+            </LeftSurfaceChromeButton>
+            <LeftSurfaceChromeButton ariaLabel="New note" onClick={onNewNote}>
+              <SquarePenIcon size={15} />
+            </LeftSurfaceChromeButton>
+          </>
+        ) : null}
       </div>
-      {sidebarExpanded ? <SidebarTimelineUpdateButton update={update} /> : null}
+      {showDownloadButton ? (
+        <SidebarTimelineUpdateButton update={update} />
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/main/update-banner.test.tsx
+++ b/apps/desktop/src/main/update-banner.test.tsx
@@ -160,9 +160,15 @@ describe("SidebarTimelineUpdateButton", () => {
 
     renderSidebarUpdateButton();
 
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Download update" }),
+    const button = await screen.findByRole("button", {
+      name: "Download update",
+    });
+
+    expect(button.className.split(" ")).toEqual(
+      expect.arrayContaining(["h-7", "w-7", "min-h-7", "min-w-7", "p-0"]),
     );
+
+    fireEvent.click(button);
 
     await waitFor(() => expect(downloadMock).toHaveBeenCalledWith("1.0.34"));
   });

--- a/apps/desktop/src/main/update-banner.tsx
+++ b/apps/desktop/src/main/update-banner.tsx
@@ -314,7 +314,7 @@ export function SidebarTimelineUpdateButton({
       data-tauri-drag-region="false"
       disabled={isDownloading || update.downloadStarting || update.installing}
       className={cn([
-        "relative flex size-7 shrink-0 items-center justify-center rounded-full",
+        "relative flex h-7 min-h-7 w-7 min-w-7 shrink-0 items-center justify-center rounded-full p-0",
         "bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm transition-colors",
         "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden",
         "disabled:bg-primary disabled:text-primary-foreground disabled:hover:bg-primary disabled:cursor-default disabled:opacity-70",

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -8,7 +8,9 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  createNewNote: vi.fn(),
   openNew: vi.fn(),
+  openSearch: vi.fn(),
   goBack: vi.fn(),
   goNext: vi.fn(),
   runEscapeShortcut: vi.fn(),
@@ -105,6 +107,16 @@ vi.mock("~/session/components/bottom-accessory/global-live", () => ({
   ),
 }));
 
+vi.mock("~/shared/open-note-dialog", () => ({
+  useOpenNoteDialog: () => ({
+    open: mocks.openSearch,
+  }),
+}));
+
+vi.mock("~/shared/useNewNote", () => ({
+  useNewNote: () => mocks.createNewNote,
+}));
+
 vi.mock("~/sidebar/toast", () => ({
   ToastArea: () => <div data-testid="toast-area" />,
 }));
@@ -128,7 +140,9 @@ import { ClassicMainBody } from "~/main/body";
 
 describe("ClassicMainBody", () => {
   beforeEach(() => {
+    mocks.createNewNote.mockClear();
     mocks.openNew.mockClear();
+    mocks.openSearch.mockClear();
     mocks.goBack.mockClear();
     mocks.goNext.mockClear();
     mocks.runEscapeShortcut.mockClear();
@@ -162,20 +176,41 @@ describe("ClassicMainBody", () => {
     render(<ClassicMainBody />);
 
     const sidebarToggle = screen.getByRole("button", { name: "Hide sidebar" });
+    const searchButton = screen.getByRole("button", { name: "Search" });
+    const newNoteButton = screen.getByRole("button", { name: "New note" });
     const chrome = sidebarToggle.parentElement?.parentElement;
+    const chromeFrame = chrome?.parentElement;
     const topArea = chrome?.parentElement?.parentElement;
+
+    fireEvent.click(searchButton);
+    fireEvent.click(newNoteButton);
 
     expect(screen.getByTestId("main-sidebar")).toBeTruthy();
     expect(screen.getByTestId("main-tab-content").textContent).toContain(
       "empty",
     );
     expect(screen.queryByTestId("timeline-update-banner")).toBeNull();
-    expect(sidebarToggle.parentElement?.className).toContain("gap-0");
+    expect(sidebarToggle.parentElement?.className.split(" ")).toContain(
+      "gap-0",
+    );
+    expect(sidebarToggle.parentElement?.className.split(" ")).not.toContain(
+      "gap-0.5",
+    );
     expect(chrome?.className).toContain("justify-between");
     expect(chrome?.className).toContain("w-full");
+    expect(chromeFrame?.className).toContain("pr-1");
+    expect(chromeFrame?.className).not.toContain("pr-3");
     expect(topArea?.className).toContain("h-12");
     expect(topArea?.className).toContain("absolute");
     expect(topArea?.className).toContain("left-0");
+    expect(sidebarToggle.compareDocumentPosition(searchButton)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(searchButton.compareDocumentPosition(newNoteButton)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(mocks.openSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.createNewNote).toHaveBeenCalledTimes(1);
   });
 
   it("does not reserve top shell chrome for onboarding", () => {
@@ -235,15 +270,27 @@ describe("ClassicMainBody", () => {
 
     const sidebarToggle = screen.getByRole("button", { name: "Hide sidebar" });
     const chrome = sidebarToggle.parentElement?.parentElement;
+    const chromeFrame = chrome?.parentElement;
 
     expect(screen.getByTestId("sidebar-update-button")).toBeTruthy();
     expect(chrome?.className).toContain("justify-between");
+    expect(chromeFrame?.className).toContain("pr-1");
+    expect(chromeFrame?.className).not.toContain("pr-3");
     expect(chrome?.lastElementChild?.getAttribute("data-testid")).toBe(
       "sidebar-update-button",
     );
     expect(
       within(sidebarToggle).queryByTestId("collapsed-sidebar-update-badge"),
     ).toBeNull();
+  });
+
+  it("only shows downloadable updates in the far-right sidebar chrome slot", () => {
+    mocks.sidebarUpdateControl.status = "ready";
+    mocks.sidebarUpdateControl.version = "1.0.34";
+
+    render(<ClassicMainBody />);
+
+    expect(screen.queryByTestId("sidebar-update-button")).toBeNull();
   });
 
   it("shows an update badge on the collapsed sidebar toggle", () => {
@@ -280,7 +327,12 @@ describe("ClassicMainBody", () => {
 
     expect(screen.queryByTestId("timeline-update-banner")).toBeNull();
     expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
-    expect(sidebarToggle.parentElement?.className).toContain("gap-0");
+    expect(sidebarToggle.parentElement?.className.split(" ")).toContain(
+      "gap-0",
+    );
+    expect(sidebarToggle.parentElement?.className.split(" ")).not.toContain(
+      "gap-0.5",
+    );
     expect(topArea?.className).toContain("h-12");
     expect(topArea?.className).toContain("absolute");
     expect(screen.getByTestId("main-tab-content").textContent).toContain(

--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -8,8 +8,6 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  newNote: vi.fn(),
-  openSearch: vi.fn(),
   openNew: vi.fn(),
   registerAnchor: vi.fn(),
   invalidateResource: vi.fn(),
@@ -36,16 +34,6 @@ vi.mock("~/shared/config", () => ({
 
 vi.mock("~/shared/hooks/useNativeContextMenu", () => ({
   useNativeContextMenu: () => vi.fn(),
-}));
-
-vi.mock("~/shared/useNewNote", () => ({
-  useNewNote: () => mocks.newNote,
-}));
-
-vi.mock("~/shared/open-note-dialog", () => ({
-  useOpenNoteDialog: () => ({
-    open: mocks.openSearch,
-  }),
 }));
 
 vi.mock("~/store/tinybase/hooks", () => ({
@@ -183,44 +171,15 @@ describe("TimelineView", () => {
     vi.useRealTimers();
   });
 
-  it("shows expanding sidebar action tabs for creating, searching, and opening calendar", () => {
+  it("does not render sidebar action tabs inside the timeline chrome", () => {
     render(<TimelineView topChromeInset />);
 
-    const newNoteButton = screen.getByRole("button", { name: "New note" });
-    const searchButton = screen.getByRole("button", { name: "Search" });
-    const calendarButton = screen.getByRole("button", {
-      name: "Open calendar",
-    });
-    const actionTabs = getSidebarActionTabs();
-
-    expect(actionTabs.className).not.toContain("bg-muted/80");
-    expect(actionTabs.className).not.toContain("rounded-full");
-    expect(newNoteButton.className).toContain("flex-1");
-    expect(newNoteButton.className).toContain("justify-center");
-    expect(newNoteButton.className).toContain("rounded-full");
-    expect(searchButton.className).toContain("w-8");
-    expect(calendarButton.className).toContain("w-8");
-
-    fireEvent.mouseEnter(searchButton);
-
-    expect(newNoteButton.className).toContain("w-8");
-    expect(searchButton.className).toContain("flex-1");
-    expect(searchButton.className).toContain("justify-center");
-
-    fireEvent.mouseLeave(actionTabs);
-
-    expect(newNoteButton.className).toContain("flex-1");
-
-    fireEvent.click(screen.getByRole("button", { name: "New note" }));
-    fireEvent.click(screen.getByRole("button", { name: "Search" }));
-    fireEvent.click(calendarButton);
-
-    expect(mocks.newNote).toHaveBeenCalledTimes(1);
-    expect(mocks.openSearch).toHaveBeenCalledTimes(1);
-    expect(mocks.openNew).toHaveBeenCalledWith({ type: "calendar" });
+    expect(screen.queryByRole("button", { name: "New note" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Search" })).toBeNull();
+    expect(getSidebarActionTabsOrNull()).toBeNull();
   });
 
-  it("keeps calendar in the sidebar action tabs without extra top spacing", () => {
+  it("shows the open calendar chip in top chrome without action tabs", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
     mocks.currentTimeMs = Date.now();
@@ -233,16 +192,19 @@ describe("TimelineView", () => {
     };
 
     const { container } = render(<TimelineView topChromeInset />);
+    const calendarButton = screen.getByRole("button", {
+      name: "Open calendar",
+    });
 
-    expect(getSidebarActions().className).not.toContain("opacity-0");
-    expect(
-      getSidebarActions().contains(
-        screen.getByRole("button", { name: "Open calendar" }),
-      ),
-    ).toBe(true);
+    expect(getSidebarActionTabsOrNull()).toBeNull();
+    expect(calendarButton.className).toContain("rounded-full");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).toContain("h-[5.25rem]");
+    ).toContain("h-20");
+
+    fireEvent.click(calendarButton);
+
+    expect(mocks.openNew).toHaveBeenCalledWith({ type: "calendar" });
   });
 
   it("shows a due calendar sync status in sidebar chrome", () => {
@@ -262,9 +224,10 @@ describe("TimelineView", () => {
     expect(screen.getByRole("status").textContent).toBe(
       "Starting calendar sync",
     );
+    expect(screen.getByRole("status").className).toContain("rounded-full");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).toContain("h-28");
+    ).toContain("h-20");
   });
 
   it("updates scheduled calendar sync status as the due window passes", () => {
@@ -319,7 +282,36 @@ describe("TimelineView", () => {
     expect(screen.getByRole("status").textContent).toBe("Syncing calendar");
   });
 
-  it("keeps calendar sync status visible while action tabs hide on scroll", () => {
+  it("hides calendar sync status while visible events are listed", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.smartCurrentTimeMs = Date.now();
+    mocks.runningTaskRunIds = ["calendar-sync-run"];
+    mocks.taskRunInfo = {
+      "calendar-sync-run": {
+        taskId: "calendarSync",
+        running: true,
+        nextTimestamp: Date.now() + 1000,
+      },
+    };
+    mocks.timelineEventsTable = {
+      standup: {
+        title: "Team standup",
+        started_at: "2024-01-15T12:30:00.000Z",
+        ended_at: "2024-01-15T13:00:00.000Z",
+        tracking_id_event: "event-standup",
+        has_recurrence_rules: false,
+      },
+    };
+
+    render(<TimelineView topChromeInset />);
+
+    expect(screen.getByTestId("timeline-item-standup")).toBeTruthy();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("keeps calendar sync status visible while scrolled", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
     mocks.runningTaskRunIds = ["calendar-sync-run"];
@@ -348,11 +340,10 @@ describe("TimelineView", () => {
     fireEvent.scroll(scroller!);
 
     expect(screen.getByRole("status").textContent).toBe("Syncing calendar");
-    expect(getSidebarActions().className).not.toContain("opacity-0");
-    expect(getSidebarActionTabs().className).toContain("opacity-0");
+    expect(getSidebarActionTabsOrNull()).toBeNull();
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).toContain("h-28");
+    ).toContain("h-20");
   });
 
   it("hides future repeated calendar sync schedules from sidebar chrome", () => {
@@ -386,14 +377,13 @@ describe("TimelineView", () => {
 
     const { container } = render(<TimelineView topChromeInset />);
 
-    expect(getSidebarActions().className).not.toContain("opacity-0");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).toContain("h-[5.25rem]");
+    ).toContain("h-12");
     expect(
       container.querySelector("[data-sidebar-timeline-bucket-header]")
         ?.className,
-    ).toContain("top-[5.25rem]");
+    ).toContain("top-12");
   });
 
   it("pins bucket headers to the sidebar chrome while scrolled", () => {
@@ -419,7 +409,7 @@ describe("TimelineView", () => {
     );
 
     expect(scroller).toBeInstanceOf(HTMLDivElement);
-    expect(header?.className).toContain("top-[5.25rem]");
+    expect(header?.className).toContain("top-12");
 
     Object.defineProperty(scroller, "clientHeight", {
       configurable: true,
@@ -463,21 +453,12 @@ describe("TimelineView", () => {
     expect(mocks.openNew).toHaveBeenCalledWith({ type: "calendar" });
   });
 
-  it("hides sidebar actions briefly after scrolling down", () => {
-    vi.useFakeTimers();
-
+  it("keeps top chrome compact while scrolled without timeline action tabs", () => {
     const { container } = render(<TimelineView topChromeInset />);
     const scroller = container.querySelector("[data-sidebar-timeline-scroll]");
-    const newNoteButton = screen.getByRole("button", { name: "New note" });
-    const searchButton = screen.getByRole("button", { name: "Search" });
 
     expect(scroller).toBeInstanceOf(HTMLDivElement);
-    expect(getSidebarActions().className).not.toContain("opacity-0");
-
-    fireEvent.mouseEnter(searchButton);
-
-    expect(newNoteButton.className).toContain("w-8");
-    expect(searchButton.className).toContain("flex-1");
+    expect(getSidebarActionTabsOrNull()).toBeNull();
 
     Object.defineProperty(scroller, "clientHeight", {
       configurable: true,
@@ -490,62 +471,9 @@ describe("TimelineView", () => {
     scroller!.scrollTop = 120;
     fireEvent.scroll(scroller!);
 
-    expect(getSidebarActions().className).toContain("opacity-0");
-    expect(getTopFade(container).className).toContain("h-20");
+    expect(getSidebarActionTabsOrNull()).toBeNull();
+    expect(getTopFade(container).className).toContain("h-16");
     expect(getTopFade(container).className).toContain("from-60%");
-
-    act(() => {
-      vi.advanceTimersByTime(900);
-    });
-
-    const revealedNewNoteButton = screen.getByRole("button", {
-      name: "New note",
-    });
-    const revealedSearchButton = screen.getByRole("button", { name: "Search" });
-
-    expect(getSidebarActions().className).not.toContain("opacity-0");
-    expect(revealedNewNoteButton.className).toContain("flex-1");
-    expect(revealedSearchButton.className).toContain("w-8");
-    expect(getTopFade(container).className).toContain("h-28");
-    expect(getTopFade(container).className).toContain("from-75%");
-  });
-
-  it("keeps sidebar actions hidden during timeline data refreshes", () => {
-    vi.useFakeTimers();
-
-    const { container, rerender } = render(<TimelineView topChromeInset />);
-    const scroller = container.querySelector("[data-sidebar-timeline-scroll]");
-
-    expect(scroller).toBeInstanceOf(HTMLDivElement);
-
-    Object.defineProperty(scroller, "clientHeight", {
-      configurable: true,
-      value: 200,
-    });
-    Object.defineProperty(scroller, "scrollHeight", {
-      configurable: true,
-      value: 1200,
-    });
-    scroller!.scrollTop = 120;
-    fireEvent.scroll(scroller!);
-
-    expect(getSidebarActions().className).toContain("opacity-0");
-
-    mocks.timelineSessionsTable = {
-      "session-1": {
-        title: "Planning",
-        created_at: "2024-01-15T12:00:00.000Z",
-      },
-    };
-    rerender(<TimelineView topChromeInset />);
-
-    expect(getSidebarActions().className).toContain("opacity-0");
-
-    act(() => {
-      vi.advanceTimersByTime(900);
-    });
-
-    expect(getSidebarActions().className).not.toContain("opacity-0");
   });
 
   it("places the fallback now indicator between future and past buckets", () => {
@@ -708,26 +636,6 @@ describe("TimelineView", () => {
     expect(isBefore(indicator, yesterdayHeading)).toBe(true);
   });
 });
-
-function getSidebarActions() {
-  const actions = screen
-    .getByRole("button", { name: "New note" })
-    .closest("[data-sidebar-timeline-actions]");
-
-  expect(actions).toBeInstanceOf(HTMLDivElement);
-
-  return actions as HTMLDivElement;
-}
-
-function getSidebarActionTabs() {
-  const actions = screen
-    .getByRole("button", { name: "New note" })
-    .closest("[data-sidebar-timeline-action-tabs]");
-
-  expect(actions).toBeInstanceOf(HTMLDivElement);
-
-  return actions as HTMLDivElement;
-}
 
 function getSidebarActionTabsOrNull() {
   return document.querySelector("[data-sidebar-timeline-action-tabs]");

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -2,8 +2,6 @@ import {
   ArrowDownIcon,
   ArrowUpIcon,
   CalendarDaysIcon,
-  SearchIcon,
-  SquarePenIcon,
   SunIcon,
 } from "lucide-react";
 import {
@@ -49,8 +47,6 @@ import {
 import { CALENDAR_SYNC_TASK_ID } from "~/services/calendar";
 import { useConfigValue } from "~/shared/config";
 import { useNativeContextMenu } from "~/shared/hooks/useNativeContextMenu";
-import { useOpenNoteDialog } from "~/shared/open-note-dialog";
-import { useNewNote } from "~/shared/useNewNote";
 import { useIgnoredEvents } from "~/store/tinybase/hooks";
 import {
   captureSessionData,
@@ -63,10 +59,8 @@ import { useTimelineSelection } from "~/store/zustand/timeline-selection";
 import { useUndoDelete } from "~/store/zustand/undo-delete";
 import { useListener } from "~/stt/contexts";
 
-const SIDEBAR_ACTIONS_REVEAL_DELAY_MS = 900;
 const DUE_CALENDAR_SYNC_VISIBLE_WINDOW_MS = 1000;
 const CALENDAR_SYNC_STATUS_TICK_MS = 500;
-type SidebarTimelineActionId = "new-note" | "search" | "calendar";
 type SidebarCalendarSyncStatus = "idle" | "scheduled" | "syncing";
 
 export function TimelineView({
@@ -86,12 +80,9 @@ export function TimelineView({
   const [showIgnored, setShowIgnored] = useState(false);
   const [isScrolledToTop, setIsScrolledToTop] = useState(true);
   const [isScrolledToBottom, setIsScrolledToBottom] = useState(true);
-  const [areSidebarActionsHidden, setAreSidebarActionsHidden] = useState(false);
 
   const { isIgnored } = useIgnoredEvents();
   const openNew = useTabs((state) => state.openNew);
-  const createNewNote = useNewNote();
-  const openNoteDialog = useOpenNoteDialog();
 
   const buckets = useMemo(() => {
     if (showIgnored) {
@@ -134,28 +125,19 @@ export function TimelineView({
       }),
     [visibleTimelineEventsTable, timelineSessionsTable, timezone],
   );
+  const hasVisibleCalendarEvents = useMemo(
+    () =>
+      buckets.some((bucket) =>
+        bucket.items.some((item) => item.type === "event"),
+      ),
+    [buckets],
+  );
   const calendarSyncStatus = useCalendarSyncStatus();
   const showCalendarSyncStatus =
-    topChromeInset && calendarSyncStatus !== "idle";
+    calendarSyncStatus !== "idle" && !hasVisibleCalendarEvents;
 
   const showOpenCalendarChip =
-    !topChromeInset &&
-    showOpenCalendarButton &&
-    isScrolledToTop &&
-    hasMoreFutureItems;
-
-  const topSpacerClassName = topChromeInset
-    ? showCalendarSyncStatus
-      ? "h-28"
-      : "h-[5.25rem]"
-    : "h-10";
-  const bucketHeaderTopClassName = topChromeInset
-    ? showCalendarSyncStatus
-      ? "top-28"
-      : isScrolledToTop
-        ? "top-[5.25rem]"
-        : "top-12"
-    : "top-0";
+    showOpenCalendarButton && isScrolledToTop && hasMoreFutureItems;
 
   const hasToday = useMemo(
     () => buckets.some((bucket) => bucket.label === "Today"),
@@ -210,16 +192,27 @@ export function TimelineView({
     registerAnchor: setCurrentTimeIndicatorRef,
     anchorNode: todayAnchorNode,
   } = useAnchor();
+  const showTopNowChip = !isTodayVisible && isScrolledPastToday;
+  const topChromeChipCount = [
+    showOpenCalendarChip,
+    topChromeInset && showCalendarSyncStatus,
+    topChromeInset && showTopNowChip,
+  ].filter(Boolean).length;
+  const topSpacerClassName = topChromeInset
+    ? topChromeChipCount > 1
+      ? "h-28"
+      : topChromeChipCount === 1
+        ? "h-20"
+        : "h-12"
+    : "h-10";
+  const bucketHeaderTopClassName = topChromeInset
+    ? topChromeChipCount > 1
+      ? "top-28"
+      : topChromeChipCount === 1
+        ? "top-20"
+        : "top-12"
+    : "top-0";
   const selectedSessionScrollFrameRef = useRef<number | null>(null);
-  const previousScrollTopRef = useRef(0);
-  const areSidebarActionsHiddenRef = useRef(false);
-  const sidebarActionsRevealTimerRef = useRef<ReturnType<
-    typeof setTimeout
-  > | null>(null);
-  const setSidebarActionsHidden = useCallback((hidden: boolean) => {
-    areSidebarActionsHiddenRef.current = hidden;
-    setAreSidebarActionsHidden(hidden);
-  }, []);
   const scrollSelectedSessionIntoView = useCallback<
     RefCallback<HTMLDivElement>
   >(
@@ -247,21 +240,6 @@ export function TimelineView({
       return;
     }
 
-    const clearSidebarActionsRevealTimer = () => {
-      if (sidebarActionsRevealTimerRef.current !== null) {
-        clearTimeout(sidebarActionsRevealTimerRef.current);
-        sidebarActionsRevealTimerRef.current = null;
-      }
-    };
-
-    const revealSidebarActionsSoon = () => {
-      clearSidebarActionsRevealTimer();
-      sidebarActionsRevealTimerRef.current = setTimeout(() => {
-        setSidebarActionsHidden(false);
-        sidebarActionsRevealTimerRef.current = null;
-      }, SIDEBAR_ACTIONS_REVEAL_DELAY_MS);
-    };
-
     const updateScrollPosition = () => {
       const maxScrollTop = Math.max(
         0,
@@ -269,48 +247,20 @@ export function TimelineView({
       );
       const nextScrollTop = container.scrollTop;
       const scrolledToTop = nextScrollTop <= 12;
-      const scrollDelta = nextScrollTop - previousScrollTopRef.current;
 
       setIsScrolledToTop(scrolledToTop);
       setIsScrolledToBottom(maxScrollTop - nextScrollTop <= 12);
-
-      if (topChromeInset && scrollDelta > 2 && !scrolledToTop) {
-        setSidebarActionsHidden(true);
-        revealSidebarActionsSoon();
-      } else if (topChromeInset && (scrolledToTop || scrollDelta < -2)) {
-        clearSidebarActionsRevealTimer();
-        setSidebarActionsHidden(false);
-      }
-
-      previousScrollTopRef.current = nextScrollTop;
-
-      return { scrolledToTop };
     };
 
-    const { scrolledToTop } = updateScrollPosition();
-    if (
-      topChromeInset &&
-      !scrolledToTop &&
-      areSidebarActionsHiddenRef.current &&
-      sidebarActionsRevealTimerRef.current === null
-    ) {
-      revealSidebarActionsSoon();
-    }
+    updateScrollPosition();
     container.addEventListener("scroll", updateScrollPosition, {
       passive: true,
     });
 
     return () => {
-      clearSidebarActionsRevealTimer();
       container.removeEventListener("scroll", updateScrollPosition);
     };
-  }, [
-    containerRef,
-    buckets.length,
-    flatItemKeys.length,
-    topChromeInset,
-    setSidebarActionsHidden,
-  ]);
+  }, [containerRef, buckets.length, flatItemKeys.length]);
 
   const scrollFadeMask = useMemo(() => {
     const topFadeEnd = isScrolledToTop ? "0px" : "28px";
@@ -345,10 +295,6 @@ export function TimelineView({
   const handleOpenCalendar = useCallback(() => {
     openNew({ type: "calendar" });
   }, [openNew]);
-
-  const handleOpenNoteDialog = useCallback(() => {
-    openNoteDialog.open();
-  }, [openNoteDialog]);
 
   const handleDeleteSelected = useCallback(() => {
     if (!store || !indexes) {
@@ -537,58 +483,37 @@ export function TimelineView({
           data-sidebar-timeline-top-fade
           className={cn([
             "pointer-events-none absolute inset-x-0 top-0 z-[15]",
-            showCalendarSyncStatus
+            topChromeChipCount > 1
               ? "bg-background h-28"
-              : areSidebarActionsHidden
-                ? "from-background via-background/95 to-background/0 h-20 bg-linear-to-b from-60% via-80%"
-                : isScrolledToTop
-                  ? "bg-background h-[5.25rem]"
-                  : "from-background via-background/95 to-background/0 h-28 bg-linear-to-b from-75% via-85%",
+              : topChromeChipCount === 1
+                ? "bg-background h-20"
+                : "from-background via-background/95 to-background/0 h-16 bg-linear-to-b from-60% via-85%",
           ])}
         />
       )}
 
-      {topChromeInset && (
-        <SidebarTimelineActions
-          key={areSidebarActionsHidden ? "hidden" : "visible"}
-          hidden={areSidebarActionsHidden}
-          onNewNote={createNewNote}
-          onOpenCalendar={handleOpenCalendar}
-          onSearch={handleOpenNoteDialog}
-          showCalendarAction={showOpenCalendarButton}
-          calendarSyncStatus={calendarSyncStatus}
-        />
-      )}
-
-      {(showOpenCalendarChip || (!isTodayVisible && isScrolledPastToday)) && (
+      {(showOpenCalendarChip ||
+        (topChromeInset && showCalendarSyncStatus) ||
+        showTopNowChip) && (
         <div
           className={cn([
             "absolute left-1/2 z-20 flex -translate-x-1/2 transform flex-col items-center gap-2",
-            topChromeInset
-              ? areSidebarActionsHidden
-                ? "top-10"
-                : "top-24"
-              : "top-2",
+            topChromeInset ? "top-12" : "top-2",
           ])}
         >
           {showOpenCalendarChip && (
-            <Button
+            <TimelineTopChip
+              ariaLabel="Open calendar"
+              icon={<CalendarDaysIcon size={12} />}
               onClick={handleOpenCalendar}
-              size="sm"
-              className={cn([
-                "bg-card hover:bg-accent rounded-full",
-                "border-border text-muted-foreground border",
-                "flex items-center gap-1",
-                "px-3",
-                "shadow-xs",
-              ])}
-              variant="outline"
             >
-              <CalendarDaysIcon size={12} />
-              <span className="text-xs">Open calendar</span>
-            </Button>
+              Open calendar
+            </TimelineTopChip>
           )}
-          {!isTodayVisible && isScrolledPastToday && (
+          {topChromeInset && showCalendarSyncStatus && (
+            <SidebarCalendarSyncStatus status={calendarSyncStatus} />
+          )}
+          {showTopNowChip && (
             <TimelineNowChip direction="up" onClick={scrollToToday} />
           )}
         </div>
@@ -608,106 +533,6 @@ export function TimelineView({
   );
 }
 
-function SidebarTimelineActions({
-  hidden,
-  onNewNote,
-  onOpenCalendar,
-  onSearch,
-  showCalendarAction,
-  calendarSyncStatus,
-}: {
-  hidden: boolean;
-  onNewNote: () => void;
-  onOpenCalendar: () => void;
-  onSearch: () => void;
-  showCalendarAction: boolean;
-  calendarSyncStatus: SidebarCalendarSyncStatus;
-}) {
-  const [expandedActionId, setExpandedActionId] =
-    useState<SidebarTimelineActionId | null>(null);
-  const activeActionId = expandedActionId ?? "new-note";
-  const showCalendarSyncStatus = calendarSyncStatus !== "idle";
-  const hideActionContainer = hidden && !showCalendarSyncStatus;
-  const actionItems = useMemo(
-    () => [
-      {
-        ariaLabel: "New note",
-        icon: <SquarePenIcon size={15} />,
-        id: "new-note" as const,
-        label: "New note",
-        onClick: onNewNote,
-      },
-      {
-        ariaLabel: "Search",
-        icon: <SearchIcon size={15} />,
-        id: "search" as const,
-        label: "Search",
-        onClick: onSearch,
-      },
-      ...(showCalendarAction
-        ? [
-            {
-              ariaLabel: "Open calendar",
-              icon: <CalendarDaysIcon size={15} />,
-              id: "calendar" as const,
-              label: "Calendar",
-              onClick: onOpenCalendar,
-            },
-          ]
-        : []),
-    ],
-    [onNewNote, onOpenCalendar, onSearch, showCalendarAction],
-  );
-
-  return (
-    <div
-      data-sidebar-timeline-actions
-      className={cn([
-        "absolute inset-x-0 top-10 z-30 pt-1 pb-2",
-        "bg-background/95 backdrop-blur",
-        "transition-[opacity,transform] duration-150 ease-out",
-        hideActionContainer
-          ? "pointer-events-none -translate-y-2 opacity-0"
-          : "translate-y-0 opacity-100",
-      ])}
-    >
-      <div
-        data-sidebar-timeline-action-tabs
-        role="toolbar"
-        aria-label="Sidebar actions"
-        className={cn([
-          "flex w-full items-center gap-1",
-          "transition-[opacity,transform] duration-150 ease-out",
-          hidden
-            ? "pointer-events-none -translate-y-2 opacity-0"
-            : "translate-y-0 opacity-100",
-        ])}
-        onMouseLeave={() => setExpandedActionId(null)}
-        onBlur={(event) => {
-          const nextFocusedNode = event.relatedTarget as Node | null;
-          if (!event.currentTarget.contains(nextFocusedNode)) {
-            setExpandedActionId(null);
-          }
-        }}
-      >
-        {actionItems.map((action) => (
-          <SidebarTimelineActionButton
-            key={action.id}
-            active={activeActionId === action.id}
-            ariaLabel={action.ariaLabel}
-            icon={action.icon}
-            id={action.id}
-            label={action.label}
-            onClick={action.onClick}
-            onExpand={setExpandedActionId}
-          />
-        ))}
-      </div>
-      <SidebarCalendarSyncStatus status={calendarSyncStatus} />
-    </div>
-  );
-}
-
 function SidebarCalendarSyncStatus({
   status,
 }: {
@@ -721,81 +546,71 @@ function SidebarCalendarSyncStatus({
     status === "scheduled" ? "Starting calendar sync" : "Syncing calendar";
 
   return (
-    <div
+    <TimelineTopChip
       role="status"
       aria-live="polite"
       data-sidebar-calendar-sync-status
-      className={cn([
-        "mt-1.5 flex h-5 items-center gap-1.5 px-3",
-        "text-muted-foreground text-[11px] leading-none font-medium",
-      ])}
-    >
-      <span className="text-muted-foreground flex size-3 shrink-0 items-center justify-center">
-        {status === "syncing" ? (
+      icon={
+        status === "syncing" ? (
           <Spinner size={12} />
         ) : (
           <CalendarDaysIcon size={12} />
-        )}
-      </span>
-      <span className="truncate">{label}</span>
-    </div>
+        )
+      }
+    >
+      {label}
+    </TimelineTopChip>
   );
 }
 
-function SidebarTimelineActionButton({
-  active,
+function TimelineTopChip({
   ariaLabel,
+  children,
   icon,
-  id,
-  label,
   onClick,
-  onExpand,
+  ...props
 }: {
-  active: boolean;
-  ariaLabel: string;
+  ariaLabel?: string;
+  children: ReactNode;
   icon: ReactNode;
-  id: SidebarTimelineActionId;
-  label: string;
-  onClick: () => void;
-  onExpand: (id: SidebarTimelineActionId) => void;
+  className?: string;
+  role?: string;
+  "aria-live"?: "off" | "polite" | "assertive";
+  "data-sidebar-calendar-sync-status"?: true;
+  onClick?: () => void;
 }) {
-  return (
-    <button
-      type="button"
-      aria-label={ariaLabel}
-      data-sidebar-timeline-action={id}
-      className={cn([
-        "flex h-8 min-w-8 items-center overflow-hidden rounded-full",
-        "border border-transparent",
-        "text-muted-foreground text-sm font-medium",
-        "transition-[width,flex-grow,background-color,border-color,color] duration-150 ease-out",
-        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
-        active
-          ? "border-border bg-card text-foreground flex-1 justify-center px-3 shadow-xs"
-          : "hover:bg-card/80 hover:text-foreground w-8 flex-none justify-center px-2",
-      ])}
-      onClick={onClick}
-      onFocus={() => onExpand(id)}
-      onMouseEnter={() => onExpand(id)}
-    >
-      <span
-        className={cn([
-          "flex size-4 shrink-0 items-center justify-center",
-          active ? "text-foreground" : "text-muted-foreground",
-        ])}
+  const className = cn([
+    "border-border bg-card/95 text-muted-foreground flex h-6 items-center gap-1 rounded-full border px-2.5 text-xs font-medium shadow-xs backdrop-blur",
+    onClick && "hover:bg-accent hover:text-foreground transition-colors",
+    "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
+    props.className,
+  ]);
+
+  if (onClick) {
+    return (
+      <Button
+        {...props}
+        aria-label={ariaLabel}
+        className={className}
+        onClick={onClick}
+        size="sm"
+        variant="outline"
       >
+        <span className="flex size-3 shrink-0 items-center justify-center">
+          {icon}
+        </span>
+        <span className="truncate">{children}</span>
+      </Button>
+    );
+  }
+
+  return (
+    <div {...props} aria-label={ariaLabel} className={className}>
+      <span className="flex size-3 shrink-0 items-center justify-center">
         {icon}
       </span>
-      <span
-        aria-hidden
-        className={cn([
-          "truncate whitespace-nowrap transition-[margin,max-width,opacity] duration-150 ease-out",
-          active ? "ml-2 max-w-28 opacity-100" : "ml-0 max-w-0 opacity-0",
-        ])}
-      >
-        {label}
-      </span>
-    </button>
+      <span className="truncate">{children}</span>
+    </div>
   );
 }
 

--- a/packages/changelog/content/1.0.43.md
+++ b/packages/changelog/content/1.0.43.md
@@ -1,0 +1,24 @@
+---
+date: "2026-06-11"
+summary: "The meeting timeline is simpler, live meeting controls are easier to reach, and transcripts are clearer during and after meetings."
+---
+
+## Meetings
+
+- The sidebar timeline is now the single place for meeting timeline navigation, replacing the old top timeline mode
+- Search, new note, calendar, and calendar sync controls now sit together in the main chrome for quicker access
+- The sidebar now collapses automatically after a meeting starts so the active note has more room
+- The floating meeting bar now has a clearer hover handle and stays easier to reveal while listening
+
+## Transcripts
+
+- Speaker labels can now be assigned directly from the live transcript footer during a meeting
+- Speaker colors now have stronger contrast in dark mode
+- The live transcript footer no longer sits on a filled panel background
+- Saved audio controls now stay hidden until the transcript panel is expanded
+
+## Notes
+
+- Note titles now align with the left header gutter for a cleaner reading position
+- Upload audio and transcript actions are hidden once a note already has content
+- The note formatting toolbar now stays above floating chat surfaces


### PR DESCRIPTION
Add search and new-note icon buttons beside the sidebar toggle, restore the open calendar chip, and render calendar sync state as a matching chip.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5536 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #5535 
- <kbd>&nbsp;1&nbsp;</kbd> #5533 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop shell and sidebar UI only; behavior is covered by updated component tests with no auth or data-layer changes.
> 
> **Overview**
> **Search** and **New note** move from the sidebar timeline into the expanded **sidebar timeline chrome** (`SidebarTimelineChrome` in `body.tsx`), next to the sidebar toggle, wired to `useOpenNoteDialog` and `useNewNote`.
> 
> The timeline drops the expanding **New note / Search / Calendar** action toolbar and scroll-hide behavior. **Open calendar**, **calendar sync**, and **jump to now** stay as centered **rounded chips** (`TimelineTopChip`), with spacer/header heights driven by how many chips are visible. Calendar sync chips are suppressed when calendar events are already on the list.
> 
> The sidebar **update** control only occupies the far-right chrome slot when an update is **available to download** (not when it is already **ready** to restart). The download button gets fixed **7×7** sizing. Tests and **1.0.43** changelog copy reflect the new layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3dac8c6e76c060ed0c85ab4a406799ca62c0039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->