### PR TITLE
Make changelog header draggable

### DIFF
--- a/apps/desktop/src/changelog/index.test.tsx
+++ b/apps/desktop/src/changelog/index.test.tsx
@@ -104,6 +104,25 @@ describe("TabContentChangelog", () => {
     expect(titleSlot?.className).not.toContain("left-1/2");
     expect(heading.className).toContain("text-left");
   });
+
+  it("marks the full top header area as draggable while keeping close clickable", () => {
+    render(<TabContentChangelog tab={buildChangelogTab()} />);
+
+    const header = getHeader();
+    const headerFrame = header.parentElement;
+    const heading = screen.getByRole("heading", {
+      name: "What's new in 1.0.36?",
+    });
+    const titleSlot = heading.parentElement;
+    const closeButton = screen.getByRole("button", {
+      name: "Close changelog",
+    });
+
+    expect(headerFrame?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(header.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(titleSlot?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(closeButton.getAttribute("data-tauri-drag-region")).toBe("false");
+  });
 });
 
 function getHeader() {

--- a/apps/desktop/src/changelog/index.tsx
+++ b/apps/desktop/src/changelog/index.tsx
@@ -36,7 +36,7 @@ export function TabContentChangelog({
   return (
     <StandardTabWrapper>
       <div className="flex h-full flex-col">
-        <div className="shrink-0 pr-1 pl-3">
+        <div data-tauri-drag-region className="shrink-0 pr-1 pl-3">
           <ChangelogHeader
             version={current}
             showSidebarTimelineHeaderGutter={showSidebarTimelineHeaderGutter}
@@ -131,12 +131,14 @@ function ChangelogHeader({
 }) {
   return (
     <div
+      data-tauri-drag-region
       className={cn([
         "relative flex h-12 w-full items-center",
         showSidebarTimelineHeaderGutter && "pl-[156px]",
       ])}
     >
       <div
+        data-tauri-drag-region
         className={cn([
           "pointer-events-none absolute inset-y-0 flex items-center",
           showExpandedSidebarTimelineHeader
@@ -162,6 +164,7 @@ function ChangelogHeader({
         <Button
           size="icon"
           variant="ghost"
+          data-tauri-drag-region="false"
           className="text-muted-foreground hover:text-foreground"
           aria-label="Close changelog"
           title="Close"


### PR DESCRIPTION
Mark the top changelog strip as a drag region and keep the close button opted out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Tauri drag-region attributes on the changelog header; no auth, data, or business-logic changes.
> 
> **Overview**
> Enables **dragging the desktop window** from the changelog tab’s top strip by marking the outer header wrapper, `ChangelogHeader` root, and title slot with `data-tauri-drag-region`, matching the pattern used elsewhere (e.g. calendar header).
> 
> The **close** control sets `data-tauri-drag-region="false"` so it stays clickable inside the drag area. A new test asserts those drag attributes on the header frame, header, title slot, and close button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d8091de4aaa211e8a9e7ae98b3dad1941824592. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->