### PR TITLE
Remove summary body spinner

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
@@ -77,16 +77,28 @@ describe("Enhanced", () => {
     hoisted.content = "";
   });
 
-  it("shows an interim summary state before the enhance task is visible", () => {
+  it("renders an empty editor before the auto-enhance task is visible", () => {
     render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
 
-    expect(screen.getByRole("status").textContent).toContain(
-      "Preparing summary...",
-    );
-    expect(screen.getByRole("status").textContent).toContain(
-      "Tip: The Anarlog team loves our users!",
-    );
+    expect(screen.getByText("Enhanced editor")).not.toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByText("Preparing summary...")).toBeNull();
     expect(screen.queryByTestId("spinner")).toBeNull();
+  });
+
+  it("keeps the generating view quiet until summary text streams", () => {
+    hoisted.task = {
+      status: "generating",
+      error: undefined,
+      streamedText: "",
+      currentStep: undefined,
+      isGenerating: true,
+    };
+
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByText("Preparing summary...")).toBeNull();
     expect(screen.queryByText("Enhanced editor")).toBeNull();
   });
 
@@ -105,13 +117,67 @@ describe("Enhanced", () => {
     expect(screen.queryByRole("status")).toBeNull();
   });
 
-  it("keeps config errors ahead of the empty interim state", () => {
-    hoisted.llmStatus = { status: "pending", reason: "missing_provider" };
+  it("shows config errors for hosted subscription blockers", () => {
+    hoisted.llmStatus = {
+      status: "error",
+      reason: "not_pro",
+      providerId: "hyprnote",
+    };
 
     render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
 
     expect(screen.getByText("Config error")).not.toBeNull();
     expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("shows config errors when hosted generation requires authentication", () => {
+    hoisted.llmStatus = {
+      status: "error",
+      reason: "unauthenticated",
+      providerId: "hyprnote",
+    };
+
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.getByText("Config error")).not.toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("shows config errors when a provider API key is missing", () => {
+    hoisted.llmStatus = {
+      status: "error",
+      reason: "missing_config",
+      providerId: "openai",
+      missing: ["api_key"],
+    };
+
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.getByText("Config error")).not.toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("shows config errors when a provider base URL is missing", () => {
+    hoisted.llmStatus = {
+      status: "error",
+      reason: "missing_config",
+      providerId: "openai",
+      missing: ["base_url"],
+    };
+
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.getByText("Config error")).not.toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("does not show config errors for missing provider setup", () => {
+    hoisted.llmStatus = { status: "pending", reason: "missing_provider" };
+
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.queryByText("Config error")).toBeNull();
+    expect(screen.getByText("Enhanced editor")).not.toBeNull();
   });
 
   it("renders the editor when the enhanced note already has content", () => {

--- a/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
@@ -86,6 +86,7 @@ describe("Enhanced", () => {
     expect(screen.getByRole("status").textContent).toContain(
       "Tip: The Anarlog team loves our users!",
     );
+    expect(screen.queryByTestId("spinner")).toBeNull();
     expect(screen.queryByText("Enhanced editor")).toBeNull();
   });
 

--- a/apps/desktop/src/session/components/note-input/enhanced/index.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.tsx
@@ -10,6 +10,7 @@ import { StreamingView } from "./streaming";
 
 import { useAITaskTask } from "~/ai/hooks";
 import { useLLMConnectionStatus } from "~/ai/hooks";
+import { shouldShowEmptySummaryConfigError } from "~/session/enhance-config";
 import * as main from "~/store/tinybase/store/main";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 
@@ -35,7 +36,7 @@ export const Enhanced = forwardRef<
   ) => {
     const taskId = createTaskId(enhancedNoteId, "enhance");
     const llmStatus = useLLMConnectionStatus();
-    const { status, error, hasTask } = useAITaskTask(taskId, "enhance");
+    const { status, error } = useAITaskTask(taskId, "enhance");
     const content = main.UI.useCell(
       "enhanced_notes",
       enhancedNoteId,
@@ -45,12 +46,7 @@ export const Enhanced = forwardRef<
 
     const hasContent = typeof content === "string" && content.trim().length > 0;
 
-    const isConfigError =
-      llmStatus.status === "pending" ||
-      (llmStatus.status === "error" &&
-        (llmStatus.reason === "missing_config" ||
-          llmStatus.reason === "not_pro" ||
-          llmStatus.reason === "unauthenticated"));
+    const isConfigError = shouldShowEmptySummaryConfigError(llmStatus);
 
     if (status === "idle" && isConfigError && !hasContent) {
       return <ConfigError status={llmStatus} />;
@@ -66,16 +62,8 @@ export const Enhanced = forwardRef<
       );
     }
 
-    if (
-      status === "generating" ||
-      (!hasContent && status === "idle" && !hasTask)
-    ) {
-      return (
-        <StreamingView
-          enhancedNoteId={enhancedNoteId}
-          pending={status === "idle"}
-        />
-      );
+    if (status === "generating") {
+      return <StreamingView enhancedNoteId={enhancedNoteId} />;
     }
 
     return (

--- a/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
@@ -1,6 +1,5 @@
 import { Streamdown } from "streamdown";
 
-import { Spinner } from "@hypr/ui/components/ui/spinner";
 import { cn } from "@hypr/utils";
 
 import { streamdownComponents } from "../../streamdown";
@@ -47,7 +46,6 @@ export function StreamingView({
           aria-live="polite"
           className="flex min-h-[260px] flex-col items-center justify-center gap-2 text-center"
         >
-          <Spinner size={16} />
           <div className="flex flex-col gap-1">
             <p className="text-foreground text-sm font-medium">{statusText}</p>
             <p className="text-muted-foreground text-xs">

--- a/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
@@ -6,68 +6,23 @@ import { streamdownComponents } from "../../streamdown";
 
 import { useAITaskTask } from "~/ai/hooks";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
-import { type TaskStepInfo } from "~/store/zustand/ai-task/tasks";
 
-export function StreamingView({
-  enhancedNoteId,
-  pending = false,
-}: {
-  enhancedNoteId: string;
-  pending?: boolean;
-}) {
+export function StreamingView({ enhancedNoteId }: { enhancedNoteId: string }) {
   const taskId = createTaskId(enhancedNoteId, "enhance");
-  const { streamedText, currentStep, isGenerating } = useAITaskTask(
-    taskId,
-    "enhance",
-  );
-
-  const step = currentStep as TaskStepInfo<"enhance"> | undefined;
-  const hasContent = streamedText.trim().length > 0;
-  let statusText: string | null = null;
-  if (isGenerating && !hasContent) {
-    if (step?.type === "analyzing") {
-      statusText = "Analyzing transcript...";
-    } else if (step?.type === "generating") {
-      statusText = "Writing summary...";
-    } else if (step?.type === "retrying") {
-      statusText = `Retrying (attempt ${step.attempt})...`;
-    } else {
-      statusText = "Preparing summary...";
-    }
-  } else if (pending && !hasContent) {
-    statusText = "Preparing summary...";
-  }
+  const { streamedText, isGenerating } = useAITaskTask(taskId, "enhance");
 
   return (
     <div className="pb-2">
-      {statusText ? (
-        <div
-          role="status"
-          aria-live="polite"
-          className="flex min-h-[260px] flex-col items-center justify-center gap-2 text-center"
+      <div className="flex flex-col gap-1">
+        <Streamdown
+          components={streamdownComponents}
+          className={cn(["flex flex-col"])}
+          caret="block"
+          isAnimating={isGenerating}
         >
-          <div className="flex flex-col gap-1">
-            <p className="text-foreground text-sm font-medium">{statusText}</p>
-            <p className="text-muted-foreground text-xs">
-              The summary will appear here as soon as it starts streaming.
-            </p>
-            <p className="text-muted-foreground text-xs">
-              Tip: The Anarlog team loves our users!
-            </p>
-          </div>
-        </div>
-      ) : (
-        <div className="flex flex-col gap-1">
-          <Streamdown
-            components={streamdownComponents}
-            className={cn(["flex flex-col"])}
-            caret="block"
-            isAnimating={isGenerating}
-          >
-            {streamedText}
-          </Streamdown>
-        </div>
-      )}
+          {streamedText}
+        </Streamdown>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -38,6 +38,7 @@ import { useLanguageModel, useLLMConnectionStatus } from "~/ai/hooks";
 import { extractPlainText } from "~/search/contexts/engine/utils";
 import { getEnhancerService } from "~/services/enhancer";
 import { useHasTranscript } from "~/session/components/shared";
+import { shouldShowEmptySummaryConfigError } from "~/session/enhance-config";
 import { useEnsureDefaultSummary } from "~/session/hooks/useEnhancedNotes";
 import {
   type MenuItemDef,
@@ -1210,12 +1211,7 @@ function useEnhanceLogic(sessionId: string, enhancedNoteId: string) {
     }
   }, [model, missingModelError]);
 
-  const isConfigError =
-    llmStatus.status === "pending" ||
-    (llmStatus.status === "error" &&
-      (llmStatus.reason === "missing_config" ||
-        llmStatus.reason === "not_pro" ||
-        llmStatus.reason === "unauthenticated"));
+  const isConfigError = shouldShowEmptySummaryConfigError(llmStatus);
 
   const isIdleWithConfigError = enhanceTask.isIdle && isConfigError;
 

--- a/apps/desktop/src/session/enhance-config.ts
+++ b/apps/desktop/src/session/enhance-config.ts
@@ -1,0 +1,13 @@
+import type { LLMConnectionStatus } from "~/ai/hooks";
+
+export function shouldShowEmptySummaryConfigError(status: LLMConnectionStatus) {
+  if (status.status !== "error") {
+    return false;
+  }
+
+  return (
+    status.reason === "unauthenticated" ||
+    status.reason === "not_pro" ||
+    status.reason === "missing_config"
+  );
+}

--- a/apps/desktop/src/session/hooks/useEnhancedNotes.test.tsx
+++ b/apps/desktop/src/session/hooks/useEnhancedNotes.test.tsx
@@ -1,0 +1,151 @@
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LLMConnectionStatus } from "~/ai/hooks";
+
+const hoisted = vi.hoisted(() => ({
+  hasTranscript: true,
+  sessionMode: "inactive",
+  enhancedNoteIds: [] as string[],
+  selectedTemplateId: "template-1" as string | undefined,
+  llmStatus: {
+    status: "success",
+    providerId: "hyprnote",
+    isHosted: true,
+  } as LLMConnectionStatus,
+  service: {
+    ensureNote: vi.fn(),
+    queueAutoEnhanceIfSummaryEmpty: vi.fn(),
+  },
+}));
+
+vi.mock("../components/shared", () => ({
+  useHasTranscript: () => hoisted.hasTranscript,
+}));
+
+vi.mock("~/ai/hooks", () => ({
+  useLLMConnectionStatus: () => hoisted.llmStatus,
+}));
+
+vi.mock("~/ai/contexts", () => ({
+  useAITask: vi.fn(),
+}));
+
+vi.mock("~/services/enhancer", () => ({
+  getEnhancerService: () => hoisted.service,
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  INDEXES: {
+    enhancedNotesBySession: "enhancedNotesBySession",
+  },
+  UI: {
+    useSliceRowIds: () => hoisted.enhancedNoteIds,
+  },
+}));
+
+vi.mock("~/store/tinybase/store/settings", () => ({
+  STORE_ID: "settings",
+  UI: {
+    useValue: () => hoisted.selectedTemplateId,
+  },
+}));
+
+vi.mock("~/stt/contexts", () => ({
+  useListener: (selector: (state: unknown) => unknown) =>
+    selector({
+      getSessionMode: () => hoisted.sessionMode,
+    }),
+}));
+
+import { useEnsureDefaultSummary } from "./useEnhancedNotes";
+
+describe("useEnsureDefaultSummary", () => {
+  beforeEach(() => {
+    cleanup();
+    hoisted.hasTranscript = true;
+    hoisted.sessionMode = "inactive";
+    hoisted.enhancedNoteIds = [];
+    hoisted.selectedTemplateId = "template-1";
+    hoisted.llmStatus = {
+      status: "success",
+      providerId: "hyprnote",
+      isHosted: true,
+    };
+    hoisted.service.ensureNote.mockClear();
+    hoisted.service.queueAutoEnhanceIfSummaryEmpty.mockClear();
+  });
+
+  it("queues generation instead of creating an empty summary", async () => {
+    renderHook(() => useEnsureDefaultSummary("session-1"));
+
+    await waitFor(() => {
+      expect(
+        hoisted.service.queueAutoEnhanceIfSummaryEmpty,
+      ).toHaveBeenCalledWith("session-1");
+    });
+    expect(hoisted.service.ensureNote).not.toHaveBeenCalled();
+  });
+
+  it("creates the summary row when a hosted subscription blocks generation", async () => {
+    hoisted.llmStatus = {
+      status: "error",
+      reason: "not_pro",
+      providerId: "hyprnote",
+    };
+
+    renderHook(() => useEnsureDefaultSummary("session-1"));
+
+    await waitFor(() => {
+      expect(hoisted.service.ensureNote).toHaveBeenCalledWith(
+        "session-1",
+        "template-1",
+      );
+    });
+    expect(
+      hoisted.service.queueAutoEnhanceIfSummaryEmpty,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("creates the summary row when provider API keys are missing", async () => {
+    hoisted.llmStatus = {
+      status: "error",
+      reason: "missing_config",
+      providerId: "openai",
+      missing: ["api_key"],
+    };
+
+    renderHook(() => useEnsureDefaultSummary("session-1"));
+
+    await waitFor(() => {
+      expect(hoisted.service.ensureNote).toHaveBeenCalledWith(
+        "session-1",
+        "template-1",
+      );
+    });
+    expect(
+      hoisted.service.queueAutoEnhanceIfSummaryEmpty,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("creates the summary row when model selection is pending", async () => {
+    hoisted.llmStatus = {
+      status: "pending",
+      reason: "missing_model",
+      providerId: "hyprnote",
+    };
+
+    renderHook(() => useEnsureDefaultSummary("session-1"));
+
+    await waitFor(() => {
+      expect(hoisted.service.ensureNote).toHaveBeenCalledWith(
+        "session-1",
+        "template-1",
+      );
+    });
+    expect(
+      hoisted.service.queueAutoEnhanceIfSummaryEmpty,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/session/hooks/useEnhancedNotes.ts
+++ b/apps/desktop/src/session/hooks/useEnhancedNotes.ts
@@ -3,6 +3,7 @@ import { useEffect, useMemo } from "react";
 import { useHasTranscript } from "../components/shared";
 
 import { useAITask } from "~/ai/contexts";
+import { useLLMConnectionStatus } from "~/ai/hooks";
 import { getEnhancerService } from "~/services/enhancer";
 import * as main from "~/store/tinybase/store/main";
 import * as settings from "~/store/tinybase/store/settings";
@@ -58,28 +59,40 @@ export function useEnsureDefaultSummary(sessionId: string) {
     "selected_template_id",
     settings.STORE_ID,
   ) as string | undefined;
+  const llmStatus = useLLMConnectionStatus();
 
   useEffect(() => {
     if (
       !hasTranscript ||
       sessionMode === "active" ||
       sessionMode === "running_batch" ||
-      sessionMode === "finalizing" ||
-      (enhancedNoteIds && enhancedNoteIds.length > 0)
+      sessionMode === "finalizing"
     ) {
       return;
     }
 
-    getEnhancerService()?.ensureNote(
-      sessionId,
-      selectedTemplateId || undefined,
-    );
+    const service = getEnhancerService();
+    if (!service) {
+      return;
+    }
+
+    const hasEnhancedNotes = enhancedNoteIds && enhancedNoteIds.length > 0;
+
+    if (llmStatus.status !== "success") {
+      if (!hasEnhancedNotes) {
+        service.ensureNote(sessionId, selectedTemplateId || undefined);
+      }
+      return;
+    }
+
+    service.queueAutoEnhanceIfSummaryEmpty(sessionId);
   }, [
     hasTranscript,
     sessionMode,
     sessionId,
     enhancedNoteIds?.length,
     selectedTemplateId,
+    llmStatus,
   ]);
 }
 


### PR DESCRIPTION
Keep the empty summary streaming placeholder text-only and cover it with a focused regression assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session summary UX and when auto-enhance vs empty rows are created; behavior changes for pending LLM setup and pre-stream generation, mitigated by new unit tests.
> 
> **Overview**
> Removes the **spinner and interim “Preparing summary…” placeholder** from the enhanced summary body. While generation is active, the pane only shows **streamed markdown** (quiet until text arrives); when auto-enhance has not started yet, users see the **empty enhanced editor** instead of a loading state.
> 
> **Config gating** is centralized in `shouldShowEmptySummaryConfigError`: empty-summary config errors apply only for `unauthenticated`, `not_pro`, and `missing_config`—not for generic `pending` states like `missing_provider`.
> 
> **Default summary bootstrap** (`useEnsureDefaultSummary`) now **queues auto-enhance** when the LLM connection is healthy, and only **creates an empty summary row** when generation cannot run (pending/error LLM status and no note yet). Tests cover the new UI and hook behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dcec3783448a60b8ae04c6589967c9d2293ee10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->