### PR TITLE
Scope transcript render subscriptions

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
@@ -309,6 +309,8 @@ describe("DuringSessionAccessory", () => {
   it("assigns live transcript speaker labels to session participants", () => {
     const setCell = vi.fn();
     const store = {
+      addRowListener: vi.fn(() => "listener-1"),
+      delListener: vi.fn(),
       forEachRow: vi.fn(
         (tableId: string, callback: (rowId: string) => void) => {
           if (tableId === "humans") {
@@ -399,6 +401,8 @@ describe("DuringSessionAccessory", () => {
 
   it("keeps the speaker selector open while live transcript words update", () => {
     const store = {
+      addRowListener: vi.fn(() => "listener-1"),
+      delListener: vi.fn(),
       forEachRow: vi.fn(),
       getCell: vi.fn((tableId: string, rowId: string, cellId: string) => {
         if (tableId === "transcripts" && rowId === "transcript-1") {

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -5,6 +5,7 @@ import { cn } from "@hypr/utils";
 
 import { SpeakerAssignPopover } from "../note-input/transcript/renderer/speaker-assign";
 
+import { useSessionTranscriptRenderData } from "~/session/components/note-input/transcript/render-request-hooks";
 import { useSegmentColorVars } from "~/session/components/note-input/transcript/renderer/utils";
 import * as main from "~/store/tinybase/store/main";
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
@@ -15,7 +16,6 @@ import {
   type Segment,
 } from "~/stt/live-segment";
 import {
-  buildRenderTranscriptRequestFromStore,
   getRenderTranscriptRequestKey,
   renderTranscriptSegments,
 } from "~/stt/render-transcript";
@@ -23,7 +23,6 @@ import {
   SpeakerLabelManager,
   defaultRenderLabelContext,
 } from "~/stt/segment/shared";
-import { parseTranscriptWords } from "~/stt/utils";
 
 export function DuringSessionAccessory({
   sessionId,
@@ -268,36 +267,8 @@ function useLiveTranscriptData(sessionId: string): {
   segments: Segment[];
   transcriptIdByWordId: Map<string, string>;
 } {
-  const store = main.UI.useStore(main.STORE_ID);
-  const transcriptIds =
-    main.UI.useSliceRowIds(
-      main.INDEXES.transcriptBySession,
-      sessionId,
-      main.STORE_ID,
-    ) ?? [];
-  const transcriptsTable = main.UI.useTable("transcripts", main.STORE_ID);
-  const participantMappingsTable = main.UI.useTable(
-    "mapping_session_participant",
-    main.STORE_ID,
-  );
-  const humansTable = main.UI.useTable("humans", main.STORE_ID);
-  const selfHumanId = main.UI.useValue("user_id", main.STORE_ID);
+  const { request, transcriptRows } = useSessionTranscriptRenderData(sessionId);
   const liveSegments = useListener((state) => state.liveSegments);
-
-  const request = useMemo(() => {
-    if (!store || transcriptIds.length === 0) {
-      return null;
-    }
-
-    return buildRenderTranscriptRequestFromStore(store, transcriptIds);
-  }, [
-    store,
-    transcriptIds,
-    transcriptsTable,
-    participantMappingsTable,
-    humansTable,
-    selfHumanId,
-  ]);
   const requestKey = useMemo(
     () => getRenderTranscriptRequestKey(request),
     [request],
@@ -323,18 +294,16 @@ function useLiveTranscriptData(sessionId: string): {
     );
     const transcriptIdByWordId = new Map<string, string>();
 
-    if (store) {
-      for (const transcriptId of transcriptIds) {
-        for (const word of parseTranscriptWords(store, transcriptId)) {
-          if (typeof word.id === "string" && word.id) {
-            transcriptIdByWordId.set(word.id, transcriptId);
-          }
+    for (const { transcriptId, row } of transcriptRows) {
+      for (const word of row.words ?? []) {
+        if (typeof word.id === "string" && word.id) {
+          transcriptIdByWordId.set(word.id, transcriptId);
         }
       }
     }
 
     return { segments, transcriptIdByWordId };
-  }, [liveSegments, renderedSegments, store, transcriptIds, transcriptsTable]);
+  }, [liveSegments, renderedSegments, transcriptRows]);
 }
 
 function getLiveTranscriptScrollKey(segments: Segment[]): string {

--- a/apps/desktop/src/session/components/note-input/transcript/export-data.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/export-data.ts
@@ -2,10 +2,11 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
 import type { TranscriptItem } from "@hypr/plugin-export";
+import type { RenderTranscriptRequest } from "@hypr/plugin-transcription";
 
-import * as main from "~/store/tinybase/store/main";
+import { useSessionTranscriptRenderData } from "./render-request-hooks";
+
 import {
-  buildRenderTranscriptRequestFromStore,
   getRenderTranscriptRequestKey,
   renderTranscriptSegments,
 } from "~/stt/render-transcript";
@@ -16,9 +17,7 @@ export type TranscriptExportSegment = TranscriptItem & {
 };
 
 export async function buildTranscriptExportSegments(
-  request: NonNullable<
-    ReturnType<typeof buildRenderTranscriptRequestFromStore>
-  >,
+  request: RenderTranscriptRequest,
 ): Promise<TranscriptExportSegment[]> {
   const segments = await renderTranscriptSegments(request);
 
@@ -34,36 +33,7 @@ export function useTranscriptExportSegments(sessionId: string): {
   data: TranscriptExportSegment[];
   isLoading: boolean;
 } {
-  const store = main.UI.useStore(main.STORE_ID);
-  const transcriptsTable = main.UI.useTable("transcripts", main.STORE_ID);
-  const participantMappingsTable = main.UI.useTable(
-    "mapping_session_participant",
-    main.STORE_ID,
-  );
-  const humansTable = main.UI.useTable("humans", main.STORE_ID);
-  const selfHumanId = main.UI.useValue("user_id", main.STORE_ID);
-
-  const transcriptIds =
-    main.UI.useSliceRowIds(
-      main.INDEXES.transcriptBySession,
-      sessionId,
-      main.STORE_ID,
-    ) ?? [];
-
-  const request = useMemo(() => {
-    if (!store || transcriptIds.length === 0) {
-      return null;
-    }
-
-    return buildRenderTranscriptRequestFromStore(store, transcriptIds);
-  }, [
-    store,
-    transcriptIds,
-    transcriptsTable,
-    participantMappingsTable,
-    humansTable,
-    selfHumanId,
-  ]);
+  const { request } = useSessionTranscriptRenderData(sessionId);
   const requestKey = useMemo(
     () => getRenderTranscriptRequestKey(request),
     [request],

--- a/apps/desktop/src/session/components/note-input/transcript/render-request-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/render-request-hooks.ts
@@ -1,0 +1,263 @@
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
+
+import type {
+  RenderTranscriptHuman,
+  RenderTranscriptRequest,
+} from "@hypr/plugin-transcription";
+
+import * as main from "~/store/tinybase/store/main";
+import {
+  buildRenderTranscriptRequestFromRows,
+  collectAssignedHumanIdsFromTranscriptRows,
+  type RenderTranscriptRequestHumans,
+  type TranscriptRow,
+} from "~/stt/render-transcript";
+import { parseTranscriptHints, parseTranscriptWords } from "~/stt/utils";
+
+type RenderTableId = "transcripts" | "mapping_session_participant" | "humans";
+type UiStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
+
+export type TranscriptRowWithId = {
+  transcriptId: string;
+  row: TranscriptRow;
+};
+
+export function useTranscriptRenderData(transcriptId: string): {
+  request: RenderTranscriptRequest | null;
+  transcriptRows: TranscriptRowWithId[];
+} {
+  const sessionId = main.UI.useCell(
+    "transcripts",
+    transcriptId,
+    "session_id",
+    main.STORE_ID,
+  );
+
+  return useRenderData(sessionId ?? "", [transcriptId]);
+}
+
+export function useSessionTranscriptRenderData(sessionId: string): {
+  request: RenderTranscriptRequest | null;
+  transcriptRows: TranscriptRowWithId[];
+} {
+  const transcriptIds =
+    main.UI.useSliceRowIds(
+      main.INDEXES.transcriptBySession,
+      sessionId,
+      main.STORE_ID,
+    ) ?? emptyIds;
+
+  return useRenderData(sessionId, transcriptIds);
+}
+
+export function useTranscriptRowsRevision(rowIds: readonly string[]): number {
+  const store = main.UI.useStore(main.STORE_ID);
+
+  return useStoreRowsRevision(store, "transcripts", rowIds);
+}
+
+function useRenderData(
+  sessionId: string,
+  transcriptIds: readonly string[],
+): {
+  request: RenderTranscriptRequest | null;
+  transcriptRows: TranscriptRowWithId[];
+} {
+  const store = main.UI.useStore(main.STORE_ID);
+  const selfHumanId = main.UI.useValue("user_id", main.STORE_ID);
+  const participantMappingIds =
+    main.UI.useSliceRowIds(
+      main.INDEXES.sessionParticipantsBySession,
+      sessionId,
+      main.STORE_ID,
+    ) ?? emptyIds;
+
+  const transcriptRowsRevision = useStoreRowsRevision(
+    store,
+    "transcripts",
+    transcriptIds,
+  );
+  const participantRowsRevision = useStoreRowsRevision(
+    store,
+    "mapping_session_participant",
+    participantMappingIds,
+  );
+
+  const transcriptIdsKey = getRowIdsKey(transcriptIds);
+  const participantMappingIdsKey = getRowIdsKey(participantMappingIds);
+
+  const transcriptRows = useMemo(() => {
+    if (!store || transcriptIds.length === 0) {
+      return [];
+    }
+
+    return transcriptIds.map((transcriptId) => ({
+      transcriptId,
+      row: getTranscriptRow(store, transcriptId),
+    }));
+  }, [store, transcriptIdsKey, transcriptRowsRevision]);
+
+  const participantHumanIds = useMemo(() => {
+    if (!store || participantMappingIds.length === 0) {
+      return [];
+    }
+
+    return collectParticipantHumanIds(store, participantMappingIds);
+  }, [store, participantMappingIdsKey, participantRowsRevision]);
+
+  const assignedHumanIds = useMemo(
+    () =>
+      collectAssignedHumanIdsFromTranscriptRows(
+        transcriptRows.map((transcriptRow) => transcriptRow.row),
+      ),
+    [transcriptRows],
+  );
+
+  const humanIds = useMemo(
+    () =>
+      getUniqueRowIds([
+        ...participantHumanIds,
+        ...assignedHumanIds,
+        typeof selfHumanId === "string" ? selfHumanId : "",
+      ]),
+    [assignedHumanIds, participantHumanIds, selfHumanId],
+  );
+  const humanIdsKey = getRowIdsKey(humanIds);
+  const humanRowsRevision = useStoreRowsRevision(store, "humans", humanIds);
+
+  const humans = useMemo(() => {
+    if (!store) {
+      return undefined;
+    }
+
+    return collectRenderHumans(store, humanIds, selfHumanId);
+  }, [store, humanIdsKey, humanRowsRevision, selfHumanId]);
+
+  const request = useMemo(
+    () =>
+      buildRenderTranscriptRequestFromRows(
+        transcriptRows.map((transcriptRow) => transcriptRow.row),
+        humans,
+        participantHumanIds,
+      ),
+    [humans, participantHumanIds, transcriptRows],
+  );
+
+  return { request, transcriptRows };
+}
+
+function useStoreRowsRevision(
+  store: UiStore | undefined,
+  tableId: RenderTableId,
+  rowIds: readonly string[],
+): number {
+  const revisionRef = useRef(0);
+  const rowIdsKey = getRowIdsKey(rowIds);
+  const subscribedRowIds = useMemo(() => getUniqueRowIds(rowIds), [rowIdsKey]);
+
+  const subscribe = useCallback(
+    (notify: () => void) => {
+      if (!store || subscribedRowIds.length === 0) {
+        return noop;
+      }
+
+      const listenerIds = subscribedRowIds.map((rowId) =>
+        store.addRowListener(tableId, rowId, () => {
+          revisionRef.current += 1;
+          notify();
+        }),
+      );
+
+      return () => {
+        for (const listenerId of listenerIds) {
+          store.delListener(listenerId);
+        }
+      };
+    },
+    [store, subscribedRowIds, tableId],
+  );
+  const getSnapshot = useCallback(() => revisionRef.current, []);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getZero);
+}
+
+function getTranscriptRow(store: UiStore, transcriptId: string): TranscriptRow {
+  const startedAt = store.getCell("transcripts", transcriptId, "started_at");
+
+  return {
+    started_at: typeof startedAt === "number" ? startedAt : null,
+    words: parseTranscriptWords(store, transcriptId),
+    speaker_hints: parseTranscriptHints(store, transcriptId),
+  };
+}
+
+function collectParticipantHumanIds(
+  store: Pick<UiStore, "getCell">,
+  participantMappingIds: readonly string[],
+): string[] {
+  const humanIds: string[] = [];
+
+  for (const mappingId of participantMappingIds) {
+    const humanId = store.getCell(
+      "mapping_session_participant",
+      mappingId,
+      "human_id",
+    );
+
+    if (typeof humanId === "string" && humanId) {
+      humanIds.push(humanId);
+    }
+  }
+
+  return getUniqueRowIds(humanIds);
+}
+
+function collectRenderHumans(
+  store: Pick<UiStore, "getRow">,
+  humanIds: readonly string[],
+  selfHumanId: unknown,
+): RenderTranscriptRequestHumans {
+  const humans: RenderTranscriptHuman[] = [];
+
+  for (const humanId of humanIds) {
+    const row = store.getRow("humans", humanId);
+    if (typeof row.name !== "string" || !row.name) {
+      continue;
+    }
+
+    humans.push({ human_id: humanId, name: row.name });
+  }
+
+  return {
+    selfHumanId: typeof selfHumanId === "string" ? selfHumanId : undefined,
+    humans,
+  };
+}
+
+function getRowIdsKey(rowIds: readonly string[]): string {
+  return getUniqueRowIds(rowIds).join("\u0000");
+}
+
+function getUniqueRowIds(rowIds: readonly string[]): string[] {
+  const uniqueRowIds: string[] = [];
+  const seen = new Set<string>();
+
+  for (const rowId of rowIds) {
+    if (!rowId || seen.has(rowId)) {
+      continue;
+    }
+
+    uniqueRowIds.push(rowId);
+    seen.add(rowId);
+  }
+
+  return uniqueRowIds;
+}
+
+function noop() {}
+
+function getZero() {
+  return 0;
+}
+
+const emptyIds: string[] = [];

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
@@ -1,38 +1,22 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
+import {
+  useTranscriptRenderData,
+  useTranscriptRowsRevision,
+} from "../render-request-hooks";
+
 import * as main from "~/store/tinybase/store/main";
 import type { Segment } from "~/stt/live-segment";
 import {
-  buildRenderTranscriptRequestFromStore,
   getRenderTranscriptRequestKey,
   renderTranscriptSegments,
 } from "~/stt/render-transcript";
 
+const emptyIds: string[] = [];
+
 export function useRenderedTranscriptSegments(transcriptId: string): Segment[] {
-  const store = main.UI.useStore(main.STORE_ID);
-  const transcriptsTable = main.UI.useTable("transcripts", main.STORE_ID);
-  const participantMappingsTable = main.UI.useTable(
-    "mapping_session_participant",
-    main.STORE_ID,
-  );
-  const humansTable = main.UI.useTable("humans", main.STORE_ID);
-  const selfHumanId = main.UI.useValue("user_id", main.STORE_ID);
-
-  const request = useMemo(() => {
-    if (!store) {
-      return null;
-    }
-
-    return buildRenderTranscriptRequestFromStore(store, [transcriptId]);
-  }, [
-    store,
-    transcriptId,
-    transcriptsTable,
-    participantMappingsTable,
-    humansTable,
-    selfHumanId,
-  ]);
+  const { request } = useTranscriptRenderData(transcriptId);
   const requestKey = useMemo(
     () => getRenderTranscriptRequestKey(request),
     [request],
@@ -56,7 +40,6 @@ export function useRenderedTranscriptSegments(transcriptId: string): Segment[] {
 
 export function useTranscriptOffset(transcriptId: string): number {
   const store = main.UI.useStore(main.STORE_ID);
-  const transcriptsTable = main.UI.useTable("transcripts", main.STORE_ID);
   const sessionId = main.UI.useCell(
     "transcripts",
     transcriptId,
@@ -64,11 +47,13 @@ export function useTranscriptOffset(transcriptId: string): number {
     main.STORE_ID,
   );
 
-  const transcriptIds = main.UI.useSliceRowIds(
-    main.INDEXES.transcriptBySession,
-    sessionId ?? "",
-    main.STORE_ID,
-  );
+  const transcriptIds =
+    main.UI.useSliceRowIds(
+      main.INDEXES.transcriptBySession,
+      sessionId ?? "",
+      main.STORE_ID,
+    ) ?? emptyIds;
+  const transcriptRowsRevision = useTranscriptRowsRevision(transcriptIds);
 
   return useMemo(() => {
     if (!store) {
@@ -99,5 +84,5 @@ export function useTranscriptOffset(transcriptId: string): number {
     return Number.isFinite(earliestStartedAt)
       ? transcriptStartedAt - earliestStartedAt
       : 0;
-  }, [store, transcriptId, transcriptIds, transcriptsTable]);
+  }, [store, transcriptId, transcriptIds, transcriptRowsRevision]);
 }

--- a/apps/desktop/src/stt/render-transcript.test.ts
+++ b/apps/desktop/src/stt/render-transcript.test.ts
@@ -12,6 +12,7 @@ vi.mock("@hypr/plugin-transcription", () => ({
 
 import {
   buildRenderTranscriptRequestFromStore,
+  collectAssignedHumanIdsFromTranscriptRows,
   getRenderTranscriptRequestKey,
   renderTranscriptSegments,
 } from "./render-transcript";
@@ -198,6 +199,32 @@ describe("buildRenderTranscriptRequestFromStore", () => {
         },
       },
     ]);
+  });
+
+  it("collects assigned speaker human ids from transcript rows", () => {
+    expect(
+      collectAssignedHumanIdsFromTranscriptRows([
+        {
+          speaker_hints: [
+            {
+              word_id: "word-1",
+              type: "user_speaker_assignment",
+              value: JSON.stringify({ human_id: "remote" }),
+            },
+            {
+              word_id: "word-2",
+              type: "user_speaker_assignment",
+              value: { human_id: "third" },
+            },
+            {
+              word_id: "word-3",
+              type: "provider_speaker_index",
+              value: JSON.stringify({ speaker_index: 1 }),
+            },
+          ],
+        },
+      ]),
+    ).toEqual(["remote", "third"]);
   });
 
   it("rounds fractional millisecond timings before invoking Rust", async () => {

--- a/apps/desktop/src/stt/render-transcript.ts
+++ b/apps/desktop/src/stt/render-transcript.ts
@@ -23,7 +23,7 @@ export type RenderedTranscriptSegmentWithWordMetadata = Omit<
   words: SegmentWord[];
 };
 
-type TranscriptRow = {
+export type TranscriptRow = {
   started_at?: number | null;
   words?: Array<{
     id?: string | null;
@@ -38,7 +38,7 @@ type TranscriptRow = {
   > | null;
 };
 
-type RenderTranscriptRequestHumans = {
+export type RenderTranscriptRequestHumans = {
   selfHumanId?: string;
   humans: RenderTranscriptHuman[];
 };
@@ -157,6 +157,40 @@ export function buildRenderTranscriptRequestFromStore(
     collectRenderHumans(store),
     collectSessionParticipantHumanIds(store, sessionId),
   );
+}
+
+export function buildRenderTranscriptRequestFromRows(
+  transcripts: TranscriptRow[],
+  humans?: RenderTranscriptRequestHumans,
+  participantHumanIds?: string[],
+): RenderTranscriptRequest | null {
+  return buildRenderTranscriptRequest(transcripts, humans, participantHumanIds);
+}
+
+export function collectAssignedHumanIdsFromTranscriptRows(
+  transcripts: TranscriptRow[],
+): string[] {
+  const humanIds = new Set<string>();
+
+  for (const transcript of transcripts) {
+    for (const hint of transcript.speaker_hints ?? []) {
+      if (hint.type !== "user_speaker_assignment") {
+        continue;
+      }
+
+      const value = parseHintValue(hint.value);
+      const humanId =
+        value && typeof value === "object"
+          ? (value as { human_id?: unknown }).human_id
+          : undefined;
+
+      if (typeof humanId === "string" && humanId) {
+        humanIds.add(humanId);
+      }
+    }
+  }
+
+  return [...humanIds];
 }
 
 export function buildRenderTranscriptRequestFromFsTranscript(


### PR DESCRIPTION
Replace broad transcript render and export table subscriptions with session-scoped row listener data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live transcript UI, export, and render request assembly; incorrect row scoping could miss updates or over-subscribe, but behavior is covered by existing and updated tests.
> 
> **Overview**
> Introduces **`render-request-hooks`** so live footer, transcript renderer, and export paths share one way to build `RenderTranscriptRequest` data without subscribing to whole Tinybase tables.
> 
> **Subscription model:** `useSessionTranscriptRenderData` / `useTranscriptRenderData` resolve session transcript IDs and participant mapping IDs from indexes, then **`useSyncExternalStore`** bumps a revision when **`addRowListener`** fires on only the relevant `transcripts`, `mapping_session_participant`, and `humans` rows. Human rows are limited to session participants, speaker-assignment hints on those transcripts, and the current user—not every human in the store.
> 
> **Call-site cleanup:** `during-session`, `export-data`, and `renderer/data-hooks` drop duplicated `useTable` + `buildRenderTranscriptRequestFromStore` logic; the live footer builds `transcriptIdByWordId` from shared `transcriptRows`. **`useTranscriptOffset`** now depends on **`useTranscriptRowsRevision`** instead of the full transcripts table.
> 
> **`render-transcript`:** adds **`buildRenderTranscriptRequestFromRows`** and **`collectAssignedHumanIdsFromTranscriptRows`** (exported types for rows/humans). Tests cover assigned-human collection; during-session tests mock **`addRowListener`** / **`delListener`** for the new hook path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d35b7c47aa8e0d0d0eda5230a5022be62abe419. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->