### PR TITLE
Cache transcript persistence state

### DIFF
--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -16,10 +16,8 @@ import type { BatchPersistCallback } from "~/store/zustand/listener/transcript";
 import { getTranscriptionLanguages } from "~/stt/capabilities";
 import type { SpeakerHintWithId, WordWithId } from "~/stt/types";
 import {
-  parseTranscriptHints,
-  parseTranscriptWords,
-  updateTranscriptHints,
-  updateTranscriptWords,
+  createTranscriptAccumulator,
+  type TranscriptAccumulator,
 } from "~/stt/utils";
 
 type RunOptions = {
@@ -169,6 +167,9 @@ export const useRunBatch = (sessionId: string) => {
       const handlePersist: BatchPersistCallback | undefined =
         options?.handlePersist;
       let wroteDefaultTranscript = false;
+      const transcriptAccumulatorRef: {
+        current: TranscriptAccumulator | null;
+      } = { current: null };
 
       const persist =
         handlePersist ??
@@ -204,6 +205,12 @@ export const useRunBatch = (sessionId: string) => {
 
               store.setRow("transcripts", currentTranscriptId, transcriptRow);
             });
+
+            transcriptAccumulatorRef.current = createTranscriptAccumulator(
+              store,
+              currentTranscriptId,
+              { words: [], hints: [] },
+            );
           }
 
           const currentTranscriptId = transcriptId;
@@ -211,13 +218,10 @@ export const useRunBatch = (sessionId: string) => {
             return;
           }
 
-          const shouldReplace = persistOptions?.mode === "replace";
-          const existingWords = shouldReplace
-            ? []
-            : parseTranscriptWords(store, currentTranscriptId);
-          const existingHints = shouldReplace
-            ? []
-            : parseTranscriptHints(store, currentTranscriptId);
+          transcriptAccumulatorRef.current ??= createTranscriptAccumulator(
+            store,
+            currentTranscriptId,
+          );
 
           const newWords: WordWithId[] = [];
           const newWordIds: string[] = [];
@@ -266,14 +270,11 @@ export const useRunBatch = (sessionId: string) => {
           });
 
           store.transaction(() => {
-            updateTranscriptWords(store, currentTranscriptId, [
-              ...existingWords,
-              ...newWords,
-            ]);
-            updateTranscriptHints(store, currentTranscriptId, [
-              ...existingHints,
-              ...newHints,
-            ]);
+            transcriptAccumulatorRef.current?.appendWordsAndHints(
+              newWords,
+              newHints,
+              persistOptions,
+            );
           });
 
           wroteDefaultTranscript = true;
