### PR TITLE
Hide floating bar from screen sharing

### DIFF
--- a/plugins/windows/swift-lib/src/FloatingBarManager.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarManager.swift
@@ -78,6 +78,7 @@ final class FloatingBarManager {
     panel.isOpaque = false
     panel.backgroundColor = .clear
     panel.hasShadow = false
+    panel.sharingType = .none
     panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
     panel.isMovableByWindowBackground = true
     panel.delegate = placement


### PR DESCRIPTION
Mark the native floating meeting panel as non-shareable so it is excluded from macOS capture surfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single macOS window property on the floating bar UI; no auth, data, or meeting pipeline changes.
> 
> **Overview**
> Sets **`panel.sharingType = .none`** on the native floating meeting **`NSPanel`** in `FloatingBarManager.createPanel()`, so macOS treats the bar as non-shareable and omits it from screen capture and sharing surfaces (e.g. Zoom/Meet window pickers, Screen Sharing).
> 
> No other floating-bar behavior (positioning, visibility, SwiftUI content) is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d527d9f49605695bc88106c811d72009a7f6aba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->