### PR TITLE
Reduce bottom accessory render work

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -63,7 +63,25 @@ export function useSessionBottomAccessory({
   const hasTranscriptError = Boolean(batchError);
   const canShowTranscriptTab =
     canUsePlayback || hasTranscript || hasTranscriptError || isRunningBatch;
-  const pastNotes = usePastSessionNotes(sessionId);
+  const live = useListener((state) => ({
+    status: state.live.status,
+    sessionId: state.live.sessionId,
+    requestedLiveTranscription: state.live.requestedLiveTranscription,
+    liveTranscriptionActive: state.live.liveTranscriptionActive,
+  }));
+  const { chat } = useShell();
+  const liveCaptureMode = getLiveCaptureUiMode(live);
+  const shouldDeferToGlobalLiveAccessory =
+    live.sessionId !== null &&
+    live.sessionId !== sessionId &&
+    shouldShowLiveTranscriptAccessory(live);
+  const showLiveAccessory =
+    !shouldDeferToGlobalLiveAccessory && isLive && liveCaptureMode === "live";
+  const shouldLoadPastNotes =
+    (isInactive || isRunningBatch) && !shouldDeferToGlobalLiveAccessory;
+  const pastNotes = usePastSessionNotes(sessionId, {
+    enabled: shouldLoadPastNotes,
+  });
   const hasPastNotes = pastNotes.hasPastNotes;
   const generateMissingPastNotes = pastNotes.generateMissing;
   const regeneratePastNote = pastNotes.canGenerate
@@ -75,15 +93,6 @@ export function useSessionBottomAccessory({
       : hasPastNotes
         ? (postSessionTab ?? "transcript")
         : "transcript";
-  const live = useListener((state) => state.live);
-  const { chat } = useShell();
-  const liveCaptureMode = getLiveCaptureUiMode(live);
-  const shouldDeferToGlobalLiveAccessory =
-    live.sessionId !== null &&
-    live.sessionId !== sessionId &&
-    shouldShowLiveTranscriptAccessory(live);
-  const showLiveAccessory =
-    !shouldDeferToGlobalLiveAccessory && isLive && liveCaptureMode === "live";
   const canExpandLiveTranscript = showLiveAccessory;
   const effectiveExpanded =
     isLive && !canExpandLiveTranscript ? false : isExpanded;

--- a/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
+++ b/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
@@ -56,20 +56,38 @@ const keyFactsSchema = z.object({
   facts: z.array(z.string()).min(1).max(MAX_KEY_FACTS),
 });
 
-export function usePastSessionNotes(sessionId: string): PastSessionNotesResult {
+export function usePastSessionNotes(
+  sessionId: string,
+  { enabled = true }: { enabled?: boolean } = {},
+): PastSessionNotesResult {
   const store = main.UI.useStore(main.STORE_ID);
-  const sessionsTable = main.UI.useTable("sessions", main.STORE_ID);
-  const participantsTable = main.UI.useTable(
-    "mapping_session_participant",
+  const sessionsTable = main.UI.useTable(
+    enabled ? "sessions" : ("__disabled_past_notes_sessions" as "sessions"),
     main.STORE_ID,
   );
-  const enhancedNotesTable = main.UI.useTable("enhanced_notes", main.STORE_ID);
-  const keyFactsTable = main.UI.useTable("session_key_facts", main.STORE_ID);
+  const participantsTable = main.UI.useTable(
+    enabled
+      ? "mapping_session_participant"
+      : ("__disabled_past_notes_participants" as "mapping_session_participant"),
+    main.STORE_ID,
+  );
+  const enhancedNotesTable = main.UI.useTable(
+    enabled
+      ? "enhanced_notes"
+      : ("__disabled_past_notes_enhanced" as "enhanced_notes"),
+    main.STORE_ID,
+  );
+  const keyFactsTable = main.UI.useTable(
+    enabled
+      ? "session_key_facts"
+      : ("__disabled_past_notes_key_facts" as "session_key_facts"),
+    main.STORE_ID,
+  );
   const userId = main.UI.useValue("user_id", main.STORE_ID);
   const model = useLanguageModel("enhance");
 
   const built = useMemo(() => {
-    if (!store) {
+    if (!enabled || !store) {
       return { notes: [], missing: [], requests: [] };
     }
 
@@ -80,6 +98,7 @@ export function usePastSessionNotes(sessionId: string): PastSessionNotesResult {
     );
   }, [
     store,
+    enabled,
     sessionId,
     userId,
     sessionsTable,
@@ -121,16 +140,21 @@ export function usePastSessionNotes(sessionId: string): PastSessionNotesResult {
   );
 
   const generateMissing = useCallback(() => {
-    if (!model || built.missing.length === 0 || mutation.isPending) {
+    if (
+      !enabled ||
+      !model ||
+      built.missing.length === 0 ||
+      mutation.isPending
+    ) {
       return;
     }
 
     void mutation.mutateAsync(built.missing);
-  }, [built.missing, model, mutation]);
+  }, [built.missing, enabled, model, mutation]);
 
   const regenerate = useCallback(
     (targetSessionId: string) => {
-      if (!model || mutation.isPending) {
+      if (!enabled || !model || mutation.isPending) {
         return;
       }
 
@@ -143,14 +167,14 @@ export function usePastSessionNotes(sessionId: string): PastSessionNotesResult {
 
       void mutation.mutateAsync([request]);
     },
-    [built.requests, model, mutation],
+    [built.requests, enabled, model, mutation],
   );
 
   return {
     notes,
     hasPastNotes: notes.length > 0,
     isGenerating: mutation.isPending,
-    canGenerate: Boolean(model),
+    canGenerate: enabled && Boolean(model),
     generateMissing,
     regenerate,
   };


### PR DESCRIPTION
Scope live-state and past-note subscriptions to only the states that can render the accessory.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5559 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5556 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only subscription scoping; wrong `enabled` gating could hide related meetings data but logic mirrors existing post-session/deferral conditions.
> 
> **Overview**
> **Reduces bottom-accessory re-renders and store subscriptions** when the session UI is not in a state that needs live or post-session chrome.
> 
> The hook now subscribes to **only the live fields** used for deferral and live-transcript visibility (`status`, `sessionId`, transcription flags) instead of the full `live` slice, and computes that **before** past-notes loading so deferral can gate both paths.
> 
> `usePastSessionNotes` accepts an **`enabled` flag** (driven by inactive/batch mode and not deferring to another session’s live accessory). When disabled, it skips TinyBase table subscriptions (via placeholder table ids), returns empty note data, and no-ops generate/regenerate so related meetings work is not done off-screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e99e56df0b602c3a84d61ab496a9d35f68552528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->