### PR TITLE
Reserve collapsed live title space

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -129,9 +129,13 @@ describe("OuterHeader", () => {
     const stopButton = screen.getByRole("button", {
       name: "Stop listening",
     });
+    const title = screen.getByText("Session title");
+    const titleSlot = title.parentElement?.parentElement;
 
     fireEvent.click(stopButton);
 
+    expect(titleSlot?.className).toContain("right-[153px]");
+    expect(titleSlot?.className).not.toContain("right-[70px]");
     expect(screen.getByTestId("dancing-sticks")).not.toBeNull();
     expect(stopButton.className).toContain("h-7");
     expect(stopButton.className).toContain("w-20");

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -27,8 +27,11 @@ export function OuterHeader({
   title?: React.ReactNode;
 }) {
   const { leftsidebar } = useShell();
+  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const showSidebarTimelineHeaderGutter = !leftsidebar.expanded;
   const showExpandedSidebarTimelineHeader = leftsidebar.expanded;
+  const reserveCollapsedLiveControls =
+    showSidebarTimelineHeaderGutter && isSidebarStopButtonMode(sessionMode);
 
   return (
     <div
@@ -41,7 +44,8 @@ export function OuterHeader({
       {title ? (
         <div
           className={cn([
-            "pointer-events-none absolute inset-y-0 right-[70px] flex items-center",
+            "pointer-events-none absolute inset-y-0 flex items-center",
+            reserveCollapsedLiveControls ? "right-[153px]" : "right-[70px]",
             showSidebarTimelineHeaderGutter
               ? "left-[104px] -translate-y-1"
               : showExpandedSidebarTimelineHeader
@@ -53,39 +57,54 @@ export function OuterHeader({
         </div>
       ) : null}
       <div className="relative z-10 ml-auto flex shrink-0 items-center gap-0 pr-1">
-        <SidebarModeStopButton sessionId={sessionId} />
-        <HeaderMeetingControl sessionId={sessionId} />
+        <SidebarModeStopButton sessionMode={sessionMode} />
+        <HeaderMeetingControl sessionId={sessionId} sessionMode={sessionMode} />
         <OverflowButton sessionId={sessionId} currentView={currentView} />
       </div>
     </div>
   );
 }
 
-function HeaderMeetingControl({ sessionId }: { sessionId: string }) {
+function HeaderMeetingControl({
+  sessionId,
+  sessionMode,
+}: {
+  sessionId: string;
+  sessionMode: string;
+}) {
   const sessionEvent = useSessionEvent(sessionId);
 
   if (!sessionEvent) {
     return <MetadataButton sessionId={sessionId} />;
   }
 
-  return <EventMeetingControl sessionId={sessionId} event={sessionEvent} />;
+  return (
+    <EventMeetingControl
+      sessionId={sessionId}
+      event={sessionEvent}
+      sessionMode={sessionMode}
+    />
+  );
 }
 
 function EventMeetingControl({
   sessionId,
   event,
+  sessionMode,
 }: {
   sessionId: string;
   event: {
     ended_at?: string;
     meeting_link?: string;
   };
+  sessionMode: string;
 }) {
-  const mode = useListener((state) => state.getSessionMode(sessionId));
   const now = useNow();
   const remote = getRemoteMeeting(event.meeting_link);
   const inProgress =
-    mode === "active" || mode === "finalizing" || mode === "running_batch";
+    sessionMode === "active" ||
+    sessionMode === "finalizing" ||
+    sessionMode === "running_batch";
   const endedAt = event.ended_at ? safeParseDate(event.ended_at) : null;
   const ended = !!endedAt && endedAt.getTime() <= now.getTime();
 
@@ -180,17 +199,16 @@ function getMeetingDisplay(type: RemoteMeeting["type"]) {
   }
 }
 
-function SidebarModeStopButton({ sessionId }: { sessionId: string }) {
+function SidebarModeStopButton({ sessionMode }: { sessionMode: string }) {
   const { leftsidebar } = useShell();
-  const { amplitude, degraded, mode, muted, stop } = useListener((state) => ({
+  const { amplitude, degraded, muted, stop } = useListener((state) => ({
     amplitude: state.live.amplitude,
     degraded: state.live.degraded,
-    mode: state.getSessionMode(sessionId),
     muted: state.live.muted,
     stop: state.stop,
   }));
-  const active = mode === "active" || mode === "finalizing";
-  const finalizing = mode === "finalizing";
+  const active = isSidebarStopButtonMode(sessionMode);
+  const finalizing = sessionMode === "finalizing";
 
   if (leftsidebar.expanded || !active) {
     return null;
@@ -257,4 +275,8 @@ function SidebarModeStopButton({ sessionId }: { sessionId: string }) {
       )}
     </button>
   );
+}
+
+function isSidebarStopButtonMode(sessionMode: string) {
+  return sessionMode === "active" || sessionMode === "finalizing";
 }


### PR DESCRIPTION
Add the collapsed active header title reservation so long titles avoid the stop listening control.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout and prop-refactor in the session outer header only; no auth, data, or API changes.
> 
> **Overview**
> When the left sidebar is **collapsed** and the session is **actively listening** (or finalizing), the session title area now reserves extra space on the right (`right-[153px]` instead of `right-[70px]`) so long titles do not run under the **Stop listening** control.
> 
> **Session mode** is read once in `OuterHeader` and passed into `SidebarModeStopButton`, `HeaderMeetingControl`, and `EventMeetingControl`, replacing duplicate `getSessionMode` subscriptions. A shared **`isSidebarStopButtonMode`** helper drives both the stop button visibility and the wider title reservation.
> 
> Tests for the collapsed active stop button now assert the title slot uses the wider right inset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adb2305c3a6f0c08198c16f59cc5bcd57e76f933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->