### PR TITLE
Reduce desktop render and audio memory overhead

### DIFF
--- a/.github/workflows/llm_e2e.yaml
+++ b/.github/workflows/llm_e2e.yaml
@@ -4,10 +4,18 @@ on:
     branches:
       - main
     paths:
+      - apps/api/**
+      - crates/api-env/**
       - crates/llm-proxy/**
+      - crates/llm-types/**
+      - crates/openrouter/**
   pull_request:
     paths:
+      - apps/api/**
+      - crates/api-env/**
       - crates/llm-proxy/**
+      - crates/llm-types/**
+      - crates/openrouter/**
 
 jobs:
   proxy-non-streaming:

--- a/.github/workflows/stt_e2e.yaml
+++ b/.github/workflows/stt_e2e.yaml
@@ -4,6 +4,7 @@ on:
       provider:
         type: choice
         options:
+          - all
           - deepgram
           - assemblyai
           - soniox
@@ -11,16 +12,27 @@ on:
           - fireworks
           - openai
           - elevenlabs
+        default: all
   push:
     branches:
       - main
     paths:
+      - apps/api/**
+      - crates/api-auth/**
+      - crates/api-env/**
+      - crates/audio-mime/**
       - crates/transcribe-proxy/**
-      - crates/owhisper-client/src/adapter/**
+      - crates/owhisper-client/**
+      - crates/owhisper-interface/**
   pull_request:
     paths:
+      - apps/api/**
+      - crates/api-auth/**
+      - crates/api-env/**
+      - crates/audio-mime/**
       - crates/transcribe-proxy/**
-      - crates/owhisper-client/src/adapter/**
+      - crates/owhisper-client/**
+      - crates/owhisper-interface/**
 
 jobs:
   detect-changes:
@@ -34,8 +46,14 @@ jobs:
         id: filter
         with:
           filters: |
-            transcribe_proxy:
+            stt_server:
+              - 'apps/api/**'
+              - 'crates/api-auth/**'
+              - 'crates/api-env/**'
+              - 'crates/audio-mime/**'
               - 'crates/transcribe-proxy/**'
+              - 'crates/owhisper-client/**'
+              - 'crates/owhisper-interface/**'
             deepgram:
               - 'crates/owhisper-client/src/adapter/deepgram/**'
             assemblyai:
@@ -65,10 +83,8 @@ jobs:
           if [ "${{ steps.filter.outputs.elevenlabs }}" == "true" ]; then providers+=("elevenlabs"); fi
 
           if [ ${#providers[@]} -eq 0 ]; then
-            if [ "${{ steps.filter.outputs.transcribe_proxy }}" == "true" ]; then
+            if [ "${{ steps.filter.outputs.stt_server }}" == "true" ]; then
               providers=("deepgram" "soniox")
-            else
-              providers=("deepgram")
             fi
           fi
 
@@ -85,14 +101,18 @@ jobs:
       - id: set
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo 'providers=["${{ inputs.provider }}"]' >> $GITHUB_OUTPUT
+            if [ "${{ inputs.provider }}" == "all" ]; then
+              echo 'providers=["assemblyai","deepgram","elevenlabs","fireworks","gladia","openai","soniox"]' >> "$GITHUB_OUTPUT"
+            else
+              echo 'providers=["${{ inputs.provider }}"]' >> "$GITHUB_OUTPUT"
+            fi
           else
             printf 'providers=%s\n' '${{ needs.detect-changes.outputs.providers }}' >> "$GITHUB_OUTPUT"
           fi
 
   direct-provider-batch-e2e:
     needs: setup
-    if: needs.setup.outputs.providers != ''
+    if: always() && needs.setup.outputs.providers != ''
     runs-on: depot-ubuntu-24.04-8
     strategy:
       fail-fast: false
@@ -148,8 +168,11 @@ jobs:
 
   proxy-provider-e2e:
     needs: setup
-    if: needs.setup.outputs.providers != ''
+    if: always() && needs.setup.outputs.providers != ''
     runs-on: depot-ubuntu-24.04-8
+    concurrency:
+      group: stt-provider-e2e-${{ matrix.provider }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12667,6 +12667,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -5,32 +5,37 @@ use hypr_db_core::Db;
 const DEV_BUNDLE_ID: &str = "com.hyprnote.dev";
 const DB_FILENAME: &str = "app.db";
 
-pub async fn open_desktop_db(identifier: &str) -> Arc<Db> {
-    let db_path = desktop_db_dir(identifier).map(|dir| {
-        std::fs::create_dir_all(&dir).expect("failed to create app data dir");
-        dir.join(DB_FILENAME)
+pub async fn open_desktop_db(identifier: &str) -> Result<Arc<Db>, String> {
+    let db_path = desktop_db_dir(identifier)?.map(|dir| {
+        std::fs::create_dir_all(&dir)
+            .map(|_| dir.join(DB_FILENAME))
+            .map_err(|error| format!("failed to create app data dir: {error}"))
     });
+    let db_path = match db_path {
+        Some(path) => Some(path?),
+        None => None,
+    };
 
     let db = tauri_plugin_db::open_app_db(db_path.as_deref())
         .await
-        .expect("failed to open app database");
+        .map_err(|error| format!("failed to open app database: {error}"))?;
 
-    Arc::new(db)
+    Ok(Arc::new(db))
 }
 
-fn desktop_db_dir(identifier: &str) -> Option<std::path::PathBuf> {
+fn desktop_db_dir(identifier: &str) -> Result<Option<std::path::PathBuf>, String> {
     if identifier == DEV_BUNDLE_ID {
-        return None;
+        return Ok(None);
     }
 
-    let data_dir = dirs::data_dir().expect("data_dir must be available");
-    let default_dir =
-        hypr_storage::global::compute_default_base(identifier).expect("data_dir must be available");
+    let data_dir = dirs::data_dir().ok_or_else(|| "data_dir must be available".to_string())?;
+    let default_dir = hypr_storage::global::compute_default_base(identifier)
+        .ok_or_else(|| "failed to compute default data dir".to_string())?;
     let identifier_dir = data_dir.join(identifier);
 
     if identifier_dir.join(DB_FILENAME).is_file() && !default_dir.join(DB_FILENAME).is_file() {
-        Some(identifier_dir)
+        Ok(Some(identifier_dir))
     } else {
-        Some(default_dir)
+        Ok(Some(default_dir))
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -86,7 +86,13 @@ pub async fn main() {
     let audio: std::sync::Arc<dyn hypr_audio_actual::AudioProvider> =
         create_audio_provider(&context.config().identifier);
 
-    let db = open_desktop_db(&context.config().identifier).await;
+    let db = match open_desktop_db(&context.config().identifier).await {
+        Ok(db) => db,
+        Err(error) => {
+            tracing::error!(%error, "failed_to_open_desktop_db");
+            return;
+        }
+    };
 
     let mut builder = tauri_plugin_windows::extend_builder(tauri::Builder::default())
         .manage(audio)
@@ -102,7 +108,9 @@ pub async fn main() {
     // should always be the first plugin
     {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
-            app.windows().show(AppWindow::Main).unwrap();
+            if let Err(error) = app.windows().show(AppWindow::Main) {
+                tracing::error!(?error, "failed_to_show_main_window_for_single_instance");
+            }
         }));
     }
 
@@ -215,13 +223,12 @@ pub async fn main() {
 
                 app_handle
                     .windows()
-                    .set_show_app_in_dock(appearance_settings.show_app_in_dock)
-                    .unwrap();
+                    .set_show_app_in_dock(appearance_settings.show_app_in_dock)?;
 
                 if appearance_settings.show_tray_icon {
-                    app_handle.tray().create_tray_menu().unwrap();
+                    app_handle.tray().create_tray_menu()?;
                 }
-                app_handle.tray().create_app_menu().unwrap();
+                app_handle.tray().create_app_menu()?;
             }
 
             {
@@ -286,7 +293,9 @@ pub async fn main() {
 
     {
         let app_handle = app.handle().clone();
-        AppWindow::Main.show(&app_handle).unwrap();
+        if let Err(error) = AppWindow::Main.show(&app_handle) {
+            tracing::error!(?error, "failed_to_show_main_window");
+        }
     }
 
     #[cfg(target_os = "macos")]
@@ -296,7 +305,9 @@ pub async fn main() {
     app.run(move |app, event| match event {
         #[cfg(target_os = "macos")]
         tauri::RunEvent::Reopen { .. } => {
-            AppWindow::Main.show(app).unwrap();
+            if let Err(error) = AppWindow::Main.show(app) {
+                tracing::error!(?error, "failed_to_show_main_window_on_reopen");
+            }
         }
         #[cfg(target_os = "macos")]
         tauri::RunEvent::ExitRequested { api, .. } => {

--- a/apps/desktop/src/calendar/components/calendar-view.tsx
+++ b/apps/desktop/src/calendar/components/calendar-view.tsx
@@ -79,6 +79,7 @@ function useVisibleCols(ref: React.RefObject<HTMLDivElement | null>) {
 export function CalendarView() {
   const { scheduleSync } = useSync();
   const now = useNow();
+  const todayKey = format(now, "yyyy-MM-dd");
   const weekStartsOn = useWeekStartsOn();
   const weekOpts = useMemo(() => ({ weekStartsOn }), [weekStartsOn]);
   const [currentMonth, setCurrentMonth] = useState(now);
@@ -304,6 +305,7 @@ export function CalendarView() {
                 day={day}
                 isCurrentMonth={isSameMonth(day, currentMonth)}
                 calendarData={calendarData}
+                todayKey={todayKey}
               />
             ))}
           </div>
@@ -347,6 +349,7 @@ export function CalendarView() {
                 day={day}
                 isCurrentMonth={true}
                 calendarData={calendarData}
+                todayKey={todayKey}
               />
             ))}
           </div>

--- a/apps/desktop/src/calendar/components/day-cell.tsx
+++ b/apps/desktop/src/calendar/components/day-cell.tsx
@@ -13,7 +13,6 @@ import { EventChip } from "./event-chip";
 import { SessionChip } from "./session-chip";
 
 import type { CalendarData } from "~/calendar/hooks";
-import { useNow } from "~/calendar/hooks";
 
 function useVisibleItemCount(
   ref: React.RefObject<HTMLDivElement | null>,
@@ -71,20 +70,21 @@ export function DayCell({
   day,
   isCurrentMonth,
   calendarData,
+  todayKey,
 }: {
   day: Date;
   isCurrentMonth: boolean;
   calendarData: CalendarData;
+  todayKey: string;
 }) {
   const dateKey = format(day, "yyyy-MM-dd");
   const eventIds = calendarData.eventIdsByDate[dateKey] ?? [];
   const sessionIds = calendarData.sessionIdsByDate[dateKey] ?? [];
 
-  const now = useNow();
   const itemsRef = useRef<HTMLDivElement>(null);
   const totalItems = eventIds.length + sessionIds.length;
   const maxVisible = useVisibleItemCount(itemsRef, totalItems);
-  const today = format(day, "yyyy-MM-dd") === format(now, "yyyy-MM-dd");
+  const today = dateKey === todayKey;
 
   const visibleEvents = eventIds.slice(0, maxVisible);
   const remainingSlots = Math.max(0, maxVisible - visibleEvents.length);

--- a/apps/desktop/src/i18n/catalogs.ts
+++ b/apps/desktop/src/i18n/catalogs.ts
@@ -1,13 +1,12 @@
 import { setupI18n, type Messages } from "@lingui/core";
 
-import type { DisplayLocale } from "./locales";
+import { SOURCE_LOCALE, type DisplayLocale } from "./locales";
 
 const catalogModules = import.meta.glob<{ messages: Messages }>(
   "./locales/*/messages.ts",
-  { eager: true },
 );
 
