### PR TITLE
Show pending summary state

### DIFF
--- a/apps/desktop/src/ai/hooks/useAITaskTask.ts
+++ b/apps/desktop/src/ai/hooks/useAITaskTask.ts
@@ -106,6 +106,7 @@ export function useAITaskTask<T extends TaskType>(
     streamedText,
     error,
     currentStep,
+    hasTask: !!taskState,
     isGenerating: status === "generating",
     isSuccess: status === "success",
     isError: status === "error",

--- a/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
@@ -1,0 +1,127 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Enhanced } from "./index";
+
+import type { LLMConnectionStatus } from "~/ai/hooks";
+
+const hoisted = vi.hoisted(() => ({
+  task: undefined as
+    | {
+        status: string;
+        error: Error | undefined;
+        streamedText: string;
+        currentStep: unknown;
+        isGenerating: boolean;
+      }
+    | undefined,
+  llmStatus: {
+    status: "success",
+    providerId: "hyprnote",
+    isHosted: true,
+  } as LLMConnectionStatus,
+  content: "",
+}));
+
+vi.mock("streamdown", () => ({
+  Streamdown: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+
+vi.mock("@hypr/ui/components/ui/spinner", () => ({
+  Spinner: () => <span data-testid="spinner" />,
+}));
+
+vi.mock("~/ai/hooks", () => ({
+  useAITaskTask: () => ({
+    status: hoisted.task?.status ?? "idle",
+    error: hoisted.task?.error,
+    streamedText: hoisted.task?.streamedText ?? "",
+    currentStep: hoisted.task?.currentStep,
+    hasTask: !!hoisted.task,
+    isGenerating: hoisted.task?.isGenerating ?? false,
+  }),
+  useLLMConnectionStatus: () => hoisted.llmStatus,
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useCell: () => hoisted.content,
+  },
+}));
+
+vi.mock("./config-error", () => ({
+  ConfigError: () => <div>Config error</div>,
+}));
+
+vi.mock("./editor", () => ({
+  EnhancedEditor: () => <div>Enhanced editor</div>,
+}));
+
+vi.mock("./enhance-error", () => ({
+  EnhanceError: () => <div>Enhance error</div>,
+}));
+
+describe("Enhanced", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    hoisted.task = undefined;
+    hoisted.llmStatus = {
+      status: "success",
+      providerId: "hyprnote",
+      isHosted: true,
+    };
+    hoisted.content = "";
+  });
+
+  it("shows an interim summary state before the enhance task is visible", () => {
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "Preparing summary...",
+    );
+    expect(screen.getByRole("status").textContent).toContain(
+      "Tip: The Anarlog team loves our users!",
+    );
+    expect(screen.queryByText("Enhanced editor")).toBeNull();
+  });
+
+  it("renders the editor after an empty enhance task returns idle", () => {
+    hoisted.task = {
+      status: "idle",
+      error: undefined,
+      streamedText: "",
+      currentStep: undefined,
+      isGenerating: false,
+    };
+
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.getByText("Enhanced editor")).not.toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("keeps config errors ahead of the empty interim state", () => {
+    hoisted.llmStatus = { status: "pending", reason: "missing_provider" };
+
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.getByText("Config error")).not.toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("renders the editor when the enhanced note already has content", () => {
+    hoisted.content = JSON.stringify({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "Hi" }] }],
+    });
+
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.getByText("Enhanced editor")).not.toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/apps/desktop/src/session/components/note-input/enhanced/index.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.tsx
@@ -22,7 +22,7 @@ export const Enhanced = forwardRef<
 >(({ sessionId, enhancedNoteId, onNavigateToTitle }, ref) => {
   const taskId = createTaskId(enhancedNoteId, "enhance");
   const llmStatus = useLLMConnectionStatus();
-  const { status, error } = useAITaskTask(taskId, "enhance");
+  const { status, error, hasTask } = useAITaskTask(taskId, "enhance");
   const content = main.UI.useCell(
     "enhanced_notes",
     enhancedNoteId,
@@ -53,8 +53,16 @@ export const Enhanced = forwardRef<
     );
   }
 
-  if (status === "generating") {
-    return <StreamingView enhancedNoteId={enhancedNoteId} />;
+  if (
+    status === "generating" ||
+    (!hasContent && status === "idle" && !hasTask)
+  ) {
+    return (
+      <StreamingView
+        enhancedNoteId={enhancedNoteId}
+        pending={status === "idle"}
+      />
+    );
   }
 
   return (

--- a/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
 import { Streamdown } from "streamdown";
 
+import { Spinner } from "@hypr/ui/components/ui/spinner";
 import { cn } from "@hypr/utils";
 
 import { streamdownComponents } from "../../streamdown";
@@ -9,7 +9,13 @@ import { useAITaskTask } from "~/ai/hooks";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import { type TaskStepInfo } from "~/store/zustand/ai-task/tasks";
 
-export function StreamingView({ enhancedNoteId }: { enhancedNoteId: string }) {
+export function StreamingView({
+  enhancedNoteId,
+  pending = false,
+}: {
+  enhancedNoteId: string;
+  pending?: boolean;
+}) {
   const taskId = createTaskId(enhancedNoteId, "enhance");
   const { streamedText, currentStep, isGenerating } = useAITaskTask(
     taskId,
@@ -17,26 +23,40 @@ export function StreamingView({ enhancedNoteId }: { enhancedNoteId: string }) {
   );
 
   const step = currentStep as TaskStepInfo<"enhance"> | undefined;
-  const hasContent = streamedText.length > 0;
+  const hasContent = streamedText.trim().length > 0;
   let statusText: string | null = null;
   if (isGenerating && !hasContent) {
     if (step?.type === "analyzing") {
-      statusText = "Analyzing structure...";
+      statusText = "Analyzing transcript...";
     } else if (step?.type === "generating") {
-      statusText = "Generating...";
+      statusText = "Writing summary...";
     } else if (step?.type === "retrying") {
       statusText = `Retrying (attempt ${step.attempt})...`;
     } else {
-      statusText = "Loading...";
+      statusText = "Preparing summary...";
     }
+  } else if (pending && !hasContent) {
+    statusText = "Preparing summary...";
   }
 
   return (
     <div className="pb-2">
       {statusText ? (
-        <div className="flex flex-col gap-1">
-          <p className="text-muted-foreground text-sm">{statusText}</p>
-          <RotatingTip />
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex min-h-[260px] flex-col items-center justify-center gap-2 text-center"
+        >
+          <Spinner size={16} />
+          <div className="flex flex-col gap-1">
+            <p className="text-foreground text-sm font-medium">{statusText}</p>
+            <p className="text-muted-foreground text-xs">
+              The summary will appear here as soon as it starts streaming.
+            </p>
+            <p className="text-muted-foreground text-xs">
+              Tip: The Anarlog team loves our users!
+            </p>
+          </div>
         </div>
       ) : (
         <div className="flex flex-col gap-1">
@@ -51,24 +71,5 @@ export function StreamingView({ enhancedNoteId }: { enhancedNoteId: string }) {
         </div>
       )}
     </div>
-  );
-}
-
-const TIPS = ["The Anarlog team loves our users!"];
-
-function RotatingTip() {
-  const [index, setIndex] = useState(() =>
-    Math.floor(Math.random() * TIPS.length),
-  );
-
-  useEffect(() => {
-    const id = setInterval(() => {
-      setIndex((i) => (i + 1) % TIPS.length);
-    }, 5_000);
-    return () => clearInterval(id);
-  }, []);
-
-  return (
-    <p className="text-muted-foreground pl-3 text-xs">└ Tip: {TIPS[index]}</p>
   );
 }


### PR DESCRIPTION
Render a centered generating state for empty enhanced notes before summary text streams.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only routing and loading copy in the enhanced note flow, covered by new component tests; no auth or data-path changes.
> 
> **Overview**
> Shows a **centered “preparing summary” state** for empty enhanced notes while the enhance task has not started yet, instead of jumping straight to the editor.
> 
> `useAITaskTask` now exposes **`hasTask`** so `Enhanced` can treat **idle + no stored content + no task** as pending and route to `StreamingView` with `pending={true}`. Once an idle task exists (or the note already has content), the editor still renders as before; config errors still win over the interim UI.
> 
> `StreamingView` is updated with a **spinner**, **`role="status"` / `aria-live`**, clearer step copy (e.g. analyzing transcript, writing summary), and a static tip—replacing the rotating tip timer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 439bed5c205a5b47db7ac1f1022ff8ac00b60270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->