### PR TITLE
Refresh LLM model options

### DIFF
--- a/apps/desktop/src/settings/ai/shared/list-anthropic.ts
+++ b/apps/desktop/src/settings/ai/shared/list-anthropic.ts
@@ -5,13 +5,13 @@ import {
   extractMetadataMap,
   fetchJson,
   type InputModality,
-  isDateSnapshot,
   isOldModel,
   type ListModelsResult,
   type ModelIgnoreReason,
   partition,
   REQUEST_TIMEOUT,
   shouldIgnoreCommonKeywords,
+  sortModelsByRecency,
 } from "./list-common";
 
 const AnthropicModelSchema = Schema.Struct({
@@ -43,8 +43,8 @@ export async function listAnthropicModels(
       "anthropic-dangerous-direct-browser-access": "true",
     }),
     Effect.andThen((json) => Schema.decodeUnknown(AnthropicModelSchema)(json)),
-    Effect.map(({ data }) => ({
-      ...partition(
+    Effect.map(({ data }) => {
+      const result = partition(
         data,
         (model) => {
           const reasons: ModelIgnoreReason[] = [];
@@ -54,19 +54,21 @@ export async function listAnthropicModels(
           if (isOldModel(model.id)) {
             reasons.push("old_model");
           }
-          if (isDateSnapshot(model.id)) {
-            reasons.push("date_snapshot");
-          }
           return reasons.length > 0 ? reasons : null;
         },
         (model) => model.id,
-      ),
-      metadata: extractMetadataMap(
-        data,
-        (model) => model.id,
-        (model) => ({ input_modalities: getInputModalities(model.id) }),
-      ),
-    })),
+      );
+
+      return {
+        models: sortModelsByRecency(result.models),
+        ignored: result.ignored,
+        metadata: extractMetadataMap(
+          data,
+          (model) => model.id,
+          (model) => ({ input_modalities: getInputModalities(model.id) }),
+        ),
+      };
+    }),
     Effect.timeout(REQUEST_TIMEOUT),
     Effect.catchAll(() => Effect.succeed(DEFAULT_RESULT)),
     Effect.runPromise,

--- a/apps/desktop/src/settings/ai/shared/list-azure-ai.ts
+++ b/apps/desktop/src/settings/ai/shared/list-azure-ai.ts
@@ -4,11 +4,13 @@ import {
   DEFAULT_RESULT,
   extractMetadataMap,
   fetchJson,
+  isOldModel,
   type ListModelsResult,
   type ModelIgnoreReason,
   partition,
   REQUEST_TIMEOUT,
   shouldIgnoreCommonKeywords,
+  sortModelsByRecency,
 } from "./list-common";
 
 const AzureAIDeploymentSchema = Schema.Struct({
@@ -35,24 +37,32 @@ export async function listAzureAIModels(
     Effect.andThen((json) =>
       Schema.decodeUnknown(AzureAIDeploymentSchema)(json),
     ),
-    Effect.map(({ data }) => ({
-      ...partition(
+    Effect.map(({ data }) => {
+      const result = partition(
         data,
         (model) => {
           const reasons: ModelIgnoreReason[] = [];
           if (shouldIgnoreCommonKeywords(model.id)) {
             reasons.push("common_keyword");
           }
+          if (isOldModel(model.id)) {
+            reasons.push("old_model");
+          }
           return reasons.length > 0 ? reasons : null;
         },
         (model) => model.id,
-      ),
-      metadata: extractMetadataMap(
-        data,
-        (model) => model.id,
-        (_model) => ({ input_modalities: ["text", "image"] }),
-      ),
-    })),
+      );
+
+      return {
+        models: sortModelsByRecency(result.models),
+        ignored: result.ignored,
+        metadata: extractMetadataMap(
+          data,
+          (model) => model.id,
+          (_model) => ({ input_modalities: ["text", "image"] }),
+        ),
+      };
+    }),
     Effect.timeout(REQUEST_TIMEOUT),
     Effect.catchAll(() => Effect.succeed(DEFAULT_RESULT)),
     Effect.runPromise,

--- a/apps/desktop/src/settings/ai/shared/list-azure-openai.ts
+++ b/apps/desktop/src/settings/ai/shared/list-azure-openai.ts
@@ -5,12 +5,14 @@ import {
   extractMetadataMap,
   fetchJson,
   isDateSnapshot,
+  isNonChatModel,
   isOldModel,
   type ListModelsResult,
   type ModelIgnoreReason,
   partition,
   REQUEST_TIMEOUT,
   shouldIgnoreCommonKeywords,
+  sortModelsByRecency,
 } from "./list-common";
 
 const AzureOpenAIModelSchema = Schema.Struct({
@@ -44,13 +46,16 @@ export async function listAzureOpenAIModels(
     Effect.andThen((json) =>
       Schema.decodeUnknown(AzureOpenAIModelSchema)(json),
     ),
-    Effect.map(({ data }) => ({
-      ...partition(
+    Effect.map(({ data }) => {
+      const result = partition(
         data,
         (model) => {
           const reasons: ModelIgnoreReason[] = [];
           if (shouldIgnoreCommonKeywords(model.id)) {
             reasons.push("common_keyword");
+          }
+          if (isNonChatModel(model.id)) {
+            reasons.push("not_chat_model");
           }
           if (isOldModel(model.id)) {
             reasons.push("old_model");
@@ -68,13 +73,18 @@ export async function listAzureOpenAIModels(
           return reasons.length > 0 ? reasons : null;
         },
         (model) => model.id,
-      ),
-      metadata: extractMetadataMap(
-        data,
-        (model) => model.id,
-        (_model) => ({ input_modalities: ["text", "image"] }),
-      ),
-    })),
+      );
+
+      return {
+        models: sortModelsByRecency(result.models),
+        ignored: result.ignored,
+        metadata: extractMetadataMap(
+          data,
+          (model) => model.id,
+          (_model) => ({ input_modalities: ["text", "image"] }),
+        ),
+      };
+    }),
     Effect.timeout(REQUEST_TIMEOUT),
     Effect.catchAll(() => Effect.succeed(DEFAULT_RESULT)),
     Effect.runPromise,

--- a/apps/desktop/src/settings/ai/shared/list-common.test.ts
+++ b/apps/desktop/src/settings/ai/shared/list-common.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+
+import { isOldModel, sortModelsByRecency } from "./list-common";
+
+describe("isOldModel", () => {
+  test("filters older OpenAI chat families while keeping current models", () => {
+    expect(isOldModel("gpt-4o")).toBe(true);
+    expect(isOldModel("gpt-4.1")).toBe(true);
+    expect(isOldModel("gpt-5")).toBe(true);
+    expect(isOldModel("gpt-5.1-chat-latest")).toBe(true);
+
+    expect(isOldModel("gpt-5.4-mini")).toBe(false);
+    expect(isOldModel("gpt-5.5")).toBe(false);
+    expect(isOldModel("chat-latest")).toBe(false);
+  });
+
+  test("filters older Claude families without hiding current pinned IDs", () => {
+    expect(isOldModel("claude-3-7-sonnet")).toBe(true);
+    expect(isOldModel("anthropic/claude-opus-4.7")).toBe(true);
+    expect(isOldModel("claude-sonnet-4-5")).toBe(true);
+
+    expect(isOldModel("claude-fable-5")).toBe(false);
+    expect(isOldModel("claude-opus-4-8")).toBe(false);
+    expect(isOldModel("claude-sonnet-4-6")).toBe(false);
+    expect(isOldModel("claude-haiku-4-5-20251001")).toBe(false);
+  });
+
+  test("filters older Gemini and Mistral families", () => {
+    expect(isOldModel("gemini-2.5-pro")).toBe(true);
+    expect(isOldModel("mistral-small-2506")).toBe(true);
+    expect(isOldModel("mistral-medium-3.1")).toBe(true);
+
+    expect(isOldModel("gemini-3.5-flash")).toBe(false);
+    expect(isOldModel("gemini-3.1-pro-preview")).toBe(false);
+    expect(isOldModel("mistral-medium-3-5")).toBe(false);
+    expect(isOldModel("mistral-large-2512")).toBe(false);
+  });
+});
+
+describe("sortModelsByRecency", () => {
+  test("prioritizes current hosted models across provider-prefixed IDs", () => {
+    expect(
+      sortModelsByRecency([
+        "openai/gpt-5.4-mini",
+        "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.5",
+        "google/gemini-3.5-flash",
+        "openai/chat-latest",
+      ]),
+    ).toEqual([
+      "openai/gpt-5.5",
+      "openai/chat-latest",
+      "openai/gpt-5.4-mini",
+      "anthropic/claude-sonnet-4.6",
+      "google/gemini-3.5-flash",
+    ]);
+  });
+});

--- a/apps/desktop/src/settings/ai/shared/list-common.ts
+++ b/apps/desktop/src/settings/ai/shared/list-common.ts
@@ -47,6 +47,31 @@ const commonIgnoreKeywords = [
   "moderation",
   "codex",
   "transcribe",
+  "search-api",
+] as const;
+
+const modelPriorityPatterns = [
+  /(?:^|\/)gpt-5\.5-pro$/,
+  /(?:^|\/)gpt-5\.5$/,
+  /(?:^|\/)(?:chat-latest|gpt-chat-latest)$/,
+  /(?:^|\/)gpt-5\.4-pro$/,
+  /(?:^|\/)gpt-5\.4$/,
+  /(?:^|\/)gpt-5\.4-mini$/,
+  /(?:^|\/)gpt-5\.4-nano$/,
+  /(?:^|\/)claude-fable-5$/,
+  /(?:^|\/)claude-opus-4[-.]8$/,
+  /(?:^|\/)claude-sonnet-4[-.]6$/,
+  /(?:^|\/)claude-haiku-4[-.]5(?:-\d{8})?$/,
+  /(?:^|\/)gemini-3\.1-pro-preview$/,
+  /(?:^|\/)gemini-3\.5-flash$/,
+  /(?:^|\/)gemini-3-flash-preview$/,
+  /(?:^|\/)gemini-3\.1-flash-lite$/,
+  /(?:^|\/)mistral-medium-3[-.]5/,
+  /(?:^|\/)(?:mistral-small-4|mistral-small-latest)/,
+  /(?:^|\/)(?:mistral-large-3|mistral-large-2512)/,
+  /(?:^|\/)devstral-2/,
+  /(?:^|\/)magistral-medium-(?:1[-.]2|2509)/,
+  /(?:^|\/)ministral-(?:3|14b-2512|8b-2512|3b-2512)/,
 ] as const;
 
 export const fetchJson = (url: string, headers: Record<string, string>) =>
@@ -90,11 +115,60 @@ export const isNonChatModel = (id: string): boolean => {
 
 export const isOldModel = (id: string): boolean => {
   const lowerId = id.toLowerCase();
-  if (/^gpt-3\.5/.test(lowerId)) return true;
-  if (/^gpt-4(?!o|\.)/.test(lowerId)) return true;
-  if (/^(davinci|babbage|curie|ada)(-|$)/.test(lowerId)) return true;
-  if (/^claude-(2|instant)/.test(lowerId)) return true;
+  const name = lowerId.includes("/") ? lowerId.split("/").pop()! : lowerId;
+  const dashedName = name.replace(/\./g, "-");
+
+  if (/^gpt-3\.5/.test(name)) return true;
+  if (/^gpt-4/.test(name)) return true;
+  if (/^gpt-5($|-)/.test(name)) return true;
+  if (/^gpt-5\.[1-3]($|-)/.test(name)) return true;
+  if (/^(davinci|babbage|curie|ada)(-|$)/.test(name)) return true;
+  if (/^claude-(2|3|instant)/.test(dashedName)) return true;
+  if (
+    /^claude-opus-4($|-)/.test(dashedName) &&
+    !/^claude-opus-4-8($|-)/.test(dashedName)
+  ) {
+    return true;
+  }
+  if (
+    /^claude-sonnet-4($|-)/.test(dashedName) &&
+    !/^claude-sonnet-4-6($|-)/.test(dashedName)
+  ) {
+    return true;
+  }
+  if (
+    /^claude-haiku-4($|-)/.test(dashedName) &&
+    !/^claude-haiku-4-5($|-)/.test(dashedName)
+  ) {
+    return true;
+  }
+  if (/^gemini-(1|2)(\.|-)/.test(name)) return true;
+  if (/^(open-)?mistral-(7b|nemo)(-|$)/.test(name)) return true;
+  if (/^open-mixtral/.test(name)) return true;
+  if (/^mistral-large-(24|240|241|2502|2508)/.test(name)) return true;
+  if (/^mistral-medium-(2505|3[.-]1)($|-)/.test(name)) return true;
+  if (/^mistral-small-(3|2503|2506)($|-)/.test(name)) return true;
+  if (/^magistral-(small|medium)-2507($|-)/.test(name)) return true;
+  if (/^ministral-(3b|8b)-24/.test(name)) return true;
   return false;
+};
+
+export const sortModelsByRecency = (models: string[]): string[] => {
+  const priority = (model: string) => {
+    const normalized = model.toLowerCase();
+    const index = modelPriorityPatterns.findIndex((pattern) =>
+      pattern.test(normalized),
+    );
+    return index === -1 ? modelPriorityPatterns.length : index;
+  };
+
+  return [...models].sort((a, b) => {
+    const priorityDelta = priority(a) - priority(b);
+    if (priorityDelta !== 0) {
+      return priorityDelta;
+    }
+    return a.localeCompare(b);
+  });
 };
 
 const hasMetadata = (metadata: ModelMetadata | undefined): boolean => {

--- a/apps/desktop/src/settings/ai/shared/list-google.ts
+++ b/apps/desktop/src/settings/ai/shared/list-google.ts
@@ -7,11 +7,13 @@ import {
   type InputModality,
   isDateSnapshot,
   isNonChatModel,
+  isOldModel,
   type ListModelsResult,
   type ModelIgnoreReason,
   partition,
   REQUEST_TIMEOUT,
   shouldIgnoreCommonKeywords,
+  sortModelsByRecency,
 } from "./list-common";
 
 const GoogleModelSchema = Schema.Struct({
@@ -51,6 +53,9 @@ export async function listGoogleModels(
     if (isNonChatModel(extractModelId(model))) {
       reasons.push("not_chat_model");
     }
+    if (isOldModel(extractModelId(model))) {
+      reasons.push("old_model");
+    }
     if (!supportsGeneration(model)) {
       reasons.push("no_completion");
     }
@@ -63,12 +68,17 @@ export async function listGoogleModels(
   return pipe(
     fetchJson(`${baseUrl}/models`, { "x-goog-api-key": apiKey }),
     Effect.andThen((json) => Schema.decodeUnknown(GoogleModelSchema)(json)),
-    Effect.map(({ models }) => ({
-      ...partition(models, getIgnoreReasons, extractModelId),
-      metadata: extractMetadataMap(models, extractModelId, (model) => ({
-        input_modalities: getInputModalities(extractModelId(model)),
-      })),
-    })),
+    Effect.map(({ models }) => {
+      const result = partition(models, getIgnoreReasons, extractModelId);
+
+      return {
+        models: sortModelsByRecency(result.models),
+        ignored: result.ignored,
+        metadata: extractMetadataMap(models, extractModelId, (model) => ({
+          input_modalities: getInputModalities(extractModelId(model)),
+        })),
+      };
+    }),
     Effect.timeout(REQUEST_TIMEOUT),
     Effect.catchAll(() => Effect.succeed(DEFAULT_RESULT)),
     Effect.runPromise,

--- a/apps/desktop/src/settings/ai/shared/list-mistral.ts
+++ b/apps/desktop/src/settings/ai/shared/list-mistral.ts
@@ -5,12 +5,13 @@ import {
   extractMetadataMap,
   fetchJson,
   type InputModality,
-  isDateSnapshot,
+  isOldModel,
   type ListModelsResult,
   type ModelIgnoreReason,
   partition,
   REQUEST_TIMEOUT,
   shouldIgnoreCommonKeywords,
+  sortModelsByRecency,
 } from "./list-common";
 
 const MistralCapabilitiesSchema = Schema.Struct({
@@ -52,8 +53,8 @@ export async function listMistralModels(
     if (!supportsChatCompletion(model)) {
       reasons.push("no_completion");
     }
-    if (isDateSnapshot(model.id)) {
-      reasons.push("date_snapshot");
+    if (isOldModel(model.id)) {
+      reasons.push("old_model");
     }
     return reasons.length > 0 ? reasons : null;
   };
@@ -65,16 +66,21 @@ export async function listMistralModels(
   return pipe(
     fetchJson(`${baseUrl}/models`, { Authorization: `Bearer ${apiKey}` }),
     Effect.andThen((json) => Schema.decodeUnknown(MistralModelSchema)(json)),
-    Effect.map(({ data }) => ({
-      ...partition(data, getIgnoreReasons, (model) => model.id),
-      metadata: extractMetadataMap(
-        data,
-        (model) => model.id,
-        (model) => ({
-          input_modalities: getInputModalities(model),
-        }),
-      ),
-    })),
+    Effect.map(({ data }) => {
+      const result = partition(data, getIgnoreReasons, (model) => model.id);
+
+      return {
+        models: sortModelsByRecency(result.models),
+        ignored: result.ignored,
+        metadata: extractMetadataMap(
+          data,
+          (model) => model.id,
+          (model) => ({
+            input_modalities: getInputModalities(model),
+          }),
+        ),
+      };
+    }),
     Effect.timeout(REQUEST_TIMEOUT),
     Effect.catchAll(() => Effect.succeed(DEFAULT_RESULT)),
     Effect.runPromise,

--- a/apps/desktop/src/settings/ai/shared/list-openai.ts
+++ b/apps/desktop/src/settings/ai/shared/list-openai.ts
@@ -12,6 +12,7 @@ import {
   partition,
   REQUEST_TIMEOUT,
   shouldIgnoreCommonKeywords,
+  sortModelsByRecency,
 } from "./list-common";
 
 const OpenAIModelSchema = Schema.Struct({
@@ -33,8 +34,8 @@ export async function listOpenAIModels(
   return pipe(
     fetchJson(`${baseUrl}/models`, { Authorization: `Bearer ${apiKey}` }),
     Effect.andThen((json) => Schema.decodeUnknown(OpenAIModelSchema)(json)),
-    Effect.map(({ data }) => ({
-      ...partition(
+    Effect.map(({ data }) => {
+      const result = partition(
         data,
         (model) => {
           const reasons: ModelIgnoreReason[] = [];
@@ -53,13 +54,18 @@ export async function listOpenAIModels(
           return reasons.length > 0 ? reasons : null;
         },
         (model) => model.id,
-      ),
-      metadata: extractMetadataMap(
-        data,
-        (model) => model.id,
-        (_model) => ({ input_modalities: ["text", "image"] }),
-      ),
-    })),
+      );
+
+      return {
+        models: sortModelsByRecency(result.models),
+        ignored: result.ignored,
+        metadata: extractMetadataMap(
+          data,
+          (model) => model.id,
+          (_model) => ({ input_modalities: ["text", "image"] }),
+        ),
+      };
+    }),
     Effect.timeout(REQUEST_TIMEOUT),
     Effect.catchAll(() => Effect.succeed(DEFAULT_RESULT)),
     Effect.runPromise,
@@ -77,8 +83,8 @@ export async function listGenericModels(
   return pipe(
     fetchJson(`${baseUrl}/models`, { Authorization: `Bearer ${apiKey}` }),
     Effect.andThen((json) => Schema.decodeUnknown(OpenAIModelSchema)(json)),
-    Effect.map(({ data }) => ({
-      ...partition(
+    Effect.map(({ data }) => {
+      const result = partition(
         data,
         (model) => {
           const reasons: ModelIgnoreReason[] = [];
@@ -97,13 +103,18 @@ export async function listGenericModels(
           return reasons.length > 0 ? reasons : null;
         },
         (model) => model.id,
-      ),
-      metadata: extractMetadataMap(
-        data,
-        (model) => model.id,
-        () => ({ input_modalities: ["text"] }),
-      ),
-    })),
+      );
+
+      return {
+        models: sortModelsByRecency(result.models),
+        ignored: result.ignored,
+        metadata: extractMetadataMap(
+          data,
+          (model) => model.id,
+          () => ({ input_modalities: ["text"] }),
+        ),
+      };
+    }),
     Effect.timeout(REQUEST_TIMEOUT),
     Effect.catchAll(() => Effect.succeed(DEFAULT_RESULT)),
     Effect.runPromise,

--- a/apps/desktop/src/settings/ai/shared/list-openrouter.test.ts
+++ b/apps/desktop/src/settings/ai/shared/list-openrouter.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+
+import { processOpenRouterModels } from "./list-openrouter";
+
+describe("processOpenRouterModels", () => {
+  test("keeps current provider-prefixed dated models", () => {
+    expect(
+      processOpenRouterModels([
+        {
+          id: "mistralai/mistral-large-2512",
+          supported_parameters: ["tools", "tool_choice"],
+          architecture: { input_modalities: ["text"] },
+        },
+        {
+          id: "anthropic/claude-haiku-4-5-20251001",
+          supported_parameters: ["tools", "tool_choice"],
+          architecture: { input_modalities: ["text", "image"] },
+        },
+        {
+          id: "mistralai/mistral-large-2508",
+          supported_parameters: ["tools", "tool_choice"],
+          architecture: { input_modalities: ["text"] },
+        },
+      ]),
+    ).toEqual({
+      models: [
+        "anthropic/claude-haiku-4-5-20251001",
+        "mistralai/mistral-large-2512",
+      ],
+      ignored: [{ id: "mistralai/mistral-large-2508", reasons: ["old_model"] }],
+      metadata: {
+        "anthropic/claude-haiku-4-5-20251001": {
+          input_modalities: ["text", "image"],
+        },
+        "mistralai/mistral-large-2512": { input_modalities: ["text"] },
+        "mistralai/mistral-large-2508": { input_modalities: ["text"] },
+      },
+    });
+  });
+});

--- a/apps/desktop/src/settings/ai/shared/list-openrouter.ts
+++ b/apps/desktop/src/settings/ai/shared/list-openrouter.ts
@@ -5,7 +5,6 @@ import {
   extractMetadataMap,
   fetchJson,
   type InputModality,
-  isDateSnapshot,
   isNonChatModel,
   isOldModel,
   type ListModelsResult,
@@ -13,6 +12,7 @@ import {
   partition,
   REQUEST_TIMEOUT,
   shouldIgnoreCommonKeywords,
+  sortModelsByRecency,
 } from "./list-common";
 
 const OpenRouterModelSchema = Schema.Struct({
@@ -42,60 +42,66 @@ export async function listOpenRouterModels(
     return DEFAULT_RESULT;
   }
 
-  const hasCommonIgnoreKeywords = (model: OpenRouterModel): boolean =>
-    shouldIgnoreCommonKeywords(model.id);
-
-  const supportsTextInput = (model: OpenRouterModel): boolean =>
-    !Array.isArray(model.architecture?.input_modalities) ||
-    model.architecture.input_modalities.includes("text");
-
-  const supportsToolUse = (model: OpenRouterModel): boolean =>
-    !model.supported_parameters ||
-    ["tools", "tool_choice"].every((parameter) =>
-      model.supported_parameters?.includes(parameter),
-    );
-
-  const getIgnoreReasons = (
-    model: OpenRouterModel,
-  ): ModelIgnoreReason[] | null => {
-    const reasons: ModelIgnoreReason[] = [];
-    if (hasCommonIgnoreKeywords(model)) {
-      reasons.push("common_keyword");
-    }
-    if (isNonChatModel(model.id)) {
-      reasons.push("not_chat_model");
-    }
-    if (!supportsTextInput(model)) {
-      reasons.push("no_text_input");
-    }
-    if (!supportsToolUse(model)) {
-      reasons.push("no_tool");
-    }
-    if (isOldModel(model.id)) {
-      reasons.push("old_model");
-    }
-    if (isDateSnapshot(model.id)) {
-      reasons.push("date_snapshot");
-    }
-    return reasons.length > 0 ? reasons : null;
-  };
-
   return pipe(
     fetchJson(`${baseUrl}/models`, { Authorization: `Bearer ${apiKey}` }),
     Effect.andThen((json) => Schema.decodeUnknown(OpenRouterModelSchema)(json)),
-    Effect.map(({ data }) => ({
-      ...partition(data, getIgnoreReasons, (model) => model.id),
-      metadata: extractMetadataMap(
-        data,
-        (model) => model.id,
-        (model) => ({ input_modalities: getInputModalities(model) }),
-      ),
-    })),
+    Effect.map(({ data }) => processOpenRouterModels(data)),
     Effect.timeout(REQUEST_TIMEOUT),
     Effect.catchAll(() => Effect.succeed(DEFAULT_RESULT)),
     Effect.runPromise,
   );
 }
+
+export const processOpenRouterModels = (
+  data: ReadonlyArray<OpenRouterModel>,
+): ListModelsResult => {
+  const result = partition(data, getIgnoreReasons, (model) => model.id);
+
+  return {
+    models: sortModelsByRecency(result.models),
+    ignored: result.ignored,
+    metadata: extractMetadataMap(
+      data,
+      (model) => model.id,
+      (model) => ({ input_modalities: getInputModalities(model) }),
+    ),
+  };
+};
+
+const hasCommonIgnoreKeywords = (model: OpenRouterModel): boolean =>
+  shouldIgnoreCommonKeywords(model.id);
+
+const supportsTextInput = (model: OpenRouterModel): boolean =>
+  !Array.isArray(model.architecture?.input_modalities) ||
+  model.architecture.input_modalities.includes("text");
+
+const supportsToolUse = (model: OpenRouterModel): boolean =>
+  !model.supported_parameters ||
+  ["tools", "tool_choice"].every((parameter) =>
+    model.supported_parameters?.includes(parameter),
+  );
+
+const getIgnoreReasons = (
+  model: OpenRouterModel,
+): ModelIgnoreReason[] | null => {
+  const reasons: ModelIgnoreReason[] = [];
+  if (hasCommonIgnoreKeywords(model)) {
+    reasons.push("common_keyword");
+  }
+  if (isNonChatModel(model.id)) {
+    reasons.push("not_chat_model");
+  }
+  if (!supportsTextInput(model)) {
+    reasons.push("no_text_input");
+  }
+  if (!supportsToolUse(model)) {
+    reasons.push("no_tool");
+  }
+  if (isOldModel(model.id)) {
+    reasons.push("old_model");
+  }
+  return reasons.length > 0 ? reasons : null;
+};
 
 const getInputModalities = (model: OpenRouterModel): InputModality[] => {
   const modalities = model.architecture?.input_modalities ?? [];


### PR DESCRIPTION
Filter outdated hosted model families and sort provider model catalogs around current official releases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which models appear and in what order in the LLM picker; mis-tuned regexes could hide still-valid deployments, but impact is limited to settings catalog fetching, not chat routing.
> 
> **Overview**
> Refreshes how hosted LLM catalogs are filtered and ordered in AI settings so pickers emphasize current official releases instead of long tail of dated IDs.
> 
> **`list-common`** expands **`isOldModel`** to handle provider-prefixed IDs and broader families (e.g. GPT through 5.3, Claude 3/4 with carve-outs for current 4.5–4.8 pins, older Gemini/Mistral lines). It adds **`sortModelsByRecency`** via a fixed priority regex list (GPT 5.5/5.4, current Claude/Gemini/Mistral SKUs, etc.), plus **`search-api`** in common keyword ignores.
> 
> **Provider listers** (OpenAI, generic, Anthropic, Google, Mistral, Azure AI/OpenAI, OpenRouter) now run returned model IDs through **`sortModelsByRecency`** and apply **`isOldModel`** where it was missing. Anthropic and Mistral drop **`date_snapshot`** filtering; OpenRouter drops **`date_snapshot`** and factors processing into exported **`processOpenRouterModels`**. Azure OpenAI also filters with **`isNonChatModel`** by ID.
> 
> Vitest coverage documents the new **`isOldModel`** / sort behavior and OpenRouter processing (including keeping dated but current models like **`claude-haiku-4-5-20251001`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfb765fea4cb3eb45f533bf2a70592d29edd2ef4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->