### PR TITLE
Fix session dark chrome

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/global-live.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/global-live.test.tsx
@@ -256,6 +256,19 @@ describe("GlobalLiveTranscriptAccessory", () => {
     expect(transcriptCard?.className).not.toContain("rounded-b-xl");
   });
 
+  it("uses dark-aware chrome for the global live handle", () => {
+    render(
+      <GlobalLiveTranscriptAccessory currentTab={{ type: "settings" } as any}>
+        <div data-testid="tab-content" />
+      </GlobalLiveTranscriptAccessory>,
+    );
+
+    const toggle = screen.getByRole("button", { name: "Expand Live" });
+
+    expect(toggle.className).toContain("bg-card");
+    expect(toggle.className).toContain("dark:bg-app-floating-chrome");
+  });
+
   it("keeps the current surface divider in top chrome mode", () => {
     render(
       <GlobalLiveTranscriptAccessory

--- a/apps/desktop/src/session/components/bottom-accessory/global-live.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/global-live.tsx
@@ -17,6 +17,7 @@ import { type Tab } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
 
 const GLOBAL_LIVE_AFTER_BORDER_EXPANDED_SIZE = 22;
+const LIVE_TRANSCRIPT_HANDLE_CLASS = "bg-card dark:bg-app-floating-chrome";
 
 export function GlobalLiveTranscriptAccessory({
   children,
@@ -92,8 +93,8 @@ function GlobalLiveTranscriptAccessoryContent({
         }))
       }
       label="Live"
-      collapsedClassName="bg-muted"
-      expandedClassName="bg-muted"
+      collapsedClassName={LIVE_TRANSCRIPT_HANDLE_CLASS}
+      expandedClassName={LIVE_TRANSCRIPT_HANDLE_CLASS}
     />
   ) : null;
 

--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -104,6 +104,11 @@ describe("useSessionBottomAccessory", () => {
   });
 
   it("collapses the post-session transcript panel on escape", () => {
+    type TranscriptToggleProps = {
+      collapsedClassName?: string;
+      onToggle: () => void;
+    };
+
     const { result } = renderHook(() =>
       useSessionBottomAccessory({
         sessionId: "session-1",
@@ -120,10 +125,14 @@ describe("useSessionBottomAccessory", () => {
     expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
 
     const toggle = result.current.bottomBorderHandle;
-    expect(isValidElement<{ onToggle: () => void }>(toggle)).toBe(true);
-    if (!isValidElement<{ onToggle: () => void }>(toggle)) {
+    expect(isValidElement<TranscriptToggleProps>(toggle)).toBe(true);
+    if (!isValidElement<TranscriptToggleProps>(toggle)) {
       return;
     }
+
+    expect(toggle.props.collapsedClassName).toBe(
+      "bg-card dark:bg-app-floating-chrome",
+    );
 
     act(() => {
       toggle.props.onToggle();
@@ -394,7 +403,15 @@ describe("useSessionBottomAccessory", () => {
     expect(result.current.bottomAccessory).not.toBeNull();
   });
 
-  it("keeps the expanded live handle on neutral 50", () => {
+  it("uses dark-aware chrome for the live handle", () => {
+    type LiveToggleProps = {
+      collapsedClassName?: string;
+      expandedClassName?: string;
+      isExpanded: boolean;
+      label?: string;
+      onToggle: () => void;
+    };
+
     const { result } = renderHook(() =>
       useSessionBottomAccessory({
         sessionId: "session-1",
@@ -405,26 +422,18 @@ describe("useSessionBottomAccessory", () => {
     );
 
     const toggle = result.current.bottomBorderHandle;
-    expect(
-      isValidElement<{
-        expandedClassName?: string;
-        isExpanded: boolean;
-        label?: string;
-        onToggle: () => void;
-      }>(toggle),
-    ).toBe(true);
-    if (
-      !isValidElement<{
-        expandedClassName?: string;
-        label?: string;
-        onToggle: () => void;
-      }>(toggle)
-    ) {
+    expect(isValidElement<LiveToggleProps>(toggle)).toBe(true);
+    if (!isValidElement<LiveToggleProps>(toggle)) {
       return;
     }
 
     expect(toggle.props.label).toBe("Live");
-    expect(toggle.props.expandedClassName).toBe("bg-muted");
+    expect(toggle.props.collapsedClassName).toBe(
+      "bg-card dark:bg-app-floating-chrome",
+    );
+    expect(toggle.props.expandedClassName).toBe(
+      "bg-card dark:bg-app-floating-chrome",
+    );
 
     act(() => {
       toggle.props.onToggle();

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -21,6 +21,8 @@ import { useShell } from "~/contexts/shell";
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
 import { useListener } from "~/stt/contexts";
 
+const BOTTOM_ACCESSORY_HANDLE_CLASS = "bg-card dark:bg-app-floating-chrome";
+
 export type BottomAccessoryState = {
   mode: "live" | "playback" | "transcript_only";
   expanded: boolean;
@@ -152,8 +154,8 @@ export function useSessionBottomAccessory({
           isExpanded={effectiveExpanded}
           onToggle={() => setIsExpanded((v) => !v)}
           label="Live"
-          collapsedClassName="bg-muted"
-          expandedClassName="bg-muted"
+          collapsedClassName={BOTTOM_ACCESSORY_HANDLE_CLASS}
+          expandedClassName={BOTTOM_ACCESSORY_HANDLE_CLASS}
         />
       ) : null,
       bottomAccessoryState,
@@ -187,7 +189,7 @@ export function useSessionBottomAccessory({
           onToggle={() => setIsExpanded((v) => !v)}
           label="Transcript"
           showExpandedCloseIcon
-          collapsedClassName="bg-muted"
+          collapsedClassName={BOTTOM_ACCESSORY_HANDLE_CLASS}
         />
       ),
       bottomAccessoryState,

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -216,6 +216,25 @@ describe("PostSessionAccessory", () => {
     });
   });
 
+  it("uses dark-aware colors for the delete recording action", () => {
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio
+        hasTranscript
+        isTranscriptExpanded
+      />,
+    );
+
+    const deleteButton = screen.getByRole("button", {
+      name: "Delete recording",
+    });
+
+    expect(deleteButton.className).toContain("dark:text-red-400");
+    expect(deleteButton.className).toContain("dark:hover:bg-red-950/50");
+    expect(deleteButton.className).toContain("dark:hover:text-red-300");
+  });
+
   it("shows Regenerate button without upload or reserved height in empty panel", async () => {
     useTranscriptScreenMock.mockReturnValue({
       kind: "ready",

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -634,9 +634,9 @@ function TranscriptReadyPanel({
             disabled={isDeletingRecording}
             className={cn([
               "flex items-center gap-1 rounded-full px-1.5 py-0.5",
-              "text-[11px] font-medium text-red-600",
-              "transition-colors hover:bg-red-50 hover:text-red-700",
-              "disabled:cursor-not-allowed disabled:text-red-300",
+              "text-[11px] font-medium text-red-600 dark:text-red-400",
+              "transition-colors hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-950/50 dark:hover:text-red-300",
+              "disabled:cursor-not-allowed disabled:text-red-300 dark:disabled:text-red-500/60",
             ])}
           >
             {isDeletingRecording ? (

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -435,6 +435,7 @@ function HeaderTabEnhanced({
         isError
           ? [
               "hover:text-foreground focus-visible:text-foreground text-red-600 hover:bg-red-50 focus-visible:bg-red-50",
+              "dark:text-red-400 dark:hover:bg-red-950/50 dark:focus-visible:bg-red-950/50",
             ]
           : ["hover:bg-accent focus-visible:bg-muted"],
       ])}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment.tsx
@@ -73,7 +73,7 @@ export const SegmentRenderer = memo(
                 data-line-current={isCurrentLine ? "true" : undefined}
                 className={cn([
                   "-mx-0.5 rounded-xs px-0.5",
-                  isCurrentLine && "bg-yellow-100/50",
+                  isCurrentLine && "bg-yellow-100/50 dark:bg-yellow-900/30",
                 ])}
               >
                 {line.words.map((word, idx) => (

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -136,6 +136,8 @@ describe("OuterHeader", () => {
     expect(stopButton.className).toContain("h-7");
     expect(stopButton.className).toContain("w-20");
     expect(stopButton.className).toContain("rounded-full");
+    expect(stopButton.className).toContain("dark:bg-red-950/50");
+    expect(stopButton.className).toContain("dark:text-red-300");
     expect(stopButton.textContent).toContain("Stop");
     expect(mocks.stopListening).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -199,13 +199,14 @@ function SidebarModeStopButton({ sessionId }: { sessionId: string }) {
   const accent = degraded ? "amber" : "red";
   const colors = {
     red: {
-      button: "text-red-500 hover:text-red-600 bg-red-50 hover:bg-red-100",
+      button:
+        "bg-red-50 text-red-500 hover:bg-red-100 hover:text-red-600 dark:bg-red-950/50 dark:text-red-300 dark:hover:bg-red-950 dark:hover:text-red-200",
       sticks: "#ef4444",
       stop: "bg-red-500",
     },
     amber: {
       button:
-        "text-amber-500 hover:text-amber-600 bg-amber-50 hover:bg-amber-100",
+        "bg-amber-50 text-amber-500 hover:bg-amber-100 hover:text-amber-600 dark:bg-amber-950/50 dark:text-amber-300 dark:hover:bg-amber-950 dark:hover:text-amber-200",
       sticks: "#f59e0b",
       stop: "bg-amber-500",
     },

--- a/apps/desktop/src/session/components/outer-header/metadata/date.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/date.tsx
@@ -138,7 +138,7 @@ function EditableDateForm({
                 type="button"
                 variant="ghost"
                 size="icon"
-                className="text-muted-foreground size-7 shrink-0 rounded-md hover:bg-red-50 hover:text-red-600"
+                className="text-muted-foreground size-7 shrink-0 rounded-md hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/50 dark:hover:text-red-300"
                 onClick={onCancel}
                 aria-label="Cancel date edit"
               >
@@ -152,7 +152,7 @@ function EditableDateForm({
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="text-muted-foreground size-7 shrink-0 rounded-md hover:bg-green-50 hover:text-green-600"
+                  className="text-muted-foreground size-7 shrink-0 rounded-md hover:bg-green-50 hover:text-green-600 dark:hover:bg-green-950/50 dark:hover:text-green-300"
                   onClick={() => void form.handleSubmit()}
                   disabled={!canSubmit}
                   aria-label="Save date"

--- a/apps/desktop/src/session/components/shared.tsx
+++ b/apps/desktop/src/session/components/shared.tsx
@@ -114,7 +114,7 @@ export function ActionableTooltipContent({
         <Button
           size="sm"
           variant="outline"
-          className="rounded-md text-black"
+          className="text-foreground rounded-md"
           onClick={action.handleClick}
         >
           {action.label}

--- a/apps/desktop/src/shared/floating-action-surface.test.ts
+++ b/apps/desktop/src/shared/floating-action-surface.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { floatingActionSurfaceClassName } from "./floating-action-surface";
+
+describe("floatingActionSurfaceClassName", () => {
+  it("uses an inverted surface against light and dark app chrome", () => {
+    expect(floatingActionSurfaceClassName).toContain("bg-foreground");
+    expect(floatingActionSurfaceClassName).toContain("text-background");
+    expect(floatingActionSurfaceClassName).toContain("dark:bg-white/92");
+    expect(floatingActionSurfaceClassName).toContain("dark:text-primary");
+  });
+});

--- a/apps/desktop/src/shared/floating-action-surface.ts
+++ b/apps/desktop/src/shared/floating-action-surface.ts
@@ -1,2 +1,2 @@
 export const floatingActionSurfaceClassName =
-  "border-primary/80 bg-primary text-primary-foreground hover:bg-primary shadow-[inset_0_0_0_1px_rgba(255,255,255,0.22),0_10px_28px_rgba(0,0,0,0.28)] dark:border-black/15 dark:bg-white/92 dark:text-primary dark:hover:bg-white/92 dark:shadow-[inset_0_0_0_1px_rgba(0,0,0,0.18),0_16px_40px_rgba(0,0,0,0.52),0_0_0_1px_rgba(255,255,255,0.14)]";
+  "border-white/20 bg-foreground text-background hover:bg-foreground shadow-[inset_0_0_0_1px_rgba(255,255,255,0.22),0_10px_28px_rgba(0,0,0,0.28)] dark:border-black/15 dark:bg-white/92 dark:text-primary dark:hover:bg-white/92 dark:shadow-[inset_0_0_0_1px_rgba(0,0,0,0.18),0_16px_40px_rgba(0,0,0,0.52),0_0_0_1px_rgba(255,255,255,0.14)]";


### PR DESCRIPTION
Use dark-aware chrome and state colors across session bottom accessories, recording controls, transcript highlights, and related action buttons.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only Tailwind class changes with no logic or data-path changes; risk is limited to theme regressions in light/dark UI.
> 
> **Overview**
> Improves **dark mode** across session UI by replacing light-only surfaces and state colors with theme-aware Tailwind classes.
> 
> **Bottom accessories:** Live and Transcript expand handles move from `bg-muted` to `bg-card dark:bg-app-floating-chrome` in both per-session and global live panels.
> 
> **Recording / destructive actions:** Delete recording, note regenerate error affordance, and collapsed-sidebar **Stop listening** (red/amber) gain `dark:` text and hover backgrounds. Date metadata cancel/save icons get matching dark red/green hovers.
> 
> **Transcript playback:** Current-line highlight adds `dark:bg-yellow-900/30`.
> 
> **Shared chrome:** Floating action surface uses inverted `bg-foreground` / `text-background` in light mode (dark mode styling largely unchanged). Tooltip outline buttons use `text-foreground` instead of hard-coded black.
> 
> Tests assert the new class names on handles, delete, stop, and floating action surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5f5e41a095e5e6af99fd2f15af3489ef68d95a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->