### PR TITLE
Keep live speaker assignment usable

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
+import type { MouseEvent, ReactElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DuringSessionAccessory } from "./during-session";
@@ -32,20 +32,65 @@ vi.mock("@tanstack/react-query", () => ({
   useQuery: useQueryMock,
 }));
 
-vi.mock("@hypr/ui/components/ui/popover", () => ({
-  AppFloatingPanel: ({
-    children,
-    className,
-  }: {
-    children: ReactNode;
-    className?: string;
-  }) => <div className={className}>{children}</div>,
-  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
-  PopoverContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
-}));
+vi.mock("@hypr/ui/components/ui/popover", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  const PopoverContext = React.createContext<{
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  } | null>(null);
+
+  return {
+    AppFloatingPanel: ({
+      children,
+      className,
+    }: {
+      children: ReactNode;
+      className?: string;
+    }) => <div className={className}>{children}</div>,
+    Popover: ({
+      children,
+      open,
+      onOpenChange,
+    }: {
+      children: ReactNode;
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+    }) => (
+      <PopoverContext.Provider value={{ open, onOpenChange }}>
+        {children}
+      </PopoverContext.Provider>
+    ),
+    PopoverContent: ({
+      children,
+      className,
+    }: {
+      children: ReactNode;
+      className?: string;
+    }) => {
+      const context = React.useContext(PopoverContext);
+      return context?.open ? (
+        <div data-popover-content className={className}>
+          {children}
+        </div>
+      ) : null;
+    },
+    PopoverTrigger: ({
+      children,
+    }: {
+      children: ReactElement<{
+        onClick?: (event: MouseEvent) => void;
+      }>;
+    }) => {
+      const context = React.useContext(PopoverContext);
+      return React.cloneElement(children, {
+        onClick: (event: MouseEvent) => {
+          children.props.onClick?.(event);
+          context?.onOpenChange(true);
+        },
+      });
+    },
+  };
+});
 
 vi.mock("~/store/tinybase/store/main", () => ({
   STORE_ID: "main",
@@ -331,6 +376,7 @@ describe("DuringSessionAccessory", () => {
     render(<DuringSessionAccessory sessionId="session-1" isExpanded />);
 
     expect(screen.getByRole("button", { name: "Speaker 1" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Speaker 1" }));
     fireEvent.click(screen.getByText("Alex"));
 
     expect(setCell).toHaveBeenCalledWith(
@@ -348,6 +394,85 @@ describe("DuringSessionAccessory", () => {
         value: JSON.stringify({ human_id: "human-1" }),
       },
     ]);
+    expect(screen.getByRole("button", { name: "Alex" })).toBeTruthy();
+  });
+
+  it("keeps the speaker selector open while live transcript words update", () => {
+    const store = {
+      forEachRow: vi.fn(),
+      getCell: vi.fn((tableId: string, rowId: string, cellId: string) => {
+        if (tableId === "transcripts" && rowId === "transcript-1") {
+          if (cellId === "session_id") return "session-1";
+          if (cellId === "started_at") return 0;
+          if (cellId === "words") {
+            return JSON.stringify([
+              {
+                id: "word-0",
+                text: "Remote words.",
+                start_ms: 0,
+                end_ms: 300,
+                channel: 1,
+              },
+            ]);
+          }
+          if (cellId === "speaker_hints") return "[]";
+        }
+        return undefined;
+      }),
+      getRow: vi.fn(() => ({ name: "Alex", email: "alex@example.com" })),
+      getValue: vi.fn(() => "user-1"),
+      setCell: vi.fn(),
+      setRow: vi.fn(),
+    };
+    const remoteSegment = {
+      ...segment("Remote words.", 0, {
+        channel: "RemoteParty",
+        speaker_index: 0,
+      }),
+      id: "live-segment-word-0",
+    };
+
+    useStoreMock.mockReturnValue(store);
+    useCellMock.mockReturnValue("session-1");
+    useQueriesMock.mockReturnValue({
+      getResultRow: vi.fn(() => ({
+        human_id: "human-1",
+        human_name: "Alex",
+        human_email: "alex@example.com",
+      })),
+    });
+    useSliceRowIdsMock.mockImplementation((indexId: string) =>
+      indexId === "transcriptBySession" ? ["transcript-1"] : ["mapping-1"],
+    );
+    useValueMock.mockReturnValue("user-1");
+    liveSegments = [remoteSegment];
+
+    const view = render(
+      <DuringSessionAccessory sessionId="session-1" isExpanded />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Speaker 1" }));
+    expect(screen.getByText("Alex")).toBeTruthy();
+
+    liveSegments = [
+      {
+        ...remoteSegment,
+        id: "live-segment-word-1",
+        words: [
+          ...remoteSegment.words,
+          {
+            id: "word-1",
+            text: " More words.",
+            start_ms: 300,
+            end_ms: 600,
+            channel: "RemoteParty",
+            is_final: false,
+          },
+        ],
+      },
+    ];
+    view.rerender(<DuringSessionAccessory sessionId="session-1" isExpanded />);
+
+    expect(screen.getByText("Alex")).toBeTruthy();
   });
 });
 

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useLayoutEffect, useMemo, useRef } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { cn } from "@hypr/utils";
 
@@ -142,6 +142,23 @@ function LiveTranscriptContent({
 }) {
   const scrollKey = getLiveTranscriptScrollKey(segments);
   const shouldPinToBottomRef = useRef(true);
+  const [speakerAssignments, setSpeakerAssignments] = useState(
+    () => new Map<string, string>(),
+  );
+
+  const handleSpeakerAssigned = useCallback(
+    (transcriptId: string, segmentKey: Segment["key"], humanId: string) => {
+      setSpeakerAssignments((current) => {
+        const next = new Map(current);
+        next.set(
+          getSpeakerAssignmentStateKey(transcriptId, segmentKey),
+          humanId,
+        );
+        return next;
+      });
+    },
+    [],
+  );
 
   useLayoutEffect(() => {
     if (!isExpanded) {
@@ -180,18 +197,31 @@ function LiveTranscriptContent({
           Transcript will appear here as you speak.
         </span>
       ) : (
-        segments.map((segment, index) => (
-          <TranscriptSegmentRow
-            key={getSegmentIdentity(segment, index)}
-            segment={segment}
-            transcriptId={getSegmentTranscriptId(segment, transcriptIdByWordId)}
-            label={SegmentKeyUtils.renderLabel(
-              segment.key,
-              labelContext,
-              speakerLabelManager,
-            )}
-          />
-        ))
+        segments.map((segment, index) => {
+          const transcriptId = getSegmentTranscriptId(
+            segment,
+            transcriptIdByWordId,
+          );
+          const labelKey = getSegmentLabelKey(
+            segment.key,
+            transcriptId,
+            speakerAssignments,
+          );
+
+          return (
+            <TranscriptSegmentRow
+              key={getSegmentIdentity(segment, index)}
+              segment={segment}
+              transcriptId={transcriptId}
+              label={SegmentKeyUtils.renderLabel(
+                labelKey,
+                labelContext,
+                speakerLabelManager,
+              )}
+              onSpeakerAssigned={handleSpeakerAssigned}
+            />
+          );
+        })
       )}
     </div>
   );
@@ -327,13 +357,17 @@ function getLiveTranscriptScrollKey(segments: Segment[]): string {
 
 function getSegmentIdentity(segment: Segment, fallbackIndex: number): string {
   const firstWord = segment.words[0];
-  const lastWord = segment.words[segment.words.length - 1];
+  const serializedKey = SegmentKeyUtils.serialize(segment.key);
 
-  if (firstWord?.id && lastWord?.id) {
-    return `${firstWord.id}:${lastWord.id}`;
+  if (firstWord?.id) {
+    return `${serializedKey}:${firstWord.id}`;
   }
 
-  return `${segment.key.channel}:${segment.key.speaker_index ?? "unknown"}:${firstWord?.start_ms ?? fallbackIndex}:${lastWord?.end_ms ?? fallbackIndex}`;
+  if (firstWord) {
+    return `${serializedKey}:${firstWord.start_ms}`;
+  }
+
+  return `${serializedKey}:${segment.id ?? fallbackIndex}`;
 }
 
 function getSegmentText(segment: Segment): string {
@@ -367,10 +401,16 @@ function TranscriptSegmentRow({
   segment,
   transcriptId,
   label,
+  onSpeakerAssigned,
 }: {
   segment: Segment;
   transcriptId: string | undefined;
   label: string;
+  onSpeakerAssigned: (
+    transcriptId: string,
+    segmentKey: Segment["key"],
+    humanId: string,
+  ) => void;
 }) {
   const colorVars = useSegmentColorVars(segment.key);
 
@@ -393,6 +433,9 @@ function TranscriptSegmentRow({
             color="var(--segment-color)"
             label={label}
             className="max-w-full min-w-0 truncate text-left"
+            onAssigned={(humanId) =>
+              onSpeakerAssigned(transcriptId, segment.key, humanId)
+            }
           />
         ) : (
           <span className="min-w-0 truncate">{label}</span>
@@ -419,4 +462,26 @@ function getSegmentTranscriptId(
   }
 
   return undefined;
+}
+
+function getSegmentLabelKey(
+  segmentKey: Segment["key"],
+  transcriptId: string | undefined,
+  speakerAssignments: Map<string, string>,
+): Segment["key"] {
+  if (!transcriptId) {
+    return segmentKey;
+  }
+
+  const humanId = speakerAssignments.get(
+    getSpeakerAssignmentStateKey(transcriptId, segmentKey),
+  );
+  return humanId ? { ...segmentKey, speaker_human_id: humanId } : segmentKey;
+}
+
+function getSpeakerAssignmentStateKey(
+  transcriptId: string,
+  segmentKey: Segment["key"],
+): string {
+  return `${transcriptId}:${SegmentKeyUtils.serialize(segmentKey)}`;
 }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -18,12 +18,14 @@ export function SpeakerAssignPopover({
   color,
   label,
   className,
+  onAssigned,
 }: {
   segment: Segment;
   transcriptId: string;
   color: string;
   label: string;
   className?: string;
+  onAssigned?: (humanId: string) => void;
 }) {
   const [open, setOpen] = useState(false);
   const store = main.UI.useStore(main.STORE_ID);
@@ -48,9 +50,10 @@ export function SpeakerAssignPopover({
         humanId,
         anchorWordId,
       );
+      onAssigned?.(humanId);
       setOpen(false);
     },
-    [store, transcriptId, segment.key, segment.words],
+    [onAssigned, store, transcriptId, segment.key, segment.words],
   );
 
   if (isSelf) {


### PR DESCRIPTION
Stabilize live transcript speaker rows during streaming and update assigned labels immediately after selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to live session transcript UI and speaker labeling; no auth or persistence contract changes beyond existing upsertSpeakerAssignment.
> 
> **Overview**
> Improves **live transcript speaker assignment** so rows stay stable while streaming and labels refresh right after you pick a participant.
> 
> **Stable segment rows:** `getSegmentIdentity` now keys rows on the serialized segment key plus the first word (not first/last word pair), so appending words to the same live segment no longer remounts the row and closes the speaker popover.
> 
> **Immediate label updates:** `LiveTranscriptContent` keeps a local `speakerAssignments` map; `SpeakerAssignPopover` calls `onAssigned` after `upsertSpeakerAssignment`, and labels render via `getSegmentLabelKey` so the chip shows the chosen name before store-driven hints fully propagate.
> 
> **Tests:** The popover mock respects `open`/`onOpenChange`; coverage asserts the assigned name on the button and that the participant list stays visible when live segments rerender with more words.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d024b9db3a637922d5cbcbe55929b305f6651c70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->