### PR TITLE
Support Soniox async v5

### DIFF
--- a/apps/desktop/src/settings/ai/stt/selection.test.ts
+++ b/apps/desktop/src/settings/ai/stt/selection.test.ts
@@ -15,10 +15,10 @@ describe("getPreferredProviderModel", () => {
   test("falls back to the first available model when none is remembered", () => {
     expect(
       getPreferredProviderModel(undefined, [
+        { id: "stt-v5" },
         { id: "stt-v4" },
-        { id: "stt-v3" },
       ]),
-    ).toBe("stt-v4");
+    ).toBe("stt-v5");
   });
 
   test("falls back to the first available model when the remembered model is gone", () => {

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -46,6 +46,10 @@ export const displayModelId = (model: string) => {
     return "Whisper RT";
   }
 
+  if (model === "stt-v5" || model === "stt-async-v5") {
+    return "Soniox v5";
+  }
+
   if (model === "stt-v4" || model === "stt-rt-v4" || model === "stt-async-v4") {
     return "Soniox v4";
   }
@@ -193,7 +197,7 @@ const _PROVIDERS = [
       />
     ),
     baseUrl: "https://api.soniox.com",
-    models: ["stt-v4", "stt-v3"],
+    models: ["stt-v5", "stt-v4"],
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
   },
   {

--- a/crates/owhisper-client/src/adapter/soniox/mod.rs
+++ b/crates/owhisper-client/src/adapter/soniox/mod.rs
@@ -10,6 +10,8 @@ use super::LanguageSupport;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, strum::EnumString, strum::AsRefStr)]
 pub enum SonioxModel {
     #[default]
+    #[strum(serialize = "stt-v5", serialize = "stt-async-v5")]
+    V5,
     #[strum(
         serialize = "stt-v4",
         serialize = "stt-rt-v4",
@@ -31,6 +33,7 @@ pub enum SonioxModel {
 impl SonioxModel {
     pub fn live_model(&self) -> &'static str {
         match self {
+            Self::V5 => "stt-rt-v4",
             Self::V4 => "stt-rt-v4",
             Self::V3 => "stt-rt-v3",
         }
@@ -38,6 +41,7 @@ impl SonioxModel {
 
     pub fn batch_model(&self) -> &'static str {
         match self {
+            Self::V5 => "stt-async-v5",
             Self::V4 => "stt-async-v4",
             Self::V3 => "stt-async-v3",
         }
@@ -119,6 +123,29 @@ pub(super) fn documented_language_codes() -> &'static [&'static str] {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn v5_uses_async_v5_for_batch_and_rt_v4_for_live() {
+        let model = SonioxAdapter::resolve_model(Some("stt-v5"));
+
+        assert_eq!(model.batch_model(), "stt-async-v5");
+        assert_eq!(model.live_model(), "stt-rt-v4");
+    }
+
+    #[test]
+    fn async_v5_model_resolves_to_v5() {
+        let model = SonioxAdapter::resolve_model(Some("stt-async-v5"));
+
+        assert_eq!(model, SonioxModel::V5);
+        assert_eq!(model.batch_model(), "stt-async-v5");
+    }
+
+    #[test]
+    fn meta_models_resolve_to_latest_soniox_model() {
+        assert_eq!(SonioxAdapter::resolve_model(Some("cloud")), SonioxModel::V5);
+        assert_eq!(SonioxAdapter::resolve_model(Some("auto")), SonioxModel::V5);
+        assert_eq!(SonioxAdapter::resolve_model(None), SonioxModel::V5);
+    }
 
     #[test]
     fn test_build_ws_url_from_base() {

--- a/crates/owhisper-client/src/providers.rs
+++ b/crates/owhisper-client/src/providers.rs
@@ -298,7 +298,7 @@ impl Provider {
         match self {
             Self::AquaVoice => "avalon-v1-en",
             Self::Deepgram => "nova-3",
-            Self::Soniox => "stt-rt-v3",
+            Self::Soniox => "stt-rt-v4",
             Self::AssemblyAI => "u3-rt-pro",
             Self::Fireworks => "whisper-v3-turbo",
             Self::OpenAI => "gpt-4o-transcribe",
@@ -323,7 +323,7 @@ impl Provider {
         match self {
             Self::AquaVoice => "avalon-v1-en",
             Self::Deepgram => "nova-3",
-            Self::Soniox => "stt-async-v3",
+            Self::Soniox => "stt-async-v5",
             Self::AssemblyAI => "universal-3-pro",
             Self::Fireworks => "whisper-v3-turbo",
             Self::OpenAI => "gpt-4o-transcribe-diarize",

--- a/crates/transcribe-proxy/src/routes/streaming/hyprnote.rs
+++ b/crates/transcribe-proxy/src/routes/streaming/hyprnote.rs
@@ -412,7 +412,7 @@ mod tests {
     #[test]
     fn test_build_initial_message_soniox() {
         let params = ListenParams {
-            model: Some("stt-rt-v3".to_string()),
+            model: Some("stt-v5".to_string()),
             languages: vec![ISO639::En.into()],
             sample_rate: 16000,
             channels: 1,
@@ -426,6 +426,7 @@ mod tests {
         let msg = initial_msg.unwrap();
         assert!(msg.contains("api_key"));
         assert!(msg.contains("test-key"));
+        assert!(msg.contains("stt-rt-v4"));
     }
 
     #[test]


### PR DESCRIPTION
Add Soniox v5 as the preferred batch model while keeping live transcription on real-time v4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Soniox model resolution for cloud/auto and batch paths, which can alter transcription behavior for users who relied on implicit v3/v4 defaults without changing settings.
> 
> **Overview**
> Adds **Soniox v5** as the default Soniox STT tier across the Rust client, transcribe proxy, and desktop STT settings.
> 
> In `SonioxModel`, **`stt-v5` / `stt-async-v5`** are new aliases for **V5** (now the default for `cloud`, `auto`, and missing model). **Batch** requests use **`stt-async-v5`**; **live** WebSocket sessions still use **`stt-rt-v4`** when v5 is selected. Provider-wide Soniox defaults move from v3 to **`stt-async-v5`** (batch) and **`stt-rt-v4`** (live).
> 
> The desktop Soniox picker now offers **`stt-v5`** and **`stt-v4`** (v3 removed from the list), with **Soniox v5** labels and tests expecting v5 as the first-choice fallback. Proxy tests assert that a **`stt-v5`** listen session’s initial message includes **`stt-rt-v4`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd02c1455554e9abec79b4e1bfa54950fb466e32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->