### PR TITLE
Clarify STT model modes

### DIFF
--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -370,16 +370,44 @@ function getProviderModelMode(
   providerId: ProviderId,
   model: string,
 ): ModelEntry["mode"] {
-  if (providerId !== "soniox") {
-    return undefined;
+  if (providerId === "assemblyai") {
+    if (model === "universal-3-pro") {
+      return "batch";
+    }
+
+    if (model === "u3-rt-pro") {
+      return "realtime";
+    }
   }
 
-  if (model === "stt-v5" || model === "stt-async-v5") {
-    return "batch";
+  if (providerId === "elevenlabs") {
+    if (model === "scribe_v2") {
+      return "batch";
+    }
+
+    if (model === "scribe_v2_realtime") {
+      return "realtime";
+    }
   }
 
-  if (model === "stt-v4" || model === "stt-rt-v4") {
-    return "realtime";
+  if (providerId === "mistral") {
+    if (model === "voxtral-mini-2602" || model === "voxtral-mini-latest") {
+      return "batch";
+    }
+
+    if (model === "voxtral-mini-transcribe-realtime-2602") {
+      return "realtime";
+    }
+  }
+
+  if (providerId === "soniox") {
+    if (model === "stt-v5" || model === "stt-async-v5") {
+      return "batch";
+    }
+
+    if (model === "stt-v4" || model === "stt-rt-v4") {
+      return "realtime";
+    }
   }
 
   return undefined;

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -34,11 +34,11 @@ export const displayModelId = (model: string) => {
     return "Pro (Cloud)";
   }
 
-  if (
-    model === "universal-3-pro" ||
-    model === "u3-rt-pro" ||
-    model === "universal"
-  ) {
+  if (model === "u3-rt-pro") {
+    return "Universal-3 Pro Streaming";
+  }
+
+  if (model === "universal-3-pro" || model === "universal") {
     return "Universal-3 Pro";
   }
 
@@ -62,6 +62,10 @@ export const displayModelId = (model: string) => {
     return "Solaria 1";
   }
 
+  if (model === "scribe_v2_realtime") {
+    return "Scribe V2 Realtime";
+  }
+
   if (model === "scribe_v2") {
     return "Scribe V2";
   }
@@ -76,6 +80,10 @@ export const displayModelId = (model: string) => {
 
   if (model === "gpt-4o-mini-transcribe") {
     return "GPT-4o mini Transcribe";
+  }
+
+  if (model === "voxtral-mini-transcribe-realtime-2602") {
+    return "Voxtral Realtime";
   }
 
   if (model === "voxtral-mini-2602") {
@@ -155,7 +163,7 @@ const _PROVIDERS = [
     badge: null,
     icon: <AssemblyAI size={12} />,
     baseUrl: "https://api.assemblyai.com",
-    models: ["universal-3-pro"],
+    models: ["universal-3-pro", "u3-rt-pro"],
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
   },
   {
@@ -207,7 +215,7 @@ const _PROVIDERS = [
     badge: null,
     icon: <ElevenLabs size={16} />,
     baseUrl: "https://api.elevenlabs.io",
-    models: ["scribe_v2"],
+    models: ["scribe_v2", "scribe_v2_realtime"],
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
   },
   {
@@ -217,7 +225,7 @@ const _PROVIDERS = [
     badge: null,
     icon: <Mistral size={16} />,
     baseUrl: "https://api.mistral.ai/v1",
-    models: ["voxtral-mini-2602"],
+    models: ["voxtral-mini-2602", "voxtral-mini-transcribe-realtime-2602"],
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
   },
   {

--- a/crates/owhisper-client/src/adapter/elevenlabs/batch.rs
+++ b/crates/owhisper-client/src/adapter/elevenlabs/batch.rs
@@ -71,13 +71,7 @@ impl ElevenLabsAdapter {
             ))
         })?;
 
-        let default = crate::providers::Provider::ElevenLabs.default_batch_model();
-        let model = match params.model.as_deref() {
-            Some(m) if crate::providers::is_meta_model(m) => default,
-            Some("scribe_v2") => default,
-            Some(m) => m,
-            None => default,
-        };
+        let model = Self::resolve_batch_model(params.model.as_deref());
 
         let part = reqwest::multipart::Part::bytes(file_bytes).file_name(file_name);
         let mut form = reqwest::multipart::Form::new()
@@ -122,6 +116,16 @@ impl ElevenLabsAdapter {
 
     fn num_speakers_hint(params: &ListenParams) -> Option<u32> {
         params.num_speakers.or(params.max_speakers)
+    }
+
+    fn resolve_batch_model(model: Option<&str>) -> &str {
+        let default = crate::providers::Provider::ElevenLabs.default_batch_model();
+        match model {
+            Some(m) if crate::providers::is_meta_model(m) => default,
+            Some("scribe_v2" | "scribe_v2_realtime") => default,
+            Some(m) => m,
+            None => default,
+        }
     }
 
     fn convert_to_batch_response(response: TranscriptResponse) -> BatchResponse {
@@ -189,6 +193,14 @@ mod tests {
         assert_eq!(
             ElevenLabsAdapter::num_speakers_hint(&ListenParams::default()),
             None
+        );
+    }
+
+    #[test]
+    fn batch_realtime_model_alias_uses_batch_model() {
+        assert_eq!(
+            ElevenLabsAdapter::resolve_batch_model(Some("scribe_v2_realtime")),
+            "scribe_v2"
         );
     }
 

--- a/crates/owhisper-client/src/adapter/elevenlabs/live.rs
+++ b/crates/owhisper-client/src/adapter/elevenlabs/live.rs
@@ -34,13 +34,7 @@ impl RealtimeSttAdapter for ElevenLabsAdapter {
                 query_pairs.append_pair(key, value);
             }
 
-            let default = crate::providers::Provider::ElevenLabs.default_live_model();
-            let model = match params.model.as_deref() {
-                Some(m) if crate::providers::is_meta_model(m) => default,
-                Some("scribe_v2") => default,
-                Some(m) => m,
-                None => default,
-            };
+            let model = Self::resolve_live_model(params.model.as_deref());
             query_pairs.append_pair("model_id", model);
 
             let audio_format = format!("pcm_{}", params.sample_rate);
@@ -201,6 +195,16 @@ enum ElevenLabsMessage {
 }
 
 impl ElevenLabsAdapter {
+    fn resolve_live_model(model: Option<&str>) -> &str {
+        let default = crate::providers::Provider::ElevenLabs.default_live_model();
+        match model {
+            Some(m) if crate::providers::is_meta_model(m) => default,
+            Some("scribe_v2") => default,
+            Some(m) => m,
+            None => default,
+        }
+    }
+
     fn build_response(
         text: &str,
         words: Vec<ElevenLabsWord>,

--- a/crates/owhisper-client/src/adapter/mistral/batch.rs
+++ b/crates/owhisper-client/src/adapter/mistral/batch.rs
@@ -95,12 +95,7 @@ async fn do_transcribe_file(
         .mime_str(mime_type)
         .map_err(|e| Error::AudioProcessing(e.to_string()))?;
 
-    let default = Provider::Mistral.default_batch_model();
-    let model = match params.model.as_deref() {
-        Some(m) if is_meta_model(m) => default,
-        Some(m) => m,
-        None => default,
-    };
+    let model = resolve_batch_model(params.model.as_deref());
 
     let mut form = Form::new()
         .part("file", file_part)
@@ -147,6 +142,16 @@ use crate::adapter::http::mime_type_from_extension;
 fn strip_punctuation(s: &str) -> String {
     s.trim_matches(|c: char| c.is_ascii_punctuation())
         .to_string()
+}
+
+fn resolve_batch_model(model: Option<&str>) -> &str {
+    let default = Provider::Mistral.default_batch_model();
+    match model {
+        Some(m) if is_meta_model(m) => default,
+        Some("voxtral-mini-transcribe-realtime-2602") => default,
+        Some(m) => m,
+        None => default,
+    }
 }
 
 fn convert_response(response: MistralBatchResponse) -> BatchResponse {
@@ -246,6 +251,14 @@ mod tests {
     use super::*;
     use crate::adapter::BatchSttAdapter;
     use crate::http_client::create_client;
+
+    #[test]
+    fn batch_realtime_model_alias_uses_batch_model() {
+        assert_eq!(
+            resolve_batch_model(Some("voxtral-mini-transcribe-realtime-2602")),
+            "voxtral-mini-2602"
+        );
+    }
 
     #[test]
     fn convert_response_marks_segment_interpolated_words() {

--- a/crates/transcribe-proxy/src/relay/builder.rs
+++ b/crates/transcribe-proxy/src/relay/builder.rs
@@ -7,8 +7,8 @@ pub use tokio_tungstenite::tungstenite::ClientRequestBuilder;
 
 use super::handler::WebSocketProxy;
 use super::types::{
-    ClientMessageFilter, FirstMessageTransformer, InitialMessage, OnCloseCallback,
-    ResponseTransformer,
+    ClientBinaryMessageMapper, ClientMessageFilter, FirstMessageTransformer, InitialMessage,
+    OnCloseCallback, ResponseTransformer,
 };
 use crate::config::DEFAULT_CONNECT_TIMEOUT_MS;
 use crate::provider_selector::SelectedProvider;
@@ -38,6 +38,7 @@ pub struct WebSocketProxyBuilder<S = NoUpstream> {
     connect_timeout: Duration,
     on_close: Option<OnCloseCallback>,
     client_message_filter: Option<ClientMessageFilter>,
+    client_binary_message_mapper: Option<ClientBinaryMessageMapper>,
 }
 
 impl Default for WebSocketProxyBuilder<NoUpstream> {
@@ -51,6 +52,7 @@ impl Default for WebSocketProxyBuilder<NoUpstream> {
             connect_timeout: Duration::from_millis(DEFAULT_CONNECT_TIMEOUT_MS),
             on_close: None,
             client_message_filter: None,
+            client_binary_message_mapper: None,
         }
     }
 }
@@ -66,6 +68,7 @@ impl<S> WebSocketProxyBuilder<S> {
             connect_timeout: self.connect_timeout,
             on_close: self.on_close,
             client_message_filter: self.client_message_filter,
+            client_binary_message_mapper: self.client_binary_message_mapper,
         }
     }
 
@@ -79,6 +82,7 @@ impl<S> WebSocketProxyBuilder<S> {
         connect_timeout: Duration,
         on_close: Option<OnCloseCallback>,
         client_message_filter: Option<ClientMessageFilter>,
+        client_binary_message_mapper: Option<ClientBinaryMessageMapper>,
     ) -> WebSocketProxy {
         let control_message_types = if control_message_types.is_empty() {
             None
@@ -95,6 +99,7 @@ impl<S> WebSocketProxyBuilder<S> {
             connect_timeout,
             on_close,
             client_message_filter,
+            client_binary_message_mapper,
         )
     }
 
@@ -143,6 +148,11 @@ impl<S> WebSocketProxyBuilder<S> {
 
     pub fn client_message_filter(mut self, filter: ClientMessageFilter) -> Self {
         self.client_message_filter = Some(filter);
+        self
+    }
+
+    pub fn client_binary_message_mapper(mut self, mapper: ClientBinaryMessageMapper) -> Self {
+        self.client_binary_message_mapper = Some(mapper);
         self
     }
 }
@@ -209,6 +219,7 @@ impl WebSocketProxyBuilder<WithUrl> {
             self.connect_timeout,
             self.on_close,
             self.client_message_filter,
+            self.client_binary_message_mapper,
         ))
     }
 }

--- a/crates/transcribe-proxy/src/relay/channel_split/io.rs
+++ b/crates/transcribe-proxy/src/relay/channel_split/io.rs
@@ -3,8 +3,8 @@ use futures_util::{SinkExt, StreamExt};
 use tokio_tungstenite::tungstenite::Message as TungsteniteMessage;
 
 use super::super::types::{
-    ClientMessageFilter, ClientReceiver, ClientSender, DEFAULT_CLOSE_CODE, ShutdownSignal,
-    UpstreamReceiver, UpstreamSender, convert,
+    ClientBinaryMessage, ClientBinaryMessageMapper, ClientMessageFilter, ClientReceiver,
+    ClientSender, DEFAULT_CLOSE_CODE, ShutdownSignal, UpstreamReceiver, UpstreamSender, convert,
 };
 use super::coordinator::SplitEvent;
 use super::payload::RewrittenSplitResponse;
@@ -74,6 +74,7 @@ pub(super) async fn relay_client_to_upstreams(
     mut mic_tx: UpstreamSender,
     mut spk_tx: UpstreamSender,
     client_message_filter: Option<ClientMessageFilter>,
+    client_binary_message_mapper: Option<ClientBinaryMessageMapper>,
     shutdown_tx: tokio::sync::broadcast::Sender<ShutdownSignal>,
     event_tx: tokio::sync::mpsc::Sender<SplitEvent>,
 ) {
@@ -122,14 +123,30 @@ pub(super) async fn relay_client_to_upstreams(
                         }
 
                         let (mic, spk) = deinterleave(&bytes);
+                        let to_upstream = |data: Vec<u8>| {
+                            let mapped = match client_binary_message_mapper.as_ref() {
+                                Some(mapper) => mapper(data)?,
+                                None => ClientBinaryMessage::Binary(data),
+                            };
+
+                            Some(match mapped {
+                                ClientBinaryMessage::Text(text) => TungsteniteMessage::Text(text.into()),
+                                ClientBinaryMessage::Binary(data) => TungsteniteMessage::Binary(data.into()),
+                            })
+                        };
+
+                        let Some(mic_message) = to_upstream(mic) else {
+                            continue;
+                        };
+                        let Some(spk_message) = to_upstream(spk) else {
+                            continue;
+                        };
+
                         if mic_tx
-                            .send(TungsteniteMessage::Binary(mic.into()))
+                            .send(mic_message)
                             .await
                             .is_err()
-                            || spk_tx
-                                .send(TungsteniteMessage::Binary(spk.into()))
-                                .await
-                                .is_err()
+                            || spk_tx.send(spk_message).await.is_err()
                         {
                             let _ = event_tx
                                 .send(SplitEvent::Fatal(upstream_send_failed_signal()))

--- a/crates/transcribe-proxy/src/relay/channel_split/mod.rs
+++ b/crates/transcribe-proxy/src/relay/channel_split/mod.rs
@@ -21,8 +21,8 @@ use self::coordinator::{CoordinatorAction, SplitCoordinator, SplitEvent};
 use self::io::{relay_client_to_upstreams, relay_upstream_to_events, send_rewritten, send_text};
 use self::payload::{FinalizeMode, rewrite_split_response};
 use super::types::{
-    ClientMessageFilter, DEFAULT_CLOSE_CODE, InitialMessage, OnCloseCallback, ResponseTransformer,
-    ShutdownSignal, convert,
+    ClientBinaryMessageMapper, ClientMessageFilter, DEFAULT_CLOSE_CODE, InitialMessage,
+    OnCloseCallback, ResponseTransformer, ShutdownSignal, convert,
 };
 
 fn proxy_debug_enabled() -> bool {
@@ -40,6 +40,7 @@ pub struct ChannelSplitProxy {
     connect_timeout: Duration,
     on_close: Option<OnCloseCallback>,
     client_message_filter: Option<ClientMessageFilter>,
+    client_binary_message_mapper: Option<ClientBinaryMessageMapper>,
 }
 
 impl ChannelSplitProxy {
@@ -76,11 +77,17 @@ impl ChannelSplitProxy {
             connect_timeout,
             on_close,
             client_message_filter: None,
+            client_binary_message_mapper: None,
         }
     }
 
     pub fn with_client_message_filter(mut self, filter: ClientMessageFilter) -> Self {
         self.client_message_filter = Some(filter);
+        self
+    }
+
+    pub fn with_client_binary_message_mapper(mut self, mapper: ClientBinaryMessageMapper) -> Self {
+        self.client_binary_message_mapper = Some(mapper);
         self
     }
 
@@ -173,6 +180,7 @@ impl ChannelSplitProxy {
             mic_tx,
             spk_tx,
             self.client_message_filter.clone(),
+            self.client_binary_message_mapper.clone(),
             shutdown_tx.clone(),
             event_tx.clone(),
         );

--- a/crates/transcribe-proxy/src/relay/handler.rs
+++ b/crates/transcribe-proxy/src/relay/handler.rs
@@ -17,9 +17,10 @@ use owhisper_client::Provider;
 use super::builder::WebSocketProxyBuilder;
 use super::pending::{FlushError, PendingState, QueuedPayload};
 use super::types::{
-    ClientMessageFilter, ClientReceiver, ClientSender, ControlMessageTypes, DEFAULT_CLOSE_CODE,
-    FirstMessageTransformer, InitialMessage, OnCloseCallback, ResponseTransformer, ShutdownSignal,
-    UpstreamReceiver, UpstreamSender, convert, is_control_message,
+    ClientBinaryMessage, ClientBinaryMessageMapper, ClientMessageFilter, ClientReceiver,
+    ClientSender, ControlMessageTypes, DEFAULT_CLOSE_CODE, FirstMessageTransformer, InitialMessage,
+    OnCloseCallback, ResponseTransformer, ShutdownSignal, UpstreamReceiver, UpstreamSender,
+    convert, is_control_message,
 };
 
 #[derive(Clone)]
@@ -32,6 +33,7 @@ pub struct WebSocketProxy {
     connect_timeout: Duration,
     on_close: Option<OnCloseCallback>,
     client_message_filter: Option<ClientMessageFilter>,
+    client_binary_message_mapper: Option<ClientBinaryMessageMapper>,
 }
 
 impl WebSocketProxy {
@@ -45,6 +47,7 @@ impl WebSocketProxy {
         connect_timeout: Duration,
         on_close: Option<OnCloseCallback>,
         client_message_filter: Option<ClientMessageFilter>,
+        client_binary_message_mapper: Option<ClientBinaryMessageMapper>,
     ) -> Self {
         Self {
             upstream_request,
@@ -55,7 +58,16 @@ impl WebSocketProxy {
             connect_timeout,
             on_close,
             client_message_filter,
+            client_binary_message_mapper,
         }
+    }
+
+    pub(crate) fn with_client_binary_message_mapper(
+        mut self,
+        mapper: ClientBinaryMessageMapper,
+    ) -> Self {
+        self.client_binary_message_mapper = Some(mapper);
+        self
     }
 
     pub fn builder() -> WebSocketProxyBuilder {
@@ -117,6 +129,7 @@ impl WebSocketProxy {
             self.response_transformer.clone(),
             self.on_close.clone(),
             self.client_message_filter.clone(),
+            self.client_binary_message_mapper.clone(),
         )
         .await;
 
@@ -151,6 +164,7 @@ impl WebSocketProxy {
         response_transformer: Option<ResponseTransformer>,
         on_close: Option<OnCloseCallback>,
         client_message_filter: Option<ClientMessageFilter>,
+        client_binary_message_mapper: Option<ClientBinaryMessageMapper>,
     ) {
         let start_time = Instant::now();
 
@@ -169,6 +183,7 @@ impl WebSocketProxy {
             transform_first_message,
             initial_message,
             client_message_filter,
+            client_binary_message_mapper,
         );
 
         let upstream_to_client = Self::run_upstream_to_client(
@@ -258,6 +273,7 @@ impl WebSocketProxy {
         mut first_msg_transformer: Option<FirstMessageTransformer>,
         initial_message: Option<InitialMessage>,
         client_message_filter: Option<ClientMessageFilter>,
+        client_binary_message_mapper: Option<ClientBinaryMessageMapper>,
     ) {
         let mut pending = PendingState::default();
 
@@ -340,9 +356,20 @@ impl WebSocketProxy {
                             if first_msg_transformer.is_some() {
                                 tracing::debug!("binary_message_received_before_text_transform");
                             }
-                            let data = bytes.to_vec();
+                            let mapped = match client_binary_message_mapper.as_ref() {
+                                Some(mapper) => match mapper(bytes.to_vec()) {
+                                    Some(message) => message,
+                                    None => continue,
+                                },
+                                None => ClientBinaryMessage::Binary(bytes.to_vec()),
+                            };
 
-                            if Self::process_data_message(&mut pending, data, false, &control_types, &shutdown_tx, &mut upstream_sender).await {
+                            let (data, is_text) = match mapped {
+                                ClientBinaryMessage::Text(text) => (text.into_bytes(), true),
+                                ClientBinaryMessage::Binary(data) => (data, false),
+                            };
+
+                            if Self::process_data_message(&mut pending, data, is_text, &control_types, &shutdown_tx, &mut upstream_sender).await {
                                 break;
                             }
                         }

--- a/crates/transcribe-proxy/src/relay/mod.rs
+++ b/crates/transcribe-proxy/src/relay/mod.rs
@@ -16,8 +16,8 @@ use owhisper_client::Auth;
 pub use builder::ClientRequestBuilder;
 pub use handler::WebSocketProxy;
 pub use types::{
-    ClientMessageFilter, FirstMessageTransformer, InitialMessage, OnCloseCallback,
-    ResponseTransformer,
+    ClientBinaryMessage, ClientBinaryMessageMapper, ClientMessageFilter, FirstMessageTransformer,
+    InitialMessage, OnCloseCallback, ResponseTransformer,
 };
 pub use upstream_error::{UpstreamError, detect_upstream_error};
 
@@ -73,6 +73,7 @@ pub struct StreamingProxyPlan {
     connect_timeout: Duration,
     on_close: Option<OnCloseCallback>,
     client_message_filter: Option<ClientMessageFilter>,
+    client_binary_message_mapper: Option<ClientBinaryMessageMapper>,
 }
 
 pub enum StreamingProxy {
@@ -92,6 +93,7 @@ impl StreamingProxyPlan {
             connect_timeout: Duration::default(),
             on_close: None,
             client_message_filter: None,
+            client_binary_message_mapper: None,
         }
     }
 
@@ -133,6 +135,11 @@ impl StreamingProxyPlan {
 
     pub fn client_message_filter(mut self, filter: ClientMessageFilter) -> Self {
         self.client_message_filter = Some(filter);
+        self
+    }
+
+    pub fn client_binary_message_mapper(mut self, mapper: ClientBinaryMessageMapper) -> Self {
+        self.client_binary_message_mapper = Some(mapper);
         self
     }
 
@@ -200,6 +207,7 @@ impl StreamingProxyPlan {
                 self.connect_timeout,
                 self.on_close,
                 self.client_message_filter,
+                self.client_binary_message_mapper,
             )),
             StreamingTransport::SplitStereo => StreamingProxy::split(
                 apply_headers(request, self.headers),
@@ -208,6 +216,7 @@ impl StreamingProxyPlan {
                 self.connect_timeout,
                 self.on_close,
                 self.client_message_filter,
+                self.client_binary_message_mapper,
             ),
         }
     }
@@ -227,6 +236,7 @@ impl StreamingProxyPlan {
                 self.connect_timeout,
                 self.on_close,
                 self.client_message_filter,
+                self.client_binary_message_mapper,
             ),
         }
     }
@@ -244,6 +254,7 @@ impl StreamingProxy {
         connect_timeout: Duration,
         on_close: Option<OnCloseCallback>,
         client_message_filter: Option<ClientMessageFilter>,
+        client_binary_message_mapper: Option<ClientBinaryMessageMapper>,
     ) -> Self {
         let proxy = ChannelSplitProxy::new(
             upstream_request,
@@ -257,6 +268,7 @@ impl StreamingProxy {
             Some(filter) => Self::ChannelSplit(proxy.with_client_message_filter(filter)),
             None => Self::ChannelSplit(proxy),
         }
+        .with_client_binary_message_mapper(client_binary_message_mapper)
     }
 
     pub fn split_with_requests(
@@ -267,6 +279,7 @@ impl StreamingProxy {
         connect_timeout: Duration,
         on_close: Option<OnCloseCallback>,
         client_message_filter: Option<ClientMessageFilter>,
+        client_binary_message_mapper: Option<ClientBinaryMessageMapper>,
     ) -> Self {
         let proxy = ChannelSplitProxy::with_split_requests(
             mic_request,
@@ -280,6 +293,19 @@ impl StreamingProxy {
         match client_message_filter {
             Some(filter) => Self::ChannelSplit(proxy.with_client_message_filter(filter)),
             None => Self::ChannelSplit(proxy),
+        }
+        .with_client_binary_message_mapper(client_binary_message_mapper)
+    }
+
+    fn with_client_binary_message_mapper(self, mapper: Option<ClientBinaryMessageMapper>) -> Self {
+        match (self, mapper) {
+            (Self::Single(proxy), Some(mapper)) => {
+                Self::Single(proxy.with_client_binary_message_mapper(mapper))
+            }
+            (Self::ChannelSplit(proxy), Some(mapper)) => {
+                Self::ChannelSplit(proxy.with_client_binary_message_mapper(mapper))
+            }
+            (proxy, None) => proxy,
         }
     }
 

--- a/crates/transcribe-proxy/src/relay/types.rs
+++ b/crates/transcribe-proxy/src/relay/types.rs
@@ -18,6 +18,14 @@ pub type InitialMessage = Arc<String>;
 pub type ResponseTransformer = Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
 
 pub type ClientMessageFilter = Arc<dyn Fn(String) -> Option<String> + Send + Sync>;
+pub type ClientBinaryMessageMapper =
+    Arc<dyn Fn(Vec<u8>) -> Option<ClientBinaryMessage> + Send + Sync>;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ClientBinaryMessage {
+    Text(String),
+    Binary(Vec<u8>),
+}
 
 #[derive(Clone, Debug)]
 pub enum ShutdownSignal {

--- a/crates/transcribe-proxy/src/routes/streaming/hyprnote.rs
+++ b/crates/transcribe-proxy/src/routes/streaming/hyprnote.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use std::sync::Arc;
 
 use owhisper_client::{
@@ -10,7 +11,10 @@ use owhisper_interface::ListenParams;
 use crate::config::SttProxyConfig;
 use crate::provider_selector::SelectedProvider;
 use crate::query_params::{QueryParams, QueryValue};
-use crate::relay::{ClientMessageFilter, StreamingProxy, StreamingProxyPlan, StreamingTransport};
+use crate::relay::{
+    ClientBinaryMessage, ClientBinaryMessageMapper, ClientMessageFilter, StreamingProxy,
+    StreamingProxyPlan, StreamingTransport,
+};
 use crate::routes::AppState;
 use crate::routes::model_resolution::resolve_model_live;
 
@@ -140,6 +144,21 @@ fn build_client_message_filter(provider: Provider) -> ClientMessageFilter {
     })
 }
 
+fn build_client_binary_message_mapper(provider: Provider) -> Option<ClientBinaryMessageMapper> {
+    if provider != Provider::ElevenLabs {
+        return None;
+    }
+
+    Some(Arc::new(|audio: Vec<u8>| {
+        let chunk = serde_json::json!({
+            "message_type": "input_audio_chunk",
+            "audio_base_64": base64::engine::general_purpose::STANDARD.encode(audio),
+        });
+
+        Some(ClientBinaryMessage::Text(chunk.to_string()))
+    }))
+}
+
 fn build_proxy_plan(
     provider: Provider,
     selected: &SelectedProvider,
@@ -156,6 +175,10 @@ fn build_proxy_plan(
     .response_transformer(build_response_transformer(provider))
     .client_message_filter(build_client_message_filter(provider))
     .apply_auth(selected);
+
+    if let Some(mapper) = build_client_binary_message_mapper(provider) {
+        plan = plan.client_binary_message_mapper(mapper);
+    }
 
     if let Some(on_close) = build_on_close_callback(config, provider, &analytics_ctx) {
         plan = plan.on_close(on_close);
@@ -531,6 +554,20 @@ mod tests {
     fn test_client_message_filter_non_json_passthrough() {
         let filter = build_client_message_filter(Provider::Soniox);
         assert_eq!(filter("not json".to_string()), Some("not json".to_string()));
+    }
+
+    #[test]
+    fn test_client_binary_message_mapper_elevenlabs_wraps_audio_chunks() {
+        assert!(build_client_binary_message_mapper(Provider::Deepgram).is_none());
+
+        let mapper = build_client_binary_message_mapper(Provider::ElevenLabs).unwrap();
+        let Some(ClientBinaryMessage::Text(text)) = mapper(vec![1, 2, 3]) else {
+            panic!("expected ElevenLabs binary audio to map to text JSON");
+        };
+
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed["message_type"], "input_audio_chunk");
+        assert_eq!(parsed["audio_base_64"], "AQID");
     }
 
     #[test]


### PR DESCRIPTION
Show batch and realtime badges for Soniox, AssemblyAI, ElevenLabs, and Mistral model variants, and keep realtime aliases safe for batch transcription.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the live WebSocket relay and provider model resolution; ElevenLabs streaming behavior changes for proxied binary audio, though batch misuse of realtime IDs is explicitly guarded.
> 
> **Overview**
> **STT settings** now expose more realtime variants and label models with **Batch** vs **Realtime** badges for AssemblyAI, ElevenLabs, Mistral, and Soniox (not only Soniox). Provider pickers add `u3-rt-pro`, `scribe_v2_realtime`, and `voxtral-mini-transcribe-realtime-2602`, with clearer display names (e.g. Universal-3 Pro Streaming).
> 
> **Batch transcription** maps realtime model IDs to each provider’s batch default (`scribe_v2_realtime` → `scribe_v2`, Mistral realtime → `voxtral-mini-2602`) so choosing a streaming model does not break file/batch paths.
> 
> **Live proxy** adds an optional **client binary message mapper** on the WebSocket relay (single and stereo split). For **ElevenLabs**, inbound binary audio is rewritten to JSON `input_audio_chunk` with base64 before upstream send, matching ElevenLabs’ text-based streaming API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a9764ee718d92eb44fa7d0983df725c44aa84bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->