### PR TITLE
Make title field draggable

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -33,6 +33,7 @@ import { type Tab, uniqueIdfromTab, useTabs } from "~/store/zustand/tabs";
 
 const MAIN_AREA_TOP_DRAG_HEIGHT_PX = 48;
 const MAIN_AREA_WINDOW_DRAG_THRESHOLD_PX = 5;
+const MAIN_AREA_WINDOW_DRAG_REGION_ATTR = "data-main-area-window-drag-region";
 
 type MainAreaWindowDragStart = {
   pointerId: number;
@@ -160,12 +161,16 @@ function useMainAreaTopWindowDrag(enabled: boolean) {
   const handlePointerDown = useCallback(
     (event: PointerEvent<HTMLDivElement>) => {
       suppressNextClickRef.current = false;
+      const explicitDragTarget = isExplicitMainAreaWindowDragTarget(
+        event.target,
+      );
 
       if (
         !enabled ||
         event.button !== 0 ||
-        isInteractiveMainAreaDragTarget(event.target) ||
-        !isWithinMainAreaTopDragRegion(event)
+        (!explicitDragTarget &&
+          (isInteractiveMainAreaDragTarget(event.target) ||
+            !isWithinMainAreaTopDragRegion(event)))
       ) {
         windowDragStartRef.current = null;
         return;
@@ -255,6 +260,10 @@ function isInteractiveMainAreaDragTarget(target: EventTarget | null): boolean {
     return false;
   }
 
+  if (isTauriDragRegionTarget(target)) {
+    return false;
+  }
+
   return Boolean(
     target.closest(
       [
@@ -268,6 +277,35 @@ function isInteractiveMainAreaDragTarget(target: EventTarget | null): boolean {
         "[role='textbox']",
       ].join(","),
     ),
+  );
+}
+
+function isExplicitMainAreaWindowDragTarget(
+  target: EventTarget | null,
+): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  const mainAreaDragRegion = target.closest(
+    `[${MAIN_AREA_WINDOW_DRAG_REGION_ATTR}]`,
+  );
+
+  if (mainAreaDragRegion) {
+    return (
+      mainAreaDragRegion.getAttribute(MAIN_AREA_WINDOW_DRAG_REGION_ATTR) !==
+      "false"
+    );
+  }
+
+  return isTauriDragRegionTarget(target);
+}
+
+function isTauriDragRegionTarget(target: Element): boolean {
+  const dragRegion = target.closest("[data-tauri-drag-region]");
+
+  return Boolean(
+    dragRegion && dragRegion.getAttribute("data-tauri-drag-region") !== "false",
   );
 }
 

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -131,7 +131,7 @@ export const NoteInput = forwardRef<
 
   return (
     <div className="-mx-2 flex h-full flex-col">
-      <div className="relative px-2">
+      <div data-tauri-drag-region className="relative px-2">
         <Header
           sessionId={sessionId}
           editorTabs={editorTabs}

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -29,14 +29,22 @@ vi.mock("./metadata", () => ({
     renderTrigger ? (
       renderTrigger({ open: false, label: "Open event metadata" })
     ) : (
-      <button type="button" aria-label="Open event metadata">
+      <button
+        type="button"
+        aria-label="Open event metadata"
+        data-tauri-drag-region="false"
+      >
         Metadata
       </button>
     ),
 }));
 
 vi.mock("./overflow", () => ({
-  OverflowButton: () => <button type="button">More</button>,
+  OverflowButton: () => (
+    <button type="button" data-tauri-drag-region="false">
+      More
+    </button>
+  ),
 }));
 
 vi.mock("@hypr/ui/components/ui/dancing-sticks", () => ({
@@ -162,6 +170,8 @@ describe("OuterHeader", () => {
     const titleSlot = titleWrapper?.parentElement;
     const header = titleSlot?.parentElement;
 
+    expect(header?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(titleSlot?.hasAttribute("data-tauri-drag-region")).toBe(true);
     expect(header?.className).toContain("pl-[156px]");
     expect(header?.className).toContain("h-[52px]");
     expect(header?.className).toContain("pb-1");
@@ -319,6 +329,7 @@ describe("OuterHeader", () => {
     });
 
     expect(screen.queryByRole("button", { name: "Join Meet" })).toBeNull();
+    expect(metadataButton.getAttribute("data-tauri-drag-region")).toBe("false");
     expect(metadataButton.textContent).toBe("Metadata");
   });
 });

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -35,6 +35,7 @@ export function OuterHeader({
 
   return (
     <div
+      data-tauri-drag-region
       className={cn([
         "relative flex w-full items-center",
         showSidebarTimelineHeaderGutter ? "h-[52px] pb-1" : "h-12",
@@ -43,6 +44,7 @@ export function OuterHeader({
     >
       {title ? (
         <div
+          data-tauri-drag-region
           className={cn([
             "pointer-events-none absolute inset-y-0 flex items-center",
             reserveCollapsedLiveControls ? "right-[153px]" : "right-[70px]",
@@ -56,7 +58,10 @@ export function OuterHeader({
           <div className="pointer-events-auto w-full min-w-0">{title}</div>
         </div>
       ) : null}
-      <div className="relative z-10 ml-auto flex shrink-0 items-center gap-0 pr-1">
+      <div
+        data-tauri-drag-region
+        className="relative z-10 ml-auto flex shrink-0 items-center gap-0 pr-1"
+      >
         <SidebarModeStopButton sessionMode={sessionMode} />
         <HeaderMeetingControl sessionId={sessionId} sessionMode={sessionMode} />
         <OverflowButton sessionId={sessionId} currentView={currentView} />
@@ -133,7 +138,10 @@ function HeaderMeetingJoinButton({
   };
 
   return (
-    <div className="border-border bg-card text-foreground mr-1 flex h-8 max-w-56 shrink-0 items-center overflow-hidden rounded-full border shadow-[0_1px_4px_rgba(0,0,0,0.08)]">
+    <div
+      data-tauri-drag-region="false"
+      className="border-border bg-card text-foreground mr-1 flex h-8 max-w-56 shrink-0 items-center overflow-hidden rounded-full border shadow-[0_1px_4px_rgba(0,0,0,0.08)]"
+    >
       <button
         type="button"
         aria-label={label}
@@ -233,6 +241,7 @@ function SidebarModeStopButton({ sessionMode }: { sessionMode: string }) {
   return (
     <button
       type="button"
+      data-tauri-drag-region="false"
       onClick={finalizing ? undefined : stop}
       disabled={finalizing}
       className={cn([

--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -58,6 +58,7 @@ const TriggerInner = forwardRef<
     <Button
       ref={ref}
       {...props}
+      data-tauri-drag-region="false"
       variant="ghost"
       size="icon"
       type="button"

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -77,6 +77,7 @@ export function OverflowButton({
       <DropdownMenu open={open} onOpenChange={setOpen}>
         <DropdownMenuTrigger asChild>
           <Button
+            data-tauri-drag-region="false"
             size="icon"
             variant="ghost"
             className="text-muted-foreground hover:bg-accent hover:text-foreground rounded-full"

--- a/apps/desktop/src/session/components/session-surface.tsx
+++ b/apps/desktop/src/session/components/session-surface.tsx
@@ -32,7 +32,11 @@ export function SessionSurface({
       mergeAfterBorder={mergeAfterBorder}
     >
       <div className="flex h-full flex-col">
-        {header ? <div className="pr-1 pl-3">{header}</div> : null}
+        {header ? (
+          <div data-tauri-drag-region className="pr-1 pl-3">
+            {header}
+          </div>
+        ) : null}
         <div className="mt-2 min-h-0 flex-1 px-2">{children}</div>
       </div>
     </StandardTabWrapper>

--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -109,6 +109,28 @@ describe("TitleInput", () => {
     ).toBeNull();
   });
 
+  it("marks the title field as a Tauri drag region until it is focused", () => {
+    renderTitleInput();
+
+    const input = screen.getByPlaceholderText("Untitled");
+    const titleInputShell = input.parentElement;
+
+    expect(titleInputShell?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(input.hasAttribute("data-tauri-drag-region")).toBe(false);
+
+    fireEvent.focus(input);
+
+    expect(titleInputShell?.getAttribute("data-tauri-drag-region")).toBe(
+      "false",
+    );
+    expect(input.hasAttribute("data-tauri-drag-region")).toBe(false);
+
+    fireEvent.blur(input);
+
+    expect(titleInputShell?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(input.hasAttribute("data-tauri-drag-region")).toBe(false);
+  });
+
   it("reveals overflowing titles with a hover scroll overlay", () => {
     const title =
       "Product Discovery Pace and Headless Agent Usage Strategy Review";

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -77,7 +77,10 @@ export const TitleInput = forwardRef<
 
     if (isGenerating) {
       return (
-        <div className="flex h-8 w-full items-center justify-start">
+        <div
+          data-tauri-drag-region
+          className="flex h-8 w-full items-center justify-start"
+        >
           <span className="text-muted-foreground animate-pulse text-xl font-semibold">
             Generating title...
           </span>
@@ -87,7 +90,10 @@ export const TitleInput = forwardRef<
 
     if (showRevealAnimation && generatedTitle) {
       return (
-        <div className="flex h-8 w-full items-center justify-start overflow-hidden">
+        <div
+          data-tauri-drag-region
+          className="flex h-8 w-full items-center justify-start overflow-hidden"
+        >
           <span className="animate-reveal-left text-xl font-semibold whitespace-nowrap">
             {generatedTitle}
           </span>
@@ -341,6 +347,7 @@ const TitleInputInner = memo(
 
       return (
         <div
+          data-tauri-drag-region={isTitleFocused ? "false" : true}
           style={titleFadeStyle}
           className="group/title-input relative flex h-8 w-full items-center overflow-hidden"
         >

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -58,7 +58,18 @@ vi.mock("~/main/tab-content", () => ({
   ClassicMainTabContent: ({ tab }: { tab: { type: string } }) =>
     tab.type === "sessions" ? (
       <div data-testid="main-tab-content">
-        <input aria-label="Session title" />
+        <div data-tauri-drag-region>
+          <input aria-label="Session title" />
+        </div>
+        <button
+          type="button"
+          aria-label="Session tab"
+          data-main-area-window-drag-region
+          data-tauri-drag-region="false"
+        >
+          Summary
+        </button>
+        <input aria-label="Session note field" />
       </div>
     ) : (
       <div data-testid="main-tab-content">{tab.type}</div>
@@ -393,7 +404,7 @@ describe("ClassicMainBody", () => {
     expect(mocks.startDragging).toHaveBeenCalledTimes(1);
   });
 
-  it("does not start window dragging from an input in the top drag strip", () => {
+  it("starts window dragging from an input inside a Tauri drag region", () => {
     mocks.currentTab = {
       active: true,
       pinned: false,
@@ -412,6 +423,35 @@ describe("ClassicMainBody", () => {
       pointerId: 1,
     });
     fireEvent.pointerMove(titleInput, {
+      clientX: 248,
+      clientY: 12,
+      pointerId: 1,
+    });
+
+    expect(mocks.startDragging).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start window dragging from a regular input in the top drag strip", () => {
+    mocks.currentTab = {
+      active: true,
+      pinned: false,
+      slotId: "slot-1",
+      type: "sessions",
+    };
+
+    render(<ClassicMainBody />);
+
+    const noteInput = screen.getByRole("textbox", {
+      name: "Session note field",
+    });
+
+    fireEvent.pointerDown(noteInput, {
+      button: 0,
+      clientX: 240,
+      clientY: 12,
+      pointerId: 1,
+    });
+    fireEvent.pointerMove(noteInput, {
       clientX: 248,
       clientY: 12,
       pointerId: 1,
@@ -438,6 +478,33 @@ describe("ClassicMainBody", () => {
     });
 
     expect(mocks.startDragging).not.toHaveBeenCalled();
+  });
+
+  it("starts window dragging from an explicit drag target below the top strip", () => {
+    mocks.currentTab = {
+      active: true,
+      pinned: false,
+      slotId: "slot-1",
+      type: "sessions",
+    };
+
+    render(<ClassicMainBody />);
+
+    const tabButton = screen.getByRole("button", { name: "Session tab" });
+
+    fireEvent.pointerDown(tabButton, {
+      button: 0,
+      clientX: 240,
+      clientY: 72,
+      pointerId: 1,
+    });
+    fireEvent.pointerMove(tabButton, {
+      clientX: 248,
+      clientY: 72,
+      pointerId: 1,
+    });
+
+    expect(mocks.startDragging).toHaveBeenCalledTimes(1);
   });
 
   it("renders the shell while the initial tab is still loading", async () => {


### PR DESCRIPTION
Mark the session title shell as a Tauri drag region and let the top-strip drag handler honor explicit drag-region targets while preserving regular input behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop UI and pointer-event behavior only; changes are covered by updated unit tests with no auth or data-path impact.
> 
> **Overview**
> Improves **frameless window dragging** on the desktop app by marking session chrome (title, outer header, note tab header, session surface header) with `data-tauri-drag-region`, while keeping real controls clickable via `data-tauri-drag-region="false"`.
> 
> The session **title** shell is draggable when unfocused; on focus it sets the shell to `false` so typing and selection work normally. The main-area pointer handler in `body.tsx` now treats `data-tauri-drag-region` (and optional `data-main-area-window-drag-region`) as **explicit drag targets**, so dragging can start from those regions even over inputs in the top strip, without stealing drags from ordinary note fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e81872f747899eae5d1957420ffa32a331567da5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->