### PR TITLE
Add desktop changelog for 1.0.44

### DIFF
--- a/packages/changelog/content/1.0.44.md
+++ b/packages/changelog/content/1.0.44.md
@@ -1,0 +1,33 @@
+---
+date: "2026-06-12"
+summary: "Anarlog now renders summary tables, starts empty summaries more smoothly, improves transcript controls, and adds Dock and menu bar visibility settings."
+---
+
+## Notes
+
+- Generated summaries can now include clean tables instead of raw markdown
+- Empty notes now start summary generation automatically and show a quieter writing state while the first draft is being written
+- Related meeting facts now appear as readable bullets without cutting off longer details
+- The raw note view no longer shows placeholder copy after note content is cleared
+
+## Transcripts
+
+- Transcript tabs now stay hidden when a meeting has no transcript content
+- Transcript regeneration is hidden when there is no recording to use
+- Live speaker assignment now stays responsive while a meeting is still streaming
+- Batch transcription is more reliable for longer recordings and saves transcript updates with less duplicate work
+
+## Settings
+
+- You can now choose whether Anarlog appears in the Dock and app switcher
+- You can now hide or show the menu bar tray icon from settings
+- Speech model settings now distinguish realtime and batch-only transcription models more clearly
+- AI model lists now prefer current hosted model options
+
+## Polish
+
+- The writing animation now matches dark mode
+- The note header and tab row now sit closer together while preserving draggable title and toolbar areas
+- The floating meeting bar now hides after live capture while the note finalizes
+- Changelog and sidebar chrome drag areas now work more consistently
+- Destructive toast actions, editor toolbars, and meeting popovers now layer more cleanly


### PR DESCRIPTION
Create the 1.0.44 release note with user-facing desktop changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime or build impact.
> 
> **Overview**
> Adds the **1.0.44** desktop release note at `packages/changelog/content/1.0.44.md`, with frontmatter (`date`, index `summary`) and user-facing bullets grouped under **Notes**, **Transcripts**, **Settings**, and **Polish**.
> 
> The content documents shipped desktop behavior for this version (summary tables, empty-note auto-generation, transcript UI, Dock/menu bar settings, transcription reliability, and UI polish)—documentation only, no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c780f8f1c8bc9374e5e2e5fda1bb35ac94a9161. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->