### PR TITLE
Make settings markdown links visible

### DIFF
--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -340,6 +340,24 @@ const streamdownComponents = {
   p: (props: React.HTMLAttributes<HTMLParagraphElement>) => {
     return <p className="mb-1">{props.children as React.ReactNode}</p>;
   },
+  a: ({
+    children,
+    className,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
+    return (
+      <a
+        {...props}
+        className={cn([
+          "text-foreground font-medium underline underline-offset-2",
+          "decoration-foreground/50 hover:decoration-foreground",
+          className,
+        ])}
+      >
+        {children as React.ReactNode}
+      </a>
+    );
+  },
 } as const;
 
 export function StyledStreamdown({


### PR DESCRIPTION
Style Streamdown anchor tags with foreground contrast and clearer underline treatment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change to markdown link styling in settings; no auth, data, or routing behavior.
> 
> **Overview**
> Adds a custom **`a`** renderer to **`StyledStreamdown`**’s `streamdownComponents` so markdown links in AI provider setup copy (LLM/STT configure) and related settings use **foreground** text, **medium** weight, and a clearer **underline** (including stronger decoration on hover).
> 
> Callers of **`StyledStreamdown`** are unchanged; only how Streamdown renders `[label](url)` anchors is updated for visibility on muted backgrounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c56874f496b410cf1e7cfb81b19cb118170a5a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->