### PR TITLE
Keep FAB open across hover gutter

### DIFF
--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -170,12 +170,14 @@ describe("FloatingActionButton", () => {
     expect(hoverZone?.className).toContain("pointer-events-auto");
     expect(hoverZone?.className).toContain("bottom-0");
     expect(hoverZone?.className).not.toContain("-bottom-4");
-    expect(hoverZone?.className).toContain("h-24");
+    expect(hoverZone?.className).toContain("h-32");
     expect(hoverZone?.className).toContain("pb-4");
     expect(hoverZone?.className).toContain("max-w-[calc(100%-2rem)]");
     expect(hoverZone?.className).not.toContain("w-96");
     expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
     expect(wrapper?.className).toContain("pointer-events-none");
+    expect(wrapper?.className).toContain("before:-inset-x-8");
+    expect(wrapper?.className).toContain("before:-inset-y-8");
     expect(wrapper?.className).toContain(
       "translate-y-[var(--floating-fab-tuck-offset)]",
     );
@@ -200,7 +202,7 @@ describe("FloatingActionButton", () => {
     expect(hoverZone?.className).toContain("pointer-events-auto");
     expect(hoverZone?.className).toContain("bottom-0");
     expect(hoverZone?.className).not.toContain("-bottom-4");
-    expect(hoverZone?.className).toContain("h-24");
+    expect(hoverZone?.className).toContain("h-32");
     expect(hoverZone?.className).toContain("pb-4");
     expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
     expect(wrapper?.style.getPropertyValue("--floating-fab-tuck-offset")).toBe(
@@ -224,7 +226,7 @@ describe("FloatingActionButton", () => {
     expect(hoverZone?.className).toContain("pointer-events-auto");
     expect(hoverZone?.className).toContain("bottom-0");
     expect(hoverZone?.className).not.toContain("-bottom-4");
-    expect(hoverZone?.className).toContain("h-24");
+    expect(hoverZone?.className).toContain("h-32");
     expect(hoverZone?.className).toContain("pb-4");
     expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
     expect(wrapper?.style.getPropertyValue("--floating-fab-tuck-offset")).toBe(

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -48,7 +48,7 @@ export function FloatingActionButton({
       className={cn([
         "absolute left-1/2 z-20 flex max-w-[calc(100%-2rem)] -translate-x-1/2 items-end justify-center",
         tuckAction
-          ? "group pointer-events-auto bottom-0 h-24 pb-4"
+          ? "group pointer-events-auto bottom-0 h-32 pb-4"
           : "pointer-events-none bottom-0 h-14 pb-4",
       ])}
     >
@@ -81,9 +81,9 @@ export function FloatingActionButton({
               } as CSSProperties
             }
             className={cn([
-              "max-w-full translate-y-[var(--floating-fab-tuck-offset)] transition-transform duration-200 ease-out",
+              "relative max-w-full translate-y-[var(--floating-fab-tuck-offset)] transition-transform duration-200 ease-out",
               tuckAction
-                ? "pointer-events-none visible group-hover:pointer-events-auto group-hover:translate-y-0 hover:pointer-events-auto hover:translate-y-0"
+                ? "pointer-events-none visible group-hover:pointer-events-auto group-hover:translate-y-0 before:absolute before:-inset-x-8 before:-inset-y-8 before:content-[''] hover:pointer-events-auto hover:translate-y-0"
                 : "pointer-events-auto visible",
             ])}
           >


### PR DESCRIPTION
Expand the tucked FAB hover corridor and cover the button gutter with an invisible hit area.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only interaction tweak on the session floating action button; no auth, data, or API changes.
> 
> **Overview**
> Improves tucked **chat/listen FAB** hover behavior so the control stays revealed when the pointer moves through the gap between the bottom hover strip and the button.
> 
> The outer hover corridor grows from **`h-24` to `h-32`**. The tucked FAB wrapper is **`relative`** and uses a **`::before` pseudo-element** with **`before:-inset-x-8` / `before:-inset-y-8`** to extend the invisible hit target over the gutter around the shifted button. Tests now assert **`h-32`** and the new **`before:*`** classes on the hidden/peek FAB case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fa21334928c2230056520f21a82389a3cc0ca1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->