### PR TITLE
fix/enhance-summary-models

### DIFF
--- a/crates/llm-proxy/src/model.rs
+++ b/crates/llm-proxy/src/model.rs
@@ -6,6 +6,7 @@ use utoipa::ToSchema;
 pub const MODEL_KEY_DEFAULT: &str = "default";
 pub const MODEL_KEY_TOOL_CALLING: &str = "tool_calling";
 pub const MODEL_KEY_AUDIO: &str = "audio";
+const MODEL_LATEST_SONNET: &str = "~anthropic/claude-sonnet-latest";
 
 #[derive(
     Debug,
@@ -47,50 +48,28 @@ impl Default for StaticModelResolver {
     fn default() -> Self {
         let mut models = HashMap::new();
 
-        models.insert(
-            CharTask::Chat.to_string(),
-            vec![
-                "anthropic/claude-haiku-4.5".into(),
-                "anthropic/claude-sonnet-4.6".into(),
-                "z-ai/glm-5".into(),
-            ],
-        );
+        models.insert(CharTask::Chat.to_string(), vec![MODEL_LATEST_SONNET.into()]);
         models.insert(
             CharTask::Title.to_string(),
-            vec![
-                "moonshotai/kimi-k2-0905".into(),
-                "google/gemini-2.5-flash-lite".into(),
-                "z-ai/glm-4.7-flash".into(),
-            ],
+            vec![MODEL_LATEST_SONNET.into()],
         );
         models.insert(
             CharTask::Enhance.to_string(),
-            vec![
-                "anthropic/claude-opus-4.8".into(),
-                "openai/gpt-5.5".into(),
-                "anthropic/claude-sonnet-4.6".into(),
-            ],
+            vec![MODEL_LATEST_SONNET.into()],
         );
         models.insert(
             MODEL_KEY_TOOL_CALLING.to_owned(),
-            vec![
-                "anthropic/claude-sonnet-4.6".into(),
-                "anthropic/claude-haiku-4.5".into(),
-                "moonshotai/kimi-k2-0905:exacto".into(),
-            ],
+            vec![MODEL_LATEST_SONNET.into()],
         );
         models.insert(
             MODEL_KEY_DEFAULT.to_owned(),
-            vec![
-                "anthropic/claude-sonnet-4.6".into(),
-                "openai/gpt-5.2-chat".into(),
-                "moonshotai/kimi-k2-0905".into(),
-            ],
+            vec![MODEL_LATEST_SONNET.into()],
         );
         models.insert(
             MODEL_KEY_AUDIO.to_owned(),
             vec![
-                "google/gemini-2.5-flash-lite".into(),
+                "google/gemini-3.1-pro-preview".into(),
+                "google/gemini-3.5-flash".into(),
                 "mistralai/voxtral-small-24b-2507".into(),
             ],
         );
@@ -160,11 +139,7 @@ mod tests {
                 false,
                 false,
                 None,
-                &[
-                    "anthropic/claude-haiku-4.5",
-                    "anthropic/claude-sonnet-4.6",
-                    "z-ai/glm-5",
-                ],
+                &[MODEL_LATEST_SONNET],
             ),
             (
                 "by_tool_calling",
@@ -172,35 +147,16 @@ mod tests {
                 true,
                 false,
                 None,
-                &[
-                    "anthropic/claude-sonnet-4.6",
-                    "anthropic/claude-haiku-4.5",
-                    "moonshotai/kimi-k2-0905:exacto",
-                ],
+                &[MODEL_LATEST_SONNET],
             ),
-            (
-                "default",
-                None,
-                false,
-                false,
-                None,
-                &[
-                    "anthropic/claude-sonnet-4.6",
-                    "openai/gpt-5.2-chat",
-                    "moonshotai/kimi-k2-0905",
-                ],
-            ),
+            ("default", None, false, false, None, &[MODEL_LATEST_SONNET]),
             (
                 "task_overrides_tool_calling",
                 Some(CharTask::Chat),
                 true,
                 false,
                 None,
-                &[
-                    "anthropic/claude-haiku-4.5",
-                    "anthropic/claude-sonnet-4.6",
-                    "z-ai/glm-5",
-                ],
+                &[MODEL_LATEST_SONNET],
             ),
             (
                 "with_models_custom_key",
@@ -216,11 +172,7 @@ mod tests {
                 false,
                 false,
                 None,
-                &[
-                    "anthropic/claude-opus-4.8",
-                    "openai/gpt-5.5",
-                    "anthropic/claude-sonnet-4.6",
-                ],
+                &[MODEL_LATEST_SONNET],
             ),
             (
                 "audio_overrides_task",
@@ -229,7 +181,8 @@ mod tests {
                 true,
                 None,
                 &[
-                    "google/gemini-2.5-flash-lite",
+                    "google/gemini-3.1-pro-preview",
+                    "google/gemini-3.5-flash",
                     "mistralai/voxtral-small-24b-2507",
                 ],
             ),
@@ -240,7 +193,8 @@ mod tests {
                 true,
                 None,
                 &[
-                    "google/gemini-2.5-flash-lite",
+                    "google/gemini-3.1-pro-preview",
+                    "google/gemini-3.5-flash",
                     "mistralai/voxtral-small-24b-2507",
                 ],
             ),

--- a/crates/llm-proxy/src/model.rs
+++ b/crates/llm-proxy/src/model.rs
@@ -64,6 +64,14 @@ impl Default for StaticModelResolver {
             ],
         );
         models.insert(
+            CharTask::Enhance.to_string(),
+            vec![
+                "anthropic/claude-opus-4.8".into(),
+                "openai/gpt-5.5".into(),
+                "anthropic/claude-sonnet-4.6".into(),
+            ],
+        );
+        models.insert(
             MODEL_KEY_TOOL_CALLING.to_owned(),
             vec![
                 "anthropic/claude-sonnet-4.6".into(),
@@ -203,15 +211,15 @@ mod tests {
                 &["foo/bar"],
             ),
             (
-                "unknown_task_falls_back_to_default",
+                "enhance_uses_quality_models",
                 Some(CharTask::Enhance),
                 false,
                 false,
                 None,
                 &[
+                    "anthropic/claude-opus-4.8",
+                    "openai/gpt-5.5",
                     "anthropic/claude-sonnet-4.6",
-                    "openai/gpt-5.2-chat",
-                    "moonshotai/kimi-k2-0905",
                 ],
             ),
             (

--- a/crates/transcribe-proxy/src/hyprnote_routing.rs
+++ b/crates/transcribe-proxy/src/hyprnote_routing.rs
@@ -89,8 +89,8 @@ impl HyprnoteRouter {
         languages: &[Language],
         available_providers: &HashSet<Provider>,
     ) -> Vec<Provider> {
-        let mut candidates: Vec<_> = self
-            .priorities
+        let priorities = self.priorities_for_mode(mode);
+        let mut candidates: Vec<_> = priorities
             .iter()
             .copied()
             .filter_map(|p| {
@@ -106,15 +106,21 @@ impl HyprnoteRouter {
         candidates.sort_by(|a, b| {
             let (p1, s1) = a;
             let (p2, s2) = b;
+            if mode == RoutingMode::Batch {
+                match (*p1 == Provider::Soniox, *p2 == Provider::Soniox) {
+                    (true, false) => return std::cmp::Ordering::Less,
+                    (false, true) => return std::cmp::Ordering::Greater,
+                    _ => {}
+                }
+            }
+
             match s2.cmp(s1) {
                 std::cmp::Ordering::Equal => {
-                    let idx1 = self
-                        .priorities
+                    let idx1 = priorities
                         .iter()
                         .position(|p| p == p1)
                         .unwrap_or(usize::MAX);
-                    let idx2 = self
-                        .priorities
+                    let idx2 = priorities
                         .iter()
                         .position(|p| p == p2)
                         .unwrap_or(usize::MAX);
@@ -149,6 +155,17 @@ impl HyprnoteRouter {
 
     pub fn retry_config(&self) -> &RetryConfig {
         &self.retry_config
+    }
+
+    fn priorities_for_mode(&self, mode: RoutingMode) -> Vec<Provider> {
+        let mut priorities = self.priorities.clone();
+        if mode == RoutingMode::Batch
+            && let Some(index) = priorities.iter().position(|p| *p == Provider::Soniox)
+        {
+            let soniox = priorities.remove(index);
+            priorities.insert(0, soniox);
+        }
+        priorities
     }
 }
 
@@ -581,6 +598,18 @@ mod tests {
         assert_eq!(
             router.select_provider_chain_with_mode(RoutingMode::Batch, &languages, &available),
             vec![Provider::OpenAI]
+        );
+    }
+
+    #[test]
+    fn batch_routing_prefers_soniox_when_available() {
+        let router = HyprnoteRouter::default();
+        let languages = langs(&[ISO639::En]);
+        let available = default_available();
+
+        assert_eq!(
+            router.select_provider_chain_with_mode(RoutingMode::Batch, &languages, &available),
+            vec![Provider::Soniox, Provider::Deepgram]
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default LLM models and transcription provider ordering for all users, which can affect quality, cost, and failover behavior without code-path isolation.
> 
> **Overview**
> **LLM proxy** default routing is simplified so chat, title, **enhance/summary**, tool-calling, and fallback paths all resolve to a single `~anthropic/claude-sonnet-latest` model instead of multi-provider fallback chains. Audio requests now prefer newer Gemini 3.x models (replacing `gemini-2.5-flash-lite`), with tests updated to match.
> 
> **Transcribe proxy** batch Hyprnote routing now **prioritizes Soniox** ahead of the configured list (including over Deepgram when both support the language), via `priorities_for_mode` and batch-specific sort logic; a new test asserts batch order `[Soniox, Deepgram]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b7be24745f322f610d16f35fe2b40704597c810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->