### PR TITLE
Stream batch audio uploads

### DIFF
--- a/crates/owhisper-client/Cargo.toml
+++ b/crates/owhisper-client/Cargo.toml
@@ -19,7 +19,7 @@ openai-transcription = { workspace = true }
 owhisper-interface = { workspace = true }
 
 futures-util = { workspace = true }
-reqwest = { workspace = true, features = ["json", "multipart"] }
+reqwest = { workspace = true, features = ["json", "multipart", "stream"] }
 reqwest-middleware = { workspace = true, features = ["json", "multipart"] }
 reqwest-tracing = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }

--- a/crates/owhisper-client/src/adapter/deepgram/batch.rs
+++ b/crates/owhisper-client/src/adapter/deepgram/batch.rs
@@ -8,6 +8,7 @@ use owhisper_interface::batch::{
 use serde::Deserialize;
 
 use crate::adapter::deepgram_compat::build_batch_url;
+use crate::adapter::http::{mime_type_from_extension, streaming_file_body};
 use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware};
 use crate::error::Error;
 
@@ -41,8 +42,6 @@ impl BatchSttAdapter for DeepgramAdapter {
     }
 }
 
-use crate::adapter::http::mime_type_from_extension;
-
 async fn do_transcribe_file(
     client: &ClientWithMiddleware,
     api_base: &str,
@@ -50,11 +49,8 @@ async fn do_transcribe_file(
     params: &ListenParams,
     file_path: PathBuf,
 ) -> Result<BatchResponse, Error> {
-    let audio_data = tokio::fs::read(&file_path)
-        .await
-        .map_err(|e| Error::AudioProcessing(format!("failed to read file: {}", e)))?;
-
     let content_type = mime_type_from_extension(&file_path);
+    let (audio_body, content_length) = streaming_file_body(&file_path).await?;
 
     let url = build_batch_url(
         api_base,
@@ -68,7 +64,8 @@ async fn do_transcribe_file(
         .header("Authorization", format!("Token {}", api_key))
         .header("Accept", "application/json")
         .header("Content-Type", content_type)
-        .body(audio_data)
+        .header("Content-Length", content_length.to_string())
+        .body(audio_body)
         .send()
         .await?;
 

--- a/crates/owhisper-client/src/adapter/http.rs
+++ b/crates/owhisper-client/src/adapter/http.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use reqwest::Response;
+use reqwest::multipart::Part;
 
 use crate::error::Error;
 
@@ -25,4 +26,38 @@ pub fn mime_type_from_extension(path: &Path) -> &'static str {
         Some("flac") => "audio/flac",
         _ => "application/octet-stream",
     }
+}
+
+pub async fn streaming_file_body(file_path: &Path) -> Result<(reqwest::Body, u64), Error> {
+    let file = tokio::fs::File::open(file_path)
+        .await
+        .map_err(|e| Error::AudioProcessing(e.to_string()))?;
+    let length = file
+        .metadata()
+        .await
+        .map_err(|e| Error::AudioProcessing(e.to_string()))?
+        .len();
+
+    Ok((reqwest::Body::from(file), length))
+}
+
+pub async fn streaming_file_part(file_path: &Path) -> Result<Part, Error> {
+    let fallback_name = match file_path.extension().and_then(|e| e.to_str()) {
+        Some(ext) => format!("audio.{}", ext),
+        None => "audio".to_string(),
+    };
+
+    let file_name = file_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or(fallback_name);
+
+    let (body, length) = streaming_file_body(file_path).await?;
+    let mime_type = mime_type_from_extension(file_path);
+
+    Part::stream_with_length(body, length)
+        .file_name(file_name)
+        .mime_str(mime_type)
+        .map_err(|e| Error::AudioProcessing(e.to_string()))
 }

--- a/crates/owhisper-client/src/adapter/openai/batch.rs
+++ b/crates/owhisper-client/src/adapter/openai/batch.rs
@@ -11,6 +11,7 @@ use owhisper_interface::batch::{Alternatives, Channel, Response as BatchResponse
 use owhisper_interface::batch_stream::BatchStreamEvent;
 use reqwest::multipart::{Form, Part};
 
+use crate::adapter::http::streaming_file_part;
 use crate::adapter::{
     BatchFuture, BatchSttAdapter, ClientWithMiddleware, MIXED_CAPTURE_CHANNEL, StreamingBatchEvent,
     StreamingBatchStream, append_path_if_missing,
@@ -146,30 +147,8 @@ async fn do_transcribe_file(
     }
 }
 
-use crate::adapter::http::mime_type_from_extension;
-
 async fn build_file_part(file_path: &Path) -> Result<Part, Error> {
-    let fallback_name = match file_path.extension().and_then(|e| e.to_str()) {
-        Some(ext) => format!("audio.{}", ext),
-        None => "audio".to_string(),
-    };
-
-    let file_name = file_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .map(ToOwned::to_owned)
-        .unwrap_or(fallback_name);
-
-    let file_bytes = tokio::fs::read(file_path)
-        .await
-        .map_err(|e| Error::AudioProcessing(e.to_string()))?;
-
-    let mime_type = mime_type_from_extension(file_path);
-
-    Part::bytes(file_bytes)
-        .file_name(file_name)
-        .mime_str(mime_type)
-        .map_err(|e| Error::AudioProcessing(e.to_string()))
+    streaming_file_part(file_path).await
 }
 
 fn build_transcription_options(

--- a/crates/transcribe-proxy/Cargo.toml
+++ b/crates/transcribe-proxy/Cargo.toml
@@ -20,7 +20,7 @@ reqwest = { workspace = true, features = ["json"] }
 reqwest-middleware = { workspace = true }
 sentry = { workspace = true }
 serde_html_form = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "time", "sync", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "time", "sync", "macros", "fs", "io-util"] }
 tokio-tungstenite = { workspace = true, features = ["native-tls"] }
 tower = { workspace = true }
 tracing = { workspace = true }

--- a/crates/transcribe-proxy/src/routes/batch/async_callback.rs
+++ b/crates/transcribe-proxy/src/routes/batch/async_callback.rs
@@ -183,14 +183,11 @@ async fn handle_sync_fallback(
         .provider_selector()
         .select(Some(provider))
         .map_err(|_| RouteError::MissingConfig("api_key not configured for provider"))?;
+    let audio_file = super::write_bytes_to_temp_file(&audio_bytes, content_type)
+        .map_err(|e| RouteError::Internal(format!("failed to create temp audio file: {e}")))?;
 
-    match super::sync::transcribe_with_provider(
-        &selected,
-        listen_params.clone(),
-        audio_bytes,
-        content_type,
-    )
-    .await
+    match super::sync::transcribe_with_provider(&selected, listen_params.clone(), audio_file.path())
+        .await
     {
         Ok(response) => {
             let raw_result = serde_json::to_value(&response)

--- a/crates/transcribe-proxy/src/routes/batch/mod.rs
+++ b/crates/transcribe-proxy/src/routes/batch/mod.rs
@@ -1,45 +1,46 @@
 pub mod async_callback;
 mod sync;
 
-use std::io::Write;
+use std::io::{self, Write};
+use std::path::Path;
 
 use axum::{
     Json,
-    body::Bytes,
+    body::{Body, Bytes},
     extract::State,
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
+use futures_util::StreamExt;
 use hypr_api_auth::AuthContext;
 use owhisper_client::normalize_listen_params;
 use owhisper_interface::ListenParams;
+use tokio::io::AsyncWriteExt;
 
 use hypr_audio_mime::content_type_to_extension;
 
 use crate::hyprnote_routing::should_use_hyprnote_routing;
 use crate::query_params::QueryParams;
 
-use super::AppState;
+use super::{AppState, MAX_BATCH_AUDIO_BODY_BYTES};
 
 pub async fn handler(
     State(state): State<AppState>,
     auth: Option<axum::Extension<AuthContext>>,
     headers: HeaderMap,
     mut params: QueryParams,
-    body: Bytes,
+    body: Body,
 ) -> Response {
-    if body.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "error": "missing_audio_data",
-                "detail": "Request body is empty"
-            })),
-        )
-            .into_response();
-    }
-
     if params.get_first("callback").is_some() {
+        let body = match axum::body::to_bytes(body, MAX_BATCH_AUDIO_BODY_BYTES).await {
+            Ok(body) => body,
+            Err(error) => return body_read_error_response(error),
+        };
+
+        if body.is_empty() {
+            return missing_audio_response();
+        }
+
         return async_callback::handle_callback(&state, auth, &mut params, body)
             .await
             .into_response();
@@ -51,13 +52,28 @@ pub async fn handler(
         .unwrap_or("application/octet-stream");
 
     let listen_params = build_listen_params(&params);
+    let audio = match write_body_to_temp_file(body, content_type).await {
+        Ok(audio) => audio,
+        Err(error) => return audio_write_error_response(error),
+    };
+
+    if audio.is_empty() {
+        return missing_audio_response();
+    }
 
     let provider_param = params.get_first("provider").map(|s| s.to_string());
     let use_hyprnote_routing = should_use_hyprnote_routing(provider_param.as_deref());
 
     if use_hyprnote_routing {
-        return sync::handle_hyprnote_batch(&state, &params, listen_params, body, content_type)
-            .await;
+        return sync::handle_hyprnote_batch(
+            &state,
+            &params,
+            listen_params,
+            audio.path(),
+            audio.len(),
+            content_type,
+        )
+        .await;
     }
 
     let selected = match state.resolve_provider(&mut params) {
@@ -68,7 +84,7 @@ pub async fn handler(
     tracing::info!(
         hyprnote.stt.provider.name = ?selected.provider(),
         hyprnote.file.mime_type = %content_type,
-        hyprnote.payload.size_bytes = %body.len(),
+        hyprnote.payload.size_bytes = %audio.len(),
         "batch_transcription_request_received"
     );
 
@@ -78,9 +94,7 @@ pub async fn handler(
         .map(|r| r.retry_config().clone())
         .unwrap_or_default();
 
-    match sync::transcribe_with_retry(&selected, listen_params, body, content_type, &retry_config)
-        .await
-    {
+    match sync::transcribe_with_retry(&selected, listen_params, audio.path(), &retry_config).await {
         Ok((response, _retries)) => Json(response).into_response(),
         Err((e, _retries)) => {
             tracing::error!(
@@ -100,6 +114,28 @@ pub async fn handler(
     }
 }
 
+fn missing_audio_response() -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({
+            "error": "missing_audio_data",
+            "detail": "Request body is empty"
+        })),
+    )
+        .into_response()
+}
+
+fn body_read_error_response(error: axum::Error) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({
+            "error": "invalid_request_body",
+            "detail": error.to_string()
+        })),
+    )
+        .into_response()
+}
+
 pub(super) fn build_listen_params(params: &QueryParams) -> ListenParams {
     normalize_listen_params(ListenParams {
         model: params.get_first("model").map(|s| s.to_string()),
@@ -112,10 +148,64 @@ pub(super) fn build_listen_params(params: &QueryParams) -> ListenParams {
     })
 }
 
-fn write_to_temp_file(
+pub(super) struct BatchAudioFile {
+    temp_file: tempfile::NamedTempFile,
+    len: u64,
+}
+
+impl BatchAudioFile {
+    pub(super) fn path(&self) -> &Path {
+        self.temp_file.path()
+    }
+
+    pub(super) fn len(&self) -> u64 {
+        self.len
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+#[derive(Debug)]
+enum BatchAudioWriteError {
+    Body(axum::Error),
+    Io(io::Error),
+    TooLarge,
+}
+
+impl From<io::Error> for BatchAudioWriteError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+fn audio_write_error_response(error: BatchAudioWriteError) -> Response {
+    match error {
+        BatchAudioWriteError::TooLarge => (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(serde_json::json!({
+                "error": "payload_too_large",
+                "detail": format!("Request body exceeds {} bytes", MAX_BATCH_AUDIO_BODY_BYTES)
+            })),
+        )
+            .into_response(),
+        BatchAudioWriteError::Body(error) => body_read_error_response(error),
+        BatchAudioWriteError::Io(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": "failed_to_store_audio",
+                "detail": error.to_string()
+            })),
+        )
+            .into_response(),
+    }
+}
+
+pub(super) fn write_bytes_to_temp_file(
     bytes: &Bytes,
     content_type: &str,
-) -> Result<tempfile::NamedTempFile, std::io::Error> {
+) -> Result<tempfile::NamedTempFile, io::Error> {
     let extension = content_type_to_extension(content_type);
     let mut temp_file = tempfile::Builder::new()
         .prefix("batch_audio_")
@@ -126,6 +216,34 @@ fn write_to_temp_file(
     temp_file.flush()?;
 
     Ok(temp_file)
+}
+
+async fn write_body_to_temp_file(
+    body: Body,
+    content_type: &str,
+) -> Result<BatchAudioFile, BatchAudioWriteError> {
+    let extension = content_type_to_extension(content_type);
+    let temp_file = tempfile::Builder::new()
+        .prefix("batch_audio_")
+        .suffix(&format!(".{}", extension))
+        .tempfile()?;
+    let mut file = tokio::fs::File::from_std(temp_file.reopen()?);
+    let mut stream = body.into_data_stream();
+    let mut len = 0u64;
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(BatchAudioWriteError::Body)?;
+        len += chunk.len() as u64;
+        if len > MAX_BATCH_AUDIO_BODY_BYTES as u64 {
+            return Err(BatchAudioWriteError::TooLarge);
+        }
+
+        file.write_all(&chunk).await?;
+    }
+
+    file.flush().await?;
+
+    Ok(BatchAudioFile { temp_file, len })
 }
 
 #[cfg(test)]
@@ -177,5 +295,18 @@ mod tests {
         assert_eq!(listen_params.num_speakers, Some(3));
         assert_eq!(listen_params.min_speakers, Some(2));
         assert_eq!(listen_params.max_speakers, Some(4));
+    }
+
+    #[tokio::test]
+    async fn test_write_body_to_temp_file_streams_chunks() {
+        let body = Body::from_stream(futures_util::stream::iter([
+            Ok::<_, io::Error>(Bytes::from_static(b"hello")),
+            Ok::<_, io::Error>(Bytes::from_static(b" world")),
+        ]));
+
+        let audio = write_body_to_temp_file(body, "audio/wav").await.unwrap();
+
+        assert_eq!(audio.len(), 11);
+        assert_eq!(tokio::fs::read(audio.path()).await.unwrap(), b"hello world");
     }
 }

--- a/crates/transcribe-proxy/src/routes/batch/sync.rs
+++ b/crates/transcribe-proxy/src/routes/batch/sync.rs
@@ -1,8 +1,8 @@
+use std::path::Path;
 use std::time::Duration;
 
 use axum::{
     Json,
-    body::Bytes,
     http::StatusCode,
     response::{IntoResponse, Response},
 };
@@ -21,7 +21,6 @@ use crate::query_params::QueryParams;
 
 use super::super::AppState;
 use super::super::model_resolution::resolve_model_batch;
-use super::write_to_temp_file;
 
 #[derive(Debug, Clone)]
 pub(super) enum BatchAttemptError {
@@ -102,7 +101,8 @@ pub(super) async fn handle_hyprnote_batch(
     state: &AppState,
     params: &QueryParams,
     listen_params: ListenParams,
-    body: Bytes,
+    audio_path: &Path,
+    audio_size_bytes: u64,
     content_type: &str,
 ) -> Response {
     let mut provider_chain =
@@ -129,7 +129,7 @@ pub(super) async fn handle_hyprnote_batch(
     tracing::info!(
         provider_chain = ?provider_chain.iter().map(|p| p.provider()).collect::<Vec<_>>(),
         content_type = %content_type,
-        body_size_bytes = %body.len(),
+        body_size_bytes = %audio_size_bytes,
         "hyprnote_batch_transcription_request"
     );
 
@@ -156,14 +156,8 @@ pub(super) async fn handle_hyprnote_batch(
         let resolved_model = provider_listen_params.model.clone();
         providers_tried.push(provider);
 
-        match transcribe_with_retry(
-            selected,
-            provider_listen_params,
-            body.clone(),
-            content_type,
-            &retry_config,
-        )
-        .await
+        match transcribe_with_retry(selected, provider_listen_params, audio_path, &retry_config)
+            .await
         {
             Ok((response, retries)) => {
                 tracing::info!(
@@ -237,8 +231,7 @@ fn append_deepgram_batch_detection_fallback(
 pub(super) async fn transcribe_with_retry(
     selected: &SelectedProvider,
     params: ListenParams,
-    audio_bytes: Bytes,
-    content_type: &str,
+    audio_path: &Path,
     retry_config: &RetryConfig,
 ) -> Result<(BatchResponse, usize), (BatchAttemptError, usize)> {
     let backoff = ExponentialBuilder::default()
@@ -247,21 +240,20 @@ pub(super) async fn transcribe_with_retry(
         .with_max_times(retry_config.num_retries);
     let mut retries = 0usize;
 
-    let result = (|| async {
-        transcribe_with_provider(selected, params.clone(), audio_bytes.clone(), content_type).await
-    })
-    .retry(backoff)
-    .notify(|err, dur| {
-        tracing::warn!(
-            hyprnote.stt.provider.name = ?selected.provider(),
-            error = %err,
-            hyprnote.retry.delay_ms = dur.as_millis(),
-            "retrying_transcription"
-        );
-        retries += 1;
-    })
-    .when(|e| e.is_retryable())
-    .await;
+    let result =
+        (|| async { transcribe_with_provider(selected, params.clone(), audio_path).await })
+            .retry(backoff)
+            .notify(|err, dur| {
+                tracing::warn!(
+                    hyprnote.stt.provider.name = ?selected.provider(),
+                    error = %err,
+                    hyprnote.retry.delay_ms = dur.as_millis(),
+                    "retrying_transcription"
+                );
+                retries += 1;
+            })
+            .when(|e| e.is_retryable())
+            .await;
 
     match result {
         Ok(response) => Ok((response, retries)),
@@ -272,13 +264,8 @@ pub(super) async fn transcribe_with_retry(
 pub(super) async fn transcribe_with_provider(
     selected: &SelectedProvider,
     params: ListenParams,
-    audio_bytes: Bytes,
-    content_type: &str,
+    audio_path: &Path,
 ) -> Result<BatchResponse, BatchAttemptError> {
-    let temp_file = write_to_temp_file(&audio_bytes, content_type)
-        .map_err(|e| BatchAttemptError::Client(format!("failed to create temp file: {e}")))?;
-
-    let file_path = temp_file.path();
     let provider = selected.provider();
     let api_base = selected
         .upstream_url()
@@ -292,7 +279,7 @@ pub(super) async fn transcribe_with_provider(
                 .api_key(api_key)
                 .params(params)
                 .build()
-                .transcribe_file(file_path)
+                .transcribe_file(audio_path)
                 .await
         };
     }


### PR DESCRIPTION
Summary:
- stream sync batch request bodies into temp files instead of extracting whole-body Bytes
- reuse the temp file path across provider retries and hyprnote routing attempts
- stream Deepgram raw uploads and OpenAI multipart file parts from disk

Verification:
- cargo check -p transcribe-proxy -p owhisper-client
- cargo test -p transcribe-proxy routes::batch
- cargo test -p owhisper-client adapter::deepgram::batch
- cargo test -p owhisper-client adapter::openai::batch
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes memory and I/O behavior on the main batch transcription path; incorrect streaming, temp file handling, or size limits could affect large uploads or retries, though logic is largely a refactor with tests added.
> 
> **Overview**
> Batch sync transcription no longer buffers the full request body in memory. The **transcribe-proxy** batch handler accepts an Axum `Body`, **streams** chunks into a temp file (with `MAX_BATCH_AUDIO_BODY_BYTES` enforcement and clearer error responses), and passes that **single file path** through hyprnote routing, retries, and provider calls. Callback requests still buffer to `Bytes` for JSON parsing.
> 
> **owhisper-client** adds shared **`streaming_file_body`** / **`streaming_file_part`** helpers (reqwest **`stream`** feature). **Deepgram** batch uploads stream from disk with `Content-Length`; **OpenAI** multipart file parts stream from disk instead of loading the whole file into memory. Async callback **sync fallback** writes downloaded audio to a temp file before transcribing, matching the path-based API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 418a5fd1b86b5857d9ff89c1387042c02c9ad857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->