### PR TITLE
Render app links as inline chips

### DIFF
--- a/apps/desktop/src/editor-bridge/app-link-view.tsx
+++ b/apps/desktop/src/editor-bridge/app-link-view.tsx
@@ -2,6 +2,7 @@ import {
   type NodeViewComponentProps,
   useEditorEventCallback,
 } from "@handlewithcare/react-prosemirror";
+import { Figma, Github, Google, Notion } from "@lobehub/icons";
 import { useQuery } from "@tanstack/react-query";
 import { CheckIcon } from "lucide-react";
 import { forwardRef } from "react";
@@ -21,13 +22,33 @@ import { collectSiblingResources, openTaskTab } from "~/task/open-task-tab";
 
 function SlackIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="none">
+    <svg className={className} viewBox="0 0 127 127" fill="none">
       <path
-        d="M6 15a2 2 0 0 1-2 2 2 2 0 0 1-2-2 2 2 0 0 1 2-2h2v2ZM7 15a2 2 0 0 1 2-2 2 2 0 0 1 2 2v5a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-5ZM9 6a2 2 0 0 1-2-2 2 2 0 0 1 2-2 2 2 0 0 1 2 2v2H9ZM9 7a2 2 0 0 1 2 2 2 2 0 0 1-2 2H4a2 2 0 0 1-2-2 2 2 0 0 1 2-2h5ZM18 9a2 2 0 0 1 2-2 2 2 0 0 1 2 2 2 2 0 0 1-2 2h-2V9ZM17 9a2 2 0 0 1-2 2 2 2 0 0 1-2-2V4a2 2 0 0 1 2-2 2 2 0 0 1 2 2v5ZM15 18a2 2 0 0 1 2 2 2 2 0 0 1-2 2 2 2 0 0 1-2-2v-2h2ZM15 17a2 2 0 0 1-2-2 2 2 0 0 1 2-2h5a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-5Z"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
+        d="M27.2 80c0 7.3-5.9 13.2-13.2 13.2C6.7 93.2.8 87.3.8 80c0-7.3 5.9-13.2 13.2-13.2h13.2V80zm6.6 0c0-7.3 5.9-13.2 13.2-13.2 7.3 0 13.2 5.9 13.2 13.2v33c0 7.3-5.9 13.2-13.2 13.2-7.3 0-13.2-5.9-13.2-13.2V80z"
+        fill="#E01E5A"
+      />
+      <path
+        d="M47 27c-7.3 0-13.2-5.9-13.2-13.2C33.8 6.5 39.7.6 47 .6c7.3 0 13.2 5.9 13.2 13.2V27H47zm0 6.7c7.3 0 13.2 5.9 13.2 13.2 0 7.3-5.9 13.2-13.2 13.2H13.9C6.6 60.1.7 54.2.7 46.9c0-7.3 5.9-13.2 13.2-13.2H47z"
+        fill="#36C5F0"
+      />
+      <path
+        d="M99.9 46.9c0-7.3 5.9-13.2 13.2-13.2 7.3 0 13.2 5.9 13.2 13.2 0 7.3-5.9 13.2-13.2 13.2H99.9V46.9zm-6.6 0c0 7.3-5.9 13.2-13.2 13.2-7.3 0-13.2-5.9-13.2-13.2V13.8C66.9 6.5 72.8.6 80.1.6c7.3 0 13.2 5.9 13.2 13.2v33.1z"
+        fill="#2EB67D"
+      />
+      <path
+        d="M80.1 99.8c7.3 0 13.2 5.9 13.2 13.2 0 7.3-5.9 13.2-13.2 13.2-7.3 0-13.2-5.9-13.2-13.2V99.8h13.2zm0-6.6c-7.3 0-13.2-5.9-13.2-13.2 0-7.3 5.9-13.2 13.2-13.2h33.1c7.3 0 13.2 5.9 13.2 13.2 0 7.3-5.9 13.2-13.2 13.2H80.1z"
+        fill="#ECB22E"
+      />
+    </svg>
+  );
+}
+
+function LinearIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 256 256" fill="none">
+      <path
+        fill="currentColor"
+        d="m8.174 102.613l145.213 145.213c2.12 2.12 1.097 5.72-1.85 6.27a128 128 0 0 1-15.02 1.896a3.78 3.78 0 0 1-2.92-1.109L1.117 122.403a3.78 3.78 0 0 1-1.109-2.92c.34-5.095.978-10.107 1.896-15.02c.55-2.947 4.15-3.97 6.27-1.85m-4.092 58.796c-.97-3.614 3.3-5.894 5.946-3.248l87.81 87.811c2.647 2.646.367 6.915-3.247 5.946c-44.03-11.805-78.704-46.478-90.51-90.509m12.727-97.245c1.233-2.135 4.147-2.463 5.89-.719L192.556 233.3c1.744 1.744 1.417 4.658-.72 5.891a128 128 0 0 1-11.1 5.705c-1.43.65-3.11.322-4.22-.79L11.893 79.487c-1.111-1.112-1.439-2.79-.79-4.221a128 128 0 0 1 5.706-11.1M127.86 0C198.63 0 256 57.37 256 128.14c0 37.57-16.168 71.362-41.926 94.8c-1.487 1.354-3.768 1.264-5.19-.157L33.217 47.116c-1.421-1.422-1.51-3.703-.158-5.19C56.498 16.168 90.291 0 127.86 0"
       />
     </svg>
   );
@@ -35,27 +56,184 @@ function SlackIcon({ className }: { className?: string }) {
 
 function DiscordIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+    <svg className={className} viewBox="0 0 24 24" fill="#5865F2">
       <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03ZM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418Zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.946 2.418-2.157 2.418Z" />
     </svg>
   );
 }
 
