### PR TITLE
Restore sidebar chrome drag region

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -301,8 +301,11 @@ function SidebarTimelineChrome({
   const showDownloadButton = sidebarExpanded && update.status === "available";
 
   return (
-    <div className="flex w-full items-center justify-between">
-      <div className="flex items-center gap-0">
+    <div
+      data-tauri-drag-region
+      className="flex w-full items-center justify-between"
+    >
+      <div data-tauri-drag-region className="flex items-center gap-0">
         <LeftSurfaceChromeButton
           ariaLabel={sidebarExpanded ? "Hide sidebar" : "Show sidebar"}
           badge={!sidebarExpanded && updateVisible}

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -203,6 +203,13 @@ describe("ClassicMainBody", () => {
     expect(topArea?.className).toContain("h-12");
     expect(topArea?.className).toContain("absolute");
     expect(topArea?.className).toContain("left-0");
+    expect(chrome?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(
+      sidebarToggle.parentElement?.hasAttribute("data-tauri-drag-region"),
+    ).toBe(true);
+    expect(sidebarToggle.getAttribute("data-tauri-drag-region")).toBe("false");
+    expect(searchButton.getAttribute("data-tauri-drag-region")).toBe("false");
+    expect(newNoteButton.getAttribute("data-tauri-drag-region")).toBe("false");
     expect(sidebarToggle.compareDocumentPosition(searchButton)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );


### PR DESCRIPTION
Mark the sidebar timeline chrome wrappers as draggable while keeping the visible controls explicitly clickable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small desktop chrome attribute change with matching unit tests; no auth, data, or business-logic impact.
> 
> **Overview**
> **Restores Tauri window dragging** on the sidebar timeline chrome by marking the chrome layout wrappers with `data-tauri-drag-region`, so pointer events on padding/gaps move the frameless window again.
> 
> Chrome controls stay explicitly non-draggable via existing `data-tauri-drag-region="false"` on `LeftSurfaceChromeButton` (sidebar toggle, search, new note). Tests now assert the chrome wrappers are draggable and those buttons remain `false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2141f9507508245bb8771e2eca25676a3ad96511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->