### PR TITLE
Show related meeting fact bullets

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -403,12 +403,12 @@ describe("PostSessionAccessory", () => {
     );
     const factsList = screen.getByRole("list");
     expect(factsList.className).toContain("list-disc");
-    expect(factsList.className).toContain("list-outside");
-    expect(factsList.className).not.toContain("flex");
+    expect(factsList.className).toContain("list-inside");
+    expect(factsList.className).not.toContain("overflow-hidden");
     const facts = screen.getAllByRole("listitem");
     expect(facts).toHaveLength(3);
     expect(facts[0].className).not.toContain("line-clamp");
-    expect(facts[0].querySelector("span")?.className).toContain("line-clamp-2");
+    expect(facts[0].querySelector(".line-clamp-2")).toBeNull();
     expect(screen.getByText("Ship the transcript panel.")).toBeTruthy();
     expect(screen.getByText("Revisit visual polish next week.")).toBeTruthy();
     expect(screen.getByText("Confirm keyboard behavior.")).toBeTruthy();

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -158,10 +158,10 @@ function PastNotesPanel({
           {notes.map((note) => (
             <div
               key={note.sessionId}
-              className="relative grid min-w-0 grid-cols-1 overflow-hidden pl-5"
+              className="relative grid min-w-0 grid-cols-1 pl-5"
             >
               <div className="border-border bg-card absolute top-1.5 left-0 h-2 w-2 rounded-full border" />
-              <div className="flex min-w-0 flex-col gap-1 overflow-hidden">
+              <div className="flex min-w-0 flex-col gap-1">
                 <div className="flex min-w-0 items-center justify-between gap-2">
                   <div className="flex min-w-0 items-baseline gap-2">
                     <span className="text-muted-foreground shrink-0 text-[11px]">
@@ -182,10 +182,10 @@ function PastNotesPanel({
                   ) : null}
                 </div>
                 {note.summary ? (
-                  <ul className="text-muted-foreground min-w-0 list-outside list-disc space-y-1 overflow-hidden pr-1 pl-4 text-xs leading-5">
+                  <ul className="text-muted-foreground min-w-0 list-inside list-disc space-y-1 pr-1 text-xs leading-5">
                     {splitKeyFacts(note.summary).map((fact) => (
                       <li key={fact} className="min-w-0 break-words">
-                        <span className="line-clamp-2">{fact}</span>
+                        {fact}
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
Render fact bullets inside the related-meetings panel and remove the two-line clamp from fact text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Tailwind changes in the post-session past-notes UI with matching test updates.
> 
> **Overview**
> Updates **Related meetings** key-fact bullets in `PastNotesPanel` so full fact text is visible and bullets read more naturally.
> 
> Fact items no longer use a `line-clamp-2` wrapper; each line renders as plain text inside the list item. The facts `<ul>` switches from `list-outside` with left padding to `list-inside`, and `overflow-hidden` is dropped from the timeline row and summary column so long facts are not clipped by layout.
> 
> Tests for the past-notes tab assert `list-inside`, no `overflow-hidden` on the list, and no `.line-clamp-2` on the first fact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7b0af557ff64f299cec1b0f02c5bf15a2fe81eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->