-const catalogs = Object.fromEntries(
+const catalogLoaders = Object.fromEntries(
   Object.entries(catalogModules).map(([path, module]) => {
     const locale = path.match(/^\.\/locales\/([^/]+)\/messages\.ts$/)?.[1];
 
@@ -15,14 +14,20 @@ const catalogs = Object.fromEntries(
       throw new Error(`Invalid i18n catalog path: ${path}`);
     }
 
-    return [locale, module.messages];
+    return [locale, module];
   }),
-) as Record<DisplayLocale, Messages>;
+) as Record<DisplayLocale, () => Promise<{ messages: Messages }>>;
 
-export function createI18n(locale: DisplayLocale) {
+export async function createI18n(locale: DisplayLocale) {
   const i18n = setupI18n();
+  const loadCatalog = catalogLoaders[locale] ?? catalogLoaders[SOURCE_LOCALE];
 
-  i18n.load(catalogs);
+  if (!loadCatalog) {
+    throw new Error(`Missing i18n catalog for locale: ${locale}`);
+  }
+
+  const { messages } = await loadCatalog();
+  i18n.load(locale, messages);
   i18n.activate(locale);
 
   return i18n;

--- a/apps/desktop/src/i18n/provider.tsx
+++ b/apps/desktop/src/i18n/provider.tsx
@@ -1,5 +1,6 @@
 import { I18nProvider } from "@lingui/react";
-import { type ReactNode, useMemo } from "react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { type ReactNode } from "react";
 
 import { createI18n } from "./catalogs";
 import { resolveDisplayLocale } from "./locales";
@@ -10,11 +11,21 @@ import { useMountEffect } from "~/shared/hooks/useMountEffect";
 export function AppI18nProvider({ children }: { children: ReactNode }) {
   const mainLanguage = useConfigValue("ai_language");
   const locale = resolveDisplayLocale(mainLanguage);
-  const i18n = useMemo(() => createI18n(locale), [locale]);
+  const { data: i18n } = useQuery({
+    queryKey: ["i18n", locale],
+    queryFn: () => createI18n(locale),
+    placeholderData: keepPreviousData,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+
+  if (!i18n) {
+    return <div className="bg-background h-screen w-screen" />;
+  }
 
   return (
     <I18nProvider i18n={i18n}>
-      <DocumentLanguage key={locale} locale={locale} />
+      <DocumentLanguage key={i18n.locale} locale={i18n.locale} />
       {children}
     </I18nProvider>
   );

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -275,6 +275,12 @@ function useLiveTranscriptData(sessionId: string): {
       sessionId,
       main.STORE_ID,
     ) ?? [];
+  const participantMappingIds =
+    main.UI.useSliceRowIds(
+      main.INDEXES.sessionParticipantsBySession,
+      sessionId,
+      main.STORE_ID,
+    ) ?? [];
   const transcriptsTable = main.UI.useTable("transcripts", main.STORE_ID);
   const participantMappingsTable = main.UI.useTable(
     "mapping_session_participant",
@@ -289,10 +295,13 @@ function useLiveTranscriptData(sessionId: string): {
       return null;
     }
 
-    return buildRenderTranscriptRequestFromStore(store, transcriptIds);
+    return buildRenderTranscriptRequestFromStore(store, transcriptIds, {
+      participantMappingIds,
+    });
   }, [
     store,
     transcriptIds,
+    participantMappingIds,
     transcriptsTable,
     participantMappingsTable,
     humansTable,

--- a/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
+++ b/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
@@ -56,20 +56,38 @@ const keyFactsSchema = z.object({
   facts: z.array(z.string()).min(1).max(MAX_KEY_FACTS),
 });
 
-export function usePastSessionNotes(sessionId: string): PastSessionNotesResult {
+export function usePastSessionNotes(
+  sessionId: string,
+  { enabled = true }: { enabled?: boolean } = {},
+): PastSessionNotesResult {
   const store = main.UI.useStore(main.STORE_ID);
-  const sessionsTable = main.UI.useTable("sessions", main.STORE_ID);
-  const participantsTable = main.UI.useTable(
-    "mapping_session_participant",
+  const sessionsTable = main.UI.useTable(
+    enabled ? "sessions" : ("__disabled_past_notes_sessions" as "sessions"),
     main.STORE_ID,
   );
-  const enhancedNotesTable = main.UI.useTable("enhanced_notes", main.STORE_ID);
-  const keyFactsTable = main.UI.useTable("session_key_facts", main.STORE_ID);
+  const participantsTable = main.UI.useTable(
+    enabled
+      ? "mapping_session_participant"
+      : ("__disabled_past_notes_participants" as "mapping_session_participant"),
+    main.STORE_ID,
+  );
+  const enhancedNotesTable = main.UI.useTable(
+    enabled
+      ? "enhanced_notes"
+      : ("__disabled_past_notes_enhanced" as "enhanced_notes"),
+    main.STORE_ID,
+  );
+  const keyFactsTable = main.UI.useTable(
+    enabled
+      ? "session_key_facts"
+      : ("__disabled_past_notes_key_facts" as "session_key_facts"),
+    main.STORE_ID,
+  );
   const userId = main.UI.useValue("user_id", main.STORE_ID);
   const model = useLanguageModel("enhance");
 
   const built = useMemo(() => {
-    if (!store) {
+    if (!enabled || !store) {
       return { notes: [], missing: [], requests: [] };
     }
 
@@ -80,6 +98,7 @@ export function usePastSessionNotes(sessionId: string): PastSessionNotesResult {
     );
   }, [
     store,
+    enabled,
     sessionId,
     userId,
     sessionsTable,
@@ -121,16 +140,21 @@ export function usePastSessionNotes(sessionId: string): PastSessionNotesResult {
   );
 
   const generateMissing = useCallback(() => {
-    if (!model || built.missing.length === 0 || mutation.isPending) {
+    if (
+      !enabled ||
+      !model ||
+      built.missing.length === 0 ||
+      mutation.isPending
+    ) {
       return;
     }
 
     void mutation.mutateAsync(built.missing);
-  }, [built.missing, model, mutation]);
+  }, [built.missing, enabled, model, mutation]);
 
   const regenerate = useCallback(
     (targetSessionId: string) => {
-      if (!model || mutation.isPending) {
+      if (!enabled || !model || mutation.isPending) {
         return;
       }
 
@@ -143,14 +167,14 @@ export function usePastSessionNotes(sessionId: string): PastSessionNotesResult {
 
       void mutation.mutateAsync([request]);
     },
-    [built.requests, model, mutation],
+    [built.requests, enabled, model, mutation],
   );
 
   return {
     notes,
     hasPastNotes: notes.length > 0,
     isGenerating: mutation.isPending,
-    canGenerate: Boolean(model),
+    canGenerate: enabled && Boolean(model),
     generateMissing,
     regenerate,
   };
@@ -170,11 +194,9 @@ export function buildPastSessionNotes(
     return { notes: [], missing: [], requests: [] };
   }
 
-  const currentParticipantIds = getSessionParticipantIds(
-    store,
-    sessionId,
-    userId,
-  );
+  const participantIdsBySession = collectParticipantIdsBySession(store, userId);
+  const currentParticipantIds =
+    participantIdsBySession.get(sessionId) ?? new Set<string>();
   const currentEvent = getSessionEvent(currentSession);
   const currentSeriesId = getRecurrenceSeriesId(currentEvent);
   const currentTitleKey = getSessionTitleKey(currentSession);
@@ -183,10 +205,9 @@ export function buildPastSessionNotes(
   }
 
   const currentTimestamp = getSessionTimestamp(currentSession);
-  const items: Array<{
-    note: PastSessionNote & { dateMs: number };
-    request: PastSessionNoteRequest;
-    isMissing: boolean;
+  const candidates: Array<{
+    sessionId: string;
+    timestamp: number;
   }> = [];
 
   store.forEachRow("sessions", (candidateSessionId, _forEachCell) => {
@@ -209,11 +230,8 @@ export function buildPastSessionNotes(
     }
 
     const candidateEvent = getSessionEvent(candidateSession);
-    const candidateParticipantIds = getSessionParticipantIds(
-      store,
-      candidateSessionId,
-      userId,
-    );
+    const candidateParticipantIds =
+      participantIdsBySession.get(candidateSessionId) ?? new Set<string>();
     if (
       !isRelatedPastSession({
         currentParticipantIds,
@@ -227,18 +245,43 @@ export function buildPastSessionNotes(
       return;
     }
 
-    const source = getSessionKeyFactsSource(store, candidateSessionId);
-    if (!source) {
-      return;
+    candidates.push({
+      sessionId: candidateSessionId,
+      timestamp: candidateTimestamp,
+    });
+  });
+
+  candidates.sort((a, b) => b.timestamp - a.timestamp);
+
+  const enhancedNotesBySession = collectEnhancedNotesBySession(store);
+  const items: Array<{
+    note: PastSessionNote & { dateMs: number };
+    request: PastSessionNoteRequest;
+    isMissing: boolean;
+  }> = [];
+
+  for (const candidate of candidates) {
+    if (items.length >= MAX_PAST_NOTES) {
+      break;
     }
 
+    const source = getSessionKeyFactsSource(
+      store,
+      candidate.sessionId,
+      enhancedNotesBySession,
+    );
+    if (!source) {
+      continue;
+    }
+
+    const candidateSession = store.getRow("sessions", candidate.sessionId);
     const title = getSessionTitle(candidateSession);
     const dateLabel = formatSessionDate(candidateSession);
     const sourceHash = createSourceHash([title, dateLabel, source].join("\n"));
-    const saved = getSavedKeyFacts(store, candidateSessionId, sourceHash);
+    const saved = getSavedKeyFacts(store, candidate.sessionId, sourceHash);
     const ownerUserId = getSessionUserId(candidateSession, userId);
     const request = {
-      sessionId: candidateSessionId,
+      sessionId: candidate.sessionId,
       userId: ownerUserId,
       title,
       dateLabel,
@@ -248,29 +291,25 @@ export function buildPastSessionNotes(
 
     items.push({
       note: {
-        sessionId: candidateSessionId,
+        sessionId: candidate.sessionId,
         title,
         dateLabel,
         summary: saved,
         isGenerating: false,
-        dateMs: candidateTimestamp,
+        dateMs: candidate.timestamp,
       },
       request,
       isMissing: !saved,
     });
-  });
-
-  const selected = items
-    .sort((a, b) => b.note.dateMs - a.note.dateMs)
-    .slice(0, MAX_PAST_NOTES);
+  }
 
   return {
-    notes: selected.map(({ note }) => {
+    notes: items.map(({ note }) => {
       const { dateMs: _dateMs, ...rest } = note;
       return rest;
     }),
-    missing: selected.flatMap((item) => (item.isMissing ? [item.request] : [])),
-    requests: selected.map((item) => item.request),
+    missing: items.flatMap((item) => (item.isMissing ? [item.request] : [])),
+    requests: items.map((item) => item.request),
   };
 }
 
@@ -401,22 +440,9 @@ function getSavedKeyFacts(
 function getSessionKeyFactsSource(
   store: MainStore,
   sessionId: string,
+  enhancedNotesBySession: Map<string, EnhancedNoteSource[]>,
 ): string | null {
-  const enhancedNotes: Array<{ content: string; position: number }> = [];
-
-  store.forEachRow("enhanced_notes", (noteId, _forEachCell) => {
-    const note = store.getRow("enhanced_notes", noteId);
-    if (note.session_id !== sessionId || !note.content?.trim()) {
-      return;
-    }
-
-    enhancedNotes.push({
-      content: note.content,
-      position: typeof note.position === "number" ? note.position : 0,
-    });
-  });
-
-  enhancedNotes.sort((a, b) => a.position - b.position);
+  const enhancedNotes = enhancedNotesBySession.get(sessionId) ?? [];
   const enhancedText = cleanSourceText(
     enhancedNotes.map((note) => extractPlainText(note.content)).join("\n\n"),
   );
@@ -427,6 +453,37 @@ function getSessionKeyFactsSource(
   const rawMd = store.getCell("sessions", sessionId, "raw_md");
   const rawText = cleanSourceText(extractPlainText(rawMd));
   return rawText ? truncateAtWord(rawText, MAX_SOURCE_LENGTH) : null;
+}
+
+type EnhancedNoteSource = { content: string; position: number };
+
+function collectEnhancedNotesBySession(
+  store: MainStore,
+): Map<string, EnhancedNoteSource[]> {
+  const notesBySession = new Map<string, EnhancedNoteSource[]>();
+
+  store.forEachRow("enhanced_notes", (noteId, _forEachCell) => {
+    const note = store.getRow("enhanced_notes", noteId);
+    const sessionId =
+      typeof note.session_id === "string" ? note.session_id : null;
+    const content = typeof note.content === "string" ? note.content.trim() : "";
+    if (!sessionId || !content) {
+      return;
+    }
+
+    const notes = notesBySession.get(sessionId) ?? [];
+    notes.push({
+      content,
+      position: typeof note.position === "number" ? note.position : 0,
+    });
+    notesBySession.set(sessionId, notes);
+  });
+
+  for (const notes of notesBySession.values()) {
+    notes.sort((a, b) => a.position - b.position);
+  }
+
+  return notesBySession;
 }
 
 function cleanSourceText(text: string): string {
@@ -450,20 +507,17 @@ function truncateAtWord(text: string, maxLength: number): string {
   return `${slice.slice(0, end).trim()}...`;
 }
 
-function getSessionParticipantIds(
+function collectParticipantIdsBySession(
   store: MainStore,
-  sessionId: string,
   userId: string | null,
-): Set<string> {
-  const participantIds = new Set<string>();
+): Map<string, Set<string>> {
+  const participantIdsBySession = new Map<string, Set<string>>();
 
   store.forEachRow("mapping_session_participant", (mappingId, _forEachCell) => {
     const mapping = store.getRow("mapping_session_participant", mappingId);
-    if (
-      mapping.session_id !== sessionId ||
-      mapping.source === "excluded" ||
-      !mapping.human_id
-    ) {
+    const sessionId =
+      typeof mapping.session_id === "string" ? mapping.session_id : null;
+    if (!sessionId || mapping.source === "excluded" || !mapping.human_id) {
       return;
     }
 
@@ -475,11 +529,14 @@ function getSessionParticipantIds(
       (userId && mapping.human_id === userId) ||
       (!userId && ownerUserId && mapping.human_id === ownerUserId);
     if (!isCurrentUser) {
+      const participantIds =
+        participantIdsBySession.get(sessionId) ?? new Set<string>();
       participantIds.add(mapping.human_id);
+      participantIdsBySession.set(sessionId, participantIds);
     }
   });
 
-  return participantIds;
+  return participantIdsBySession;
 }
 
 function isRelatedPastSession({

--- a/apps/desktop/src/session/components/note-input/search/context.tsx
+++ b/apps/desktop/src/session/components/note-input/search/context.tsx
@@ -36,10 +36,24 @@ interface SearchContextValue {
   setReplaceQuery: (query: string) => void;
 }
 
+interface SearchHighlightsContextValue {
+  query: string;
+  isVisible: boolean;
+  activeMatchId: string | null;
+  caseSensitive: boolean;
+  wholeWord: boolean;
+}
+
 const SearchContext = createContext<SearchContextValue | null>(null);
+const SearchHighlightsContext =
+  createContext<SearchHighlightsContextValue | null>(null);
 
 export function useSearch() {
   return useContext(SearchContext);
+}
+
+export function useSearchHighlights() {
+  return useContext(SearchHighlightsContext);
 }
 
 interface SearchState {
@@ -280,7 +294,28 @@ export function SearchProvider({ children }: { children: React.ReactNode }) {
     [state, onNext, onPrev],
   );
 
+  const highlightsValue = useMemo(
+    () => ({
+      query: state.query,
+      isVisible: state.isVisible,
+      activeMatchId: state.activeMatchId,
+      caseSensitive: state.caseSensitive,
+      wholeWord: state.wholeWord,
+    }),
+    [
+      state.activeMatchId,
+      state.caseSensitive,
+      state.isVisible,
+      state.query,
+      state.wholeWord,
+    ],
+  );
+
   return (
-    <SearchContext.Provider value={value}>{children}</SearchContext.Provider>
+    <SearchContext.Provider value={value}>
+      <SearchHighlightsContext.Provider value={highlightsValue}>
+        {children}
+      </SearchHighlightsContext.Provider>
+    </SearchContext.Provider>
   );
 }

--- a/apps/desktop/src/session/components/note-input/transcript/export-data.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/export-data.ts
@@ -49,16 +49,25 @@ export function useTranscriptExportSegments(sessionId: string): {
       sessionId,
       main.STORE_ID,
     ) ?? [];
+  const participantMappingIds =
+    main.UI.useSliceRowIds(
+      main.INDEXES.sessionParticipantsBySession,
+      sessionId,
+      main.STORE_ID,
+    ) ?? [];
 
   const request = useMemo(() => {
     if (!store || transcriptIds.length === 0) {
       return null;
     }
 
-    return buildRenderTranscriptRequestFromStore(store, transcriptIds);
+    return buildRenderTranscriptRequestFromStore(store, transcriptIds, {
+      participantMappingIds,
+    });
   }, [
     store,
     transcriptIds,
+    participantMappingIds,
     transcriptsTable,
     participantMappingsTable,
     humansTable,

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
@@ -11,6 +11,18 @@ import {
 
 export function useRenderedTranscriptSegments(transcriptId: string): Segment[] {
   const store = main.UI.useStore(main.STORE_ID);
+  const sessionId = main.UI.useCell(
+    "transcripts",
+    transcriptId,
+    "session_id",
+    main.STORE_ID,
+  );
+  const participantMappingIds =
+    main.UI.useSliceRowIds(
+      main.INDEXES.sessionParticipantsBySession,
+      sessionId ?? "",
+      main.STORE_ID,
+    ) ?? [];
   const transcriptsTable = main.UI.useTable("transcripts", main.STORE_ID);
   const participantMappingsTable = main.UI.useTable(
     "mapping_session_participant",
@@ -24,10 +36,13 @@ export function useRenderedTranscriptSegments(transcriptId: string): Segment[] {
       return null;
     }
 
-    return buildRenderTranscriptRequestFromStore(store, [transcriptId]);
+    return buildRenderTranscriptRequestFromStore(store, [transcriptId], {
+      participantMappingIds,
+    });
   }, [
     store,
     transcriptId,
+    participantMappingIds,
     transcriptsTable,
     participantMappingsTable,
     humansTable,

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
@@ -71,6 +71,10 @@ export function useAutoScroll(
   const rafRef = useRef<number | null>(null);
   const lastHeightRef = useRef(0);
   const initialFlushRef = useRef(enabled);
+  const enabledRef = useRef(enabled);
+  const scheduleRef = useRef<(force?: boolean) => void>(() => {});
+
+  enabledRef.current = enabled;
 
   useEffect(() => {
     const element = containerRef.current;
@@ -91,7 +95,7 @@ export function useAutoScroll(
     };
 
     const schedule = (force = false) => {
-      if (!force && (!enabled || !isPinned())) {
+      if (!force && (!enabledRef.current || !isPinned())) {
         return;
       }
 
@@ -104,12 +108,7 @@ export function useAutoScroll(
       });
     };
 
-    if (initialFlushRef.current) {
-      initialFlushRef.current = false;
-      schedule(true);
-    } else {
-      schedule();
-    }
+    scheduleRef.current = schedule;
 
     const resizeObserver = new ResizeObserver(() => {
       const nextHeight = element.scrollHeight;
@@ -128,11 +127,22 @@ export function useAutoScroll(
 
     return () => {
       resizeObserver.disconnect();
+      scheduleRef.current = () => {};
       if (rafRef.current !== null) {
         cancelAnimationFrame(rafRef.current);
         rafRef.current = null;
       }
     };
+  }, [containerRef]);
+
+  useEffect(() => {
+    if (initialFlushRef.current) {
+      initialFlushRef.current = false;
+      scheduleRef.current(true);
+      return;
+    }
+
+    scheduleRef.current();
   }, deps);
 }
 

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/word-span.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/word-span.tsx
@@ -4,7 +4,7 @@ import { cn } from "@hypr/utils";
 
 import type { HighlightSegment } from "./utils";
 
-import { useSearch } from "~/session/components/note-input/search/context";
+import { useSearchHighlights } from "~/session/components/note-input/search/context";
 import { createHighlightSegments } from "~/session/components/note-input/search/matching";
 import type { SegmentWord } from "~/stt/live-segment";
 import { isTranscriptWordSeekable } from "~/stt/timing";
@@ -52,7 +52,7 @@ export function WordSpan(props: WordSpanProps) {
 }
 
 function useTranscriptSearchHighlights(word: SegmentWord, displayText: string) {
-  const search = useSearch();
+  const search = useSearchHighlights();
   const query = search?.query?.trim() ?? "";
   const isVisible = Boolean(search?.isVisible);
   const activeMatchId = search?.activeMatchId ?? null;

--- a/apps/desktop/src/session/components/note-input/transcript/state.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/state.ts
@@ -50,7 +50,11 @@ export function useTranscriptScreen({
     (state) => state.batch[sessionId]?.error ?? null,
   );
   const batchProgress = useListener((state) => state.batch[sessionId] ?? null);
-  const live = useListener((state) => state.live);
+  const live = useListener((state) => ({
+    requestedLiveTranscription: state.live.requestedLiveTranscription,
+    liveTranscriptionActive: state.live.liveTranscriptionActive,
+    degraded: state.live.degraded,
+  }));
   const { audioExists } = useAudioPlayer();
 
   const { transcriptIds, liveSegments, hasTranscriptWords } =

--- a/apps/desktop/src/shared/config/index.ts
+++ b/apps/desktop/src/shared/config/index.ts
@@ -29,7 +29,7 @@ export function useConfigValue<K extends SettingsValueKey>(
   const storedValue = settings.UI.useValue(key, settings.STORE_ID);
   const hasStoredValue = settings.UI.useHasValue(key, settings.STORE_ID);
   const legacySaveRecordings = settings.UI.useValue(
-    "save_recordings",
+    key === "audio_retention" ? "save_recordings" : key,
     settings.STORE_ID,
   );
   const mapping = settings.SETTINGS_MAPPING.values[key];

--- a/apps/desktop/src/sidebar/contacts.tsx
+++ b/apps/desktop/src/sidebar/contacts.tsx
@@ -104,89 +104,37 @@ function ContactsList({
   const allOrgs = main.UI.useTable("organizations", main.STORE_ID);
   const store = main.UI.useStore(main.STORE_ID);
 
-  const alphabeticalHumanIds = main.UI.useResultSortedRowIds(
+  const sortConfig = useMemo(() => {
+    switch (sortOption) {
+      case "reverse-alphabetical":
+        return { cellId: "name", descending: true };
+      case "newest":
+        return { cellId: "created_at", descending: true };
+      case "oldest":
+        return { cellId: "created_at", descending: false };
+      case "alphabetical":
+      default:
+        return { cellId: "name", descending: false };
+    }
+  }, [sortOption]);
+
+  const sortedHumanIds = main.UI.useResultSortedRowIds(
     main.QUERIES.visibleHumans,
-    "name",
-    false,
-    0,
-    undefined,
-    main.STORE_ID,
-  );
-  const reverseAlphabeticalHumanIds = main.UI.useResultSortedRowIds(
-    main.QUERIES.visibleHumans,
-    "name",
-    true,
-    0,
-    undefined,
-    main.STORE_ID,
-  );
-  const newestHumanIds = main.UI.useResultSortedRowIds(
-    main.QUERIES.visibleHumans,
-    "created_at",
-    true,
-    0,
-    undefined,
-    main.STORE_ID,
-  );
-  const oldestHumanIds = main.UI.useResultSortedRowIds(
-    main.QUERIES.visibleHumans,
-    "created_at",
-    false,
+    sortConfig.cellId,
+    sortConfig.descending,
     0,
     undefined,
     main.STORE_ID,
   );
 
-  const alphabeticalOrgIds = main.UI.useResultSortedRowIds(
+  const sortedOrgIds = main.UI.useResultSortedRowIds(
     main.QUERIES.visibleOrganizations,
-    "name",
-    false,
+    sortConfig.cellId,
+    sortConfig.descending,
     0,
     undefined,
     main.STORE_ID,
   );
-  const reverseAlphabeticalOrgIds = main.UI.useResultSortedRowIds(
-    main.QUERIES.visibleOrganizations,
-    "name",
-    true,
-    0,
-    undefined,
-    main.STORE_ID,
-  );
-  const newestOrgIds = main.UI.useResultSortedRowIds(
-    main.QUERIES.visibleOrganizations,
-    "created_at",
-    true,
-    0,
-    undefined,
-    main.STORE_ID,
-  );
-  const oldestOrgIds = main.UI.useResultSortedRowIds(
-    main.QUERIES.visibleOrganizations,
-    "created_at",
-    false,
-    0,
-    undefined,
-    main.STORE_ID,
-  );
-
-  const sortedHumanIds =
-    sortOption === "alphabetical"
-      ? alphabeticalHumanIds
-      : sortOption === "reverse-alphabetical"
-        ? reverseAlphabeticalHumanIds
-        : sortOption === "newest"
-          ? newestHumanIds
-          : oldestHumanIds;
-
-  const sortedOrgIds =
-    sortOption === "alphabetical"
-      ? alphabeticalOrgIds
-      : sortOption === "reverse-alphabetical"
-        ? reverseAlphabeticalOrgIds
-        : sortOption === "newest"
-          ? newestOrgIds
-          : oldestOrgIds;
 
   const { pinnedHumanIds, unpinnedHumanIds } = useMemo(() => {
     const pinned = sortedHumanIds.filter((id) => allHumans[id]?.pinned);

--- a/apps/desktop/src/stt/render-transcript.ts
+++ b/apps/desktop/src/stt/render-transcript.ts
@@ -142,6 +142,7 @@ export function getRenderTranscriptRequestKey(
 export function buildRenderTranscriptRequestFromStore(
   store: NonNullable<ReturnType<typeof main.UI.useStore>>,
   transcriptIds: string[],
+  options: { participantMappingIds?: readonly string[] } = {},
 ): RenderTranscriptRequest | null {
   const sessionId = getSessionIdForTranscripts(store, transcriptIds);
   const transcripts = transcriptIds.map((transcriptId) => ({
@@ -155,7 +156,11 @@ export function buildRenderTranscriptRequestFromStore(
   return buildRenderTranscriptRequest(
     transcripts,
     collectRenderHumans(store),
-    collectSessionParticipantHumanIds(store, sessionId),
+    collectSessionParticipantHumanIds(
+      store,
+      sessionId,
+      options.participantMappingIds,
+    ),
   );
 }
 
@@ -385,13 +390,15 @@ function getSessionIdForTranscripts(
 function collectSessionParticipantHumanIds(
   store: Pick<main.Store, "forEachRow" | "getCell">,
   sessionId?: string,
+  participantMappingIds?: readonly string[],
 ): string[] {
   if (!sessionId) {
     return [];
   }
 
   const participantHumanIds: string[] = [];
-  store.forEachRow("mapping_session_participant", (mappingId, _forEachCell) => {
+
+  const collect = (mappingId: string) => {
     const mappingSessionId = store.getCell(
       "mapping_session_participant",
       mappingId,
@@ -409,7 +416,20 @@ function collectSessionParticipantHumanIds(
     if (typeof humanId === "string" && humanId) {
       participantHumanIds.push(humanId);
     }
-  });
+  };
+
+  if (participantMappingIds) {
+    for (const mappingId of participantMappingIds) {
+      collect(mappingId);
+    }
+  } else {
+    store.forEachRow(
+      "mapping_session_participant",
+      (mappingId, _forEachCell) => {
+        collect(mappingId);
+      },
+    );
+  }
 
   return participantHumanIds;
 }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -79,8 +79,7 @@ const tauri: UserConfig = {
     chunkSizeWarningLimit: 500 * 10,
     target:
       process.env.TAURI_ENV_PLATFORM == "windows" ? "chrome105" : "safari13",
-    // minify: !process.env.TAURI_ENV_DEBUG ? "esbuild" : false,
-    minify: false,
+    minify: !process.env.TAURI_ENV_DEBUG ? "esbuild" : false,
     sourcemap: !!process.env.TAURI_ENV_DEBUG,
   },
 };

--- a/crates/audio-actual/src/lib.rs
+++ b/crates/audio-actual/src/lib.rs
@@ -84,11 +84,10 @@ pub struct AudioInput {
 impl AudioInput {
     pub fn get_default_device_name() -> String {
         let host = cpal::default_host();
-        let device = host.default_input_device().unwrap();
-        device
-            .description()
-            .map(|d| d.name().to_string())
-            .unwrap_or("Unknown Microphone".to_string())
+        host.default_input_device()
+            .and_then(|device| device.description().ok())
+            .map(|description| description.name().to_string())
+            .unwrap_or_else(|| "Unknown Microphone".to_string())
     }
 
     pub fn sample_rate(&self) -> u32 {
@@ -144,13 +143,13 @@ impl AudioInput {
         })
     }
 
-    pub fn from_speaker() -> Self {
-        Self {
+    pub fn from_speaker() -> Result<Self, Error> {
+        Ok(Self {
             source: AudioSource::RealtimeSpeaker,
             mic: None,
-            speaker: Some(SpeakerInput::new().unwrap()),
+            speaker: Some(SpeakerInput::new().map_err(|_| Error::SpeakerStreamSetupFailed)?),
             data: None,
-        }
+        })
     }
 
     pub fn device_name(&self) -> String {

--- a/crates/audio-actual/src/speaker/macos.rs
+++ b/crates/audio-actual/src/speaker/macos.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::task::Poll;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use futures_util::Stream;
 use futures_util::task::AtomicWaker;
 use hypr_audio_interface::AsyncSource;
@@ -53,9 +53,12 @@ impl SpeakerInput {
         let tap_desc = ca::TapDesc::with_mono_global_tap_excluding_processes(&ns::Array::new());
         let tap = tap_desc.create_process_tap()?;
 
+        let tap_uid = tap
+            .uid()
+            .map_err(|error| anyhow!("process tap has no uid: {error}"))?;
         let sub_tap = cf::DictionaryOf::with_keys_values(
             &[ca::sub_device_keys::uid()],
-            &[tap.uid().unwrap().as_type_ref()],
+            &[tap_uid.as_type_ref()],
         );
 
         let agg_desc = cf::DictionaryOf::with_keys_values(
@@ -79,7 +82,10 @@ impl SpeakerInput {
     }
 
     pub fn sample_rate(&self) -> u32 {
-        self.tap.asbd().unwrap().sample_rate as u32
+        self.tap
+            .asbd()
+            .map(|asbd| asbd.sample_rate as u32)
+            .unwrap_or(48_000)
     }
 
     fn start_device(
@@ -95,7 +101,9 @@ impl SpeakerInput {
             _output_time: &cat::AudioTimeStamp,
             ctx: Option<&mut Ctx>,
         ) -> os::Status {
-            let ctx = ctx.unwrap();
+            let Some(ctx) = ctx else {
+                return os::Status::NO_ERR;
+            };
 
             let first_buffer = &input_data.buffers[0];
 
@@ -131,10 +139,14 @@ impl SpeakerInput {
         Ok(started_device)
     }
 
-    pub fn stream(self) -> SpeakerStream {
-        let asbd = self.tap.asbd().unwrap();
+    pub fn stream(self) -> Result<SpeakerStream> {
+        let asbd = self
+            .tap
+            .asbd()
+            .map_err(|error| anyhow!("process tap has no stream format: {error}"))?;
 
-        let format = av::AudioFormat::with_asbd(&asbd).unwrap();
+        let format = av::AudioFormat::with_asbd(&asbd)
+            .ok_or_else(|| anyhow!("process tap has unsupported audio format"))?;
         let common_format = format.common_format();
 
         let rb = HeapRb::<f32>::new(BUFFER_SIZE);
@@ -156,9 +168,9 @@ impl SpeakerInput {
             conversion_buffer: vec![0.0f32; crate::rt_ring::DEFAULT_SCRATCH_LEN],
         });
 
-        let device = self.start_device(&mut ctx).unwrap();
+        let device = self.start_device(&mut ctx)?;
 
-        SpeakerStream {
+        Ok(SpeakerStream {
             reader: RingbufAsyncReader::new(
                 consumer,
                 waker,
@@ -172,7 +184,7 @@ impl SpeakerInput {
             current_sample_rate,
             sample_rate_probe_counter: 0,
             buffer_rate: asbd.sample_rate as u32,
-        }
+        })
     }
 }
 
@@ -252,9 +264,11 @@ impl Stream for SpeakerStream {
                 .sample_rate_probe_counter
                 .is_multiple_of(SAMPLE_RATE_PROBE_INTERVAL)
             {
-                let after = this._tap.asbd().unwrap().sample_rate as u32;
-                if this.current_sample_rate != after {
-                    this.current_sample_rate = after;
+                if let Ok(asbd) = this._tap.asbd() {
+                    let after = asbd.sample_rate as u32;
+                    if this.current_sample_rate != after {
+                        this.current_sample_rate = after;
+                    }
                 }
             }
         }

--- a/crates/audio-actual/src/speaker/mod.rs
+++ b/crates/audio-actual/src/speaker/mod.rs
@@ -55,7 +55,7 @@ impl SpeakerInput {
 
     #[cfg(all(target_os = "macos", not(test)))]
     pub fn stream(self) -> Result<SpeakerStream> {
-        Ok(self.inner.stream())
+        self.inner.stream()
     }
 
     #[cfg(all(not(target_os = "macos"), not(test)))]

--- a/crates/owhisper-client/Cargo.toml
+++ b/crates/owhisper-client/Cargo.toml
@@ -24,6 +24,7 @@ reqwest-middleware = { workspace = true, features = ["json", "multipart"] }
 reqwest-tracing = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true, features = ["io"] }
 
 backon = { workspace = true }
 base64 = { workspace = true }

--- a/crates/owhisper-client/src/adapter/aquavoice/batch.rs
+++ b/crates/owhisper-client/src/adapter/aquavoice/batch.rs
@@ -4,7 +4,7 @@ use owhisper_interface::ListenParams;
 use owhisper_interface::batch::{Alternatives, Channel, Response as BatchResponse, Results};
 use reqwest::multipart::{Form, Part};
 
-use crate::adapter::http::mime_type_from_extension;
+use crate::adapter::http::streaming_file_part;
 use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware, append_path_if_missing};
 use crate::error::Error;
 
@@ -79,27 +79,7 @@ struct AquaVoiceResponse {
 }
 
 async fn build_file_part(file_path: &Path) -> Result<Part, Error> {
-    let fallback_name = match file_path.extension().and_then(|e| e.to_str()) {
-        Some(ext) => format!("audio.{}", ext),
-        None => "audio".to_string(),
-    };
-
-    let file_name = file_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .map(ToOwned::to_owned)
-        .unwrap_or(fallback_name);
-
-    let file_bytes = tokio::fs::read(file_path)
-        .await
-        .map_err(|e| Error::AudioProcessing(e.to_string()))?;
-
-    let mime_type = mime_type_from_extension(file_path);
-
-    Part::bytes(file_bytes)
-        .file_name(file_name)
-        .mime_str(mime_type)
-        .map_err(|e| Error::AudioProcessing(e.to_string()))
+    streaming_file_part(file_path).await
 }
 
 fn transcription_url(api_base: &str) -> Result<url::Url, Error> {

--- a/crates/owhisper-client/src/adapter/assemblyai/batch.rs
+++ b/crates/owhisper-client/src/adapter/assemblyai/batch.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use super::AssemblyAIAdapter;
 use super::language::BATCH_LANGUAGES;
-use crate::adapter::http::ensure_success;
+use crate::adapter::http::{ensure_success, mime_type_from_extension, streaming_file_body};
 use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware, append_path_if_missing};
 use crate::error::Error;
 use crate::polling::{PollingConfig, PollingResult, poll_until};
@@ -171,19 +171,8 @@ impl AssemblyAIAdapter {
     ) -> Result<BatchResponse, Error> {
         let base_url = Self::batch_api_url(api_base);
 
-        let audio_data = tokio::fs::read(&file_path)
-            .await
-            .map_err(|e| Error::AudioProcessing(format!("failed to read file: {}", e)))?;
-
-        let content_type = match file_path.extension().and_then(|e| e.to_str()) {
-            Some("wav") => "audio/wav",
-            Some("mp3") => "audio/mpeg",
-            Some("ogg") => "audio/ogg",
-            Some("flac") => "audio/flac",
-            Some("m4a") => "audio/mp4",
-            Some("webm") => "audio/webm",
-            _ => "application/octet-stream",
-        };
+        let audio = streaming_file_body(&file_path).await?;
+        let content_type = mime_type_from_extension(&file_path);
 
         let mut upload_url = base_url.clone();
         append_path_if_missing(&mut upload_url, "upload");
@@ -191,7 +180,8 @@ impl AssemblyAIAdapter {
             .post(upload_url.to_string())
             .header("Authorization", api_key)
             .header("Content-Type", content_type)
-            .body(audio_data)
+            .header("Content-Length", audio.len)
+            .body(audio.body)
             .send()
             .await?;
 

--- a/crates/owhisper-client/src/adapter/assemblyai/mod.rs
+++ b/crates/owhisper-client/src/adapter/assemblyai/mod.rs
@@ -71,9 +71,11 @@ impl AssemblyAIAdapter {
 
         if url.host_str() == Some("api.assemblyai.com") {
             let _ = url.set_host(Some("streaming.assemblyai.com"));
+            url.set_path(Provider::AssemblyAI.ws_path());
+        } else {
+            super::append_path_if_missing(&mut url, Provider::AssemblyAI.ws_path());
         }
 
-        super::append_path_if_missing(&mut url, Provider::AssemblyAI.ws_path());
         super::set_scheme_from_host(&mut url);
 
         (url, existing_params)
@@ -99,6 +101,7 @@ impl AssemblyAIAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Provider;
 
     #[test]
     fn test_streaming_ws_url_appends_v3_ws() {
@@ -110,6 +113,14 @@ mod tests {
     #[test]
     fn test_streaming_ws_url_empty_uses_default() {
         let (url, params) = AssemblyAIAdapter::streaming_ws_url("");
+        assert_eq!(url.as_str(), "wss://streaming.assemblyai.com/v3/ws");
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn test_streaming_ws_url_default_api_base_uses_streaming_path() {
+        let (url, params) =
+            AssemblyAIAdapter::streaming_ws_url(Provider::AssemblyAI.default_api_base());
         assert_eq!(url.as_str(), "wss://streaming.assemblyai.com/v3/ws");
         assert!(params.is_empty());
     }

--- a/crates/owhisper-client/src/adapter/deepgram/batch.rs
+++ b/crates/owhisper-client/src/adapter/deepgram/batch.rs
@@ -41,7 +41,7 @@ impl BatchSttAdapter for DeepgramAdapter {
     }
 }
 
-use crate::adapter::http::mime_type_from_extension;
+use crate::adapter::http::{mime_type_from_extension, streaming_file_body};
 
 async fn do_transcribe_file(
     client: &ClientWithMiddleware,
@@ -50,11 +50,8 @@ async fn do_transcribe_file(
     params: &ListenParams,
     file_path: PathBuf,
 ) -> Result<BatchResponse, Error> {
-    let audio_data = tokio::fs::read(&file_path)
-        .await
-        .map_err(|e| Error::AudioProcessing(format!("failed to read file: {}", e)))?;
-
     let content_type = mime_type_from_extension(&file_path);
+    let audio = streaming_file_body(&file_path).await?;
 
     let url = build_batch_url(
         api_base,
@@ -68,7 +65,8 @@ async fn do_transcribe_file(
         .header("Authorization", format!("Token {}", api_key))
         .header("Accept", "application/json")
         .header("Content-Type", content_type)
-        .body(audio_data)
+        .header("Content-Length", audio.len)
+        .body(audio.body)
         .send()
         .await?;
 

--- a/crates/owhisper-client/src/adapter/elevenlabs/batch.rs
+++ b/crates/owhisper-client/src/adapter/elevenlabs/batch.rs
@@ -8,6 +8,7 @@ use owhisper_interface::batch::{
 use serde::Deserialize;
 
 use super::{ElevenLabsAdapter, ElevenLabsWord};
+use crate::adapter::http::streaming_file_part;
 use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware, MIXED_CAPTURE_CHANNEL};
 use crate::error::Error;
 
@@ -57,20 +58,6 @@ impl ElevenLabsAdapter {
         params: &ListenParams,
         file_path: &Path,
     ) -> Result<BatchResponse, Error> {
-        let file_name = file_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("audio.wav")
-            .to_string();
-
-        let file_bytes = tokio::fs::read(file_path).await.map_err(|e| {
-            Error::AudioProcessing(format!(
-                "failed to read file {}: {}",
-                file_path.display(),
-                e
-            ))
-        })?;
-
         let default = crate::providers::Provider::ElevenLabs.default_batch_model();
         let model = match params.model.as_deref() {
             Some(m) if crate::providers::is_meta_model(m) => default,
@@ -79,7 +66,7 @@ impl ElevenLabsAdapter {
             None => default,
         };
 
-        let part = reqwest::multipart::Part::bytes(file_bytes).file_name(file_name);
+        let part = streaming_file_part(file_path).await?;
         let mut form = reqwest::multipart::Form::new()
             .part("file", part)
             .text("model_id", model.to_string())

--- a/crates/owhisper-client/src/adapter/fireworks/batch.rs
+++ b/crates/owhisper-client/src/adapter/fireworks/batch.rs
@@ -8,6 +8,7 @@ use owhisper_interface::batch::{
 use serde::Deserialize;
 
 use super::FireworksAdapter;
+use crate::adapter::http::streaming_file_part;
 use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware};
 use crate::error::Error;
 
@@ -48,21 +49,7 @@ impl FireworksAdapter {
         params: &ListenParams,
         file_path: &Path,
     ) -> Result<BatchResponse, Error> {
-        let file_name = file_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("audio.wav")
-            .to_string();
-
-        let file_bytes = tokio::fs::read(file_path).await.map_err(|e| {
-            Error::AudioProcessing(format!(
-                "failed to read file {}: {}",
-                file_path.display(),
-                e
-            ))
-        })?;
-
-        let file_part = reqwest::multipart::Part::bytes(file_bytes).file_name(file_name);
+        let file_part = streaming_file_part(file_path).await?;
         let mut form = reqwest::multipart::Form::new().part("file", file_part);
 
         let default = crate::providers::Provider::Fireworks.default_batch_model();

--- a/crates/owhisper-client/src/adapter/fireworks/mod.rs
+++ b/crates/owhisper-client/src/adapter/fireworks/mod.rs
@@ -43,12 +43,12 @@ impl FireworksAdapter {
 
     pub(crate) fn batch_api_host(api_base: &str) -> String {
         let host = Self::api_host(api_base);
-        format!("audio-turbo.{}", host)
+        format!("audio-prod.{}", host)
     }
 
     pub(crate) fn ws_host(api_base: &str) -> String {
         let host = Self::api_host(api_base);
-        format!("audio-streaming-v2.{}", host)
+        format!("audio-streaming.{}", host)
     }
 
     pub(crate) fn build_ws_url_from_base(api_base: &str) -> (url::Url, Vec<(String, String)>) {
@@ -73,7 +73,7 @@ mod tests {
         let (url, params) = FireworksAdapter::build_ws_url_from_base("");
         assert_eq!(
             url.as_str(),
-            "wss://audio-streaming-v2.api.fireworks.ai/v1/audio/transcriptions/streaming"
+            "wss://audio-streaming.api.fireworks.ai/v1/audio/transcriptions/streaming"
         );
         assert!(params.is_empty());
     }
@@ -83,7 +83,7 @@ mod tests {
         let (url, params) = FireworksAdapter::build_ws_url_from_base("https://api.fireworks.ai");
         assert_eq!(
             url.as_str(),
-            "wss://audio-streaming-v2.api.fireworks.ai/v1/audio/transcriptions/streaming"
+            "wss://audio-streaming.api.fireworks.ai/v1/audio/transcriptions/streaming"
         );
         assert!(params.is_empty());
     }
@@ -104,5 +104,13 @@ mod tests {
         );
         assert_eq!(url.as_str(), "ws://localhost:8787/listen");
         assert_eq!(params, vec![("provider".into(), "fireworks".into())]);
+    }
+
+    #[test]
+    fn test_batch_api_host_default_api_base() {
+        assert_eq!(
+            FireworksAdapter::batch_api_host("https://api.fireworks.ai"),
+            "audio-prod.api.fireworks.ai"
+        );
     }
 }

--- a/crates/owhisper-client/src/adapter/gladia/batch.rs
+++ b/crates/owhisper-client/src/adapter/gladia/batch.rs
@@ -11,6 +11,7 @@ use owhisper_interface::batch::{
 use serde::{Deserialize, Serialize};
 
 use super::GladiaAdapter;
+use crate::adapter::http::streaming_file_part;
 use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware, append_path_if_missing};
 use crate::error::Error;
 use crate::polling::{PollingConfig, PollingResult, poll_until};
@@ -166,35 +167,10 @@ impl GladiaAdapter {
     ) -> Result<BatchResponse, Error> {
         let base_url = Self::batch_api_url(api_base);
 
-        let file_bytes = tokio::fs::read(&file_path)
-            .await
-            .map_err(|e| Error::AudioProcessing(format!("failed to read file: {}", e)))?;
-
-        let file_name = file_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("audio.wav")
-            .to_string();
-
-        let mime_type = match file_path.extension().and_then(|e| e.to_str()) {
-            Some("wav") => "audio/wav",
-            Some("mp3") => "audio/mpeg",
-            Some("ogg") => "audio/ogg",
-            Some("flac") => "audio/flac",
-            Some("m4a") => "audio/mp4",
-            Some("webm") => "audio/webm",
-            _ => "application/octet-stream",
-        };
-
         let mut upload_url = base_url.clone();
         append_path_if_missing(&mut upload_url, "upload");
-        let form = reqwest::multipart::Form::new().part(
-            "audio",
-            reqwest::multipart::Part::bytes(file_bytes)
-                .file_name(file_name)
-                .mime_str(mime_type)
-                .map_err(|e| Error::AudioProcessing(e.to_string()))?,
-        );
+        let form =
+            reqwest::multipart::Form::new().part("audio", streaming_file_part(&file_path).await?);
 
         let upload_response = client
             .post(upload_url.to_string())

--- a/crates/owhisper-client/src/adapter/http.rs
+++ b/crates/owhisper-client/src/adapter/http.rs
@@ -1,8 +1,16 @@
 use std::path::Path;
 
-use reqwest::Response;
+use reqwest::multipart::Part;
+use reqwest::{Body, Response};
+use tokio::fs::File;
+use tokio_util::io::ReaderStream;
 
 use crate::error::Error;
+
+pub struct FileBody {
+    pub body: Body,
+    pub len: u64,
+}
 
 pub async fn ensure_success(response: Response) -> Result<Response, Error> {
     let status = response.status();
@@ -12,6 +20,41 @@ pub async fn ensure_success(response: Response) -> Result<Response, Error> {
         let body = response.text().await.unwrap_or_default();
         Err(Error::UnexpectedStatus { status, body })
     }
+}
+
+pub async fn streaming_file_body(path: &Path) -> Result<FileBody, Error> {
+    let file = File::open(path)
+        .await
+        .map_err(|e| Error::AudioProcessing(format!("failed to open file: {e}")))?;
+    let len = file
+        .metadata()
+        .await
+        .map_err(|e| Error::AudioProcessing(format!("failed to stat file: {e}")))?
+        .len();
+    let stream = ReaderStream::new(file);
+
+    Ok(FileBody {
+        body: Body::wrap_stream(stream),
+        len,
+    })
+}
+
+pub async fn streaming_file_part(path: &Path) -> Result<Part, Error> {
+    let fallback_name = match path.extension().and_then(|e| e.to_str()) {
+        Some(ext) => format!("audio.{ext}"),
+        None => "audio".to_string(),
+    };
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or(fallback_name);
+    let file = streaming_file_body(path).await?;
+
+    Part::stream_with_length(file.body, file.len)
+        .file_name(file_name)
+        .mime_str(mime_type_from_extension(path))
+        .map_err(|e| Error::AudioProcessing(e.to_string()))
 }
 
 pub fn mime_type_from_extension(path: &Path) -> &'static str {

--- a/crates/owhisper-client/src/adapter/hyprnote/batch.rs
+++ b/crates/owhisper-client/src/adapter/hyprnote/batch.rs
@@ -4,7 +4,7 @@ use owhisper_interface::ListenParams;
 use owhisper_interface::batch::Response as BatchResponse;
 
 use super::HyprnoteAdapter;
-use crate::adapter::http::mime_type_from_extension;
+use crate::adapter::http::{mime_type_from_extension, streaming_file_body};
 use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware, append_path_if_missing};
 use crate::error::Error;
 
@@ -72,15 +72,14 @@ async fn do_transcribe_file(
         }
     }
 
-    let bytes = tokio::fs::read(&file_path)
-        .await
-        .map_err(|e| Error::AudioProcessing(format!("failed to read file: {e}")))?;
+    let audio = streaming_file_body(&file_path).await?;
 
     let response = client
         .post(url.to_string())
         .header("Authorization", format!("Bearer {api_key}"))
         .header("Content-Type", mime_type_from_extension(&file_path))
-        .body(bytes)
+        .header("Content-Length", audio.len)
+        .body(audio.body)
         .send()
         .await?;
 

--- a/crates/owhisper-client/src/adapter/mistral/batch.rs
+++ b/crates/owhisper-client/src/adapter/mistral/batch.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use owhisper_interface::ListenParams;
 use owhisper_interface::batch::{Alternatives, Channel, Response as BatchResponse, Results, Word};
-use reqwest::multipart::{Form, Part};
+use reqwest::multipart::Form;
 
 use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware, append_path_if_missing};
 use crate::error::Error;
@@ -73,27 +73,7 @@ async fn do_transcribe_file(
     params: &ListenParams,
     file_path: PathBuf,
 ) -> Result<BatchResponse, Error> {
-    let fallback_name = match file_path.extension().and_then(|e| e.to_str()) {
-        Some(ext) => format!("audio.{}", ext),
-        None => "audio".to_string(),
-    };
-
-    let file_name = file_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .map(ToOwned::to_owned)
-        .unwrap_or(fallback_name);
-
-    let file_bytes = tokio::fs::read(&file_path)
-        .await
-        .map_err(|e| Error::AudioProcessing(e.to_string()))?;
-
-    let mime_type = mime_type_from_extension(&file_path);
-
-    let file_part = Part::bytes(file_bytes)
-        .file_name(file_name)
-        .mime_str(mime_type)
-        .map_err(|e| Error::AudioProcessing(e.to_string()))?;
+    let file_part = streaming_file_part(&file_path).await?;
 
     let default = Provider::Mistral.default_batch_model();
     let model = match params.model.as_deref() {
@@ -142,7 +122,7 @@ async fn do_transcribe_file(
     }
 }
 
-use crate::adapter::http::mime_type_from_extension;
+use crate::adapter::http::streaming_file_part;
 
 fn strip_punctuation(s: &str) -> String {
     s.trim_matches(|c: char| c.is_ascii_punctuation())

--- a/crates/owhisper-client/src/adapter/openai/batch.rs
+++ b/crates/owhisper-client/src/adapter/openai/batch.rs
@@ -146,30 +146,10 @@ async fn do_transcribe_file(
     }
 }
 
-use crate::adapter::http::mime_type_from_extension;
+use crate::adapter::http::streaming_file_part;
 
 async fn build_file_part(file_path: &Path) -> Result<Part, Error> {
-    let fallback_name = match file_path.extension().and_then(|e| e.to_str()) {
-        Some(ext) => format!("audio.{}", ext),
-        None => "audio".to_string(),
-    };
-
-    let file_name = file_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .map(ToOwned::to_owned)
-        .unwrap_or(fallback_name);
-
-    let file_bytes = tokio::fs::read(file_path)
-        .await
-        .map_err(|e| Error::AudioProcessing(e.to_string()))?;
-
-    let mime_type = mime_type_from_extension(file_path);
-
-    Part::bytes(file_bytes)
-        .file_name(file_name)
-        .mime_str(mime_type)
-        .map_err(|e| Error::AudioProcessing(e.to_string()))
+    streaming_file_part(file_path).await
 }
 
 fn build_transcription_options(

--- a/crates/owhisper-client/src/adapter/pyannote/batch.rs
+++ b/crates/owhisper-client/src/adapter/pyannote/batch.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use super::model::PyannoteDiarizationModel;
 use super::{PyannoteAdapter, PyannoteTranscriptionModel};
-use crate::adapter::http::{ensure_success, mime_type_from_extension};
+use crate::adapter::http::{ensure_success, mime_type_from_extension, streaming_file_body};
 use crate::adapter::parsing::parse_speaker_id;
 use crate::adapter::{
     BatchFuture, BatchSttAdapter, ClientWithMiddleware, MIXED_CAPTURE_CHANNEL,
@@ -142,13 +142,9 @@ impl PyannoteAdapter {
     ) -> Result<BatchResponse, Error> {
         let base_url = Self::batch_api_url(api_base);
 
-        let file_bytes = tokio::fs::read(&file_path)
-            .await
-            .map_err(|e| Error::AudioProcessing(format!("failed to read file: {}", e)))?;
-
         let media_url = Self::create_media_url(&file_path);
         let upload_url = Self::create_upload_url(client, &base_url, api_key, &media_url).await?;
-        Self::upload_audio(client, &upload_url, &file_path, file_bytes).await?;
+        Self::upload_audio(client, &upload_url, &file_path).await?;
 
         let job = Self::submit_job(client, &base_url, api_key, params, &media_url).await?;
         tracing::info!(
@@ -200,12 +196,13 @@ impl PyannoteAdapter {
         client: &ClientWithMiddleware,
         upload_url: &str,
         file_path: &Path,
-        file_bytes: Vec<u8>,
     ) -> Result<(), Error> {
+        let audio = streaming_file_body(file_path).await?;
         let response = client
             .put(upload_url)
             .header("Content-Type", mime_type_from_extension(file_path))
-            .body(file_bytes)
+            .header("Content-Length", audio.len)
+            .body(audio.body)
             .send()
             .await?;
 

--- a/crates/owhisper-client/src/adapter/smallestai/batch.rs
+++ b/crates/owhisper-client/src/adapter/smallestai/batch.rs
@@ -8,6 +8,7 @@ use owhisper_interface::batch::{
 use serde::{Deserialize, Serialize};
 
 use super::SmallestAIAdapter;
+use crate::adapter::http::streaming_file_body;
 use crate::adapter::parsing::parse_speaker_id;
 use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware, MIXED_CAPTURE_CHANNEL};
 use crate::error::Error;
@@ -48,15 +49,8 @@ impl SmallestAIAdapter {
         params: &ListenParams,
         file_path: &Path,
     ) -> Result<BatchResponse, Error> {
-        let file_bytes = tokio::fs::read(file_path).await.map_err(|error| {
-            Error::AudioProcessing(format!(
-                "failed to read file {}: {}",
-                file_path.display(),
-                error
-            ))
-        })?;
-
         let (mut url, existing_params) = SmallestAIAdapter::batch_api_url(api_base);
+        let audio = streaming_file_body(file_path).await?;
         {
             let mut query_pairs = url.query_pairs_mut();
 
@@ -76,7 +70,8 @@ impl SmallestAIAdapter {
             .post(url)
             .header("Authorization", format!("Bearer {api_key}"))
             .header("Content-Type", "application/octet-stream")
-            .body(file_bytes)
+            .header("Content-Length", audio.len)
+            .body(audio.body)
             .send()
             .await?;
 

--- a/crates/owhisper-client/src/adapter/soniox/batch.rs
+++ b/crates/owhisper-client/src/adapter/soniox/batch.rs
@@ -7,6 +7,7 @@ use owhisper_interface::batch::{
 };
 
 use super::{SonioxAdapter, words};
+use crate::adapter::http::streaming_file_part;
 use crate::adapter::parsing::ms_to_secs_opt;
 use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware, MIXED_CAPTURE_CHANNEL};
 use crate::error::Error;
@@ -19,24 +20,11 @@ impl SonioxAdapter {
     ) -> Result<BatchResponse, Error> {
         let client = reqwest::Client::new();
 
-        let file_name = file_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("audio.wav")
-            .to_string();
-
-        let file_bytes = tokio::fs::read(file_path).await.map_err(|e| {
-            Error::AudioProcessing(format!(
-                "failed to read file {}: {}",
-                file_path.display(),
-                e
-            ))
-        })?;
-
         tracing::info!(hyprnote.file.path = %file_path.display(), "uploading_file_to_soniox");
-        let file_id = soniox::upload_file(&client, &file_name, file_bytes, api_key)
-            .await
-            .map_err(soniox_err)?;
+        let file_id =
+            soniox::upload_file_part(&client, streaming_file_part(file_path).await?, api_key)
+                .await
+                .map_err(soniox_err)?;
 
         tracing::info!(hyprnote.file.id = %file_id, "soniox_file_uploaded");
         let result = Self::transcribe_and_fetch(&client, api_key, params, &file_id).await;

--- a/crates/owhisper-client/src/providers.rs
+++ b/crates/owhisper-client/src/providers.rs
@@ -186,7 +186,7 @@ impl Provider {
             Self::Deepgram => "api.deepgram.com",
             Self::AssemblyAI => "streaming.assemblyai.com",
             Self::Soniox => "stt-rt.soniox.com",
-            Self::Fireworks => "audio-streaming-v2.api.fireworks.ai",
+            Self::Fireworks => "audio-streaming.api.fireworks.ai",
             Self::OpenAI => "api.openai.com",
             Self::Gladia => "api.gladia.io",
             Self::ElevenLabs => "api.elevenlabs.io",
@@ -449,5 +449,18 @@ impl Provider {
 
     pub fn detect_any_error(data: &[u8]) -> Option<ProviderError> {
         Self::ALL.iter().find_map(|p| p.detect_error(data))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fireworks_auth_uses_raw_api_key() {
+        assert_eq!(
+            Provider::Fireworks.build_auth_header("fw-key"),
+            Some(("Authorization", "fw-key".to_string()))
+        );
     }
 }

--- a/crates/soniox/src/lib.rs
+++ b/crates/soniox/src/lib.rs
@@ -228,6 +228,14 @@ pub async fn upload_file(
     api_key: &str,
 ) -> Result<String, Error> {
     let part = reqwest::multipart::Part::bytes(file_bytes).file_name(file_name.to_string());
+    upload_file_part(client, part, api_key).await
+}
+
+pub async fn upload_file_part(
+    client: &reqwest::Client,
+    part: reqwest::multipart::Part,
+    api_key: &str,
+) -> Result<String, Error> {
     let form = reqwest::multipart::Form::new().part("file", part);
 
     let response = client

--- a/crates/transcribe-proxy/src/relay/builder.rs
+++ b/crates/transcribe-proxy/src/relay/builder.rs
@@ -7,8 +7,8 @@ pub use tokio_tungstenite::tungstenite::ClientRequestBuilder;
 
 use super::handler::WebSocketProxy;
 use super::types::{
-    ClientMessageFilter, FirstMessageTransformer, InitialMessage, OnCloseCallback,
-    ResponseTransformer,
+    ClientBinaryTransformer, ClientMessageFilter, FirstMessageTransformer, InitialMessage,
+    OnCloseCallback, ResponseTransformer,
 };
 use crate::config::DEFAULT_CONNECT_TIMEOUT_MS;
 use crate::provider_selector::SelectedProvider;
@@ -38,6 +38,7 @@ pub struct WebSocketProxyBuilder<S = NoUpstream> {
     connect_timeout: Duration,
     on_close: Option<OnCloseCallback>,
     client_message_filter: Option<ClientMessageFilter>,
+    client_binary_transformer: Option<ClientBinaryTransformer>,
 }
 
 impl Default for WebSocketProxyBuilder<NoUpstream> {
@@ -51,6 +52,7 @@ impl Default for WebSocketProxyBuilder<NoUpstream> {
             connect_timeout: Duration::from_millis(DEFAULT_CONNECT_TIMEOUT_MS),
             on_close: None,
             client_message_filter: None,
+            client_binary_transformer: None,
         }
     }
 }
@@ -66,6 +68,7 @@ impl<S> WebSocketProxyBuilder<S> {
             connect_timeout: self.connect_timeout,
             on_close: self.on_close,
             client_message_filter: self.client_message_filter,
+            client_binary_transformer: self.client_binary_transformer,
         }
     }
 
@@ -79,6 +82,7 @@ impl<S> WebSocketProxyBuilder<S> {
         connect_timeout: Duration,
         on_close: Option<OnCloseCallback>,
         client_message_filter: Option<ClientMessageFilter>,
+        client_binary_transformer: Option<ClientBinaryTransformer>,
     ) -> WebSocketProxy {
         let control_message_types = if control_message_types.is_empty() {
             None
@@ -95,6 +99,7 @@ impl<S> WebSocketProxyBuilder<S> {
             connect_timeout,
             on_close,
             client_message_filter,
+            client_binary_transformer,
         )
     }
 
@@ -143,6 +148,11 @@ impl<S> WebSocketProxyBuilder<S> {
 
     pub fn client_message_filter(mut self, filter: ClientMessageFilter) -> Self {
         self.client_message_filter = Some(filter);
+        self
+    }
+
+    pub fn client_binary_transformer(mut self, transformer: ClientBinaryTransformer) -> Self {
+        self.client_binary_transformer = Some(transformer);
         self
     }
 }
@@ -209,6 +219,7 @@ impl WebSocketProxyBuilder<WithUrl> {
             self.connect_timeout,
             self.on_close,
             self.client_message_filter,
+            self.client_binary_transformer,
         ))
     }
 }

--- a/crates/transcribe-proxy/src/relay/channel_split/io.rs
+++ b/crates/transcribe-proxy/src/relay/channel_split/io.rs
@@ -3,8 +3,8 @@ use futures_util::{SinkExt, StreamExt};
 use tokio_tungstenite::tungstenite::Message as TungsteniteMessage;
 
 use super::super::types::{
-    ClientMessageFilter, ClientReceiver, ClientSender, DEFAULT_CLOSE_CODE, ShutdownSignal,
-    UpstreamReceiver, UpstreamSender, convert,
+    ClientBinaryTransformer, ClientMessageFilter, ClientReceiver, ClientSender, DEFAULT_CLOSE_CODE,
+    ShutdownSignal, UpstreamReceiver, UpstreamSender, convert,
 };
 use super::coordinator::SplitEvent;
 use super::payload::RewrittenSplitResponse;
@@ -54,6 +54,24 @@ fn upstream_receive_error_signal(error: &impl std::fmt::Display) -> ShutdownSign
     }
 }
 
+fn transform_binary_message(
+    payload: Vec<u8>,
+    transformer: &Option<ClientBinaryTransformer>,
+) -> Option<TungsteniteMessage> {
+    let (data, is_text) = match transformer {
+        Some(transformer) => transformer(payload)?,
+        None => (payload, false),
+    };
+
+    if is_text {
+        String::from_utf8(data)
+            .ok()
+            .map(|text| TungsteniteMessage::Text(text.into()))
+    } else {
+        Some(TungsteniteMessage::Binary(data.into()))
+    }
+}
+
 pub(super) async fn send_text(client_tx: &mut ClientSender, text: String) -> bool {
     client_tx.send(Message::Text(text.into())).await.is_ok()
 }
@@ -74,6 +92,7 @@ pub(super) async fn relay_client_to_upstreams(
     mut mic_tx: UpstreamSender,
     mut spk_tx: UpstreamSender,
     client_message_filter: Option<ClientMessageFilter>,
+    client_binary_transformer: Option<ClientBinaryTransformer>,
     shutdown_tx: tokio::sync::broadcast::Sender<ShutdownSignal>,
     event_tx: tokio::sync::mpsc::Sender<SplitEvent>,
 ) {
@@ -122,14 +141,31 @@ pub(super) async fn relay_client_to_upstreams(
                         }
 
                         let (mic, spk) = deinterleave(&bytes);
-                        if mic_tx
-                            .send(TungsteniteMessage::Binary(mic.into()))
-                            .await
-                            .is_err()
-                            || spk_tx
-                                .send(TungsteniteMessage::Binary(spk.into()))
-                                .await
-                                .is_err()
+                        let Some(mic_message) =
+                            transform_binary_message(mic, &client_binary_transformer)
+                        else {
+                            let _ = event_tx
+                                .send(SplitEvent::Fatal(ShutdownSignal::Close {
+                                    code: DEFAULT_CLOSE_CODE,
+                                    reason: "invalid_transformed_audio_message".to_string(),
+                                }))
+                                .await;
+                            break;
+                        };
+                        let Some(spk_message) =
+                            transform_binary_message(spk, &client_binary_transformer)
+                        else {
+                            let _ = event_tx
+                                .send(SplitEvent::Fatal(ShutdownSignal::Close {
+                                    code: DEFAULT_CLOSE_CODE,
+                                    reason: "invalid_transformed_audio_message".to_string(),
+                                }))
+                                .await;
+                            break;
+                        };
+
+                        if mic_tx.send(mic_message).await.is_err()
+                            || spk_tx.send(spk_message).await.is_err()
                         {
                             let _ = event_tx
                                 .send(SplitEvent::Fatal(upstream_send_failed_signal()))

--- a/crates/transcribe-proxy/src/relay/channel_split/mod.rs
+++ b/crates/transcribe-proxy/src/relay/channel_split/mod.rs
@@ -21,8 +21,8 @@ use self::coordinator::{CoordinatorAction, SplitCoordinator, SplitEvent};
 use self::io::{relay_client_to_upstreams, relay_upstream_to_events, send_rewritten, send_text};
 use self::payload::{FinalizeMode, rewrite_split_response};
 use super::types::{
-    ClientMessageFilter, DEFAULT_CLOSE_CODE, InitialMessage, OnCloseCallback, ResponseTransformer,
-    ShutdownSignal, convert,
+    ClientBinaryTransformer, ClientMessageFilter, DEFAULT_CLOSE_CODE, InitialMessage,
+    OnCloseCallback, ResponseTransformer, ShutdownSignal, convert,
 };
 
 fn proxy_debug_enabled() -> bool {
@@ -40,6 +40,7 @@ pub struct ChannelSplitProxy {
     connect_timeout: Duration,
     on_close: Option<OnCloseCallback>,
     client_message_filter: Option<ClientMessageFilter>,
+    client_binary_transformer: Option<ClientBinaryTransformer>,
 }
 
 impl ChannelSplitProxy {
@@ -76,11 +77,20 @@ impl ChannelSplitProxy {
             connect_timeout,
             on_close,
             client_message_filter: None,
+            client_binary_transformer: None,
         }
     }
 
     pub fn with_client_message_filter(mut self, filter: ClientMessageFilter) -> Self {
         self.client_message_filter = Some(filter);
+        self
+    }
+
+    pub fn with_client_binary_transformer(
+        mut self,
+        transformer: Option<ClientBinaryTransformer>,
+    ) -> Self {
+        self.client_binary_transformer = transformer;
         self
     }
 
@@ -173,6 +183,7 @@ impl ChannelSplitProxy {
             mic_tx,
             spk_tx,
             self.client_message_filter.clone(),
+            self.client_binary_transformer.clone(),
             shutdown_tx.clone(),
             event_tx.clone(),
         );

--- a/crates/transcribe-proxy/src/relay/handler.rs
+++ b/crates/transcribe-proxy/src/relay/handler.rs
@@ -17,9 +17,10 @@ use owhisper_client::Provider;
 use super::builder::WebSocketProxyBuilder;
 use super::pending::{FlushError, PendingState, QueuedPayload};
 use super::types::{
-    ClientMessageFilter, ClientReceiver, ClientSender, ControlMessageTypes, DEFAULT_CLOSE_CODE,
-    FirstMessageTransformer, InitialMessage, OnCloseCallback, ResponseTransformer, ShutdownSignal,
-    UpstreamReceiver, UpstreamSender, convert, is_control_message,
+    ClientBinaryTransformer, ClientMessageFilter, ClientReceiver, ClientSender,
+    ControlMessageTypes, DEFAULT_CLOSE_CODE, FirstMessageTransformer, InitialMessage,
+    OnCloseCallback, ResponseTransformer, ShutdownSignal, UpstreamReceiver, UpstreamSender,
+    convert, is_control_message,
 };
 
 #[derive(Clone)]
@@ -32,6 +33,7 @@ pub struct WebSocketProxy {
     connect_timeout: Duration,
     on_close: Option<OnCloseCallback>,
     client_message_filter: Option<ClientMessageFilter>,
+    client_binary_transformer: Option<ClientBinaryTransformer>,
 }
 
 impl WebSocketProxy {
@@ -45,6 +47,7 @@ impl WebSocketProxy {
         connect_timeout: Duration,
         on_close: Option<OnCloseCallback>,
         client_message_filter: Option<ClientMessageFilter>,
+        client_binary_transformer: Option<ClientBinaryTransformer>,
     ) -> Self {
         Self {
             upstream_request,
@@ -55,6 +58,7 @@ impl WebSocketProxy {
             connect_timeout,
             on_close,
             client_message_filter,
+            client_binary_transformer,
         }
     }
 
@@ -117,6 +121,7 @@ impl WebSocketProxy {
             self.response_transformer.clone(),
             self.on_close.clone(),
             self.client_message_filter.clone(),
+            self.client_binary_transformer.clone(),
         )
         .await;
 
@@ -151,6 +156,7 @@ impl WebSocketProxy {
         response_transformer: Option<ResponseTransformer>,
         on_close: Option<OnCloseCallback>,
         client_message_filter: Option<ClientMessageFilter>,
+        client_binary_transformer: Option<ClientBinaryTransformer>,
     ) {
         let start_time = Instant::now();
 
@@ -169,6 +175,7 @@ impl WebSocketProxy {
             transform_first_message,
             initial_message,
             client_message_filter,
+            client_binary_transformer,
         );
 
         let upstream_to_client = Self::run_upstream_to_client(
@@ -258,6 +265,7 @@ impl WebSocketProxy {
         mut first_msg_transformer: Option<FirstMessageTransformer>,
         initial_message: Option<InitialMessage>,
         client_message_filter: Option<ClientMessageFilter>,
+        client_binary_transformer: Option<ClientBinaryTransformer>,
     ) {
         let mut pending = PendingState::default();
 
@@ -340,9 +348,15 @@ impl WebSocketProxy {
                             if first_msg_transformer.is_some() {
                                 tracing::debug!("binary_message_received_before_text_transform");
                             }
-                            let data = bytes.to_vec();
+                            let (data, is_text) = match client_binary_transformer.as_ref() {
+                                Some(transformer) => match transformer(bytes.to_vec()) {
+                                    Some(payload) => payload,
+                                    None => continue,
+                                },
+                                None => (bytes.to_vec(), false),
+                            };
 
-                            if Self::process_data_message(&mut pending, data, false, &control_types, &shutdown_tx, &mut upstream_sender).await {
+                            if Self::process_data_message(&mut pending, data, is_text, &control_types, &shutdown_tx, &mut upstream_sender).await {
                                 break;
                             }
                         }

--- a/crates/transcribe-proxy/src/relay/mod.rs
+++ b/crates/transcribe-proxy/src/relay/mod.rs
@@ -16,8 +16,8 @@ use owhisper_client::Auth;
 pub use builder::ClientRequestBuilder;
 pub use handler::WebSocketProxy;
 pub use types::{
-    ClientMessageFilter, FirstMessageTransformer, InitialMessage, OnCloseCallback,
-    ResponseTransformer,
+    ClientBinaryTransformer, ClientMessageFilter, FirstMessageTransformer, InitialMessage,
+    OnCloseCallback, ResponseTransformer,
 };
 pub use upstream_error::{UpstreamError, detect_upstream_error};
 
@@ -73,6 +73,7 @@ pub struct StreamingProxyPlan {
     connect_timeout: Duration,
     on_close: Option<OnCloseCallback>,
     client_message_filter: Option<ClientMessageFilter>,
+    client_binary_transformer: Option<ClientBinaryTransformer>,
 }
 
 pub enum StreamingProxy {
@@ -92,6 +93,7 @@ impl StreamingProxyPlan {
             connect_timeout: Duration::default(),
             on_close: None,
             client_message_filter: None,
+            client_binary_transformer: None,
         }
     }
 
@@ -133,6 +135,11 @@ impl StreamingProxyPlan {
 
     pub fn client_message_filter(mut self, filter: ClientMessageFilter) -> Self {
         self.client_message_filter = Some(filter);
+        self
+    }
+
+    pub fn client_binary_transformer(mut self, transformer: ClientBinaryTransformer) -> Self {
+        self.client_binary_transformer = Some(transformer);
         self
     }
 
@@ -200,6 +207,7 @@ impl StreamingProxyPlan {
                 self.connect_timeout,
                 self.on_close,
                 self.client_message_filter,
+                self.client_binary_transformer,
             )),
             StreamingTransport::SplitStereo => StreamingProxy::split(
                 apply_headers(request, self.headers),
@@ -208,6 +216,7 @@ impl StreamingProxyPlan {
                 self.connect_timeout,
                 self.on_close,
                 self.client_message_filter,
+                self.client_binary_transformer,
             ),
         }
     }
@@ -227,6 +236,7 @@ impl StreamingProxyPlan {
                 self.connect_timeout,
                 self.on_close,
                 self.client_message_filter,
+                self.client_binary_transformer,
             ),
         }
     }
@@ -237,6 +247,15 @@ impl StreamingProxy {
         Self::Single(proxy)
     }
 
+    fn with_client_binary_transformer(self, transformer: Option<ClientBinaryTransformer>) -> Self {
+        match self {
+            Self::ChannelSplit(proxy) => {
+                Self::ChannelSplit(proxy.with_client_binary_transformer(transformer))
+            }
+            Self::Single(proxy) => Self::Single(proxy),
+        }
+    }
+
     pub fn split(
         upstream_request: ClientRequestBuilder,
         initial_message: Option<InitialMessage>,
@@ -244,6 +263,7 @@ impl StreamingProxy {
         connect_timeout: Duration,
         on_close: Option<OnCloseCallback>,
         client_message_filter: Option<ClientMessageFilter>,
+        client_binary_transformer: Option<ClientBinaryTransformer>,
     ) -> Self {
         let proxy = ChannelSplitProxy::new(
             upstream_request,
@@ -257,6 +277,7 @@ impl StreamingProxy {
             Some(filter) => Self::ChannelSplit(proxy.with_client_message_filter(filter)),
             None => Self::ChannelSplit(proxy),
         }
+        .with_client_binary_transformer(client_binary_transformer)
     }
 
     pub fn split_with_requests(
@@ -267,6 +288,7 @@ impl StreamingProxy {
         connect_timeout: Duration,
         on_close: Option<OnCloseCallback>,
         client_message_filter: Option<ClientMessageFilter>,
+        client_binary_transformer: Option<ClientBinaryTransformer>,
     ) -> Self {
         let proxy = ChannelSplitProxy::with_split_requests(
             mic_request,
@@ -281,6 +303,7 @@ impl StreamingProxy {
             Some(filter) => Self::ChannelSplit(proxy.with_client_message_filter(filter)),
             None => Self::ChannelSplit(proxy),
         }
+        .with_client_binary_transformer(client_binary_transformer)
     }
 
     pub async fn handle_upgrade(&self, ws: WebSocketUpgrade) -> Response<Body> {

--- a/crates/transcribe-proxy/src/relay/types.rs
+++ b/crates/transcribe-proxy/src/relay/types.rs
@@ -18,6 +18,7 @@ pub type InitialMessage = Arc<String>;
 pub type ResponseTransformer = Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
 
 pub type ClientMessageFilter = Arc<dyn Fn(String) -> Option<String> + Send + Sync>;
+pub type ClientBinaryTransformer = Arc<dyn Fn(Vec<u8>) -> Option<(Vec<u8>, bool)> + Send + Sync>;
 
 #[derive(Clone, Debug)]
 pub enum ShutdownSignal {

--- a/crates/transcribe-proxy/src/routes/streaming/hyprnote.rs
+++ b/crates/transcribe-proxy/src/routes/streaming/hyprnote.rs
@@ -10,7 +10,10 @@ use owhisper_interface::ListenParams;
 use crate::config::SttProxyConfig;
 use crate::provider_selector::SelectedProvider;
 use crate::query_params::{QueryParams, QueryValue};
-use crate::relay::{ClientMessageFilter, StreamingProxy, StreamingProxyPlan, StreamingTransport};
+use crate::relay::{
+    ClientBinaryTransformer, ClientMessageFilter, StreamingProxy, StreamingProxyPlan,
+    StreamingTransport,
+};
 use crate::routes::AppState;
 use crate::routes::model_resolution::resolve_model_live;
 
@@ -140,6 +143,32 @@ fn build_client_message_filter(provider: Provider) -> ClientMessageFilter {
     })
 }
 
+fn encode_audio_message<A: RealtimeSttAdapter>(audio: Vec<u8>) -> Option<(Vec<u8>, bool)> {
+    match A::default().audio_to_message(bytes::Bytes::from(audio)) {
+        owhisper_client::hypr_ws_client::client::Message::Text(text) => {
+            Some((text.to_string().into_bytes(), true))
+        }
+        owhisper_client::hypr_ws_client::client::Message::Binary(bytes) => {
+            Some((bytes.to_vec(), false))
+        }
+        _ => None,
+    }
+}
+
+fn build_client_binary_transformer(provider: Provider) -> ClientBinaryTransformer {
+    Arc::new(move |audio: Vec<u8>| match provider {
+        Provider::Deepgram => encode_audio_message::<DeepgramAdapter>(audio),
+        Provider::AssemblyAI => encode_audio_message::<AssemblyAIAdapter>(audio),
+        Provider::Soniox => encode_audio_message::<SonioxAdapter>(audio),
+        Provider::Fireworks => encode_audio_message::<FireworksAdapter>(audio),
+        Provider::Gladia => encode_audio_message::<GladiaAdapter>(audio),
+        Provider::ElevenLabs => encode_audio_message::<ElevenLabsAdapter>(audio),
+        Provider::DashScope => encode_audio_message::<DashScopeAdapter>(audio),
+        Provider::Mistral => encode_audio_message::<MistralAdapter>(audio),
+        Provider::AquaVoice | Provider::OpenAI | Provider::Pyannote => Some((audio, false)),
+    })
+}
+
 fn build_proxy_plan(
     provider: Provider,
     selected: &SelectedProvider,
@@ -155,6 +184,7 @@ fn build_proxy_plan(
     .control_message_types(provider.control_message_types())
     .response_transformer(build_response_transformer(provider))
     .client_message_filter(build_client_message_filter(provider))
+    .client_binary_transformer(build_client_binary_transformer(provider))
     .apply_auth(selected);
 
     if let Some(on_close) = build_on_close_callback(config, provider, &analytics_ctx) {
@@ -531,6 +561,25 @@ mod tests {
     fn test_client_message_filter_non_json_passthrough() {
         let filter = build_client_message_filter(Provider::Soniox);
         assert_eq!(filter("not json".to_string()), Some("not json".to_string()));
+    }
+
+    #[test]
+    fn test_client_binary_transformer_preserves_deepgram_binary() {
+        let transformer = build_client_binary_transformer(Provider::Deepgram);
+
+        assert_eq!(transformer(vec![1, 2, 3]), Some((vec![1, 2, 3], false)));
+    }
+
+    #[test]
+    fn test_client_binary_transformer_encodes_elevenlabs_audio() {
+        let transformer = build_client_binary_transformer(Provider::ElevenLabs);
+        let (data, is_text) = transformer(vec![1, 2, 3]).unwrap();
+
+        assert!(is_text);
+        let text = String::from_utf8(data).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["message_type"], "input_audio_chunk");
+        assert_eq!(json["audio_base_64"], "AQID");
     }
 
     #[test]


### PR DESCRIPTION
Scope React subscriptions and transcript/past-note work, lazily load locale catalogs, stream batch STT uploads, and replace startup/audio unwraps with error handling.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5558 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5555 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live transcription proxy encoding, Fireworks/AssemblyAI endpoints, and desktop startup when DB open fails; mostly performance and resilience changes with provider behavior risk in streaming STT.
> 
> **Overview**
> Reduces desktop memory and render churn while hardening audio/STT paths and CI coverage.
> 
> **Desktop UI** lazily loads i18n catalogs via React Query instead of eager bundling, splits note search into a highlights-only context so transcript words don’t re-render on every search state change, and narrows Tinybase subscriptions (session participant slices for transcript render, optional `enabled` on past-notes, one sorted-ID hook for contacts). Calendar passes a single `todayKey` from the parent; past-notes builds participant/enhanced-note maps once and stops after `MAX_PAST_NOTES`. Production Vite minification is turned back on.
> 
> **Tauri** returns `Result` from DB open and logs/aborts startup on failure; window/tray show paths drop `unwrap` for traced errors. **audio-actual** treats default mic and macOS speaker tap/stream setup as fallible `Result`s instead of panicking.
> 
> **STT client** streams batch uploads from disk (`streaming_file_body` / `streaming_file_part`) across providers; Fireworks batch/WS hosts move to `audio-prod` / `audio-streaming`; AssemblyAI streaming WS path handling is fixed for default API base. **transcribe-proxy** adds per-provider **client binary transformers** (e.g. ElevenLabs base64 JSON) on single and stereo-split relays.
> 
> **CI**: `llm_e2e` / `stt_e2e` path filters widen to API and shared crates; STT dispatch can run **all** providers, detects broader “stt_server” changes, and serializes proxy e2e per provider with `concurrency` groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92dd875938a9c1a7bb51b85800a270912b81feca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->