### PR TITLE
Prevent now indicator clipping

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -511,7 +511,7 @@ describe("TimelineView", () => {
     expect(isBefore(indicator, twoDaysAgoHeading)).toBe(true);
     expect(
       indicator.closest("[data-sidebar-current-time-header-gap]")?.className,
-    ).toContain("pb-3");
+    ).toContain("py-3");
   });
 
   it("hides the now indicator while an active meeting is visible", () => {

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -405,7 +405,7 @@ export function TimelineView({
           return (
             <div key={bucket.label} className={cn([isTopIndicator && "pt-3"])}>
               {shouldRenderIndicatorBefore && (
-                <div data-sidebar-current-time-header-gap className="pb-3">
+                <div data-sidebar-current-time-header-gap className="py-3">
                   <CurrentTimeIndicator
                     ref={setCurrentTimeIndicatorRef}
                     timezone={timezone}

--- a/apps/desktop/src/sidebar/timeline/realtime.tsx
+++ b/apps/desktop/src/sidebar/timeline/realtime.tsx
@@ -32,8 +32,8 @@ export const CurrentTimeIndicator = forwardRef<
       aria-hidden
       className={
         variant === "inside"
-          ? "group absolute inset-x-0 z-20 h-px"
-          : "group relative z-20 h-px"
+          ? "group absolute inset-x-0 z-30 h-px"
+          : "group relative z-30 h-px"
       }
       style={variant === "inside" ? { top: insideOffset } : undefined}
     >

--- a/packages/changelog/content/1.0.43.md
+++ b/packages/changelog/content/1.0.43.md
@@ -6,6 +6,7 @@ summary: "The meeting timeline is simpler, live meeting controls are easier to r
 ## Meetings
 
 - The sidebar timeline is now the single place for meeting timeline navigation, replacing the old top timeline mode
+- The current-time marker now stays readable between day sections in the sidebar timeline
 - Search, new note, calendar, and calendar sync controls now sit together in the main chrome for quicker access
 - The sidebar now collapses automatically after a meeting starts so the active note has more room
 - The floating meeting bar now has a clearer hover handle and stays easier to reveal while listening
@@ -19,6 +20,7 @@ summary: "The meeting timeline is simpler, live meeting controls are easier to r
 
 ## Notes
 
+- Work app links now appear as compact inline chips for easier scanning in notes
 - Note titles now align with the left header gutter for a cleaner reading position
 - Upload audio and transcript actions are hidden once a note already has content
 - The note formatting toolbar now stays above floating chat surfaces


### PR DESCRIPTION
Reserve vertical space around the fallback now marker and keep it above sticky timeline headers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Timeline sidebar layout and z-index only; no auth, data, or API changes.
> 
> **Overview**
> Fixes **sidebar “now” indicator clipping** when it sits between day buckets (no “Today” section).
> 
> The fallback marker wrapper now uses **`py-3`** instead of **`pb-3`**, adding space above and below so the red line and time label aren’t squeezed against adjacent bucket headers. **`CurrentTimeIndicator`** stacking is raised from **`z-20`** to **`z-30`** so it paints above **sticky day headers** (also `z-20`). Tests and the **1.0.43** changelog note the improved readability between sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 789592be39da9799cf297768bd6dfbfc9cf67f6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->