### PR TITLE
Replace editor view polling with callbacks

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -1,3 +1,4 @@
+import type { EditorView } from "prosemirror-view";
 import { forwardRef, useMemo } from "react";
 
 import { parseJsonContent } from "@hypr/editor/markdown";
@@ -23,48 +24,63 @@ export const EnhancedEditor = forwardRef<
     sessionId: string;
     enhancedNoteId: string;
     onNavigateToTitle?: (pixelWidth?: number) => void;
+    onViewReady?: (view: EditorView) => void;
+    onViewDisposed?: (view: EditorView) => void;
   }
->(({ sessionId, enhancedNoteId, onNavigateToTitle }, ref) => {
-  const onFileUpload = useFileUpload(sessionId);
-  const content = main.UI.useCell(
-    "enhanced_notes",
-    enhancedNoteId,
-    "content",
-    main.STORE_ID,
-  );
+>(
+  (
+    {
+      sessionId,
+      enhancedNoteId,
+      onNavigateToTitle,
+      onViewReady,
+      onViewDisposed,
+    },
+    ref,
+  ) => {
+    const onFileUpload = useFileUpload(sessionId);
+    const content = main.UI.useCell(
+      "enhanced_notes",
+      enhancedNoteId,
+      "content",
+      main.STORE_ID,
+    );
 
-  const initialContent = useMemo<JSONContent>(
-    () => parseJsonContent(content as string),
-    [content],
-  );
+    const initialContent = useMemo<JSONContent>(
+      () => parseJsonContent(content as string),
+      [content],
+    );
 
-  const handleChange = main.UI.useSetPartialRowCallback(
-    "enhanced_notes",
-    enhancedNoteId,
-    (input: JSONContent) => ({ content: JSON.stringify(input) }),
-    [],
-    main.STORE_ID,
-  );
+    const handleChange = main.UI.useSetPartialRowCallback(
+      "enhanced_notes",
+      enhancedNoteId,
+      (input: JSONContent) => ({ content: JSON.stringify(input) }),
+      [],
+      main.STORE_ID,
+    );
 
-  const fileHandlerConfig = useMemo(() => ({ onFileUpload }), [onFileUpload]);
-  const mentionConfig = useMentionConfig();
+    const fileHandlerConfig = useMemo(() => ({ onFileUpload }), [onFileUpload]);
+    const mentionConfig = useMentionConfig();
 
-  return (
-    <div className="h-full">
-      <NoteEditor
-        ref={ref}
-        className="enhanced-summary-editor"
-        key={`enhanced-note-${enhancedNoteId}`}
-        initialContent={initialContent}
-        handleChange={handleChange}
-        mentionConfig={mentionConfig}
-        sessionMentionDropConfig={sessionMentionDropConfig}
-        onNavigateToTitle={onNavigateToTitle}
-        onLinkOpen={openEditorLink}
-        fileHandlerConfig={fileHandlerConfig}
-        taskSource={{ type: "enhanced_note", id: enhancedNoteId }}
-        extraNodeViews={extraNodeViews}
-      />
-    </div>
-  );
-});
+    return (
+      <div className="h-full">
+        <NoteEditor
+          ref={ref}
+          className="enhanced-summary-editor"
+          key={`enhanced-note-${enhancedNoteId}`}
+          initialContent={initialContent}
+          handleChange={handleChange}
+          mentionConfig={mentionConfig}
+          sessionMentionDropConfig={sessionMentionDropConfig}
+          onNavigateToTitle={onNavigateToTitle}
+          onLinkOpen={openEditorLink}
+          fileHandlerConfig={fileHandlerConfig}
+          taskSource={{ type: "enhanced_note", id: enhancedNoteId }}
+          extraNodeViews={extraNodeViews}
+          onViewReady={onViewReady}
+          onViewDisposed={onViewDisposed}
+        />
+      </div>
+    );
+  },
+);

--- a/apps/desktop/src/session/components/note-input/enhanced/index.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.tsx
@@ -1,3 +1,4 @@
+import type { EditorView } from "prosemirror-view";
 import { forwardRef } from "react";
 
 import type { NoteEditorRef } from "@hypr/editor/note";
@@ -18,59 +19,74 @@ export const Enhanced = forwardRef<
     sessionId: string;
     enhancedNoteId: string;
     onNavigateToTitle?: (pixelWidth?: number) => void;
+    onViewReady?: (view: EditorView) => void;
+    onViewDisposed?: (view: EditorView) => void;
   }