-function isCheckboxKind(kind: string | null | undefined): boolean {
-  return kind === "issue" || kind === "pull_request";
+function AtlassianIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none">
+      <path
+        d="M7.6 3.4c.4-.7 1.4-.7 1.8 0l6.7 11.6c.4.7-.1 1.6-.9 1.6h-3.4c-.4 0-.7-.2-.9-.5L5.9 7.5c-.2-.3-.2-.7 0-1l1.7-3.1Z"
+        fill="#2684FF"
+      />
+      <path
+        d="M16.4 3.4c-.4-.7-1.4-.7-1.8 0L7.9 15c-.4.7.1 1.6.9 1.6h3.4c.4 0 .7-.2.9-.5l5-8.6c.2-.3.2-.7 0-1l-1.7-3.1Z"
+        fill="#0052CC"
+      />
+      <path
+        d="M12 12.9 8.7 18.6c-.4.7.1 1.6.9 1.6h4.8c.8 0 1.3-.9.9-1.6L12 12.9Z"
+        fill="#172B4D"
+      />
+    </svg>
+  );
+}
+
+function AsanaIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none">
+      <circle cx="12" cy="7" r="3.2" fill="#FF7361" />
+      <circle cx="7.5" cy="15.5" r="3.2" fill="#F06A6A" />
+      <circle cx="16.5" cy="15.5" r="3.2" fill="#E65AA0" />
+    </svg>
+  );
+}
+
+function TrelloIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none">
+      <rect width="20" height="20" x="2" y="2" rx="4" fill="#0079BF" />
+      <rect width="5" height="12" x="6" y="6" rx="1.5" fill="white" />
+      <rect width="5" height="8" x="13" y="6" rx="1.5" fill="white" />
+    </svg>
+  );
+}
+
+function AirtableIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none">
+      <path d="M12 3 3.5 6.8 12 10.6l8.5-3.8L12 3Z" fill="#FCB400" />
+      <path d="M4 9.2 10.8 12v7L4 15.9V9.2Z" fill="#18BFFF" />
+      <path d="M20 9.2 13.2 12v7l6.8-3.1V9.2Z" fill="#F82B60" />
+    </svg>
+  );
+}
+
+function MiroIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none">
+      <rect width="20" height="20" x="2" y="2" rx="4" fill="#FFD02F" />
+      <path
+        d="M7 17V7h2.2l1.6 4.1L12.8 7H15v10h-2.1v-5.4l-1.4 3.2h-1.4l-1.1-3.1V17H7Z"
+        fill="#050038"
+      />
+    </svg>
+  );
+}
+
+function LoomIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none">
+      <circle cx="12" cy="12" r="3.2" fill="#625DF5" />
+      <circle cx="12" cy="5" r="2.2" fill="#625DF5" />
+      <circle cx="12" cy="19" r="2.2" fill="#625DF5" />
+      <circle cx="5" cy="12" r="2.2" fill="#625DF5" />
+      <circle cx="19" cy="12" r="2.2" fill="#625DF5" />
+      <circle cx="7.1" cy="7.1" r="2" fill="#625DF5" />
+      <circle cx="16.9" cy="16.9" r="2" fill="#625DF5" />
+      <circle cx="16.9" cy="7.1" r="2" fill="#625DF5" />
+      <circle cx="7.1" cy="16.9" r="2" fill="#625DF5" />
+    </svg>
+  );
+}
+
+function DropboxIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none">
+      <path d="m7 3 5 3.2L7 9.4 2 6.2 7 3Z" fill="#0061FF" />
+      <path d="m17 3 5 3.2-5 3.2-5-3.2L17 3Z" fill="#0061FF" />
+      <path d="m7 10.6 5 3.2L7 17l-5-3.2 5-3.2Z" fill="#0061FF" />
+      <path d="m17 10.6 5 3.2-5 3.2-5-3.2 5-3.2Z" fill="#0061FF" />
+      <path d="m12 15 5 3.2-5 3.2-5-3.2 5-3.2Z" fill="#0061FF" />
+    </svg>
+  );
+}
+
+function ZoomIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none">
+      <rect width="20" height="20" x="2" y="2" rx="5" fill="#0B5CFF" />
+      <path d="M6.5 8.5h7a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2h-7v-7Z" fill="white" />
+      <path d="m15.5 11 3-2v6l-3-2v-2Z" fill="white" />
+    </svg>
+  );
+}
+
+function CalendlyIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none">
+      <rect width="18" height="18" x="3" y="3" rx="5" fill="#006BFF" />
+      <path
+        d="M15.8 9.1a4.8 4.8 0 1 0 .1 5.7"
+        stroke="white"
+        strokeLinecap="round"
+        strokeWidth="2.2"
+      />
+    </svg>
+  );
+}
+
+function BrandIcon({ attrs }: { attrs: AppLinkAttrs }) {
+  switch (attrs.provider) {
+    case "slack":
+      return <SlackIcon className="size-3.5 shrink-0" />;
+    case "discord":
+      return <DiscordIcon className="size-3.5 shrink-0" />;
+    case "linear":
+      return <LinearIcon className="text-muted-foreground size-3.5 shrink-0" />;
+    case "notion":
+      return (
+        <Notion className="text-muted-foreground size-3.5 shrink-0" size={14} />
+      );
+    case "google":
+      return <Google className="size-3.5 shrink-0" size={14} />;
+    case "figma":
+      return <Figma className="size-3.5 shrink-0" size={14} />;
+    case "atlassian":
+      return <AtlassianIcon className="size-3.5 shrink-0" />;
+    case "asana":
+      return <AsanaIcon className="size-3.5 shrink-0" />;
+    case "trello":
+      return <TrelloIcon className="size-3.5 shrink-0" />;
+    case "airtable":
+      return <AirtableIcon className="size-3.5 shrink-0" />;
+    case "miro":
+      return <MiroIcon className="size-3.5 shrink-0" />;
+    case "loom":
+      return <LoomIcon className="size-3.5 shrink-0" />;
+    case "dropbox":
+      return <DropboxIcon className="size-3.5 shrink-0" />;
+    case "zoom":
+      return <ZoomIcon className="size-3.5 shrink-0" />;
+    case "calendly":
+      return <CalendlyIcon className="size-3.5 shrink-0" />;
+    case "github":
+      return (
+        <Github className="text-muted-foreground size-3.5 shrink-0" size={14} />
+      );
+  }
+}
+
+function isGitHubCheckboxKind(attrs: AppLinkAttrs): attrs is GitHubAttrs {
+  return (
+    attrs.provider === "github" &&
+    (attrs.kind === "issue" || attrs.kind === "pull_request")
+  );
 }
 
 function useGitHubIssueState(attrs: AppLinkAttrs) {
-  const gh = attrs as GitHubAttrs;
-  const enabled = isCheckboxKind(gh.kind) && !!gh.number;
+  const gh = isGitHubCheckboxKind(attrs) ? attrs : null;
+  const enabled = !!gh?.number;
 
   const { data } = useQuery({
-    queryKey: ["github-issue-state", gh.owner, gh.repo, gh.number],
+    queryKey: ["github-issue-state", gh?.owner, gh?.repo, gh?.number],
     queryFn: async () => {
       const result = await todoCommands.githubIssueState(
-        gh.owner,
-        gh.repo,
-        gh.number!,
+        gh!.owner,
+        gh!.repo,
+        gh!.number!,
       );
       if (result.status === "error") {
         throw new Error(result.error);
@@ -95,7 +273,7 @@ export const AppLinkView = forwardRef<HTMLSpanElement, NodeViewComponentProps>(
     const { header, subline } = getAppLinkDisplayParts(attrs);
     const href = attrs.url;
     const ghState = useGitHubIssueState(attrs);
-    const showCheckbox = isCheckboxKind(attrs.kind);
+    const showCheckbox = isGitHubCheckboxKind(attrs);
     const checked = ghState === "Closed" || ghState === "Merged";
 
     const handleClick = useEditorEventCallback(async (view) => {
@@ -139,28 +317,20 @@ export const AppLinkView = forwardRef<HTMLSpanElement, NodeViewComponentProps>(
             void handleClick();
           }}
           className={cn([
-            "inline-flex max-w-full items-center gap-2.5 rounded-lg px-2 py-1 text-left align-middle",
+            "border-border/60 bg-muted/35 inline-flex h-6 max-w-full items-center gap-1.5 rounded-md border px-1.5 text-left align-baseline",
             "hover:bg-accent transition-colors",
           ])}
         >
           {showCheckbox ? (
             <Checkbox checked={checked} />
-          ) : attrs.provider === "slack" ? (
-            <SlackIcon className="text-muted-foreground size-4 shrink-0" />
-          ) : attrs.provider === "discord" ? (
-            <DiscordIcon className="text-muted-foreground size-4 shrink-0" />
           ) : (
-            <img
-              src="/assets/github-icon.svg"
-              alt="github"
-              className="size-4 shrink-0 opacity-70"
-            />
+            <BrandIcon attrs={attrs} />
           )}
-          <span className="min-w-0">
-            <span className="text-foreground block truncate text-sm font-medium">
+          <span className="flex min-w-0 items-baseline gap-1.5">
+            <span className="text-foreground truncate text-sm leading-none font-medium">
               {header}
             </span>
-            <span className="text-muted-foreground block truncate text-xs">
+            <span className="text-muted-foreground truncate text-xs leading-none">
               {subline}
             </span>
           </span>

--- a/packages/editor/src/app-link/atlassian.ts
+++ b/packages/editor/src/app-link/atlassian.ts
@@ -1,0 +1,116 @@
+export type AtlassianLinkKind =
+  | "confluence_page"
+  | "confluence_space"
+  | "jira_issue";
+
+export interface AtlassianAttrs {
+  provider: "atlassian";
+  kind: AtlassianLinkKind;
+  url: string;
+  workspace?: string;
+  resourceId?: string;
+  resourceTitle?: string;
+}
+
+function decodePathSegment(value: string | undefined): string {
+  if (!value) {
+    return "";
+  }
+
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function titleFromSlug(value: string | undefined): string {
+  return decodePathSegment(value)
+    .replace(/\+/g, " ")
+    .replace(/[-_]+/g, " ")
+    .trim();
+}
+
+function build(
+  url: URL,
+  attrs: Omit<AtlassianAttrs, "provider" | "url">,
+): AtlassianAttrs {
+  return { provider: "atlassian", url: url.toString(), ...attrs };
+}
+
+function workspaceFromHost(hostname: string): string | undefined {
+  return hostname.endsWith(".atlassian.net")
+    ? hostname.replace(/\.atlassian\.net$/, "")
+    : undefined;
+}
+
+export function parseAtlassianUrl(rawUrl: string): AtlassianAttrs | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  const workspace = workspaceFromHost(hostname);
+  const segments = url.pathname.split("/").filter(Boolean);
+
+  if (!workspace) {
+    return null;
+  }
+
+  if (segments[0] === "browse" && segments[1]) {
+    return build(url, {
+      kind: "jira_issue",
+      workspace,
+      resourceId: decodePathSegment(segments[1]),
+    });
+  }
+
+  if (segments[0] !== "wiki" || segments[1] !== "spaces" || !segments[2]) {
+    return null;
+  }
+
+  if (segments[3] === "pages" && segments[4]) {
+    return build(url, {
+      kind: "confluence_page",
+      workspace,
+      resourceId: decodePathSegment(segments[4]),
+      resourceTitle: titleFromSlug(segments[5]) || undefined,
+    });
+  }
+
+  return build(url, {
+    kind: "confluence_space",
+    workspace,
+    resourceId: decodePathSegment(segments[2]),
+  });
+}
+
+export function getAtlassianDisplayParts(attrs: AtlassianAttrs): {
+  header: string;
+  subline: string;
+} {
+  switch (attrs.kind) {
+    case "jira_issue":
+      return {
+        header: attrs.workspace ?? "Jira",
+        subline: attrs.resourceId ? `Jira ${attrs.resourceId}` : "Jira issue",
+      };
+    case "confluence_page":
+      return {
+        header: attrs.workspace ?? "Confluence",
+        subline: attrs.resourceTitle
+          ? `Confluence: ${attrs.resourceTitle}`
+          : "Confluence page",
+      };
+    case "confluence_space":
+      return {
+        header: attrs.workspace ?? "Confluence",
+        subline: attrs.resourceId
+          ? `Confluence space ${attrs.resourceId}`
+          : "Confluence space",
+      };
+  }
+}

--- a/packages/editor/src/app-link/figma.ts
+++ b/packages/editor/src/app-link/figma.ts
@@ -1,0 +1,112 @@
+export type FigmaLinkKind =
+  | "board"
+  | "design"
+  | "file"
+  | "prototype"
+  | "slides";
+
+export interface FigmaAttrs {
+  provider: "figma";
+  kind: FigmaLinkKind;
+  url: string;
+  resourceId?: string;
+  resourceTitle?: string;
+}
+
+const HOSTS = new Set(["figma.com", "www.figma.com"]);
+
+function decodePathSegment(value: string | undefined): string {
+  if (!value) {
+    return "";
+  }
+
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function titleFromSlug(value: string | undefined): string {
+  const decoded = decodePathSegment(value);
+  if (!decoded) {
+    return "";
+  }
+
+  return decoded.replace(/[-_]+/g, " ").trim();
+}
+
+function build(
+  url: URL,
+  attrs: Omit<FigmaAttrs, "provider" | "url">,
+): FigmaAttrs {
+  return { provider: "figma", url: url.toString(), ...attrs };
+}
+
+function normalizeKind(value: string | undefined): FigmaLinkKind | null {
+  switch (value) {
+    case "board":
+    case "design":
+    case "file":
+    case "slides":
+      return value;
+    case "proto":
+      return "prototype";
+    default:
+      return null;
+  }
+}
+
+export function parseFigmaUrl(rawUrl: string): FigmaAttrs | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  if (!HOSTS.has(url.hostname.toLowerCase())) {
+    return null;
+  }
+
+  const [kindSegment, resourceId, titleSegment] = url.pathname
+    .split("/")
+    .filter(Boolean);
+  const kind = normalizeKind(kindSegment);
+
+  if (!kind || !resourceId) {
+    return null;
+  }
+
+  return build(url, {
+    kind,
+    resourceId,
+    resourceTitle: titleFromSlug(titleSegment) || undefined,
+  });
+}
+
+function getKindLabel(kind: FigmaLinkKind): string {
+  switch (kind) {
+    case "board":
+      return "FigJam board";
+    case "design":
+    case "file":
+      return "Design file";
+    case "prototype":
+      return "Prototype";
+    case "slides":
+      return "Slides";
+  }
+}
+
+export function getFigmaDisplayParts(attrs: FigmaAttrs): {
+  header: string;
+  subline: string;
+} {
+  return {
+    header: "Figma",
+    subline: attrs.resourceTitle
+      ? `${getKindLabel(attrs.kind)}: ${attrs.resourceTitle}`
+      : getKindLabel(attrs.kind),
+  };
+}

--- a/packages/editor/src/app-link/google.ts
+++ b/packages/editor/src/app-link/google.ts
@@ -1,0 +1,117 @@
+export type GoogleLinkKind =
+  | "document"
+  | "file"
+  | "folder"
+  | "form"
+  | "presentation"
+  | "spreadsheet";
+
+export interface GoogleAttrs {
+  provider: "google";
+  kind: GoogleLinkKind;
+  url: string;
+  resourceId?: string;
+}
+
+function build(
+  url: URL,
+  attrs: Omit<GoogleAttrs, "provider" | "url">,
+): GoogleAttrs {
+  return { provider: "google", url: url.toString(), ...attrs };
+}
+
+function resourceIdAfter(segments: string[], marker: string): string | null {
+  const index = segments.indexOf(marker);
+  return index >= 0 && segments[index + 1] ? segments[index + 1] : null;
+}
+
+export function parseGoogleUrl(rawUrl: string): GoogleAttrs | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  const segments = url.pathname.split("/").filter(Boolean);
+
+  if (hostname === "docs.google.com") {
+    const [kindSegment] = segments;
+
+    switch (kindSegment) {
+      case "document": {
+        const resourceId = resourceIdAfter(segments, "d");
+        if (!resourceId) {
+          return null;
+        }
+        return build(url, { kind: "document", resourceId });
+      }
+      case "spreadsheets": {
+        const resourceId = resourceIdAfter(segments, "d");
+        if (!resourceId) {
+          return null;
+        }
+        return build(url, { kind: "spreadsheet", resourceId });
+      }
+      case "presentation": {
+        const resourceId = resourceIdAfter(segments, "d");
+        if (!resourceId) {
+          return null;
+        }
+        return build(url, { kind: "presentation", resourceId });
+      }
+      case "forms": {
+        const resourceId =
+          segments[1] === "d" && segments[2] === "e"
+            ? segments[3]
+            : resourceIdAfter(segments, "d");
+        if (!resourceId) {
+          return null;
+        }
+        return build(url, { kind: "form", resourceId });
+      }
+    }
+  }
+
+  if (hostname === "drive.google.com") {
+    const [first, second, third] = segments;
+
+    if (first === "file" && second === "d" && third) {
+      return build(url, { kind: "file", resourceId: third });
+    }
+
+    if (first === "drive" && second === "folders" && third) {
+      return build(url, { kind: "folder", resourceId: third });
+    }
+
+    if (first === "open" || first === "uc") {
+      const resourceId = url.searchParams.get("id") ?? undefined;
+      if (resourceId) {
+        return build(url, { kind: "file", resourceId });
+      }
+    }
+  }
+
+  return null;
+}
+
+export function getGoogleDisplayParts(attrs: GoogleAttrs): {
+  header: string;
+  subline: string;
+} {
+  switch (attrs.kind) {
+    case "document":
+      return { header: "Google Docs", subline: "Document" };
+    case "spreadsheet":
+      return { header: "Google Sheets", subline: "Spreadsheet" };
+    case "presentation":
+      return { header: "Google Slides", subline: "Presentation" };
+    case "form":
+      return { header: "Google Forms", subline: "Form" };
+    case "folder":
+      return { header: "Google Drive", subline: "Folder" };
+    case "file":
+      return { header: "Google Drive", subline: "File" };
+  }
+}

--- a/packages/editor/src/app-link/index.test.ts
+++ b/packages/editor/src/app-link/index.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+
+import { getAppLinkDisplayParts, getAppLinkLabel, parseAppLinkUrl } from ".";
+
+describe("app link parsing", () => {
+  it("parses Linear document URLs", () => {
+    const attrs = parseAppLinkUrl(
+      "https://linear.app/fastrepl-inc/document/real-world-use-cases-8dcac4144e38",
+    );
+
+    expect(attrs).toMatchObject({
+      provider: "linear",
+      kind: "document",
+      workspace: "fastrepl-inc",
+      resourceId: "real-world-use-cases-8dcac4144e38",
+      resourceTitle: "Real world use cases",
+    });
+    expect(getAppLinkDisplayParts(attrs!).subline).toBe(
+      "Document: Real world use cases",
+    );
+  });
+
+  it("parses Linear issue URLs", () => {
+    const attrs = parseAppLinkUrl(
+      "https://linear.app/fastrepl-inc/issue/ANLG-53/storage-model",
+    );
+
+    expect(attrs).toMatchObject({
+      provider: "linear",
+      kind: "issue",
+      workspace: "fastrepl-inc",
+      resourceId: "ANLG-53",
+      resourceTitle: "Storage model",
+    });
+    expect(getAppLinkLabel(attrs!)).toBe("fastrepl-inc Issue ANLG-53");
+  });
+
+  it("parses unknown Linear routes without labeling them as workspaces", () => {
+    const attrs = parseAppLinkUrl(
+      "https://linear.app/fastrepl-inc/inbox/assigned-to-me",
+    );
+
+    expect(attrs).toMatchObject({
+      provider: "linear",
+      kind: "route",
+      workspace: "fastrepl-inc",
+      resourceId: "inbox/assigned-to-me",
+      resourceTitle: "Inbox / Assigned to me",
+    });
+    expect(getAppLinkDisplayParts(attrs!)).toEqual({
+      header: "fastrepl-inc",
+      subline: "Route: Inbox / Assigned to me",
+    });
+  });
+
+  it("parses Notion page URLs", () => {
+    const attrs = parseAppLinkUrl(
+      "https://www.notion.so/Product-Plan-0123456789abcdef0123456789abcdef",
+    );
+
+    expect(attrs).toMatchObject({
+      provider: "notion",
+      kind: "page",
+      resourceId: "0123456789abcdef0123456789abcdef",
+      resourceTitle: "Product Plan",
+    });
+    expect(getAppLinkDisplayParts(attrs!)).toEqual({
+      header: "Notion",
+      subline: "Page: Product Plan",
+    });
+  });
+
+  it("parses Google workspace URLs", () => {
+    const attrs = parseAppLinkUrl(
+      "https://docs.google.com/spreadsheets/d/1a2b3c4d5e6f/edit",
+    );
+
+    expect(attrs).toMatchObject({
+      provider: "google",
+      kind: "spreadsheet",
+      resourceId: "1a2b3c4d5e6f",
+    });
+    expect(getAppLinkDisplayParts(attrs!)).toEqual({
+      header: "Google Sheets",
+      subline: "Spreadsheet",
+    });
+  });
+
+  it("parses Google Forms public URLs", () => {
+    const attrs = parseAppLinkUrl(
+      "https://docs.google.com/forms/d/e/1FAIpQLSc12345/viewform",
+    );
+
+    expect(attrs).toMatchObject({
+      provider: "google",
+      kind: "form",
+      resourceId: "1FAIpQLSc12345",
+    });
+  });
+
+  it("parses Figma design URLs", () => {
+    const attrs = parseAppLinkUrl(
+      "https://www.figma.com/design/abc123/Product-Roadmap?node-id=1-2",
+    );
+
+    expect(attrs).toMatchObject({
+      provider: "figma",
+      kind: "design",
+      resourceId: "abc123",
+      resourceTitle: "Product Roadmap",
+    });
+    expect(getAppLinkDisplayParts(attrs!)).toEqual({
+      header: "Figma",
+      subline: "Design file: Product Roadmap",
+    });
+  });
+
+  it("parses Jira issue URLs", () => {
+    const attrs = parseAppLinkUrl(
+      "https://fastrepl.atlassian.net/browse/ANLG-5540",
+    );
+
+    expect(attrs).toMatchObject({
+      provider: "atlassian",
+      kind: "jira_issue",
+      workspace: "fastrepl",
+      resourceId: "ANLG-5540",
+    });
+    expect(getAppLinkLabel(attrs!)).toBe("fastrepl Jira ANLG-5540");
+  });
+
+  it("parses Confluence page URLs", () => {
+    const attrs = parseAppLinkUrl(
+      "https://fastrepl.atlassian.net/wiki/spaces/ENG/pages/123456/Product+Plan",
+    );
+
+    expect(attrs).toMatchObject({
+      provider: "atlassian",
+      kind: "confluence_page",
+      workspace: "fastrepl",
+      resourceId: "123456",
+      resourceTitle: "Product Plan",
+    });
+    expect(getAppLinkDisplayParts(attrs!)).toEqual({
+      header: "fastrepl",
+      subline: "Confluence: Product Plan",
+    });
+  });
+
+  it.each([
+    [
+      "Asana task URLs",
+      "https://app.asana.com/0/1200000000000000/1200000000000001/f",
+      {
+        provider: "asana",
+        kind: "task",
+        resourceId: "1200000000000001",
+      },
+      "Asana Task 1200000000000001",
+    ],
+    [
+      "Trello card URLs",
+      "https://trello.com/c/a1b2c3d4/product-roadmap",
+      {
+        provider: "trello",
+        kind: "card",
+        resourceId: "a1b2c3d4",
+        resourceTitle: "product roadmap",
+      },
+      "Trello Card: product roadmap",
+    ],
+    [
+      "Airtable view URLs",
+      "https://airtable.com/appBase123/tblTable123/viwView123",
+      {
+        provider: "airtable",
+        kind: "view",
+        workspace: "appBase123",
+        resourceId: "viwView123",
+      },
+      "Airtable View",
+    ],
+    [
+      "Miro board URLs",
+      "https://miro.com/app/board/uXjVKwz123=/",
+      {
+        provider: "miro",
+        kind: "board",
+        resourceId: "uXjVKwz123=",
+      },
+      "Miro Board",
+    ],
+    [
+      "Loom share URLs",
+      "https://www.loom.com/share/abcdef1234567890",
+      {
+        provider: "loom",
+        kind: "video",
+        resourceId: "abcdef1234567890",
+      },
+      "Loom Video",
+    ],
+    [
+      "Dropbox file URLs",
+      "https://www.dropbox.com/scl/fi/abc123/Product-Plan.pdf?dl=0",
+      {
+        provider: "dropbox",
+        kind: "file",
+        resourceId: "abc123",
+        resourceTitle: "Product Plan",
+      },
+      "Dropbox File: Product Plan",
+    ],
+    [
+      "Zoom meeting URLs",
+      "https://fastrepl.zoom.us/j/1234567890",
+      {
+        provider: "zoom",
+        kind: "meeting",
+        resourceId: "1234567890",
+        workspace: "fastrepl",
+      },
+      "Zoom Meeting 1234567890",
+    ],
+    [
+      "Calendly event URLs",
+      "https://calendly.com/john/product-demo",
+      {
+        provider: "calendly",
+        kind: "event",
+        workspace: "john",
+        resourceId: "product-demo",
+        resourceTitle: "product demo",
+      },
+      "Calendly Event: product demo",
+    ],
+  ])("parses %s", (_, url, expectedAttrs, expectedLabel) => {
+    const attrs = parseAppLinkUrl(url);
+
+    expect(attrs).toMatchObject(expectedAttrs);
+    expect(getAppLinkLabel(attrs!)).toBe(expectedLabel);
+  });
+});

--- a/packages/editor/src/app-link/index.ts
+++ b/packages/editor/src/app-link/index.ts
@@ -1,20 +1,57 @@
 import {
+  getAtlassianDisplayParts,
+  parseAtlassianUrl,
+  type AtlassianAttrs,
+} from "./atlassian";
+import {
   getDiscordDisplayParts,
   parseDiscordUrl,
   type DiscordAttrs,
 } from "./discord";
+import { getFigmaDisplayParts, parseFigmaUrl, type FigmaAttrs } from "./figma";
 import {
   getGitHubDisplayParts,
   parseGitHubUrl,
   type GitHubAttrs,
 } from "./github";
+import {
+  getGoogleDisplayParts,
+  parseGoogleUrl,
+  type GoogleAttrs,
+} from "./google";
+import {
+  getLinearDisplayParts,
+  parseLinearUrl,
+  type LinearAttrs,
+} from "./linear";
+import {
+  getNotionDisplayParts,
+  parseNotionUrl,
+  type NotionAttrs,
+} from "./notion";
 import { getSlackDisplayParts, parseSlackUrl, type SlackAttrs } from "./slack";
+import { getWorkDisplayParts, parseWorkUrl, type WorkAttrs } from "./work";
 
 export type { GitHubAttrs, GitHubLinkKind as AppLinkKind } from "./github";
 export type { SlackAttrs } from "./slack";
 export type { DiscordAttrs } from "./discord";
+export type { LinearAttrs } from "./linear";
+export type { NotionAttrs } from "./notion";
+export type { GoogleAttrs } from "./google";
+export type { FigmaAttrs } from "./figma";
+export type { AtlassianAttrs } from "./atlassian";
+export type { WorkAttrs } from "./work";
 
-export type AppLinkAttrs = GitHubAttrs | SlackAttrs | DiscordAttrs;
+export type AppLinkAttrs =
+  | GitHubAttrs
+  | SlackAttrs
+  | DiscordAttrs
+  | LinearAttrs
+  | NotionAttrs
+  | GoogleAttrs
+  | FigmaAttrs
+  | AtlassianAttrs
+  | WorkAttrs;
 
 export function parseAppLinkUrl(rawUrl: string): AppLinkAttrs | null {
   const trimmed = rawUrl.trim();
@@ -25,7 +62,13 @@ export function parseAppLinkUrl(rawUrl: string): AppLinkAttrs | null {
   return (
     parseGitHubUrl(trimmed) ??
     parseSlackUrl(trimmed) ??
-    parseDiscordUrl(trimmed)
+    parseDiscordUrl(trimmed) ??
+    parseLinearUrl(trimmed) ??
+    parseNotionUrl(trimmed) ??
+    parseGoogleUrl(trimmed) ??
+    parseFigmaUrl(trimmed) ??
+    parseAtlassianUrl(trimmed) ??
+    parseWorkUrl(trimmed)
   );
 }
 
@@ -40,6 +83,25 @@ export function getAppLinkDisplayParts(attrs: AppLinkAttrs): {
       return getSlackDisplayParts(attrs);
     case "discord":
       return getDiscordDisplayParts(attrs);
+    case "linear":
+      return getLinearDisplayParts(attrs);
+    case "notion":
+      return getNotionDisplayParts(attrs);
+    case "google":
+      return getGoogleDisplayParts(attrs);
+    case "figma":
+      return getFigmaDisplayParts(attrs);
+    case "atlassian":
+      return getAtlassianDisplayParts(attrs);
+    case "airtable":
+    case "asana":
+    case "calendly":
+    case "dropbox":
+    case "loom":
+    case "miro":
+    case "trello":
+    case "zoom":
+      return getWorkDisplayParts(attrs);
   }
 }
 

--- a/packages/editor/src/app-link/linear.ts
+++ b/packages/editor/src/app-link/linear.ts
@@ -1,0 +1,161 @@
+export type LinearLinkKind =
+  | "document"
+  | "issue"
+  | "initiative"
+  | "project"
+  | "route"
+  | "team"
+  | "view"
+  | "workspace";
+
+export interface LinearAttrs {
+  provider: "linear";
+  kind: LinearLinkKind;
+  url: string;
+  workspace?: string;
+  resourceTitle?: string;
+  resourceId?: string;
+}
+
+const HOSTS = new Set(["linear.app", "www.linear.app"]);
+
+function decodePathSegment(value: string | undefined): string {
+  if (!value) {
+    return "";
+  }
+
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function titleFromSlug(value: string | undefined): string {
+  const decoded = decodePathSegment(value);
+  if (!decoded) {
+    return "";
+  }
+
+  const title = decoded
+    .replace(/[a-f0-9]{8,}$/i, "")
+    .replace(/[-_]+$/g, "")
+    .replace(/[-_]+/g, " ")
+    .trim();
+
+  return title ? title[0].toUpperCase() + title.slice(1) : "";
+}
+
+function build(
+  url: URL,
+  attrs: Omit<LinearAttrs, "provider" | "url">,
+): LinearAttrs {
+  return { provider: "linear", url: url.toString(), ...attrs };
+}
+
+function titleFromPathSegments(values: string[]): string {
+  return values.map(titleFromSlug).filter(Boolean).join(" / ");
+}
+
+function normalizeKnownKind(
+  value: string | undefined,
+): Exclude<LinearLinkKind, "route" | "workspace"> | null {
+  switch (value) {
+    case "document":
+    case "issue":
+    case "initiative":
+    case "project":
+    case "team":
+    case "view":
+      return value;
+    default:
+      return null;
+  }
+}
+
+export function parseLinearUrl(rawUrl: string): LinearAttrs | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  if (!HOSTS.has(url.hostname.toLowerCase())) {
+    return null;
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  const [workspaceSegment, kindSegment, resourceSegment, detailSegment] =
+    segments;
+  const workspace = decodePathSegment(workspaceSegment);
+
+  if (!workspace) {
+    return null;
+  }
+
+  if (!kindSegment) {
+    return build(url, {
+      kind: "workspace",
+      workspace,
+    });
+  }
+
+  const kind = normalizeKnownKind(kindSegment);
+  if (!kind) {
+    const routeSegments = segments.slice(1);
+
+    return build(url, {
+      kind: "route",
+      workspace,
+      resourceId: routeSegments.map(decodePathSegment).join("/") || undefined,
+      resourceTitle: titleFromPathSegments(routeSegments) || undefined,
+    });
+  }
+
+  const titleSegment = kind === "issue" ? detailSegment : resourceSegment;
+
+  return build(url, {
+    kind,
+    workspace,
+    resourceId: decodePathSegment(resourceSegment) || undefined,
+    resourceTitle: titleFromSlug(titleSegment) || undefined,
+  });
+}
+
+function getKindLabel(attrs: LinearAttrs): string {
+  switch (attrs.kind) {
+    case "document":
+      return attrs.resourceTitle
+        ? `Document: ${attrs.resourceTitle}`
+        : "Document";
+    case "issue":
+      return attrs.resourceId ? `Issue ${attrs.resourceId}` : "Issue";
+    case "initiative":
+      return attrs.resourceTitle
+        ? `Initiative: ${attrs.resourceTitle}`
+        : "Initiative";
+    case "project":
+      return attrs.resourceTitle
+        ? `Project: ${attrs.resourceTitle}`
+        : "Project";
+    case "route":
+      return attrs.resourceTitle ? `Route: ${attrs.resourceTitle}` : "Route";
+    case "team":
+      return attrs.resourceTitle ? `Team: ${attrs.resourceTitle}` : "Team";
+    case "view":
+      return attrs.resourceTitle ? `View: ${attrs.resourceTitle}` : "View";
+    case "workspace":
+      return "Workspace";
+  }
+}
+
+export function getLinearDisplayParts(attrs: LinearAttrs): {
+  header: string;
+  subline: string;
+} {
+  return {
+    header: attrs.workspace ?? "Linear",
+    subline: getKindLabel(attrs),
+  };
+}

--- a/packages/editor/src/app-link/notion.ts
+++ b/packages/editor/src/app-link/notion.ts
@@ -1,0 +1,116 @@
+export type NotionLinkKind = "database" | "page" | "workspace";
+
+export interface NotionAttrs {
+  provider: "notion";
+  kind: NotionLinkKind;
+  url: string;
+  workspace?: string;
+  resourceTitle?: string;
+  resourceId?: string;
+}
+
+const HOSTS = new Set(["notion.so", "www.notion.so", "notion.site"]);
+
+function isNotionHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return HOSTS.has(normalized) || normalized.endsWith(".notion.site");
+}
+
+function decodePathSegment(value: string | undefined): string {
+  if (!value) {
+    return "";
+  }
+
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function parseNotionResource(value: string | undefined): {
+  id?: string;
+  title?: string;
+} {
+  const decoded = decodePathSegment(value);
+  if (!decoded) {
+    return {};
+  }
+
+  const idMatch = decoded.match(/[a-f0-9]{32}$/i);
+  const id = idMatch?.[0];
+  const title = decoded
+    .replace(/[a-f0-9]{32}$/i, "")
+    .replace(/[-_]+$/g, "")
+    .replace(/[-_]+/g, " ")
+    .trim();
+
+  return {
+    id,
+    title: title || undefined,
+  };
+}
+
+function build(
+  url: URL,
+  attrs: Omit<NotionAttrs, "provider" | "url">,
+): NotionAttrs {
+  return { provider: "notion", url: url.toString(), ...attrs };
+}
+
+export function parseNotionUrl(rawUrl: string): NotionAttrs | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  if (!isNotionHost(hostname)) {
+    return null;
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  const workspace =
+    hostname.endsWith(".notion.site") && hostname !== "notion.site"
+      ? hostname.replace(/\.notion\.site$/, "")
+      : undefined;
+
+  if (segments.length === 0) {
+    return build(url, { kind: "workspace", workspace });
+  }
+
+  const databaseIndex = segments.findIndex((segment) => segment === "database");
+  const resourceSegment =
+    databaseIndex >= 0
+      ? segments[databaseIndex + 1]
+      : segments[segments.length - 1];
+  const resource = parseNotionResource(resourceSegment);
+  const kind = databaseIndex >= 0 ? "database" : "page";
+
+  return build(url, {
+    kind,
+    workspace,
+    resourceId: resource.id,
+    resourceTitle: resource.title,
+  });
+}
+
+export function getNotionDisplayParts(attrs: NotionAttrs): {
+  header: string;
+  subline: string;
+} {
+  if (attrs.kind === "workspace") {
+    return {
+      header: attrs.workspace ?? "Notion",
+      subline: "Workspace",
+    };
+  }
+
+  const label = attrs.kind === "database" ? "Database" : "Page";
+  return {
+    header: attrs.workspace ?? "Notion",
+    subline: attrs.resourceTitle ? `${label}: ${attrs.resourceTitle}` : label,
+  };
+}

--- a/packages/editor/src/app-link/work.ts
+++ b/packages/editor/src/app-link/work.ts
@@ -1,0 +1,386 @@
+export type WorkProvider =
+  | "airtable"
+  | "asana"
+  | "calendly"
+  | "dropbox"
+  | "loom"
+  | "miro"
+  | "trello"
+  | "zoom";
+
+export type WorkLinkKind =
+  | "base"
+  | "board"
+  | "card"
+  | "event"
+  | "file"
+  | "folder"
+  | "meeting"
+  | "project"
+  | "recording"
+  | "share"
+  | "table"
+  | "task"
+  | "video"
+  | "view";
+
+export interface WorkAttrs {
+  provider: WorkProvider;
+  kind: WorkLinkKind;
+  url: string;
+  workspace?: string;
+  resourceId?: string;
+  resourceTitle?: string;
+}
+
+function decodePathSegment(value: string | undefined): string {
+  if (!value) {
+    return "";
+  }
+
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function titleFromSlug(value: string | undefined): string {
+  return decodePathSegment(value)
+    .replace(/\.[a-z0-9]+$/i, "")
+    .replace(/[-_+]+/g, " ")
+    .trim();
+}
+
+function build(url: URL, attrs: Omit<WorkAttrs, "url">): WorkAttrs {
+  return { url: url.toString(), ...attrs };
+}
+
+function parseAsanaUrl(url: URL): WorkAttrs | null {
+  if (url.hostname.toLowerCase() !== "app.asana.com") {
+    return null;
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+
+  if (segments[0] === "0" && segments[1] && segments[2]) {
+    return build(url, {
+      provider: "asana",
+      kind: "task",
+      resourceId: decodePathSegment(segments[2]),
+      workspace: decodePathSegment(segments[1]),
+    });
+  }
+
+  const taskIndex = segments.indexOf("task");
+  if (taskIndex >= 0 && segments[taskIndex + 1]) {
+    return build(url, {
+      provider: "asana",
+      kind: "task",
+      resourceId: decodePathSegment(segments[taskIndex + 1]),
+    });
+  }
+
+  const projectIndex = segments.indexOf("project");
+  if (projectIndex >= 0 && segments[projectIndex + 1]) {
+    return build(url, {
+      provider: "asana",
+      kind: "project",
+      resourceId: decodePathSegment(segments[projectIndex + 1]),
+    });
+  }
+
+  return null;
+}
+
+function parseTrelloUrl(url: URL): WorkAttrs | null {
+  const hostname = url.hostname.toLowerCase();
+  if (hostname !== "trello.com" && hostname !== "www.trello.com") {
+    return null;
+  }
+
+  const [kindSegment, resourceId, titleSegment] = url.pathname
+    .split("/")
+    .filter(Boolean);
+
+  if (kindSegment === "c" && resourceId) {
+    return build(url, {
+      provider: "trello",
+      kind: "card",
+      resourceId,
+      resourceTitle: titleFromSlug(titleSegment) || undefined,
+    });
+  }
+
+  if (kindSegment === "b" && resourceId) {
+    return build(url, {
+      provider: "trello",
+      kind: "board",
+      resourceId,
+      resourceTitle: titleFromSlug(titleSegment) || undefined,
+    });
+  }
+
+  return null;
+}
+
+function parseAirtableUrl(url: URL): WorkAttrs | null {
+  const hostname = url.hostname.toLowerCase();
+  if (hostname !== "airtable.com" && hostname !== "www.airtable.com") {
+    return null;
+  }
+
+  const [first, second, third] = url.pathname.split("/").filter(Boolean);
+
+  if (!first) {
+    return null;
+  }
+
+  if (first.startsWith("shr")) {
+    return build(url, {
+      provider: "airtable",
+      kind: "share",
+      resourceId: first,
+    });
+  }
+
+  if (!first.startsWith("app")) {
+    return null;
+  }
+
+  if (third?.startsWith("viw")) {
+    return build(url, {
+      provider: "airtable",
+      kind: "view",
+      resourceId: third,
+      workspace: first,
+    });
+  }
+
+  if (second?.startsWith("tbl")) {
+    return build(url, {
+      provider: "airtable",
+      kind: "table",
+      resourceId: second,
+      workspace: first,
+    });
+  }
+
+  return build(url, {
+    provider: "airtable",
+    kind: "base",
+    resourceId: first,
+  });
+}
+
+function parseMiroUrl(url: URL): WorkAttrs | null {
+  const hostname = url.hostname.toLowerCase();
+  if (hostname !== "miro.com" && hostname !== "www.miro.com") {
+    return null;
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  const boardIndex = segments.indexOf("board");
+  const resourceId = boardIndex >= 0 ? segments[boardIndex + 1] : undefined;
+
+  if (!resourceId) {
+    return null;
+  }
+
+  return build(url, {
+    provider: "miro",
+    kind: "board",
+    resourceId: decodePathSegment(resourceId),
+  });
+}
+
+function parseLoomUrl(url: URL): WorkAttrs | null {
+  const hostname = url.hostname.toLowerCase();
+  if (hostname !== "loom.com" && hostname !== "www.loom.com") {
+    return null;
+  }
+
+  const [kindSegment, resourceId] = url.pathname.split("/").filter(Boolean);
+  if ((kindSegment === "share" || kindSegment === "embed") && resourceId) {
+    return build(url, {
+      provider: "loom",
+      kind: "video",
+      resourceId,
+    });
+  }
+
+  return null;
+}
+
+function parseDropboxUrl(url: URL): WorkAttrs | null {
+  const hostname = url.hostname.toLowerCase();
+  if (hostname !== "dropbox.com" && hostname !== "www.dropbox.com") {
+    return null;
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  const [first, second, third, fourth] = segments;
+
+  if (first === "s" && second) {
+    return build(url, {
+      provider: "dropbox",
+      kind: "file",
+      resourceId: second,
+      resourceTitle: titleFromSlug(third) || undefined,
+    });
+  }
+
+  if (first === "scl" && second === "fi" && third) {
+    return build(url, {
+      provider: "dropbox",
+      kind: "file",
+      resourceId: third,
+      resourceTitle: titleFromSlug(fourth) || undefined,
+    });
+  }
+
+  if (first === "scl" && second === "fo" && third) {
+    return build(url, {
+      provider: "dropbox",
+      kind: "folder",
+      resourceId: third,
+    });
+  }
+
+  return null;
+}
+
+function parseZoomUrl(url: URL): WorkAttrs | null {
+  const hostname = url.hostname.toLowerCase();
+  if (hostname !== "zoom.us" && !hostname.endsWith(".zoom.us")) {
+    return null;
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+
+  if (segments[0] === "j" && segments[1]) {
+    return build(url, {
+      provider: "zoom",
+      kind: "meeting",
+      resourceId: segments[1],
+      workspace: hostname.replace(/\.zoom\.us$/, ""),
+    });
+  }
+
+  if (segments[0] === "rec" && segments[1] === "share" && segments[2]) {
+    return build(url, {
+      provider: "zoom",
+      kind: "recording",
+      resourceId: segments[2],
+      workspace: hostname.replace(/\.zoom\.us$/, ""),
+    });
+  }
+
+  return null;
+}
+
+function parseCalendlyUrl(url: URL): WorkAttrs | null {
+  const hostname = url.hostname.toLowerCase();
+  if (hostname !== "calendly.com" && hostname !== "www.calendly.com") {
+    return null;
+  }
+
+  const [userSegment, eventSegment] = url.pathname.split("/").filter(Boolean);
+  const user = decodePathSegment(userSegment);
+
+  if (!user || !eventSegment) {
+    return null;
+  }
+
+  return build(url, {
+    provider: "calendly",
+    kind: "event",
+    workspace: user,
+    resourceId: decodePathSegment(eventSegment),
+    resourceTitle: titleFromSlug(eventSegment) || undefined,
+  });
+}
+
+export function parseWorkUrl(rawUrl: string): WorkAttrs | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  return (
+    parseAsanaUrl(url) ??
+    parseTrelloUrl(url) ??
+    parseAirtableUrl(url) ??
+    parseMiroUrl(url) ??
+    parseLoomUrl(url) ??
+    parseDropboxUrl(url) ??
+    parseZoomUrl(url) ??
+    parseCalendlyUrl(url)
+  );
+}
+
+function getProviderLabel(provider: WorkProvider): string {
+  switch (provider) {
+    case "airtable":
+      return "Airtable";
+    case "asana":
+      return "Asana";
+    case "calendly":
+      return "Calendly";
+    case "dropbox":
+      return "Dropbox";
+    case "loom":
+      return "Loom";
+    case "miro":
+      return "Miro";
+    case "trello":
+      return "Trello";
+    case "zoom":
+      return "Zoom";
+  }
+}
+
+function getKindLabel(attrs: WorkAttrs): string {
+  switch (attrs.kind) {
+    case "base":
+      return "Base";
+    case "board":
+      return attrs.resourceTitle ? `Board: ${attrs.resourceTitle}` : "Board";
+    case "card":
+      return attrs.resourceTitle ? `Card: ${attrs.resourceTitle}` : "Card";
+    case "event":
+      return attrs.resourceTitle ? `Event: ${attrs.resourceTitle}` : "Event";
+    case "file":
+      return attrs.resourceTitle ? `File: ${attrs.resourceTitle}` : "File";
+    case "folder":
+      return "Folder";
+    case "meeting":
+      return attrs.resourceId ? `Meeting ${attrs.resourceId}` : "Meeting";
+    case "project":
+      return attrs.resourceId ? `Project ${attrs.resourceId}` : "Project";
+    case "recording":
+      return "Recording";
+    case "share":
+      return "Shared view";
+    case "table":
+      return "Table";
+    case "task":
+      return attrs.resourceId ? `Task ${attrs.resourceId}` : "Task";
+    case "video":
+      return "Video";
+    case "view":
+      return "View";
+  }
+}
+
+export function getWorkDisplayParts(attrs: WorkAttrs): {
+  header: string;
+  subline: string;
+} {
+  return {
+    header: getProviderLabel(attrs.provider),
+    subline: getKindLabel(attrs),
+  };
+}

--- a/packages/editor/src/node-views/app-link-spec.ts
+++ b/packages/editor/src/node-views/app-link-spec.ts
@@ -22,6 +22,8 @@ export const appLinkNodeSpec: NodeSpec = {
     guildId: { default: null },
     messageId: { default: null },
     inviteCode: { default: null },
+    resourceId: { default: null },
+    resourceTitle: { default: null },
   },
   parseDOM: [
     {
@@ -45,6 +47,8 @@ export const appLinkNodeSpec: NodeSpec = {
           guildId: el.getAttribute("data-guild-id"),
           messageId: el.getAttribute("data-message-id"),
           inviteCode: el.getAttribute("data-invite-code"),
+          resourceId: el.getAttribute("data-resource-id"),
+          resourceTitle: el.getAttribute("data-resource-title"),
         };
       },
     },
@@ -82,6 +86,12 @@ export const appLinkNodeSpec: NodeSpec = {
     }
     if (node.attrs.inviteCode) {
       attrs["data-invite-code"] = String(node.attrs.inviteCode);
+    }
+    if (node.attrs.resourceId) {
+      attrs["data-resource-id"] = String(node.attrs.resourceId);
+    }
+    if (node.attrs.resourceTitle) {
+      attrs["data-resource-title"] = String(node.attrs.resourceTitle);
     }
 
     return [


### PR DESCRIPTION
Use compact brand-logo chips for app links and add Linear and Notion URL parsing with coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive parsing and presentation changes with defaults on new node attrs; GitHub task-tab and issue-state behavior is preserved behind stricter typing.
> 
> **Overview**
> **App links** in the desktop editor now render as **compact inline chips** (bordered, `h-6`, header/subline on one baseline) with a centralized **`BrandIcon`** path: provider-specific SVGs plus `@lobehub/icons` for GitHub, Google, Figma, and Notion. GitHub issue/PR chips still use the live checkbox; detection is tightened via **`isGitHubCheckboxKind`** instead of a loose `kind` check.
> 
> The **`@hypr/editor` app-link layer** expands beyond GitHub/Slack/Discord: new parsers and display helpers for **Linear**, **Notion**, **Google Workspace**, **Figma**, and **Atlassian (Jira/Confluence)**, plus a shared **`work`** module for Asana, Trello, Airtable, Miro, Loom, Dropbox, Zoom, and Calendly. **`parseAppLinkUrl`** chains the new parsers; **`AppLinkAttrs`** and the ProseMirror **`app-link`** spec gain **`resourceId`** / **`resourceTitle`** for round-trip DOM serialization. Vitest coverage in **`index.test.ts`** exercises the new URL shapes and labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0697d4dc321274db3ad1aa321e66f18acb76f40e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->