### PR TITLE
Hide floating bar after live capture

### DIFF
--- a/apps/desktop/src/meeting-float/host.test.ts
+++ b/apps/desktop/src/meeting-float/host.test.ts
@@ -59,4 +59,15 @@ describe("getFloatingRouteState", () => {
       )?.status,
     ).toBe("error");
   });
+
+  it("hides the floating route while the session is finalizing", () => {
+    expect(
+      getFloatingRouteState(
+        createListenerState({
+          status: "finalizing",
+          sessionId: "session-1",
+        }),
+      ),
+    ).toBeNull();
+  });
 });

--- a/apps/desktop/src/meeting-float/host.tsx
+++ b/apps/desktop/src/meeting-float/host.tsx
@@ -143,7 +143,7 @@ export function getFloatingRouteState(
   state: ListenerState,
   sessionId?: string,
 ): FloatingRouteState | null {
-  if (state.live.status !== "active" && state.live.status !== "finalizing") {
+  if (state.live.status !== "active") {
     return null;
   }
 

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OverflowButton } from "./index";
 
+import { openFloatingMeetingPanel } from "~/meeting-float/host";
 import type { EditorView } from "~/store/zustand/tabs/schema";
 
 const {
@@ -146,6 +147,51 @@ describe("OverflowButton", () => {
     expect(screen.queryByRole("button", { name: "Upload audio" })).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Upload transcript" }),
+    ).toBeNull();
+  });
+
+  it("opens the floating panel while actively listening", () => {
+    useConfigValueMock.mockReturnValue(true);
+    useListenerMock.mockImplementation((selector) =>
+      selector({
+        getSessionMode: () => "active",
+      }),
+    );
+
+    render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open floating panel" }),
+    );
+
+    expect(openFloatingMeetingPanel).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      enabled: true,
+    });
+  });
+
+  it("hides the floating panel action while finalizing", () => {
+    useConfigValueMock.mockReturnValue(true);
+    useListenerMock.mockImplementation((selector) =>
+      selector({
+        getSessionMode: () => "finalizing",
+      }),
+    );
+
+    render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Open floating panel" }),
     ).toBeNull();
   });
 });

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -51,9 +51,7 @@ export function OverflowButton({
   const { audioExists } = useAudioPlayer();
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const floatingBarEnabled = useConfigValue("floating_bar_enabled");
-  const canOpenFloatingPanel =
-    floatingBarEnabled &&
-    (sessionMode === "active" || sessionMode === "finalizing");
+  const canOpenFloatingPanel = floatingBarEnabled && sessionMode === "active";
   const openExportModal = () => {
     setOpen(false);
     requestAnimationFrame(() => setIsExportModalOpen(true));


### PR DESCRIPTION
Limit the native floating panel to active listening and hide the manual reopen action during finalization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/state-gating change around listener lifecycle with no auth or data-path impact; behavior is covered by new unit tests.
> 
> **Overview**
> Restricts the native **floating meeting bar** to **active** live capture only. When the listener enters **`finalizing`**, `getFloatingRouteState` no longer returns route state, so the window host sync hides the panel instead of keeping it visible.
> 
> The session overflow menu’s **Open floating panel** action is shown only while `sessionMode === "active"` (not during finalization). Tests cover both the route helper and overflow UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c086e8b3e6a7ed69d9dd6977a7ee1cbc51dda8ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->