->(({ sessionId, enhancedNoteId, onNavigateToTitle }, ref) => {
-  const taskId = createTaskId(enhancedNoteId, "enhance");
-  const llmStatus = useLLMConnectionStatus();
-  const { status, error, hasTask } = useAITaskTask(taskId, "enhance");
-  const content = main.UI.useCell(
-    "enhanced_notes",
-    enhancedNoteId,
-    "content",
-    main.STORE_ID,
-  );
+>(
+  (
+    {
+      sessionId,
+      enhancedNoteId,
+      onNavigateToTitle,
+      onViewReady,
+      onViewDisposed,
+    },
+    ref,
+  ) => {
+    const taskId = createTaskId(enhancedNoteId, "enhance");
+    const llmStatus = useLLMConnectionStatus();
+    const { status, error, hasTask } = useAITaskTask(taskId, "enhance");
+    const content = main.UI.useCell(
+      "enhanced_notes",
+      enhancedNoteId,
+      "content",
+      main.STORE_ID,
+    );
 
-  const hasContent = typeof content === "string" && content.trim().length > 0;
+    const hasContent = typeof content === "string" && content.trim().length > 0;
 
-  const isConfigError =
-    llmStatus.status === "pending" ||
-    (llmStatus.status === "error" &&
-      (llmStatus.reason === "missing_config" ||
-        llmStatus.reason === "not_pro" ||
-        llmStatus.reason === "unauthenticated"));
+    const isConfigError =
+      llmStatus.status === "pending" ||
+      (llmStatus.status === "error" &&
+        (llmStatus.reason === "missing_config" ||
+          llmStatus.reason === "not_pro" ||
+          llmStatus.reason === "unauthenticated"));
 
-  if (status === "idle" && isConfigError && !hasContent) {
-    return <ConfigError status={llmStatus} />;
-  }
+    if (status === "idle" && isConfigError && !hasContent) {
+      return <ConfigError status={llmStatus} />;
+    }
 
-  if (status === "error") {
+    if (status === "error") {
+      return (
+        <EnhanceError
+          sessionId={sessionId}
+          enhancedNoteId={enhancedNoteId}
+          error={error}
+        />
+      );
+    }
+
+    if (
+      status === "generating" ||
+      (!hasContent && status === "idle" && !hasTask)
+    ) {
+      return (
+        <StreamingView
+          enhancedNoteId={enhancedNoteId}
+          pending={status === "idle"}
+        />
+      );
+    }
+
     return (
-      <EnhanceError
+      <EnhancedEditor
+        ref={ref}
         sessionId={sessionId}
         enhancedNoteId={enhancedNoteId}
-        error={error}
+        onNavigateToTitle={onNavigateToTitle}
+        onViewReady={onViewReady}
+        onViewDisposed={onViewDisposed}
       />
     );
-  }
-
-  if (
-    status === "generating" ||
-    (!hasContent && status === "idle" && !hasTask)
-  ) {
-    return (
-      <StreamingView
-        enhancedNoteId={enhancedNoteId}
-        pending={status === "idle"}
-      />
-    );
-  }
-
-  return (
-    <EnhancedEditor
-      ref={ref}
-      sessionId={sessionId}
-      enhancedNoteId={enhancedNoteId}
-      onNavigateToTitle={onNavigateToTitle}
-    />
-  );
-});
+  },
+);

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -104,12 +104,13 @@ export const NoteInput = forwardRef<
     }
   }, [currentTab, isMeetingInProgress]);
 
-  useEffect(() => {
-    const editorView = internalEditorRef.current?.view ?? null;
-    if (editorView !== view) {
-      setView(editorView);
-    }
-  });
+  const handleViewReady = useCallback((editorView: EditorView) => {
+    setView(editorView);
+  }, []);
+
+  const handleViewDisposed = useCallback((editorView: EditorView) => {
+    setView((currentView) => (currentView === editorView ? null : currentView));
+  }, []);
 
   useCaretNearBottom({
     view,
@@ -166,6 +167,8 @@ export const NoteInput = forwardRef<
               sessionId={sessionId}
               enhancedNoteId={currentTab.id}
               onNavigateToTitle={onNavigateToTitle}
+              onViewReady={handleViewReady}
+              onViewDisposed={handleViewDisposed}
             />
           )}
           {currentTab.type === "raw" && (
@@ -173,6 +176,8 @@ export const NoteInput = forwardRef<
               ref={internalEditorRef}
               sessionId={sessionId}
               onNavigateToTitle={onNavigateToTitle}
+              onViewReady={handleViewReady}
+              onViewDisposed={handleViewDisposed}
             />
           )}
         </div>

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -1,3 +1,4 @@
+import type { EditorView } from "prosemirror-view";
 import { forwardRef, useCallback, useEffect, useMemo, useRef } from "react";
 
 import { parseJsonContent } from "@hypr/editor/markdown";
