### PR TITLE
Delete processed audio when retention is disabled

### DIFF
--- a/apps/desktop/src/services/audio-retention.test.ts
+++ b/apps/desktop/src/services/audio-retention.test.ts
@@ -5,6 +5,7 @@ import { SCHEMA as MAIN_SCHEMA } from "@hypr/store";
 
 import {
   cleanupExpiredAudio,
+  deleteProcessedAudioForRetention,
   normalizeAudioRetention,
   sessionAudioExpired,
 } from "./audio-retention";
@@ -191,6 +192,93 @@ describe("audio retention", () => {
     expect(audioDeleteMock).toHaveBeenCalledTimes(1);
     expect(audioDeleteMock).toHaveBeenCalledWith("processed");
     expect(deleted).toEqual(["processed"]);
+  });
+
+  test("deletes processed audio immediately when retention is none", async () => {
+    const now = Date.parse("2026-05-13T00:00:00.000Z");
+    const store = createMainStore();
+    const settingsStore = createSettingsStore();
+
+    settingsStore.setValue("audio_retention", "none");
+    store.setRow("sessions", "processed", {
+      user_id: "user",
+      created_at: "2026-05-13T00:00:00.000Z",
+      title: "",
+      raw_md: "",
+    });
+    store.setRow("transcripts", "processed-transcript", {
+      user_id: "user",
+      created_at: "2026-05-13T00:00:00.000Z",
+      session_id: "processed",
+      started_at: now,
+      words: JSON.stringify([{ text: " saved" }]),
+      speaker_hints: "[]",
+      memo_md: "",
+    });
+
+    const deleted = await deleteProcessedAudioForRetention(
+      store,
+      settingsStore,
+      "processed",
+    );
+
+    expect(deleted).toBe(true);
+    expect(audioDeleteMock).toHaveBeenCalledTimes(1);
+    expect(audioDeleteMock).toHaveBeenCalledWith("processed");
+  });
+
+  test("does not delete unprocessed audio immediately when retention is none", async () => {
+    const store = createMainStore();
+    const settingsStore = createSettingsStore();
+
+    settingsStore.setValue("audio_retention", "none");
+    store.setRow("sessions", "unprocessed", {
+      user_id: "user",
+      created_at: "2026-05-13T00:00:00.000Z",
+      title: "",
+      raw_md: "",
+    });
+
+    const deleted = await deleteProcessedAudioForRetention(
+      store,
+      settingsStore,
+      "unprocessed",
+    );
+
+    expect(deleted).toBe(false);
+    expect(audioDeleteMock).not.toHaveBeenCalled();
+  });
+
+  test("does not delete processed audio immediately when retention is not none", async () => {
+    const now = Date.parse("2026-05-13T00:00:00.000Z");
+    const store = createMainStore();
+    const settingsStore = createSettingsStore();
+
+    settingsStore.setValue("audio_retention", "oneDay");
+    store.setRow("sessions", "processed", {
+      user_id: "user",
+      created_at: "2026-05-13T00:00:00.000Z",
+      title: "",
+      raw_md: "",
+    });
+    store.setRow("transcripts", "processed-transcript", {
+      user_id: "user",
+      created_at: "2026-05-13T00:00:00.000Z",
+      session_id: "processed",
+      started_at: now,
+      words: JSON.stringify([{ text: " saved" }]),
+      speaker_hints: "[]",
+      memo_md: "",
+    });
+
+    const deleted = await deleteProcessedAudioForRetention(
+      store,
+      settingsStore,
+      "processed",
+    );
+
+    expect(deleted).toBe(false);
+    expect(audioDeleteMock).not.toHaveBeenCalled();
   });
 
   test("does not delete session or orphaned audio when retention is forever", async () => {

--- a/apps/desktop/src/services/audio-retention.ts
+++ b/apps/desktop/src/services/audio-retention.ts
@@ -92,6 +92,44 @@ function audioRetentionDurationMs(policy: ExpiringAudioRetentionPolicy) {
   return AUDIO_RETENTION_DURATION_MS[policy];
 }
 
+export async function deleteProcessedAudioForRetention(
+  store: main.Store,
+  settingsStore: settings.Store,
+  sessionId: string,
+) {
+  const policy = getAudioRetentionPolicy(settingsStore);
+  if (policy !== "none") {
+    return false;
+  }
+
+  if (listenerStore.getState().getSessionMode(sessionId) !== "inactive") {
+    return false;
+  }
+
+  if (!sessionHasTranscriptWords(store, sessionId)) {
+    return false;
+  }
+
+  try {
+    const result = await fsSyncCommands.audioDelete(sessionId);
+    if (result.status === "error") {
+      console.error("[audio-retention] failed to delete audio", {
+        sessionId,
+        error: result.error,
+      });
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error("[audio-retention] failed to delete audio", {
+      sessionId,
+      error,
+    });
+    return false;
+  }
+}
+
 export async function cleanupExpiredAudio(
   store: main.Store,
   settingsStore: settings.Store,

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -7,9 +7,11 @@ import { useListener } from "./contexts";
 import { useKeywords } from "./useKeywords";
 import { useSTTConnection } from "./useSTTConnection";
 
+import { deleteProcessedAudioForRetention } from "~/services/audio-retention";
 import { useConfigValue } from "~/shared/config";
 import { id } from "~/shared/utils";
 import * as main from "~/store/tinybase/store/main";
+import * as settings from "~/store/tinybase/store/settings";
 import type { BatchPersistCallback } from "~/store/zustand/listener/transcript";
 import { getTranscriptionLanguages } from "~/stt/capabilities";
 import type { SpeakerHintWithId, WordWithId } from "~/stt/types";
@@ -118,6 +120,7 @@ export const useRunBatch = (sessionId: string) => {
   const store = main.UI.useStore(main.STORE_ID);
   const indexes = main.UI.useIndexes(main.STORE_ID);
   const { user_id } = main.UI.useValues(main.STORE_ID);
+  const settingsStore = settings.UI.useStore(settings.STORE_ID);
 
   const startTranscription = useListener((state) => state.startTranscription);
   const { conn } = useSTTConnection();
@@ -290,6 +293,14 @@ export const useRunBatch = (sessionId: string) => {
       };
 
       await startTranscription(params, { handlePersist: persist });
+
+      if (settingsStore) {
+        await deleteProcessedAudioForRetention(
+          store as main.Store,
+          settingsStore as settings.Store,
+          sessionId,
+        );
+      }
     },
     [
       conn,
@@ -299,6 +310,7 @@ export const useRunBatch = (sessionId: string) => {
       spokenLanguages,
       startTranscription,
       sessionId,
+      settingsStore,
       store,
       user_id,
     ],

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -16,6 +16,10 @@ const {
   useSTTConnectionMock,
   isSupportedLanguagesLiveMock,
   setLeftSidebarExpandedMock,
+  settingsUseStoreMock,
+  deleteProcessedAudioForRetentionMock,
+  mainStoreMock,
+  settingsStoreMock,
 } = vi.hoisted(() => ({
   queueAutoEnhanceIfSummaryEmptyMock: vi.fn(),
   startMock: vi.fn(),
@@ -28,6 +32,16 @@ const {
   useSTTConnectionMock: vi.fn(),
   isSupportedLanguagesLiveMock: vi.fn(),
   setLeftSidebarExpandedMock: vi.fn(),
+  settingsUseStoreMock: vi.fn(),
+  deleteProcessedAudioForRetentionMock: vi.fn(),
+  mainStoreMock: {
+    getCell: vi.fn(() => ""),
+    forEachRow: vi.fn(),
+    setRow: vi.fn(),
+    delRow: vi.fn(),
+    transaction: vi.fn((fn: () => void) => fn()),
+  },
+  settingsStoreMock: { id: "settings-store" },
 }));
 
 vi.mock("@hypr/plugin-transcription", () => ({
@@ -65,6 +79,10 @@ vi.mock("~/services/enhancer", () => ({
   })),
 }));
 
+vi.mock("~/services/audio-retention", () => ({
+  deleteProcessedAudioForRetention: deleteProcessedAudioForRetentionMock,
+}));
+
 vi.mock("~/contexts/shell", () => ({
   useShell: vi.fn(() => ({
     leftsidebar: {
@@ -94,6 +112,13 @@ vi.mock("~/store/tinybase/store/main", () => ({
     useValues: useValuesMock,
     useStore: useStoreMock,
     useIndexes: useIndexesMock,
+  },
+}));
+
+vi.mock("~/store/tinybase/store/settings", () => ({
+  STORE_ID: "settings",
+  UI: {
+    useStore: settingsUseStoreMock,
   },
 }));
 
@@ -161,6 +186,7 @@ describe("useStartListening", () => {
     useConfigValueMock.mockImplementation((key) =>
       key === "ai_language" ? "en" : [],
     );
+    settingsUseStoreMock.mockReturnValue(settingsStoreMock);
     useSTTConnectionMock.mockReturnValue({
       conn: {
         provider: "hyprnote",
@@ -169,13 +195,7 @@ describe("useStartListening", () => {
         apiKey: "",
       },
     });
-    useStoreMock.mockReturnValue({
-      getCell: vi.fn(() => ""),
-      forEachRow: vi.fn(),
-      setRow: vi.fn(),
-      delRow: vi.fn(),
-      transaction: vi.fn((fn: () => void) => fn()),
-    });
+    useStoreMock.mockReturnValue(mainStoreMock);
     startMock.mockResolvedValue(true);
     runBatchMock.mockResolvedValue(undefined);
     isSupportedLanguagesLiveMock.mockResolvedValue({
@@ -227,6 +247,40 @@ describe("useStartListening", () => {
 
     expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav");
     expect(queueAutoEnhanceIfSummaryEmptyMock).toHaveBeenCalledWith(
+      "session-1",
+    );
+    expect(deleteProcessedAudioForRetentionMock).toHaveBeenCalledWith(
+      mainStoreMock,
+      settingsStoreMock,
+      "session-1",
+    );
+  });
+
+  test("cleans up processed audio after live capture stops", async () => {
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    const onStopped = startMock.mock.calls[0]?.[1]?.onStopped;
+
+    await act(async () => {
+      await onStopped?.("session-1", {
+        durationSeconds: 42,
+        audioPath: "/tmp/session.wav",
+        requestedLiveTranscription: true,
+        liveTranscriptionActive: true,
+      });
+    });
+
+    expect(runBatchMock).not.toHaveBeenCalled();
+    expect(queueAutoEnhanceIfSummaryEmptyMock).toHaveBeenCalledWith(
+      "session-1",
+    );
+    expect(deleteProcessedAudioForRetentionMock).toHaveBeenCalledWith(
+      mainStoreMock,
+      settingsStoreMock,
       "session-1",
     );
   });

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -13,11 +13,13 @@ import {
 import { useSTTConnection } from "./useSTTConnection";
 
 import { useShell } from "~/contexts/shell";
+import { deleteProcessedAudioForRetention } from "~/services/audio-retention";
 import { getEnhancerService } from "~/services/enhancer";
 import { getSessionEventById } from "~/session/utils";
 import { useConfigValue } from "~/shared/config";
 import { id } from "~/shared/utils";
 import * as main from "~/store/tinybase/store/main";
+import * as settings from "~/store/tinybase/store/settings";
 import type {
   LiveTranscriptPersistCallback,
   OnStoppedCallback,
@@ -50,6 +52,7 @@ export function useStartListening(sessionId: string) {
   const { user_id } = main.UI.useValues(main.STORE_ID);
   const store = main.UI.useStore(main.STORE_ID);
   const indexes = main.UI.useIndexes(main.STORE_ID);
+  const settingsStore = settings.UI.useStore(settings.STORE_ID);
 
   const aiLanguage = useConfigValue("ai_language");
   const spokenLanguages = useConfigValue("spoken_languages");
@@ -102,6 +105,14 @@ export function useStartListening(sessionId: string) {
       }
 
       getEnhancerService()?.queueAutoEnhanceIfSummaryEmpty(sessionId);
+
+      if (settingsStore) {
+        await deleteProcessedAudioForRetention(
+          store as main.Store,
+          settingsStore as settings.Store,
+          sessionId,
+        );
+      }
     };
 
     const handlePersist: LiveTranscriptPersistCallback = (delta) => {
@@ -206,6 +217,7 @@ export function useStartListening(sessionId: string) {
     user_id,
     spokenLanguages,
     setLeftSidebarExpanded,
+    settingsStore,
   ]);
 
   return startListening;


### PR DESCRIPTION
Run audio retention cleanup immediately after successful live or batch transcription while preserving unprocessed recordings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when local audio files are deleted relative to user retention settings; mistakes could remove audio before transcription is persisted, though guards require transcript words and an inactive session.
> 
> **Overview**
> When **audio retention** is set to **none** (including legacy `save_recordings: false`), processed session audio is removed as soon as transcription finishes, instead of waiting only on the periodic cleanup job.
> 
> A new **`deleteProcessedAudioForRetention`** helper deletes via `audioDelete` only when retention is `none`, the session is **inactive**, and the session already has **transcript words**—so recordings without a saved transcript are kept until they are processed.
> 
> That helper runs after **batch** transcription completes in `useRunBatch`, and after **live** or **record-then-batch** capture ends in `useStartListening` (alongside the existing auto-enhance step). Unit tests cover the retention gates and hook wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 974372c8580ff71843d972ed5e9cd06239ad02cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->