### PR TITLE
Flush batch transcript save once

### DIFF
--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -1,6 +1,125 @@
-import { describe, expect, test } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { getBatchProvider, getSessionSpeakerCount } from "./useRunBatch";
+import { useRunBatch } from "./useRunBatch";
+
+const {
+  startTranscriptionMock,
+  useListenerMock,
+  useStoreMock,
+  useIndexesMock,
+  useValuesMock,
+  useSTTConnectionMock,
+  useConfigValueMock,
+  settingsUseStoreMock,
+  deleteProcessedAudioForRetentionMock,
+  saveMock,
+  idMock,
+} = vi.hoisted(() => ({
+  startTranscriptionMock: vi.fn(),
+  useListenerMock: vi.fn(),
+  useStoreMock: vi.fn(),
+  useIndexesMock: vi.fn(),
+  useValuesMock: vi.fn(),
+  useSTTConnectionMock: vi.fn(),
+  useConfigValueMock: vi.fn(),
+  settingsUseStoreMock: vi.fn(),
+  deleteProcessedAudioForRetentionMock: vi.fn(),
+  saveMock: vi.fn(),
+  idMock: vi.fn(),
+}));
+
+vi.mock("./contexts", () => ({
+  useListener: useListenerMock,
+}));
+
+vi.mock("./useKeywords", () => ({
+  useKeywords: vi.fn(() => []),
+}));
+
+vi.mock("./useSTTConnection", () => ({
+  useSTTConnection: useSTTConnectionMock,
+}));
+
+vi.mock("~/services/audio-retention", () => ({
+  deleteProcessedAudioForRetention: deleteProcessedAudioForRetentionMock,
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValue: useConfigValueMock,
+}));
+
+vi.mock("~/shared/utils", () => ({
+  id: idMock,
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  INDEXES: {
+    transcriptBySession: "transcriptBySession",
+  },
+  UI: {
+    useStore: useStoreMock,
+    useIndexes: useIndexesMock,
+    useValues: useValuesMock,
+  },
+}));
+
+vi.mock("~/store/tinybase/store/settings", () => ({
+  STORE_ID: "settings",
+  UI: {
+    useStore: settingsUseStoreMock,
+  },
+}));
+
+vi.mock("~/store/tinybase/store/save", () => ({
+  save: saveMock,
+}));
+
+function createStore() {
+  const tables = {
+    sessions: new Map<string, Record<string, unknown>>([
+      ["session-1", { raw_md: "Existing memo" }],
+    ]),
+    transcripts: new Map<string, Record<string, unknown>>(),
+    mapping_session_participant: new Map<string, Record<string, unknown>>(),
+  };
+
+  return {
+    tables,
+    forEachRow: (
+      tableId: keyof typeof tables,
+      callback: (rowId: string) => void,
+    ) => {
+      for (const rowId of tables[tableId].keys()) callback(rowId);
+    },
+    getCell: (tableId: keyof typeof tables, rowId: string, cellId: string) =>
+      tables[tableId].get(rowId)?.[cellId],
+    setCell: (
+      tableId: keyof typeof tables,
+      rowId: string,
+      cellId: string,
+      value: unknown,
+    ) => {
+      tables[tableId].set(rowId, {
+        ...tables[tableId].get(rowId),
+        [cellId]: value,
+      });
+    },
+    setRow: (
+      tableId: keyof typeof tables,
+      rowId: string,
+      row: Record<string, unknown>,
+    ) => {
+      tables[tableId].set(rowId, row);
+    },
+    delRow: (tableId: keyof typeof tables, rowId: string) => {
+      tables[tableId].delete(rowId);
+    },
+    transaction: (callback: () => void) => callback(),
+  };
+}
 
 describe("getBatchProvider", () => {
   test("maps pyannote to the batch transcription provider", () => {
@@ -17,6 +136,102 @@ describe("getBatchProvider", () => {
     expect(getBatchProvider("hyprnote", "soniqo-parakeet-batch")).toBe(
       "soniqo",
     );
+  });
+});
+
+describe("useRunBatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    let nextId = 0;
+    idMock.mockImplementation(() => `generated-${++nextId}`);
+    saveMock.mockResolvedValue(undefined);
+    deleteProcessedAudioForRetentionMock.mockResolvedValue(undefined);
+    useListenerMock.mockImplementation((selector) =>
+      selector({ startTranscription: startTranscriptionMock }),
+    );
+    useStoreMock.mockReturnValue(createStore());
+    useIndexesMock.mockReturnValue({
+      getSliceRowIds: vi.fn(() => []),
+    });
+    useValuesMock.mockReturnValue({ user_id: "user-1" });
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "deepgram",
+        model: "nova-3",
+        baseUrl: "https://api.deepgram.com/v1/listen",
+        apiKey: "test-key",
+      },
+    });
+    useConfigValueMock.mockImplementation((key) =>
+      key === "ai_language" ? "en" : [],
+    );
+    settingsUseStoreMock.mockReturnValue({ id: "settings-store" });
+  });
+
+  test("saves once after streamed default batch persists finish", async () => {
+    startTranscriptionMock.mockImplementation(async (_params, options) => {
+      options.handlePersist(
+        [{ text: "hello", start_ms: 0, end_ms: 100, channel: 0 }],
+        [],
+      );
+      options.handlePersist(
+        [{ text: "world", start_ms: 100, end_ms: 200, channel: 0 }],
+        [],
+      );
+    });
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await act(async () => {
+      await result.current("/tmp/session.wav");
+    });
+
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(deleteProcessedAudioForRetentionMock).toHaveBeenCalledTimes(1);
+    expect(saveMock.mock.invocationCallOrder[0]).toBeLessThan(
+      deleteProcessedAudioForRetentionMock.mock.invocationCallOrder[0],
+    );
+  });
+
+  test("does not save for custom batch persist handlers", async () => {
+    const handlePersist = vi.fn();
+    startTranscriptionMock.mockImplementation(async (_params, options) => {
+      options.handlePersist(
+        [{ text: "custom", start_ms: 0, end_ms: 100, channel: 0 }],
+        [],
+      );
+    });
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await act(async () => {
+      await result.current("/tmp/session.wav", { handlePersist });
+    });
+
+    expect(handlePersist).toHaveBeenCalledTimes(1);
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  test("flushes default batch persists before rethrowing transcription errors", async () => {
+    startTranscriptionMock.mockImplementation(async (_params, options) => {
+      options.handlePersist(
+        [{ text: "partial", start_ms: 0, end_ms: 100, channel: 0 }],
+        [],
+      );
+      throw new Error("provider failed");
+    });
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await expect(
+      act(async () => {
+        await result.current("/tmp/session.wav");
+      }),
+    ).rejects.toThrow("provider failed");
+
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -116,6 +116,15 @@ export function getSessionSpeakerCount(
   return humanIds.size > 1 ? humanIds.size : undefined;
 }
 
+async function saveCompletedBatchTranscript(): Promise<void> {
+  try {
+    const { save } = await import("~/store/tinybase/store/save");
+    await save();
+  } catch (error) {
+    console.error("[runBatch] failed to save completed transcript", error);
+  }
+}
+
 export const useRunBatch = (sessionId: string) => {
   const store = main.UI.useStore(main.STORE_ID);
   const indexes = main.UI.useIndexes(main.STORE_ID);
@@ -159,6 +168,7 @@ export const useRunBatch = (sessionId: string) => {
 
       const handlePersist: BatchPersistCallback | undefined =
         options?.handlePersist;
+      let wroteDefaultTranscript = false;
 
       const persist =
         handlePersist ??
@@ -266,14 +276,7 @@ export const useRunBatch = (sessionId: string) => {
             ]);
           });
 
-          void import("~/store/tinybase/store/save")
-            .then(({ save }) => save())
-            .catch((error) => {
-              console.error(
-                "[runBatch] failed to save streamed transcript",
-                error,
-              );
-            });
+          wroteDefaultTranscript = true;
         });
 
       const params: TranscriptionParams = {
@@ -292,7 +295,13 @@ export const useRunBatch = (sessionId: string) => {
         max_speakers: options?.maxSpeakers,
       };
 
-      await startTranscription(params, { handlePersist: persist });
+      try {
+        await startTranscription(params, { handlePersist: persist });
+      } finally {
+        if (!handlePersist && wroteDefaultTranscript) {
+          await saveCompletedBatchTranscript();
+        }
+      }
 
       if (settingsStore) {
         await deleteProcessedAudioForRetention(


### PR DESCRIPTION
Replace per-chunk batch transcript saves with a single best-effort flush after the default persist path finishes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when transcript data hits disk during batch STT; a crash mid-stream could lose unsaved chunks until completion, though errors still trigger a final flush.
> 
> **Overview**
> **Batch transcript persistence** no longer calls `save()` on every streamed persist chunk in the default `useRunBatch` path. In-memory Tinybase updates still happen per chunk, but persistence to disk is deferred to a single **best-effort** `saveCompletedBatchTranscript()` in a `finally` block after `startTranscription` finishes (success or failure).
> 
> Custom `handlePersist` callbacks are unchanged: they still own persistence and do not trigger the automatic flush. On transcription errors, partial default-path transcript data is still flushed once; **audio retention cleanup** (`deleteProcessedAudioForRetention`) only runs after a successful run, so it is skipped when the provider throws.
> 
> Hook tests were added with mocks to assert one save across multiple persists, no save with a custom handler, save-before-rethrow on errors, and save ordering before retention deletion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fd7b14f3835ddea4cd4a32e61aa5347bbd00201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->