@@ -28,6 +29,8 @@ export const RawEditor = forwardRef<
     onNavigateToTitle?: (pixelWidth?: number) => void;
     syncTasks?: boolean;
     showFormatToolbar?: boolean;
+    onViewReady?: (view: EditorView) => void;
+    onViewDisposed?: (view: EditorView) => void;
   }
 >(
   (
@@ -37,6 +40,8 @@ export const RawEditor = forwardRef<
       onNavigateToTitle,
       syncTasks = true,
       showFormatToolbar = true,
+      onViewReady,
+      onViewDisposed,
     },
     ref,
   ) => {
@@ -120,6 +125,8 @@ export const RawEditor = forwardRef<
         }
         extraNodeViews={extraNodeViews}
         showFormatToolbar={showFormatToolbar}
+        onViewReady={onViewReady}
+        onViewDisposed={onViewDisposed}
       />
     );
   },

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -160,6 +160,8 @@ export interface NoteEditorProps {
   extraNodeViews?: NodeViewComponents;
   sessionMentionDropConfig?: SessionMentionDropConfig;
   showFormatToolbar?: boolean;
+  onViewReady?: (view: EditorView) => void;
+  onViewDisposed?: (view: EditorView) => void;
 }
 
 const baseNodeViews = {
@@ -272,16 +274,31 @@ function createSessionMentionDropPlugin(config: SessionMentionDropConfig) {
 function ViewCapture({
   viewRef,
   onViewReady,
+  onViewDisposed,
 }: {
   viewRef: React.RefObject<EditorView | null>;
   onViewReady: (view: EditorView) => void;
+  onViewDisposed?: (view: EditorView) => void;
 }) {
-  useEditorEffect((view) => {
-    if (view && viewRef.current !== view) {
-      viewRef.current = view;
-      onViewReady(view);
-    }
-  });
+  const callbacksRef = useRef({ onViewReady, onViewDisposed });
+  callbacksRef.current = { onViewReady, onViewDisposed };
+
+  useEditorEffect(
+    (view) => {
+      if (view && viewRef.current !== view) {
+        viewRef.current = view;
+        callbacksRef.current.onViewReady(view);
+      }
+
+      return () => {
+        if (viewRef.current === view) {
+          viewRef.current = null;
+          callbacksRef.current.onViewDisposed?.(view);
+        }
+      };
+    },
+    [viewRef],
+  );
   return null;
 }
 
@@ -454,6 +471,8 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       extraNodeViews,
       sessionMentionDropConfig,
       showFormatToolbar = true,
+      onViewReady: onViewReadyProp,
+      onViewDisposed,
     } = props;
 
     const taskStorage = useTaskStorageOptional();
@@ -620,8 +639,9 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
     const onViewReady = useCallback(
       (view: EditorView) => {
         onUpdate(view.state.doc.toJSON() as JSONContent);
+        onViewReadyProp?.(view);
       },
-      [onUpdate],
+      [onUpdate, onViewReadyProp],
     );
 
     return (
@@ -656,7 +676,11 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
               }}
             >
               <ProseMirrorDoc />
-              <ViewCapture viewRef={viewRef} onViewReady={onViewReady} />
+              <ViewCapture
+                viewRef={viewRef}
+                onViewReady={onViewReady}
+                onViewDisposed={onViewDisposed}
+              />
               <EditorCommandsBridge commandsRef={commandsRef} />
               {showFormatToolbar && <FormatToolbar />}
               <SlashCommandMenu />


### PR DESCRIPTION
Expose NoteEditor view lifecycle callbacks and use them in NoteInput instead of polling the editor ref after render.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized editor lifecycle wiring for UI caret behavior; no auth, persistence, or API changes.
> 
> **Overview**
> Replaces **per-render polling** of `internalEditorRef.current?.view` in session **NoteInput** with explicit **ProseMirror view lifecycle hooks**, so caret-near-bottom tracking gets a stable `EditorView` when the editor mounts and clears it on teardown (e.g. raw ↔ enhanced tab switches).
> 
> **`NoteEditor`** gains optional `onViewReady` / `onViewDisposed` props. `ViewCapture` now runs disposal in the `useEditorEffect` cleanup (with a ref for latest callbacks) and still invokes the internal ready path that seeds debounced `onUpdate` before forwarding `onViewReady`. **Raw**, **Enhanced**, and **EnhancedEditor** pass these callbacks through unchanged.
> 
> **NoteInput** wires `handleViewReady` / `handleViewDisposed` into both tab editors; dispose only nulls state when the disposed view matches the current one, avoiding races if a new view is already active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 791c91962cec367a6a1faf9c727130ccaa2b2275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->