### PR TITLE
Hide transcript regeneration without audio

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -18,6 +18,7 @@ const {
   useTranscriptExportSegmentsMock,
   runBatchMock,
   handleBatchFailedMock,
+  audioExistsMock,
   writeTextMock,
   showTransientToastMock,
 } = vi.hoisted(() => ({
@@ -28,6 +29,7 @@ const {
   useTranscriptExportSegmentsMock: vi.fn(),
   runBatchMock: vi.fn(),
   handleBatchFailedMock: vi.fn(),
+  audioExistsMock: vi.fn(),
   writeTextMock: vi.fn(),
   showTransientToastMock: vi.fn(),
 }));
@@ -85,7 +87,7 @@ vi.mock("~/audio-player", () => ({
     <div>{children}</div>
   ),
   useAudioPlayer: () => ({
-    audioExists: true,
+    audioExists: audioExistsMock(),
     deleteRecording: vi.fn(),
     isDeletingRecording: false,
   }),
@@ -146,6 +148,7 @@ describe("PostSessionAccessory", () => {
       status: "ok",
       data: "/tmp/session.wav",
     });
+    audioExistsMock.mockReturnValue(true);
 
     useTranscriptScreenMock.mockReturnValue({
       kind: "ready",
@@ -191,6 +194,51 @@ describe("PostSessionAccessory", () => {
     });
 
     expect(handleBatchFailedMock).not.toHaveBeenCalled();
+  });
+
+  it("hides ready transcript regeneration when the recording is missing", () => {
+    audioExistsMock.mockReturnValue(false);
+
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio={false}
+        hasTranscript
+        isTranscriptExpanded
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Regenerate" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Delete recording" }),
+    ).toBeNull();
+  });
+
+  it("shows an error toast when regeneration cannot find the recording", async () => {
+    audioPathMock.mockResolvedValue({
+      status: "error",
+      error: "audio_path_not_found",
+    });
+
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio
+        hasTranscript
+        isTranscriptExpanded
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Regenerate" }));
+
+    await waitFor(() => {
+      expect(showTransientToastMock).toHaveBeenCalledWith({
+        id: "transcript-regenerate-audio-missing-session-1",
+        description: "Recording not found. It may have been deleted.",
+        variant: "error",
+      });
+    });
+    expect(runBatchMock).not.toHaveBeenCalled();
   });
 
   it("copies transcript text from the expanded transcript panel", async () => {

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -313,7 +313,14 @@ function useRegenerateTranscript(sessionId: string) {
 
   return useCallback(async () => {
     const result = await fsSyncCommands.audioPath(sessionId);
-    if (result.status === "error") return;
+    if (result.status === "error") {
+      showTransientToast({
+        id: `transcript-regenerate-audio-missing-${sessionId}`,
+        description: "Recording not found. It may have been deleted.",
+        variant: "error",
+      });
+      return;
+    }
 
     const audioPath = result.data;
 
@@ -614,18 +621,20 @@ function TranscriptReadyPanel({
             <CopyIcon size={10} />
             {isTranscriptLoading ? "Loading..." : "Copy"}
           </button>
-          <button
-            type="button"
-            onClick={regenerate}
-            className={cn([
-              "flex items-center gap-1 rounded-full px-1.5 py-0.5",
-              "text-muted-foreground text-[11px] font-medium",
-              "hover:bg-accent/60 hover:text-muted-foreground transition-colors",
-            ])}
-          >
-            <RefreshCw size={10} />
-            Regenerate
-          </button>
+          {audioExists ? (
+            <button
+              type="button"
+              onClick={regenerate}
+              className={cn([
+                "flex items-center gap-1 rounded-full px-1.5 py-0.5",
+                "text-muted-foreground text-[11px] font-medium",
+                "hover:bg-accent/60 hover:text-muted-foreground transition-colors",
+              ])}
+            >
+              <RefreshCw size={10} />
+              Regenerate
+            </button>
+          ) : null}
         </div>
         {audioExists ? (
           <button


### PR DESCRIPTION
Hide the transcript regenerate action when no recording exists and show an error toast if the recording lookup fails.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only post-session transcript actions and error feedback; no auth or data-model changes.
> 
> **Overview**
> **Hides transcript Regenerate when there is no local recording** in the expanded ready-transcript toolbar, matching the existing **Delete recording** visibility (`audioExists` from `useAudioPlayer`).
> 
> **Surfaces a clear failure** when regeneration still runs but `fsSyncCommands.audioPath` fails: an error transient toast (*"Recording not found. It may have been deleted."*) and no batch run, instead of failing silently.
> 
> Tests mock `audioExists` and cover the hidden actions case and the toast + no `runBatch` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 396494c7a48fde34ef978a7294f45fb7700b0a39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->