### PR TITLE
Restore destructive toast button styling

### DIFF
--- a/apps/desktop/src/sidebar/toast/component.test.tsx
+++ b/apps/desktop/src/sidebar/toast/component.test.tsx
@@ -26,12 +26,38 @@ describe("Toast", () => {
     const pill = container.querySelector(".inline-flex");
 
     expect(pill?.className).toContain("rounded-full");
+    expect(pill?.className).toContain("bg-card");
     expect(screen.getByText("Language model needed")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Add" }).className).toContain(
+      "bg-muted",
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Add" }));
     fireEvent.click(screen.getByRole("button", { name: "Hide" }));
 
     expect(onAdd).toHaveBeenCalledTimes(1);
     expect(onHide).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the destructive button color for error primary actions", () => {
+    render(
+      <Toast
+        toast={{
+          id: "transcription-unavailable",
+          description: "Transcription unavailable",
+          dismissible: true,
+          variant: "error",
+          primaryAction: {
+            label: "Settings",
+            onClick: vi.fn(),
+          },
+        }}
+      />,
+    );
+
+    const action = screen.getByRole("button", { name: "Settings" });
+
+    expect(action.className).toContain("bg-destructive");
+    expect(action.className).toContain("text-destructive-foreground");
   });
 });

--- a/apps/desktop/src/sidebar/toast/component.tsx
+++ b/apps/desktop/src/sidebar/toast/component.tsx
@@ -17,7 +17,7 @@ export function Toast({
       <div
         className={cn([
           "relative z-50 inline-flex max-w-[calc(100vw-24px)] items-center gap-3 py-1.5 pr-1.5 pl-4",
-          "bg-secondary text-secondary-foreground rounded-full",
+          "bg-card text-card-foreground rounded-full",
           "border shadow-lg backdrop-blur-none",
           toast.variant === "error"
             ? "border-alert-border shadow-red-100 dark:shadow-red-950/30"
@@ -89,14 +89,14 @@ function getActions(
 
 function getActionClassName(toast: ToastType, index: number) {
   if (toast.variant === "error" && index === 0) {
-    return "bg-alert text-alert-foreground hover:bg-alert/90";
+    return "bg-destructive text-destructive-foreground hover:bg-destructive/90";
   }
 
   if (index === 0) {
-    return "bg-primary text-primary-foreground hover:bg-primary/90";
+    return "bg-muted text-foreground hover:bg-accent";
   }
 
-  return "border-border bg-card text-foreground hover:bg-accent border";
+  return "border-border bg-muted text-foreground hover:bg-accent border";
 }
 
 function getProgress(toast: ToastType) {

--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
@@ -288,7 +288,7 @@ function ToastPill({
       <div
         className={cn([
           "flex items-center gap-3 py-1.5 pr-1.5 pl-4",
-          "bg-secondary text-secondary-foreground rounded-full",
+          "bg-card text-card-foreground rounded-full",
           "border-border border shadow-lg backdrop-blur-none",
         ])}
       >
@@ -301,8 +301,8 @@ function ToastPill({
           className={cn([
             "rounded-full px-3 py-1.5 text-xs font-medium",
             "whitespace-nowrap",
-            "bg-alert text-alert-foreground",
-            "hover:bg-alert/90",
+            "bg-destructive text-destructive-foreground",
+            "hover:bg-destructive/90",
             "transition-colors",
           ])}
         >
@@ -314,7 +314,7 @@ function ToastPill({
           className={cn([
             "rounded-full px-3 py-1.5 text-xs font-medium",
             "whitespace-nowrap",
-            "border-border bg-card text-foreground hover:bg-accent border",
+            "border-border bg-muted text-foreground hover:bg-accent border",
             "transition-colors",
           ])}
         >


### PR DESCRIPTION
Use white toast surfaces with subtle non-destructive buttons and red destructive actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only Tailwind class changes in sidebar toast components with no logic or data-path changes.
> 
> **Overview**
> Sidebar toast pills now use **card** surfaces (`bg-card`) instead of **secondary**, so notifications read as white/light panels rather than tinted bars.
> 
> **Non-destructive actions** (primary and secondary) switch from **primary** / **card** styling to **muted** backgrounds with standard foreground text. **Destructive actions** on error toasts and the undo-delete **Delete** control move from **alert** tokens to **destructive** / **destructive-foreground**, restoring explicit red destructive buttons.
> 
> Tests assert the default pill uses `bg-card` and muted primary buttons, and that error-variant primary actions use destructive colors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b523b31dd8882f8b91ad8e3eea864e941122f9b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->