### PR TITLE
Lower bubble menu below app popovers

### DIFF
--- a/packages/editor/src/widgets/format-toolbar.tsx
+++ b/packages/editor/src/widgets/format-toolbar.tsx
@@ -112,7 +112,7 @@ export function FormatToolbar() {
         "border-border bg-card/95 fixed flex items-center gap-0.5 rounded-lg border p-1",
         "shadow-[0_2px_8px_rgba(0,0,0,0.08),0_18px_42px_-16px_rgba(0,0,0,0.34)] backdrop-blur-sm",
       ])}
-      style={{ top: 0, left: 0, zIndex: 10000 }}
+      style={{ top: 0, left: 0, zIndex: 40 }}
       onMouseDown={(e) => e.preventDefault()}
     >
       {TOOLBAR_BUTTONS.map((button) => {


### PR DESCRIPTION
Keep the editor selection toolbar under Radix popovers so event details stay on top.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single stacking-context tweak in the editor toolbar with no logic or data changes.
> 
> **Overview**
> Lowers the editor **format toolbar** (`FormatToolbar`) stacking order by changing its inline `zIndex` from **10000** to **40**, so the selection bubble menu no longer covers Radix-style overlays (e.g. event detail popovers at `z-50`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59965244d18ca45978a83049e240800a15c3ce57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->