### PR TITLE
Hide empty transcript tabs

### DIFF
--- a/apps/desktop/src/audio-player/provider.tsx
+++ b/apps/desktop/src/audio-player/provider.tsx
@@ -328,7 +328,7 @@ export function AudioPlayerProvider({
     },
   });
 
-  const audioExistsValue = Boolean(url) || (audioExists.data ?? false);
+  const audioExistsValue = audioExists.data ?? false;
 
   const value = useMemo<AudioPlayerContextValue>(
     () => ({

--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -1,4 +1,11 @@
-import { act, renderHook } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from "@testing-library/react";
 import { isValidElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -25,6 +32,7 @@ const hoisted = vi.hoisted(() => ({
     summary: string | null;
     isGenerating: boolean;
   }>,
+  batch: {} as Record<string, { error: string | null }>,
   generateMissingPastNotes: vi.fn(),
   regeneratePastNote: vi.fn(),
 }));
@@ -69,10 +77,12 @@ vi.mock("~/stt/contexts", () => ({
         requestedLiveTranscription: boolean | null;
         liveTranscriptionActive: boolean | null;
       };
+      batch: Record<string, { error: string | null }>;
     }) => unknown,
   ) =>
     selector({
       live: hoisted.live,
+      batch: hoisted.batch,
     }),
 }));
 
