### PR TITLE
Render markdown tables in summaries

### DIFF
--- a/packages/editor/src/markdown.test.ts
+++ b/packages/editor/src/markdown.test.ts
@@ -1,3 +1,4 @@
+import { Node as PMNode } from "prosemirror-model";
 import { describe, expect, test } from "vitest";
 
 import {
@@ -8,6 +9,7 @@ import {
   md2json,
   parseJsonContent,
 } from "./markdown";
+import { schema as noteSchema } from "./note/schema";
 
 describe("json2md", () => {
   test("renders underline as html tags", () => {
@@ -105,6 +107,314 @@ describe("json2md", () => {
     expect(markdown).toBe(
       '![alt text](https://example.com/image.png "char-editor-width=42|Example")',
     );
+  });
+
+  test("renders table nodes as markdown tables", () => {
+    const markdown = json2md({
+      type: "doc",
+      content: [
+        {
+          type: "table",
+          content: [
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableHeader",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Name" }],
+                    },
+                  ],
+                },
+                {
+                  type: "tableHeader",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Role | Notes" }],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableCell",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Alasdair" }],
+                    },
+                  ],
+                },
+                {
+                  type: "tableCell",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Account Executive" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(markdown).toBe(
+      "| Name | Role \\| Notes |\n| --- | --- |\n| Alasdair | Account Executive |",
+    );
+  });
+
+  test("renders merged and shorter table rows with consistent columns", () => {
+    const markdown = json2md({
+      type: "doc",
+      content: [
+        {
+          type: "table",
+          content: [
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableHeader",
+                  attrs: { colspan: 2 },
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Quarter" }],
+                    },
+                  ],
+                },
+                {
+                  type: "tableHeader",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Status" }],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableCell",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Q3" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(markdown).toBe(
+      "| Quarter |  | Status |\n| --- | --- | --- |\n| Q3 |  |  |",
+    );
+
+    const roundtripped = md2json(markdown);
+    expect(roundtripped.content?.[0]?.content?.[0]?.content).toHaveLength(3);
+    expect(roundtripped.content?.[0]?.content?.[1]?.content).toHaveLength(3);
+  });
+
+  test("renders table cell hard breaks as parseable break tags", () => {
+    const markdown = json2md({
+      type: "doc",
+      content: [
+        {
+          type: "table",
+          content: [
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableHeader",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Summary" }],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableCell",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [
+                        { type: "text", text: "First" },
+                        { type: "hardBreak" },
+                        { type: "text", text: "Second" },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(markdown).toBe("| Summary |\n| --- |\n| First<br>Second |");
+  });
+
+  test("escapes literal table cell break tags", () => {
+    const markdown = json2md({
+      type: "doc",
+      content: [
+        {
+          type: "table",
+          content: [
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableHeader",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Raw" }],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableCell",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "literal <br>" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(markdown).toBe("| Raw |\n| --- |\n| literal \\<br> |");
+  });
+
+  test("preserves table cell backslashes across roundtrip", () => {
+    const json: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "table",
+          content: [
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableHeader",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Path" }],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableCell",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "C:\\Users\\John" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const roundtripped = md2json(json2md(json));
+    const cellText =
+      roundtripped.content?.[0]?.content?.[1]?.content?.[0]?.content?.[0]
+        ?.content?.[0]?.text;
+
+    expect(cellText).toBe("C:\\Users\\John");
+  });
+
+  test("preserves table cell backslashes before pipes across roundtrip", () => {
+    const json: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "table",
+          content: [
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableHeader",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Pattern" }],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableCell",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "literal \\| marker" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const roundtripped = md2json(json2md(json));
+    const cellText =
+      roundtripped.content?.[0]?.content?.[1]?.content?.[0]?.content?.[0]
+        ?.content?.[0]?.text;
+
+    expect(cellText).toBe("literal \\| marker");
   });
 });
 
@@ -211,6 +521,48 @@ We appreciate your patience while you wait.`);
     expect(json.content![0].type).toBe("image");
     expect(json.content![0].attrs?.src).toBe("https://example.com/welcome.png");
     expect(json.content![1].type).toBe("paragraph");
+  });
+
+  test("converts markdown tables to editor-compatible table JSON", () => {
+    const json = md2json(`| Name | Company | Role / Notes |
+| --- | --- | --- |
+| Alasdair | Cloudflare | Account Executive |
+| Rick | Cloudflare | Solutions Engineer |`);
+
+    const table = json.content?.[0];
+    expect(table?.type).toBe("table");
+    expect(table?.content?.[0]?.type).toBe("tableRow");
+    expect(table?.content?.[0]?.content?.[0]?.type).toBe("tableHeader");
+    expect(
+      table?.content?.[0]?.content?.[0]?.content?.[0]?.content?.[0]?.text,
+    ).toBe("Name");
+    expect(table?.content?.[1]?.content?.[0]?.type).toBe("tableCell");
+    expect(() => PMNode.fromJSON(noteSchema, json)).not.toThrow();
+  });
+
+  test("converts table cell break tags to hard breaks", () => {
+    const json = md2json(`| Summary |
+| --- |
+| First<br>Second |`);
+
+    const cellContent =
+      json.content?.[0]?.content?.[1]?.content?.[0]?.content?.[0]?.content;
+    expect(cellContent).toEqual([
+      { type: "text", text: "First" },
+      { type: "hardBreak" },
+      { type: "text", text: "Second" },
+    ]);
+    expect(() => PMNode.fromJSON(noteSchema, json)).not.toThrow();
+  });
+
+  test("keeps escaped table cell break tags as text", () => {
+    const json = md2json(`| Raw |
+| --- |
+| literal \\<br> |`);
+
+    const cellContent =
+      json.content?.[0]?.content?.[1]?.content?.[0]?.content?.[0]?.content;
+    expect(cellContent).toEqual([{ type: "text", text: "literal <br>" }]);
   });
 });
 

--- a/packages/editor/src/markdown.ts
+++ b/packages/editor/src/markdown.ts
@@ -26,6 +26,38 @@ import {
 // JSON post-processing (see liftBlockImages / wrapBlockImages).
 // ---------------------------------------------------------------------------
 
+const tableCellAttrs = {
+  colspan: { default: 1 },
+  rowspan: { default: 1 },
+  colwidth: { default: null },
+};
+
+function getTableCellAttrs(dom: Node | string) {
+  if (typeof dom === "string") return {};
+  const element = dom as HTMLElement;
+  const widthAttr = element.getAttribute("data-colwidth");
+  const widths =
+    widthAttr && /^\d+(,\d+)*$/.test(widthAttr)
+      ? widthAttr.split(",").map((value) => Number(value))
+      : null;
+  const colspan = Number(element.getAttribute("colspan") || 1);
+
+  return {
+    colspan,
+    rowspan: Number(element.getAttribute("rowspan") || 1),
+    colwidth: widths && widths.length === colspan ? widths : null,
+  };
+}
+
+function setTableCellAttrs(node: PMNode) {
+  const attrs: Record<string, string | number> = {};
+  if (node.attrs.colspan !== 1) attrs.colspan = node.attrs.colspan;
+  if (node.attrs.rowspan !== 1) attrs.rowspan = node.attrs.rowspan;
+  if (node.attrs.colwidth)
+    attrs["data-colwidth"] = node.attrs.colwidth.join(",");
+  return attrs;
+}
+
 const nodes: Record<string, NodeSpec> = {
   doc: { content: "block+" },
 
@@ -132,6 +164,48 @@ const nodes: Record<string, NodeSpec> = {
     parseDOM: [{ tag: "li" }],
     toDOM() {
       return ["li", 0];
+    },
+  },
+
+  table: {
+    content: "tableRow+",
+    group: "block",
+    isolating: true,
+    tableRole: "table",
+    parseDOM: [{ tag: "table" }],
+    toDOM() {
+      return ["table", ["tbody", 0]];
+    },
+  },
+
+  tableRow: {
+    content: "(tableCell | tableHeader)*",
+    tableRole: "row",
+    parseDOM: [{ tag: "tr" }],
+    toDOM() {
+      return ["tr", 0];
+    },
+  },
+
+  tableCell: {
+    content: "block+",
+    attrs: tableCellAttrs,
+    isolating: true,
+    tableRole: "cell",
+    parseDOM: [{ tag: "td", getAttrs: getTableCellAttrs }],
+    toDOM(node) {
+      return ["td", setTableCellAttrs(node), 0];
+    },
+  },
+
+  tableHeader: {
+    content: "block+",
+    attrs: tableCellAttrs,
+    isolating: true,
+    tableRole: "header_cell",
+    parseDOM: [{ tag: "th", getAttrs: getTableCellAttrs }],
+    toDOM(node) {
+      return ["th", setTableCellAttrs(node), 0];
     },
   },
 
@@ -481,6 +555,25 @@ function highlightPlugin(md: MarkdownIt) {
   );
 }
 
+function hardBreakTagPlugin(md: MarkdownIt) {
+  md.inline.ruler.before(
+    "html_inline",
+    "hardbreak_tag",
+    (state: StateInline, silent: boolean) => {
+      const match = state.src.slice(state.pos).match(/^<br\s*\/?>/i);
+      if (!match) return false;
+
+      if (!silent) {
+        const token = state.push("hardbreak", "br", 0);
+        token.markup = match[0];
+      }
+
+      state.pos += match[0].length;
+      return true;
+    },
+  );
+}
+
 function taskListPlugin(md: MarkdownIt) {
   md.core.ruler.after("inline", "task_lists", (state) => {
     const tokens = state.tokens;
@@ -557,6 +650,39 @@ function taskListPlugin(md: MarkdownIt) {
         }
       }
     }
+  });
+}
+
+function tableCellParagraphsPlugin(md: MarkdownIt) {
+  md.core.ruler.after("inline", "table_cell_paragraphs", (state) => {
+    const tokens = state.tokens;
+    const out: Token[] = [];
+
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+      const prev = tokens[i - 1];
+      const next = tokens[i + 1];
+
+      if (
+        token.type === "inline" &&
+        (prev?.type === "th_open" || prev?.type === "td_open") &&
+        (next?.type === "th_close" || next?.type === "td_close")
+      ) {
+        const open = new state.Token("paragraph_open", "p", 1);
+        open.level = token.level;
+        const inline = new state.Token("inline", "", 0);
+        Object.assign(inline, token);
+        inline.level = token.level + 1;
+        const close = new state.Token("paragraph_close", "p", -1);
+        close.level = token.level;
+
+        out.push(open, inline, close);
+      } else {
+        out.push(token);
+      }
+    }
+
+    state.tokens = out;
   });
 }
 
@@ -850,6 +976,9 @@ function getParser(): MarkdownParser {
   md.use(strikethroughPlugin);
   md.use(underlinePlugin);
   md.use(highlightPlugin);
+  md.use(hardBreakTagPlugin);
+  md.enable("table");
+  md.use(tableCellParagraphsPlugin);
   md.use(taskListPlugin);
   md.use(clipPlugin);
   md.use(fileAttachmentPlugin);
@@ -891,6 +1020,12 @@ function getParser(): MarkdownParser {
       },
     },
     hardbreak: { node: "hardBreak" },
+    table: { block: "table" },
+    thead: { ignore: true },
+    tbody: { ignore: true },
+    tr: { block: "tableRow" },
+    th: { block: "tableHeader" },
+    td: { block: "tableCell" },
 
     em: { mark: "italic" },
     strong: { mark: "bold" },
@@ -960,6 +1095,107 @@ function backticksFor(node: PMNode, side: number): string {
   return result;
 }
 
+function escapeTableCell(markdown: string): string {
+  const breakPlaceholder = "\u0000TABLE_CELL_BREAK\u0000";
+
+  return markdown
+    .replace(/\\\n/g, breakPlaceholder)
+    .replace(/\n+/g, breakPlaceholder)
+    .replace(/\|/g, "\\|")
+    .replace(/<br\s*\/?>/gi, "\\$&")
+    .split(breakPlaceholder)
+    .join("<br>")
+    .trim();
+}
+
+function tableCellToMarkdown(cell: PMNode): string {
+  const parts: string[] = [];
+
+  cell.forEach((child) => {
+    const doc = markdownSchema.node("doc", null, [child]);
+    parts.push(getSerializer().serialize(doc));
+  });
+
+  return escapeTableCell(parts.join("\n"));
+}
+
+function tableCellSpan(cell: PMNode, attr: "colspan" | "rowspan"): number {
+  const span = Number(cell.attrs[attr] ?? 1);
+  return Number.isInteger(span) && span > 0 ? span : 1;
+}
+
+function tableCellsToMarkdown(cells: string[]): string {
+  return `| ${cells.join(" | ")} |`;
+}
+
+function tableRowsToMarkdown(rows: PMNode[]): {
+  rows: string[];
+  columnCount: number;
+} {
+  const pendingRowspans: number[] = [];
+  const renderedRows: string[][] = [];
+  let columnCount = 0;
+
+  for (const row of rows) {
+    const cells: string[] = [];
+    let columnIndex = 0;
+
+    const addPendingRowspans = () => {
+      while ((pendingRowspans[columnIndex] ?? 0) > 0) {
+        cells.push("");
+        pendingRowspans[columnIndex] -= 1;
+        columnIndex += 1;
+      }
+    };
+
+    row.forEach((cell) => {
+      addPendingRowspans();
+
+      const startColumn = columnIndex;
+      const colspan = tableCellSpan(cell, "colspan");
+      const rowspan = tableCellSpan(cell, "rowspan");
+
+      cells.push(tableCellToMarkdown(cell));
+      columnIndex += 1;
+
+      for (let i = 1; i < colspan; i++) {
+        cells.push("");
+        columnIndex += 1;
+      }
+
+      if (rowspan > 1) {
+        for (let i = 0; i < colspan; i++) {
+          pendingRowspans[startColumn + i] = Math.max(
+            pendingRowspans[startColumn + i] ?? 0,
+            rowspan - 1,
+          );
+        }
+      }
+    });
+
+    addPendingRowspans();
+    columnCount = Math.max(columnCount, cells.length);
+    renderedRows.push(cells);
+  }
+
+  columnCount = Math.max(columnCount, 1);
+
+  return {
+    rows: renderedRows.map((cells) => {
+      while (cells.length < columnCount) {
+        cells.push("");
+      }
+
+      return tableCellsToMarkdown(cells);
+    }),
+    columnCount,
+  };
+}
+
+function tableDelimiterRow(columnCount: number): string {
+  return `| ${Array.from({ length: columnCount }, () => "---").join(" | ")} |`;
+}
+
 let _serializer: MarkdownSerializer | null = null;
 
 function getSerializer(): MarkdownSerializer {
@@ -1009,6 +1245,34 @@ function getSerializer(): MarkdownSerializer {
       listItem(state, node) {
         state.renderContent(node);
       },
+
+      table(state, node) {
+        const rows: PMNode[] = [];
+        node.forEach((row) => rows.push(row));
+        if (rows.length === 0) {
+          state.closeBlock(node);
+          return;
+        }
+
+        const table = tableRowsToMarkdown(rows);
+
+        state.write(table.rows[0]);
+        state.write("\n");
+        state.write(tableDelimiterRow(table.columnCount));
+
+        for (let i = 1; i < table.rows.length; i++) {
+          state.write("\n");
+          state.write(table.rows[i]);
+        }
+
+        state.closeBlock(node);
+      },
+
+      tableRow() {},
+
+      tableCell() {},
+
+      tableHeader() {},
 
       taskList(state, node) {
         state.renderList(node, "  ", () => "- ");

--- a/packages/editor/src/note/schema.ts
+++ b/packages/editor/src/note/schema.ts
@@ -11,6 +11,38 @@ import {
 } from "../node-views";
 import { clipNodeSpec } from "../plugins";
 
+const tableCellAttrs = {
+  colspan: { default: 1 },
+  rowspan: { default: 1 },
+  colwidth: { default: null },
+};
+
+function getTableCellAttrs(dom: Node | string) {
+  if (typeof dom === "string") return {};
+  const element = dom as HTMLElement;
+  const widthAttr = element.getAttribute("data-colwidth");
+  const widths =
+    widthAttr && /^\d+(,\d+)*$/.test(widthAttr)
+      ? widthAttr.split(",").map((value) => Number(value))
+      : null;
+  const colspan = Number(element.getAttribute("colspan") || 1);
+
+  return {
+    colspan,
+    rowspan: Number(element.getAttribute("rowspan") || 1),
+    colwidth: widths && widths.length === colspan ? widths : null,
+  };
+}
+
+function setTableCellAttrs(node: { attrs: Record<string, any> }) {
+  const attrs: Record<string, string | number> = {};
+  if (node.attrs.colspan !== 1) attrs.colspan = node.attrs.colspan;
+  if (node.attrs.rowspan !== 1) attrs.rowspan = node.attrs.rowspan;
+  if (node.attrs.colwidth)
+    attrs["data-colwidth"] = node.attrs.colwidth.join(",");
+  return attrs;
+}
+
 // Node names match Tiptap for JSON content compatibility.
 const nodes: Record<string, NodeSpec> = {
   doc: { content: "block+" },
@@ -117,6 +149,48 @@ const nodes: Record<string, NodeSpec> = {
     parseDOM: [{ tag: "li:not([data-type])" }],
     toDOM() {
       return ["li", 0];
+    },
+  },
+
+  table: {
+    content: "tableRow+",
+    group: "block",
+    isolating: true,
+    tableRole: "table",
+    parseDOM: [{ tag: "table" }],
+    toDOM() {
+      return ["table", ["tbody", 0]];
+    },
+  },
+
+  tableRow: {
+    content: "(tableCell | tableHeader)*",
+    tableRole: "row",
+    parseDOM: [{ tag: "tr" }],
+    toDOM() {
+      return ["tr", 0];
+    },
+  },
+
+  tableCell: {
+    content: "block+",
+    attrs: tableCellAttrs,
+    isolating: true,
+    tableRole: "cell",
+    parseDOM: [{ tag: "td", getAttrs: getTableCellAttrs }],
+    toDOM(node) {
+      return ["td", setTableCellAttrs(node), 0];
+    },
+  },
+
+  tableHeader: {
+    content: "block+",
+    attrs: tableCellAttrs,
+    isolating: true,
+    tableRole: "header_cell",
+    parseDOM: [{ tag: "th", getAttrs: getTableCellAttrs }],
+    toDOM(node) {
+      return ["th", setTableCellAttrs(node), 0];
     },
   },
 


### PR DESCRIPTION
Add table parsing, editor schema support, and markdown round-trip tests for generated summary tables.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared markdown conversion and editor document schema; behavior is broad but confined to new table paths and covered by round-trip tests.
> 
> **Overview**
> Adds **markdown table** support end-to-end so summary (and note) JSON with `table` nodes can render as GitHub-style pipe tables and round-trip through `json2md` / `md2json`.
> 
> The markdown layer gains table-related ProseMirror nodes (with `colspan` / `rowspan` / `colwidth`), enables CommonMark tables in `markdown-it`, wraps cell inlines in paragraphs for parsing, and maps `<br>` in cells to hard breaks. Serialization builds delimiter rows, pads merged or short rows, escapes `|` and literal `<br>` in cells, and emits `<br>` for in-cell line breaks.
> 
> The **note editor schema** mirrors the same table nodes so parsed table JSON validates with `PMNode.fromJSON(noteSchema, …)`. Tests cover pipes, merges, breaks, escapes, and backslash preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9072314958da352b97864576fb43ece1c8ebf262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->