@@ -301,6 +302,9 @@ export const useRunBatch = (sessionId: string) => {
         if (!handlePersist && wroteDefaultTranscript) {
           await saveCompletedBatchTranscript();
         }
+
+        transcriptAccumulatorRef.current?.dispose();
+        transcriptAccumulatorRef.current = null;
       }
 
       if (settingsStore) {

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -28,7 +28,10 @@ import {
   getLiveTranscriptionConfig,
   getTranscriptionLanguages,
 } from "~/stt/capabilities";
-import { applyLiveTranscriptDelta } from "~/stt/utils";
+import {
+  createTranscriptAccumulator,
+  type TranscriptAccumulator,
+} from "~/stt/utils";
 
 export function getPostCaptureAction(
   details: {
@@ -78,8 +81,14 @@ export function useStartListening(sessionId: string) {
     const startedAt = Date.now();
     const memoMd = store.getCell("sessions", sessionId, "raw_md");
     const createdAt = new Date().toISOString();
+    const transcriptAccumulatorRef: {
+      current: TranscriptAccumulator | null;
+    } = { current: null };
 
     const onStopped: OnStoppedCallback = async (_sessionId, details) => {
+      transcriptAccumulatorRef.current?.dispose();
+      transcriptAccumulatorRef.current = null;
+
       const postCaptureAction = getPostCaptureAction(
         details,
         canRunBatchRef.current,
@@ -133,10 +142,20 @@ export function useStartListening(sessionId: string) {
         } satisfies TranscriptStorage;
 
         store.setRow("transcripts", transcriptId, transcriptRow);
+        transcriptAccumulatorRef.current = createTranscriptAccumulator(
+          store,
+          transcriptId,
+          { words: [], hints: [] },
+        );
       }
 
+      transcriptAccumulatorRef.current ??= createTranscriptAccumulator(
+        store,
+        transcriptId,
+      );
+
       store.transaction(() => {
-        applyLiveTranscriptDelta(store, transcriptId!, delta);
+        transcriptAccumulatorRef.current?.applyLiveDelta(delta);
       });
     };
 
@@ -188,6 +207,9 @@ export function useStartListening(sessionId: string) {
     );
 
     if (!started) {
+      transcriptAccumulatorRef.current?.dispose();
+      transcriptAccumulatorRef.current = null;
+
       if (transcriptId) {
         store.delRow("transcripts", transcriptId);
       }

--- a/apps/desktop/src/stt/utils.test.ts
+++ b/apps/desktop/src/stt/utils.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { upsertSpeakerAssignment } from "./utils";
+import type { LiveTranscriptDelta } from "@hypr/plugin-transcription";
+
+import {
+  createTranscriptAccumulator,
+  updateTranscriptHints,
+  upsertSpeakerAssignment,
+} from "./utils";
 
 import type { SegmentKey } from "~/stt/live-segment";
 
@@ -14,8 +20,11 @@ function createStore(row: TranscriptRow) {
     words: row.words ?? JSON.stringify([]),
     speaker_hints: row.speaker_hints ?? JSON.stringify([]),
   };
+  const getCellCalls: string[] = [];
 
   return {
+    getCellCalls,
+    readCell: (cellId: "words" | "speaker_hints") => transcript[cellId],
     getCell: (
       tableId: "transcripts",
       rowId: string,
@@ -25,6 +34,7 @@ function createStore(row: TranscriptRow) {
         return undefined;
       }
 
+      getCellCalls.push(cellId);
       return transcript[cellId];
     },
     setCell: (
@@ -41,6 +51,285 @@ function createStore(row: TranscriptRow) {
     },
   };
 }
+
+function liveDelta(
+  newWords: LiveTranscriptDelta["new_words"],
+  replacedIds: string[] = [],
+): LiveTranscriptDelta {
+  return {
+    new_words: newWords,
+    replaced_ids: replacedIds,
+    partials: [],
+  };
+}
+
+describe("TranscriptAccumulator", () => {
+  it("applies live deltas without rereading newly-created transcript JSON", () => {
+    const store = createStore({});
+    const accumulator = createTranscriptAccumulator(store, "transcript-1", {
+      words: [],
+      hints: [],
+    });
+
+    accumulator.applyLiveDelta(
+      liveDelta([
+        {
+          id: "word-1",
+          text: "hello",
+          start_ms: 100,
+          end_ms: 200,
+          channel: 0,
+          state: "final",
+          speaker_index: 1,
+        },
+      ]),
+    );
+    accumulator.applyLiveDelta(
+      liveDelta(
+        [
+          {
+            id: "word-2",
+            text: "hello",
+            start_ms: 100,
+            end_ms: 220,
+            channel: 0,
+            state: "final",
+          },
+        ],
+        ["word-1"],
+      ),
+    );
+    accumulator.dispose();
+
+    expect(store.getCellCalls).toEqual([]);
+    expect(JSON.parse(store.readCell("words"))).toEqual([
+      {
+        id: "word-2",
+        text: "hello",
+        start_ms: 100,
+        end_ms: 220,
+        channel: 0,
+      },
+    ]);
+    expect(JSON.parse(store.readCell("speaker_hints"))).toEqual([]);
+  });
+
+  it("appends batch chunks without reparsing stored words and hints", () => {
+    const store = createStore({
+      words: JSON.stringify([
+        {
+          id: "existing-word",
+          text: "existing",
+          start_ms: 0,
+          end_ms: 100,
+          channel: 0,
+        },
+      ]),
+      speaker_hints: JSON.stringify([]),
+    });
+    const accumulator = createTranscriptAccumulator(store, "transcript-1");
+
+    accumulator.appendWordsAndHints(
+      [
+        {
+          id: "word-1",
+          text: "hello",
+          start_ms: 100,
+          end_ms: 200,
+          channel: 0,
+        },
+      ],
+      [],
+    );
+    accumulator.appendWordsAndHints(
+      [
+        {
+          id: "word-2",
+          text: "world",
+          start_ms: 200,
+          end_ms: 300,
+          channel: 0,
+        },
+      ],
+      [],
+    );
+    accumulator.dispose();
+
+    expect(store.getCellCalls).toEqual(["words", "speaker_hints"]);
+    expect(JSON.parse(store.readCell("words"))).toEqual([
+      {
+        id: "existing-word",
+        text: "existing",
+        start_ms: 0,
+        end_ms: 100,
+        channel: 0,
+      },
+      {
+        id: "word-1",
+        text: "hello",
+        start_ms: 100,
+        end_ms: 200,
+        channel: 0,
+      },
+      {
+        id: "word-2",
+        text: "world",
+        start_ms: 200,
+        end_ms: 300,
+        channel: 0,
+      },
+    ]);
+  });
+
+  it("preserves live speaker assignments made while an accumulator is active", () => {
+    const store = createStore({});
+    const accumulator = createTranscriptAccumulator(store, "transcript-1", {
+      words: [],
+      hints: [],
+    });
+
+    accumulator.applyLiveDelta(
+      liveDelta([
+        {
+          id: "word-1",
+          text: "hello",
+          start_ms: 0,
+          end_ms: 100,
+          channel: 1,
+          state: "final",
+          speaker_index: 2,
+        },
+      ]),
+    );
+    upsertSpeakerAssignment(
+      store,
+      "transcript-1",
+      remoteSpeakerKey(2),
+      "human-1",
+      "word-1",
+    );
+    accumulator.applyLiveDelta(
+      liveDelta([
+        {
+          id: "word-2",
+          text: "there",
+          start_ms: 100,
+          end_ms: 200,
+          channel: 1,
+          state: "final",
+          speaker_index: 2,
+        },
+      ]),
+    );
+    accumulator.dispose();
+
+    expect(JSON.parse(store.readCell("speaker_hints"))).toEqual([
+      {
+        id: "word-1:provider_speaker_index",
+        word_id: "word-1",
+        type: "provider_speaker_index",
+        value: JSON.stringify({ channel: 1, speaker_index: 2 }),
+      },
+      {
+        id: "word-1:user_speaker_assignment",
+        word_id: "word-1",
+        type: "user_speaker_assignment",
+        value: JSON.stringify({ human_id: "human-1" }),
+      },
+      {
+        id: "word-2:provider_speaker_index",
+        word_id: "word-2",
+        type: "provider_speaker_index",
+        value: JSON.stringify({ channel: 1, speaker_index: 2 }),
+      },
+    ]);
+  });
+
+  it("does not restore externally removed speaker assignments from the accumulator cache", () => {
+    const store = createStore({});
+    const accumulator = createTranscriptAccumulator(store, "transcript-1", {
+      words: [],
+      hints: [],
+    });
+
+    accumulator.applyLiveDelta(
+      liveDelta([
+        {
+          id: "word-1",
+          text: "hello",
+          start_ms: 0,
+          end_ms: 100,
+          channel: 1,
+          state: "final",
+          speaker_index: 2,
+        },
+      ]),
+    );
+    upsertSpeakerAssignment(
+      store,
+      "transcript-1",
+      remoteSpeakerKey(2),
+      "human-1",
+      "word-1",
+    );
+    accumulator.applyLiveDelta(
+      liveDelta([
+        {
+          id: "word-2",
+          text: "there",
+          start_ms: 100,
+          end_ms: 200,
+          channel: 1,
+          state: "final",
+          speaker_index: 2,
+        },
+      ]),
+    );
+
+    const hintsWithoutAssignment = JSON.parse(
+      store.readCell("speaker_hints"),
+    ).filter(
+      (hint: { type?: string }) => hint.type !== "user_speaker_assignment",
+    );
+    updateTranscriptHints(store, "transcript-1", hintsWithoutAssignment);
+
+    accumulator.applyLiveDelta(
+      liveDelta([
+        {
+          id: "word-3",
+          text: "again",
+          start_ms: 200,
+          end_ms: 300,
+          channel: 1,
+          state: "final",
+          speaker_index: 2,
+        },
+      ]),
+    );
+    accumulator.dispose();
+
+    expect(JSON.parse(store.readCell("speaker_hints"))).toEqual([
+      {
+        id: "word-1:provider_speaker_index",
+        word_id: "word-1",
+        type: "provider_speaker_index",
+        value: JSON.stringify({ channel: 1, speaker_index: 2 }),
+      },
+      {
+        id: "word-2:provider_speaker_index",
+        word_id: "word-2",
+        type: "provider_speaker_index",
+        value: JSON.stringify({ channel: 1, speaker_index: 2 }),
+      },
+      {
+        id: "word-3:provider_speaker_index",
+        word_id: "word-3",
+        type: "provider_speaker_index",
+        value: JSON.stringify({ channel: 1, speaker_index: 2 }),
+      },
+    ]);
+  });
+});
 
 function remoteSpeakerKey(speakerIndex: number | null): SegmentKey {
   return {

--- a/apps/desktop/src/stt/utils.ts
+++ b/apps/desktop/src/stt/utils.ts
@@ -18,6 +18,14 @@ interface TranscriptStore {
   ): void;
 }
 
+const dirtyAccumulatorTranscriptIds = new Set<string>();
+const activeAccumulatorCounts = new Map<string, number>();
+
+type TranscriptAccumulatorInitialState = {
+  words: WordWithId[];
+  hints: SpeakerHintWithId[];
+};
+
 export function parseTranscriptWords(
   store: TranscriptStore,
   transcriptId: string,
@@ -63,6 +71,15 @@ export function updateTranscriptHints(
   transcriptId: string,
   hints: SpeakerHintWithId[],
 ): void {
+  writeTranscriptHints(store, transcriptId, hints);
+  markTranscriptAccumulatorDirty(transcriptId);
+}
+
+function writeTranscriptHints(
+  store: TranscriptStore,
+  transcriptId: string,
+  hints: SpeakerHintWithId[],
+): void {
   store.setCell(
     "transcripts",
     transcriptId,
@@ -71,42 +88,126 @@ export function updateTranscriptHints(
   );
 }
 
+export function createTranscriptAccumulator(
+  store: TranscriptStore,
+  transcriptId: string,
+  initialState?: TranscriptAccumulatorInitialState,
+): TranscriptAccumulator {
+  return new TranscriptAccumulator(store, transcriptId, initialState);
+}
+
+export class TranscriptAccumulator {
+  private words: WordWithId[];
+  private hints: SpeakerHintWithId[];
+  private disposed = false;
+
+  constructor(
+    private readonly store: TranscriptStore,
+    private readonly transcriptId: string,
+    initialState?: TranscriptAccumulatorInitialState,
+  ) {
+    this.words = initialState
+      ? [...initialState.words]
+      : parseTranscriptWords(store, transcriptId);
+    this.hints = initialState
+      ? [...initialState.hints]
+      : parseTranscriptHints(store, transcriptId);
+
+    activeAccumulatorCounts.set(
+      transcriptId,
+      (activeAccumulatorCounts.get(transcriptId) ?? 0) + 1,
+    );
+  }
+
+  applyLiveDelta(delta: LiveTranscriptDelta): void {
+    this.refreshIfDirty();
+
+    const replacedIds = new Set(delta.replaced_ids);
+    const newWords: WordWithId[] = delta.new_words.map((word) => ({
+      id: word.id,
+      text: word.text,
+      start_ms: word.start_ms,
+      end_ms: word.end_ms,
+      channel: word.channel,
+    }));
+    const newWordIds = new Set(newWords.map((word) => word.id));
+
+    this.words = this.words
+      .filter((word) => {
+        const wordId = word.id ?? "";
+        return !replacedIds.has(wordId) && !newWordIds.has(wordId);
+      })
+      .concat(newWords)
+      .sort((a, b) => (a.start_ms ?? 0) - (b.start_ms ?? 0));
+
+    this.hints = this.hints
+      .filter((hint) => {
+        const wordId = hint.word_id ?? "";
+        return !replacedIds.has(wordId) && !newWordIds.has(wordId);
+      })
+      .concat(delta.new_words.flatMap(toStorageSpeakerHints))
+      .sort((a, b) => (a.word_id ?? "").localeCompare(b.word_id ?? ""));
+
+    this.flush();
+  }
+
+  appendWordsAndHints(
+    words: WordWithId[],
+    hints: SpeakerHintWithId[],
+    options?: { mode?: "append" | "replace" },
+  ): void {
+    if (options?.mode === "replace") {
+      this.words = [];
+      this.hints = [];
+    } else {
+      this.refreshIfDirty();
+    }
+
+    this.words = this.words.concat(words);
+    this.hints = this.hints.concat(hints);
+    this.flush();
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+
+    this.disposed = true;
+
+    const nextCount = (activeAccumulatorCounts.get(this.transcriptId) ?? 1) - 1;
+    if (nextCount > 0) {
+      activeAccumulatorCounts.set(this.transcriptId, nextCount);
+      return;
+    }
+
+    activeAccumulatorCounts.delete(this.transcriptId);
+    dirtyAccumulatorTranscriptIds.delete(this.transcriptId);
+  }
+
+  private refreshIfDirty(): void {
+    if (!dirtyAccumulatorTranscriptIds.delete(this.transcriptId)) {
+      return;
+    }
+
+    this.words = parseTranscriptWords(this.store, this.transcriptId);
+    this.hints = parseTranscriptHints(this.store, this.transcriptId);
+  }
+
+  private flush(): void {
+    updateTranscriptWords(this.store, this.transcriptId, this.words);
+    writeTranscriptHints(this.store, this.transcriptId, this.hints);
+  }
+}
+
 export function applyLiveTranscriptDelta(
   store: TranscriptStore,
   transcriptId: string,
   delta: LiveTranscriptDelta,
 ): void {
-  const existingWords = parseTranscriptWords(store, transcriptId);
-  const existingHints = parseTranscriptHints(store, transcriptId);
-
-  const replacedIds = new Set(delta.replaced_ids);
-  const newWords: WordWithId[] = delta.new_words.map((word) => ({
-    id: word.id,
-    text: word.text,
-    start_ms: word.start_ms,
-    end_ms: word.end_ms,
-    channel: word.channel,
-  }));
-  const newWordIds = new Set(newWords.map((word) => word.id));
-
-  const nextWords = existingWords
-    .filter((word) => {
-      const wordId = word.id ?? "";
-      return !replacedIds.has(wordId) && !newWordIds.has(wordId);
-    })
-    .concat(newWords)
-    .sort((a, b) => (a.start_ms ?? 0) - (b.start_ms ?? 0));
-
-  const nextHints = existingHints
-    .filter((hint) => {
-      const wordId = hint.word_id ?? "";
-      return !replacedIds.has(wordId) && !newWordIds.has(wordId);
-    })
-    .concat(delta.new_words.flatMap(toStorageSpeakerHints))
-    .sort((a, b) => (a.word_id ?? "").localeCompare(b.word_id ?? ""));
-
-  updateTranscriptWords(store, transcriptId, nextWords);
-  updateTranscriptHints(store, transcriptId, nextHints);
+  const accumulator = createTranscriptAccumulator(store, transcriptId);
+  accumulator.applyLiveDelta(delta);
+  accumulator.dispose();
 }
 
 export function upsertSpeakerAssignment(
@@ -159,6 +260,12 @@ export function upsertSpeakerAssignment(
 
   nextHints.push(newHint);
   updateTranscriptHints(store, transcriptId, nextHints);
+}
+
+function markTranscriptAccumulatorDirty(transcriptId: string): void {
+  if (activeAccumulatorCounts.has(transcriptId)) {
+    dirtyAccumulatorTranscriptIds.add(transcriptId);
+  }
 }
 
 type SpeakerAssignmentScope = {


### PR DESCRIPTION
Summary:
- add a per-run transcript accumulator for live and batch STT persistence
- avoid repeated transcript JSON parses between live deltas and batch chunks
- preserve live speaker assignments through a dirty refresh path

Verification:
- pnpm exec vitest run src/stt/utils.test.ts src/stt/useRunBatch.test.ts src/stt/useStartListening.test.ts
- pnpm -F desktop typecheck
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core transcript persistence for live and batch flows; incorrect dirty/refresh behavior could corrupt words or speaker assignments, though new tests target those edge cases.
> 
> **Overview**
> Introduces a **per-run `TranscriptAccumulator`** so live listening and batch STT no longer re-parse transcript `words` / `speaker_hints` JSON on every persist chunk.
> 
> **Live** (`useStartListening`) and **batch** (`useRunBatch`) keep one accumulator for the session run, seeding empty state when a new transcript row is created and calling `dispose()` when capture stops or batch finishes. Batch appends go through `appendWordsAndHints` (including replace mode) instead of read-merge-write each time.
> 
> **`utils.ts`** centralizes delta/append logic on the accumulator; `applyLiveTranscriptDelta` becomes a thin create-apply-dispose wrapper. External hint edits (e.g. **`upsertSpeakerAssignment`** via `updateTranscriptHints`) mark the transcript **dirty** so the next accumulator operation reloads from the store—preserving user speaker labels and not resurrecting removed assignments from stale cache.
> 
> Tests in **`utils.test.ts`** cover no redundant reads, batch append behavior, and dirty-refresh semantics for speaker hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bc40169d3e5c0c671e25306f95de2ba665ecfb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->