@@ -88,12 +98,14 @@ import { useSessionBottomAccessory } from "./index";
 
 describe("useSessionBottomAccessory", () => {
   beforeEach(() => {
+    cleanup();
     hoisted.hotkeys.clear();
     hoisted.live.status = "inactive";
     hoisted.live.sessionId = null;
     hoisted.live.requestedLiveTranscription = true;
     hoisted.live.liveTranscriptionActive = true;
     hoisted.pastNotes = [];
+    hoisted.batch = {};
     hoisted.generateMissingPastNotes.mockClear();
     hoisted.regeneratePastNote.mockClear();
     useShellMock.mockReturnValue({
@@ -113,7 +125,7 @@ describe("useSessionBottomAccessory", () => {
       useSessionBottomAccessory({
         sessionId: "session-1",
         sessionMode: "inactive",
-        audioUrl: "file:///session.wav",
+        audioExists: true,
         hasTranscript: true,
       }),
     );
@@ -166,7 +178,7 @@ describe("useSessionBottomAccessory", () => {
       useSessionBottomAccessory({
         sessionId: "session-1",
         sessionMode: "inactive",
-        audioUrl: "file:///session.wav",
+        audioExists: true,
         hasTranscript: true,
       }),
     );
@@ -199,7 +211,7 @@ describe("useSessionBottomAccessory", () => {
       useSessionBottomAccessory({
         sessionId: "session-1",
         sessionMode: "inactive",
-        audioUrl: "file:///session.wav",
+        audioExists: true,
         hasTranscript: true,
       }),
     );
@@ -222,7 +234,7 @@ describe("useSessionBottomAccessory", () => {
       useSessionBottomAccessory({
         sessionId: "session-1",
         sessionMode: "inactive",
-        audioUrl: "file:///session.wav",
+        audioExists: true,
         hasTranscript: true,
       }),
     );
@@ -249,7 +261,7 @@ describe("useSessionBottomAccessory", () => {
       useSessionBottomAccessory({
         sessionId: "session-1",
         sessionMode: "inactive",
-        audioUrl: "file:///session.wav",
+        audioExists: true,
         hasTranscript: true,
       }),
     );
@@ -273,6 +285,165 @@ describe("useSessionBottomAccessory", () => {
     });
   });
 
+  it("uses related meetings as the only tab when there is no transcript content", () => {
+    hoisted.pastNotes = [
+      {
+        sessionId: "past-session",
+        title: "Weekly sync",
+        dateLabel: "May 28, 2026",
+        summary: null,
+        isGenerating: false,
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useSessionBottomAccessory({
+        sessionId: "session-1",
+        sessionMode: "inactive",
+        audioExists: false,
+        hasTranscript: false,
+      }),
+    );
+
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "transcript_only",
+      expanded: false,
+    });
+
+    render(result.current.bottomBorderHandle);
+
+    expect(screen.queryByRole("button", { name: /Transcript/ })).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Expand Related meetings" }),
+    );
+
+    expect(hoisted.generateMissingPastNotes).toHaveBeenCalledTimes(1);
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "transcript_only",
+      expanded: true,
+    });
+  });
+
+  it("keeps the transcript panel available after batch transcription fails without words", () => {
+    hoisted.batch = {
+      "session-1": {
+        error: "batch start failed: connection refused",
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useSessionBottomAccessory({
+        sessionId: "session-1",
+        sessionMode: "inactive",
+        audioExists: false,
+        hasTranscript: false,
+      }),
+    );
+
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "transcript_only",
+      expanded: false,
+    });
+    expect(result.current.bottomBorderHandle).not.toBeNull();
+  });
+
+  it("keeps the transcript tab visible for batch errors next to related meetings", () => {
+    hoisted.batch = {
+      "session-1": {
+        error: "batch start failed: connection refused",
+      },
+    };
+    hoisted.pastNotes = [
+      {
+        sessionId: "past-session",
+        title: "Weekly sync",
+        dateLabel: "May 28, 2026",
+        summary: null,
+        isGenerating: false,
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useSessionBottomAccessory({
+        sessionId: "session-1",
+        sessionMode: "inactive",
+        audioExists: false,
+        hasTranscript: false,
+      }),
+    );
+
+    render(result.current.bottomBorderHandle);
+
+    expect(
+      screen.getByRole("button", { name: "Expand Transcript" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Expand Related meetings" }),
+    ).not.toBeNull();
+  });
+
+  it("keeps playback disabled until the audio URL is ready", () => {
+    const { result, rerender } = renderHook(
+      ({ audioUrlReady }: { audioUrlReady: boolean }) =>
+        useSessionBottomAccessory({
+          sessionId: "session-1",
+          sessionMode: "inactive",
+          audioExists: true,
+          audioUrlReady,
+          hasTranscript: false,
+        }),
+      {
+        initialProps: {
+          audioUrlReady: false,
+        },
+      },
+    );
+
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "transcript_only",
+      expanded: false,
+    });
+    expect(result.current.bottomBorderHandle).not.toBeNull();
+
+    rerender({ audioUrlReady: true });
+
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "playback",
+      expanded: false,
+    });
+  });
+
+  it("keeps the post-session handle visible while audio lookup is loading", () => {
+    const { result, rerender } = renderHook(
+      ({ isAudioLoading }: { isAudioLoading: boolean }) =>
+        useSessionBottomAccessory({
+          sessionId: "session-1",
+          sessionMode: "inactive",
+          audioExists: false,
+          audioUrlReady: false,
+          isAudioLoading,
+          hasTranscript: false,
+        }),
+      {
+        initialProps: {
+          isAudioLoading: true,
+        },
+      },
+    );
+
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "transcript_only",
+      expanded: false,
+    });
+    expect(result.current.bottomBorderHandle).not.toBeNull();
+
+    rerender({ isAudioLoading: false });
+
+    expect(result.current.bottomAccessoryState).toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
+  });
+
   it("hides the bottom accessory while recording for batch transcription", () => {
     hoisted.live.requestedLiveTranscription = false;
     hoisted.live.liveTranscriptionActive = false;
@@ -281,7 +452,7 @@ describe("useSessionBottomAccessory", () => {
       useSessionBottomAccessory({
         sessionId: "session-1",
         sessionMode: "active",
-        audioUrl: null,
+        audioExists: false,
         hasTranscript: false,
       }),
     );
@@ -296,7 +467,7 @@ describe("useSessionBottomAccessory", () => {
       useSessionBottomAccessory({
         sessionId: "session-1",
         sessionMode: "finalizing",
-        audioUrl: null,
+        audioExists: false,
         hasTranscript: false,
       }),
     );
@@ -314,7 +485,7 @@ describe("useSessionBottomAccessory", () => {
       useSessionBottomAccessory({
         sessionId: "session-1",
         sessionMode: "inactive",
-        audioUrl: "file:///session.wav",
+        audioExists: true,
         hasTranscript: true,
       }),
     );
@@ -332,7 +503,7 @@ describe("useSessionBottomAccessory", () => {
       useSessionBottomAccessory({
         sessionId: "session-1",
         sessionMode: "running_batch",
-        audioUrl: "file:///session.wav",
+        audioExists: true,
         hasTranscript: true,
       }),
     );
@@ -350,7 +521,7 @@ describe("useSessionBottomAccessory", () => {
       useSessionBottomAccessory({
         sessionId: "session-1",
         sessionMode: "running_batch",
-        audioUrl: "file:///session.wav",
+        audioExists: true,
         hasTranscript: true,
       }),
     );
@@ -369,7 +540,7 @@ describe("useSessionBottomAccessory", () => {
         useSessionBottomAccessory({
           sessionId: "session-1",
           sessionMode,
-          audioUrl: "file:///session.wav",
+          audioExists: true,
           hasTranscript: true,
         }),
       {
@@ -416,7 +587,7 @@ describe("useSessionBottomAccessory", () => {
       useSessionBottomAccessory({
         sessionId: "session-1",
         sessionMode: "active",
-        audioUrl: null,
+        audioExists: false,
         hasTranscript: false,
       }),
     );

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -31,12 +31,16 @@ export type BottomAccessoryState = {
 export function useSessionBottomAccessory({
   sessionId,
   sessionMode,
-  audioUrl,
+  audioExists,
+  audioUrlReady = audioExists,
+  isAudioLoading = false,
   hasTranscript,
 }: {
   sessionId: string;
   sessionMode: string;
-  audioUrl: string | null | undefined;
+  audioExists: boolean;
+  audioUrlReady?: boolean;
+  isAudioLoading?: boolean;
   hasTranscript: boolean;
 }): {
   bottomAccessory: ReactNode;
@@ -50,19 +54,27 @@ export function useSessionBottomAccessory({
   const isLive = sessionMode === "active";
   const isInactive = sessionMode === "inactive";
   const isRunningBatch = sessionMode === "running_batch";
-  const hasAudio = Boolean(audioUrl) && (isInactive || isRunningBatch);
+  const canUsePlayback = audioUrlReady && (isInactive || isRunningBatch);
+  const mayHaveAudio =
+    (audioExists || isAudioLoading) && (isInactive || isRunningBatch);
+  const batchError = useListener(
+    (state) => state.batch[sessionId]?.error ?? null,
+  );
+  const hasTranscriptError = Boolean(batchError);
+  const canShowTranscriptTab =
+    canUsePlayback || hasTranscript || hasTranscriptError || isRunningBatch;
   const pastNotes = usePastSessionNotes(sessionId);
   const hasPastNotes = pastNotes.hasPastNotes;
   const generateMissingPastNotes = pastNotes.generateMissing;
   const regeneratePastNote = pastNotes.canGenerate
     ? pastNotes.regenerate
     : undefined;
-  const activePostSessionTab: PostSessionTab = hasPastNotes
-    ? (postSessionTab ??
-      (!hasAudio && !hasTranscript && !isRunningBatch
-        ? "past_notes"
-        : "transcript"))
-    : "transcript";
+  const activePostSessionTab: PostSessionTab =
+    hasPastNotes && !canShowTranscriptTab
+      ? "past_notes"
+      : hasPastNotes
+        ? (postSessionTab ?? "transcript")
+        : "transcript";
   const live = useListener((state) => state.live);
   const { chat } = useShell();
   const liveCaptureMode = getLiveCaptureUiMode(live);
@@ -96,7 +108,7 @@ export function useSessionBottomAccessory({
     isRunningBatch ||
     (!shouldDeferToGlobalLiveAccessory &&
       isInactive &&
-      (hasAudio || hasTranscript || hasPastNotes));
+      (mayHaveAudio || hasTranscript || hasTranscriptError || hasPastNotes));
   const selectPostSessionTab = useCallback(
     (tab: PostSessionTab) => {
       const shouldExpand = activePostSessionTab !== tab || !isExpanded;
@@ -130,7 +142,7 @@ export function useSessionBottomAccessory({
     showLiveAccessory
       ? "live"
       : showPostSession
-        ? hasAudio || isRunningBatch
+        ? canUsePlayback || isRunningBatch
           ? "playback"
           : "transcript_only"
         : null;
@@ -168,7 +180,7 @@ export function useSessionBottomAccessory({
       bottomAccessory: hasAccessoryContent ? (
         <PostSessionAccessory
           sessionId={sessionId}
-          hasAudio={hasAudio}
+          hasAudio={canUsePlayback}
           hasTranscript={hasTranscript}
           isTranscriptExpanded={isExpanded}
           activeTab={activePostSessionTab}
@@ -181,6 +193,7 @@ export function useSessionBottomAccessory({
         <PostSessionTabHandle
           isExpanded={isExpanded}
           activeTab={activePostSessionTab}
+          showTranscriptTab={canShowTranscriptTab}
           onSelect={selectPostSessionTab}
         />
       ) : (
@@ -206,22 +219,26 @@ export function useSessionBottomAccessory({
 function PostSessionTabHandle({
   isExpanded,
   activeTab,
+  showTranscriptTab,
   onSelect,
 }: {
   isExpanded: boolean;
   activeTab: PostSessionTab;
+  showTranscriptTab: boolean;
   onSelect: (tab: PostSessionTab) => void;
 }) {
   return (
     <div className="relative left-3 z-10 flex h-5 items-center gap-1">
-      <PostSessionTabButton
-        label="Transcript"
-        tab="transcript"
-        activeTab={activeTab}
-        isExpanded={isExpanded}
-        onSelect={onSelect}
-        className="rounded-t-[10px] border-x"
-      />
+      {showTranscriptTab ? (
+        <PostSessionTabButton
+          label="Transcript"
+          tab="transcript"
+          activeTab={activeTab}
+          isExpanded={isExpanded}
+          onSelect={onSelect}
+          className="rounded-t-[10px] border-x"
+        />
+      ) : null}
       <PostSessionTabButton
         label="Related meetings"
         tab="past_notes"

--- a/apps/desktop/src/session/components/shared.tsx
+++ b/apps/desktop/src/session/components/shared.tsx
@@ -9,17 +9,29 @@ import * as main from "~/store/tinybase/store/main";
 import type { Tab } from "~/store/zustand/tabs/schema";
 import { type EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
+import { parseTranscriptWords } from "~/stt/utils";
 
 export { computeCurrentNoteTab } from "./compute-note-tab";
 
 export function useHasTranscript(sessionId: string): boolean {
-  const transcriptIds = main.UI.useSliceRowIds(
-    main.INDEXES.transcriptBySession,
-    sessionId,
-    main.STORE_ID,
-  );
+  const transcriptIds =
+    main.UI.useSliceRowIds(
+      main.INDEXES.transcriptBySession,
+      sessionId,
+      main.STORE_ID,
+    ) ?? [];
+  const transcriptsTable = main.UI.useTable("transcripts", main.STORE_ID);
+  const store = main.UI.useStore(main.STORE_ID);
 
-  return !!transcriptIds && transcriptIds.length > 0;
+  return useMemo(() => {
+    if (!store) {
+      return false;
+    }
+
+    return transcriptIds.some(
+      (transcriptId) => parseTranscriptWords(store, transcriptId).length > 0,
+    );
+  }, [store, transcriptIds, transcriptsTable]);
 }
 
 export function hasStoredNoteContent(value: unknown): boolean {

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -70,7 +70,7 @@ export function TabContentNote({
     updateSessionTabState,
   ]);
 
-  const { data: audioUrl } = useQuery({
+  const audioUrlQuery = useQuery({
     enabled: sessionMode !== "active" && sessionMode !== "finalizing",
     queryKey: ["audio", tab.id, "url"],
     queryFn: () => fsSyncCommands.audioPath(tab.id),
@@ -81,12 +81,17 @@ export function TabContentNote({
       return convertFileSrc(result.data);
     },
   });
+  const audioUrl = audioUrlQuery.data;
 
   return (
     <CaretPositionProvider>
       <SearchProvider>
         <AudioPlayer.Provider sessionId={tab.id} url={audioUrl ?? ""}>
-          <TabContentNoteInner tab={tab} audioUrl={audioUrl} />
+          <TabContentNoteInner
+            tab={tab}
+            audioUrlReady={Boolean(audioUrl)}
+            isAudioUrlLoading={audioUrlQuery.isPending}
+          />
         </AudioPlayer.Provider>
       </SearchProvider>
     </CaretPositionProvider>
@@ -95,10 +100,12 @@ export function TabContentNote({
 
 function TabContentNoteInner({
   tab,
-  audioUrl,
+  audioUrlReady,
+  isAudioUrlLoading,
 }: {
   tab: Extract<Tab, { type: "sessions" }>;
-  audioUrl: string | null | undefined;
+  audioUrlReady: boolean;
+  isAudioUrlLoading: boolean;
 }) {
   const titleInputRef = React.useRef<TitleInputHandle>(null);
   const noteInputRef = React.useRef<NoteInputHandle>(null);
@@ -125,6 +132,7 @@ function TabContentNoteInner({
   const sessionId = tab.id;
   const { skipReason } = useAutoEnhance(tab);
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
+  const { audioExists } = AudioPlayer.useAudioPlayer();
 
   useAutoFocusTitle({ sessionId, titleInputRef });
   usePendingUpload(sessionId);
@@ -133,7 +141,9 @@ function TabContentNoteInner({
     useSessionBottomAccessory({
       sessionId,
       sessionMode,
-      audioUrl,
+      audioExists,
+      audioUrlReady,
+      isAudioLoading: isAudioUrlLoading,
       hasTranscript,
     });
 


### PR DESCRIPTION
Treat transcript rows without words as empty and show related meetings without an empty transcript panel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session bottom-panel visibility and audio vs URL semantics across several UI entry points; behavior is well covered by new tests but affects post-session UX paths.
> 
> **Overview**
> **Treats “has transcript” as rows with actual words**, not merely linked transcript IDs, so empty transcript storage no longer drives the bottom panel.
> 
> **Splits audio presence from playback readiness**: `audioExists` comes from the audio player query (URL is no longer treated as proof of existence), while **playback** waits on `audioUrlReady` and the post-session chrome can stay visible during `isAudioLoading`.
> 
> **Bottom accessory behavior** hides the **Transcript** tab when there is nothing to show (no words, no playback, no batch run), defaulting to **Related meetings** only; **batch transcription errors** still show the transcript tab/panel so failures remain visible. Expanded tests cover these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c18b15b6c150892eeeb0bc741c86a8f2847f7456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5559 
- <kbd>&nbsp;1&nbsp;</kbd> #5556 👈 
<!-- GitButler Footer Boundary Bottom -->

