### PR TITLE
Consolidate timeline window derivation

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   addDeletion: vi.fn(),
   configValue: undefined as string | undefined,
   currentTimeMs: undefined as number | undefined,
+  isIgnored: vi.fn(() => false),
   liveSessionId: null as string | null,
   liveStatus: "inactive" as "inactive" | "active" | "finalizing",
   smartCurrentTimeMs: undefined as number | undefined,
@@ -38,7 +39,7 @@ vi.mock("~/shared/hooks/useNativeContextMenu", () => ({
 
 vi.mock("~/store/tinybase/hooks", () => ({
   useIgnoredEvents: () => ({
-    isIgnored: () => false,
+    isIgnored: mocks.isIgnored,
   }),
 }));
 
@@ -156,6 +157,7 @@ describe("TimelineView", () => {
     vi.clearAllMocks();
     mocks.configValue = undefined;
     mocks.currentTimeMs = undefined;
+    mocks.isIgnored.mockReturnValue(false);
     mocks.liveSessionId = null;
     mocks.liveStatus = "inactive";
     mocks.smartCurrentTimeMs = undefined;

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -33,9 +33,8 @@ import {
 import {
   buildTimelineBuckets,
   calculateTodayIndicatorPlacement,
-  filterTimelineTablesUpToTomorrow,
+  deriveTimelineWindowData,
   getItemTimestamp,
-  hasTimelineItemsAfterTomorrow,
   type TimelineBucket,
   type TimelineEventsTable,
   type TimelineIndicatorPlacement,
@@ -72,66 +71,20 @@ export function TimelineView({
 } = {}) {
   const timezone = useConfigValue("timezone") || undefined;
   const { timelineEventsTable, timelineSessionsTable } = useTimelineTables();
-  const allBuckets = useTimelineData({
-    timelineEventsTable,
-    timelineSessionsTable,
-    timezone,
-  });
   const [showIgnored, setShowIgnored] = useState(false);
   const [isScrolledToTop, setIsScrolledToTop] = useState(true);
   const [isScrolledToBottom, setIsScrolledToBottom] = useState(true);
 
   const { isIgnored } = useIgnoredEvents();
+  const { buckets, hasMoreFutureItems, hasVisibleCalendarEvents } =
+    useTimelineData({
+      isEventIgnored: isIgnored,
+      showIgnored,
+      timelineEventsTable,
+      timelineSessionsTable,
+      timezone,
+    });
   const openNew = useTabs((state) => state.openNew);
-
-  const buckets = useMemo(() => {
-    if (showIgnored) {
-      return allBuckets;
-    }
-
-    return allBuckets
-      .map((bucket) => ({
-        ...bucket,
-        items: bucket.items.filter((item) => {
-          if (item.type !== "event") return true;
-          return !isIgnored(
-            item.data.tracking_id_event,
-            item.data.recurrence_series_id,
-          );
-        }),
-      }))
-      .filter((bucket) => bucket.items.length > 0);
-  }, [allBuckets, showIgnored, isIgnored, timezone]);
-
-  const visibleTimelineEventsTable = useMemo(() => {
-    if (showIgnored || !timelineEventsTable) {
-      return timelineEventsTable;
-    }
-
-    return Object.fromEntries(
-      Object.entries(timelineEventsTable).filter(
-        ([, item]) =>
-          !isIgnored(item.tracking_id_event, item.recurrence_series_id),
-      ),
-    );
-  }, [timelineEventsTable, showIgnored, isIgnored]);
-
-  const hasMoreFutureItems = useMemo(
-    () =>
-      hasTimelineItemsAfterTomorrow({
-        timelineEventsTable: visibleTimelineEventsTable,
-        timelineSessionsTable,
-        timezone,
-      }),
-    [visibleTimelineEventsTable, timelineSessionsTable, timezone],
-  );
-  const hasVisibleCalendarEvents = useMemo(
-    () =>
-      buckets.some((bucket) =>
-        bucket.items.some((item) => item.type === "event"),
-      ),
-    [buckets],
-  );
   const calendarSyncStatus = useCalendarSyncStatus();
   const showCalendarSyncStatus =
     calendarSyncStatus !== "idle" && !hasVisibleCalendarEvents;
@@ -951,35 +904,60 @@ function useTimelineTables(): {
 }
 
 function useTimelineData({
+  isEventIgnored,
+  showIgnored,
   timelineEventsTable,
   timelineSessionsTable,
   timezone,
 }: {
+  isEventIgnored: (
+    trackingId: string | null | undefined,
+    recurrenceSeriesId: string | null | undefined,
+  ) => boolean;
+  showIgnored: boolean;
   timelineEventsTable: TimelineEventsTable;
   timelineSessionsTable: TimelineSessionsTable;
   timezone?: string;
-}): TimelineBucket[] {
-  const filteredTables = useMemo(
+}): {
+  buckets: TimelineBucket[];
+  hasMoreFutureItems: boolean;
+  hasVisibleCalendarEvents: boolean;
+} {
+  const windowData = useMemo(
     () =>
-      filterTimelineTablesUpToTomorrow({
+      deriveTimelineWindowData({
+        isEventIgnored,
+        showIgnored,
         timelineEventsTable,
         timelineSessionsTable,
         timezone,
       }),
-    [timelineEventsTable, timelineSessionsTable, timezone],
+    [
+      isEventIgnored,
+      showIgnored,
+      timelineEventsTable,
+      timelineSessionsTable,
+      timezone,
+    ],
   );
   const currentTimeMs = useSmartCurrentTime(
-    filteredTables.timelineEventsTable,
-    filteredTables.timelineSessionsTable,
+    windowData.timelineEventsTable,
+    windowData.timelineSessionsTable,
   );
 
-  return useMemo(
-    () =>
-      buildTimelineBuckets({
-        timelineEventsTable: filteredTables.timelineEventsTable,
-        timelineSessionsTable: filteredTables.timelineSessionsTable,
-        timezone,
-      }),
-    [filteredTables, currentTimeMs, timezone],
-  );
+  return useMemo(() => {
+    const buckets = buildTimelineBuckets({
+      timelineEventsTable: windowData.timelineEventsTable,
+      timelineSessionsTable: windowData.timelineSessionsTable,
+      timezone,
+    });
+
+    return {
+      buckets,
+      hasMoreFutureItems: windowData.hasMoreFutureItems,
+      hasVisibleCalendarEvents: buckets.some((bucket) =>
+        bucket.items.some((item) => item.type === "event"),
+      ),
+    };
+  }, [windowData, currentTimeMs, timezone]);
 }

--- a/apps/desktop/src/sidebar/timeline/utils/index.test.ts
+++ b/apps/desktop/src/sidebar/timeline/utils/index.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   buildTimelineBuckets,
   calculateTodayIndicatorPlacement,
+  deriveTimelineWindowData,
   filterTimelineTablesUpToTomorrow,
   getBucketInfo,
   hasTimelineItemsAfterTomorrow,
@@ -236,6 +237,75 @@ describe("timeline utils", () => {
         },
       }),
     ).toBe(false);
+  });
+
+  test("deriveTimelineWindowData filters ignored events before window and future derivation", () => {
+    const visible = deriveTimelineWindowData({
+      timelineEventsTable: {
+        ignoredTomorrow: {
+          title: "Ignored Tomorrow",
+          started_at: "2024-01-16T09:00:00.000Z",
+          ended_at: "2024-01-16T10:00:00.000Z",
+          calendar_id: "cal-1",
+          tracking_id_event: "ignored",
+          has_recurrence_rules: false,
+        },
+        ignoredLater: {
+          title: "Ignored Later",
+          started_at: "2024-01-17T09:00:00.000Z",
+          ended_at: "2024-01-17T10:00:00.000Z",
+          calendar_id: "cal-1",
+          tracking_id_event: "ignored-later",
+          has_recurrence_rules: false,
+        },
+        visibleLater: {
+          title: "Visible Later",
+          started_at: "2024-01-17T11:00:00.000Z",
+          ended_at: "2024-01-17T12:00:00.000Z",
+          calendar_id: "cal-1",
+          tracking_id_event: "visible-later",
+          has_recurrence_rules: false,
+        },
+      },
+      timelineSessionsTable: {
+        tomorrow: {
+          title: "Tomorrow Session",
+          created_at: "2024-01-14T12:00:00.000Z",
+          event_json: JSON.stringify({
+            started_at: "2024-01-16T11:00:00.000Z",
+          }),
+        },
+      },
+      showIgnored: false,
+      isEventIgnored: (trackingId) =>
+        trackingId?.startsWith("ignored") ?? false,
+    });
+
+    expect(Object.keys(visible.timelineEventsTable ?? {})).toEqual([]);
+    expect(Object.keys(visible.timelineSessionsTable ?? {})).toEqual([
+      "tomorrow",
+    ]);
+    expect(visible.hasMoreFutureItems).toBe(true);
+
+    const withIgnored = deriveTimelineWindowData({
+      timelineEventsTable: {
+        ignoredTomorrow: {
+          title: "Ignored Tomorrow",
+          started_at: "2024-01-16T09:00:00.000Z",
+          ended_at: "2024-01-16T10:00:00.000Z",
+          calendar_id: "cal-1",
+          tracking_id_event: "ignored",
+          has_recurrence_rules: false,
+        },
+      },
+      timelineSessionsTable: null,
+      showIgnored: true,
+      isEventIgnored: () => true,
+    });
+
+    expect(Object.keys(withIgnored.timelineEventsTable ?? {})).toEqual([
+      "ignoredTomorrow",
+    ]);
   });
 
   test("buildTimelineBuckets prioritizes sessions to events and avoid duplicate timeline items", () => {

--- a/apps/desktop/src/sidebar/timeline/utils/index.ts
+++ b/apps/desktop/src/sidebar/timeline/utils/index.ts
@@ -63,6 +63,12 @@ export type TimelineBucket = {
   items: TimelineItem[];
 };
 
+export type TimelineWindowData = {
+  timelineEventsTable: TimelineEventsTable;
+  timelineSessionsTable: TimelineSessionsTable;
+  hasMoreFutureItems: boolean;
+};
+
 export type TimelineIndicatorPlacement =
   | { type: "inside"; index: number; progress: number }
   | { type: "before"; index: number }
@@ -315,6 +321,74 @@ export function filterTimelineTablesUpToTomorrow({
           ),
         )
       : timelineSessionsTable,
+  };
+}
+
+export function deriveTimelineWindowData({
+  timelineEventsTable,
+  timelineSessionsTable,
+  timezone,
+  showIgnored = true,
+  isEventIgnored = () => false,
+}: {
+  timelineEventsTable: TimelineEventsTable;
+  timelineSessionsTable: TimelineSessionsTable;
+  timezone?: string;
+  showIgnored?: boolean;
+  isEventIgnored?: (
+    trackingId: string | null | undefined,
+    recurrenceSeriesId: string | null | undefined,
+  ) => boolean;
+}): TimelineWindowData {
+  const filteredEventsTable = timelineEventsTable
+    ? ({} as Record<string, TimelineEventRow>)
+    : timelineEventsTable;
+  const filteredSessionsTable = timelineSessionsTable
+    ? ({} as Record<string, TimelineSessionRow>)
+    : timelineSessionsTable;
+  let hasMoreFutureItems = false;
+
+  if (timelineSessionsTable && filteredSessionsTable) {
+    for (const [sessionId, row] of Object.entries(timelineSessionsTable)) {
+      const date = safeParseDate(
+        getSessionEvent(row)?.started_at ?? row.created_at,
+      );
+
+      if (isAfterTomorrow(date, timezone)) {
+        hasMoreFutureItems = true;
+        continue;
+      }
+
+      if (isAtOrBeforeTomorrow(date, timezone)) {
+        filteredSessionsTable[sessionId] = row;
+      }
+    }
+  }
+
+  if (timelineEventsTable && filteredEventsTable) {
+    for (const [eventId, row] of Object.entries(timelineEventsTable)) {
+      const ignored =
+        !showIgnored &&
+        isEventIgnored(row.tracking_id_event, row.recurrence_series_id);
+      const date = safeParseDate(row.started_at) ?? safeParseDate(row.ended_at);
+
+      if (isAfterTomorrow(date, timezone)) {
+        if (!ignored) {
+          hasMoreFutureItems = true;
+        }
+        continue;
+      }
+
+      if (!ignored && isAtOrBeforeTomorrow(date, timezone)) {
+        filteredEventsTable[eventId] = row;
+      }
+    }
+  }
+
+  return {
+    timelineEventsTable: filteredEventsTable,
+    timelineSessionsTable: filteredSessionsTable,
+    hasMoreFutureItems,
   };
 }
 


### PR DESCRIPTION
Combine sidebar timeline window filtering and future-item detection so the view avoids redundant full-table scans.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes around ignored events and the “Open calendar” / sync chrome flags depend on one combined pass; regressions could affect what appears in the sidebar or whether future calendar affordances show.
> 
> **Overview**
> Consolidates sidebar timeline **window derivation** into a single `deriveTimelineWindowData` pass so the view no longer runs separate full-table scans for “up to tomorrow” filtering, ignored-event hiding, and “more future items” detection.
> 
> **`TimelineView`** drops several `useMemo` layers (post-bucket ignored filtering, a filtered events table, and standalone `hasTimelineItemsAfterTomorrow` / calendar-event checks). **`useTimelineData`** now takes `showIgnored` and `isEventIgnored`, calls `deriveTimelineWindowData`, and returns `buckets`, `hasMoreFutureItems`, and `hasVisibleCalendarEvents` together.
> 
> The new util applies ignored-event rules **before** window and future flags: ignored events are omitted from the visible window, and only non-ignored post-tomorrow events set `hasMoreFutureItems`. Unit tests cover `deriveTimelineWindowData`; timeline view tests expose `isIgnored` as a hoisted mock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd32915f1911fd7f3e4ac4efef83f5f0611c3332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->