### PR TITLE
Reduce session header gap

### DIFF
--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -94,6 +94,7 @@ function getStoredNoteMarkdown(content: string | undefined) {
 const UUID_TITLE_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const ISO_TITLE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
+const SESSION_NOTE_TAB_CLASSNAME = "my-0";
 
 function getEnhancedNoteTitle({
   rawTitle,
@@ -197,6 +198,9 @@ function HeaderTabRaw({
 
   return (
     <NoteTab
+      data-main-area-window-drag-region
+      data-tauri-drag-region="false"
+      className={SESSION_NOTE_TAB_CLASSNAME}
       isActive={isActive}
       onClick={onClick}
       onContextMenu={showContextMenu}
@@ -376,6 +380,8 @@ function HeaderTabEnhanced({
 
     return wrapWithTemplateTooltip(
       <div
+        data-main-area-window-drag-region
+        data-tauri-drag-region="false"
         role="button"
         tabIndex={0}
         onClick={onClick}
@@ -387,7 +393,8 @@ function HeaderTabEnhanced({
           }
         }}
         className={cn([
-          "group/tab relative my-2 shrink-0 cursor-pointer border-b-2 px-1 py-0.5 text-xs font-medium transition-all duration-200 select-none",
+          "group/tab relative shrink-0 cursor-pointer border-b-2 px-1 py-0.5 text-xs font-medium transition-all duration-200 select-none",
+          SESSION_NOTE_TAB_CLASSNAME,
           isActive
             ? ["text-foreground", "border-foreground"]
             : [
@@ -401,6 +408,7 @@ function HeaderTabEnhanced({
           <TruncatedTitle title={tabTitle} isActive={isActive} />
           <button
             type="button"
+            data-tauri-drag-region="false"
             onClick={handleCancelClick}
             className={cn([
               "hover:bg-accent inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-xs",
@@ -437,6 +445,8 @@ function HeaderTabEnhanced({
 
   const regenerateIcon = (
     <span
+      data-main-area-window-drag-region
+      data-tauri-drag-region="false"
       onClick={handleRegenerateClick}
       className={cn([
         "group relative inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-xs transition-colors",
@@ -468,6 +478,9 @@ function HeaderTabEnhanced({
 
   return wrapWithTemplateTooltip(
     <NoteTab
+      data-main-area-window-drag-region
+      data-tauri-drag-region="false"
+      className={SESSION_NOTE_TAB_CLASSNAME}
       isActive={isActive}
       onClick={onClick}
       onContextMenu={showContextMenu}
@@ -935,8 +948,11 @@ function CreateOtherFormatButton({
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <button
+          data-main-area-window-drag-region
+          data-tauri-drag-region="false"
           className={cn([
-            "relative my-2 shrink-0 px-1 py-0.5 text-xs font-medium whitespace-nowrap transition-all duration-200 select-none",
+            "relative shrink-0 px-1 py-0.5 text-xs font-medium whitespace-nowrap transition-all duration-200 select-none",
+            SESSION_NOTE_TAB_CLASSNAME,
             "text-muted-foreground hover:text-foreground",
             "flex items-center gap-1",
             "border-b-2 border-transparent",

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -143,6 +143,7 @@ describe("OuterHeader", () => {
     expect(stopButton.className).toContain("dark:bg-red-950/50");
     expect(stopButton.className).toContain("dark:text-red-300");
     expect(stopButton.textContent).toContain("Stop");
+    expect(stopButton.getAttribute("data-tauri-drag-region")).toBe("false");
     expect(mocks.stopListening).toHaveBeenCalledTimes(1);
   });
 
@@ -163,12 +164,12 @@ describe("OuterHeader", () => {
     const header = titleSlot?.parentElement;
 
     expect(header?.className).toContain("pl-[156px]");
-    expect(header?.className).toContain("h-[52px]");
-    expect(header?.className).toContain("pb-1");
+    expect(header?.className).toContain("h-11");
+    expect(header?.className).not.toContain("pb-1");
     expect(titleWrapper?.className).toContain("w-full");
     expect(titleWrapper?.className).not.toContain("max-w-[680px]");
     expect(titleSlot?.className).toContain("left-[104px]");
-    expect(titleSlot?.className).toContain("-translate-y-1");
+    expect(titleSlot?.className).not.toContain("-translate-y-1");
     expect(titleSlot?.className).toContain("right-[70px]");
     expect(screen.queryByRole("button", { name: "Show sidebar" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
@@ -257,13 +258,15 @@ describe("OuterHeader", () => {
     );
 
     const joinButton = screen.getByRole("button", { name: "Join Meet" });
+    const metadataButton = screen.getByRole("button", {
+      name: "Open event metadata",
+    });
 
     fireEvent.click(joinButton);
 
     expect(joinButton.textContent).toContain("Join Meet");
-    expect(
-      screen.getByRole("button", { name: "Open event metadata" }),
-    ).not.toBeNull();
+    expect(joinButton.getAttribute("data-tauri-drag-region")).toBe("false");
+    expect(metadataButton.getAttribute("data-tauri-drag-region")).toBe("false");
     expect(mocks.openUrl).toHaveBeenCalledWith(
       "https://meet.google.com/abc-defg-hij",
       null,

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -37,7 +37,7 @@ export function OuterHeader({
     <div
       className={cn([
         "relative flex w-full items-center",
-        showSidebarTimelineHeaderGutter ? "h-[52px] pb-1" : "h-12",
+        showSidebarTimelineHeaderGutter ? "h-11" : "h-12",
         showSidebarTimelineHeaderGutter && "pl-[156px]",
       ])}
     >
@@ -47,7 +47,7 @@ export function OuterHeader({
             "pointer-events-none absolute inset-y-0 flex items-center",
             reserveCollapsedLiveControls ? "right-[153px]" : "right-[70px]",
             showSidebarTimelineHeaderGutter
-              ? "left-[104px] -translate-y-1"
+              ? "left-[104px]"
               : showExpandedSidebarTimelineHeader
                 ? "left-0"
                 : "left-[114px]",
@@ -136,6 +136,7 @@ function HeaderMeetingJoinButton({
     <div className="border-border bg-card text-foreground mr-1 flex h-8 max-w-56 shrink-0 items-center overflow-hidden rounded-full border shadow-[0_1px_4px_rgba(0,0,0,0.08)]">
       <button
         type="button"
+        data-tauri-drag-region="false"
         aria-label={label}
         title={label}
         onClick={handleJoin}
@@ -153,6 +154,7 @@ function HeaderMeetingJoinButton({
         renderTrigger={({ open, label: metadataLabel }) => (
           <button
             type="button"
+            data-tauri-drag-region="false"
             aria-label={metadataLabel}
             title={metadataLabel}
             className={cn([
@@ -233,6 +235,7 @@ function SidebarModeStopButton({ sessionMode }: { sessionMode: string }) {
   return (
     <button
       type="button"
+      data-tauri-drag-region="false"
       onClick={finalizing ? undefined : stop}
       disabled={finalizing}
       className={cn([

--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -61,6 +61,7 @@ const TriggerInner = forwardRef<
       variant="ghost"
       size="icon"
       type="button"
+      data-tauri-drag-region="false"
       aria-label={label}
       title={label}
       className={cn([

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -134,6 +134,21 @@ describe("OverflowButton", () => {
     expect(uploadTranscriptMock).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the overflow trigger out of the header drag region", () => {
+    const { container } = render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    const trigger = container.querySelector(
+      "button[data-tauri-drag-region='false']",
+    );
+
+    expect(trigger).not.toBeNull();
+  });
+
   it("hides upload actions when the current note has content", () => {
     useCurrentNoteHasContentMock.mockReturnValue(true);
 

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -79,6 +79,7 @@ export function OverflowButton({
           <Button
             size="icon"
             variant="ghost"
+            data-tauri-drag-region="false"
             className="text-muted-foreground hover:bg-accent hover:text-foreground rounded-full"
           >
             <MoreHorizontalIcon size={16} />

--- a/apps/desktop/src/session/components/session-surface.test.tsx
+++ b/apps/desktop/src/session/components/session-surface.test.tsx
@@ -1,0 +1,32 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/shared/main", () => ({
+  StandardTabWrapper: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="standard-tab-wrapper">{children}</div>
+  ),
+}));
+
+import { SessionSurface } from "./session-surface";
+
+describe("SessionSurface", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps note content tight below the outer header", () => {
+    render(
+      <SessionSurface header={<div data-testid="header" />}>
+        <div data-testid="content" />
+      </SessionSurface>,
+    );
+
+    const headerWrapper = screen.getByTestId("header").parentElement;
+    const contentWrapper = screen.getByTestId("content").parentElement;
+
+    expect(headerWrapper?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(contentWrapper?.className).not.toContain("mt-2");
+    expect(contentWrapper?.className).toContain("min-h-0");
+    expect(contentWrapper?.className).toContain("flex-1");
+  });
+});

--- a/apps/desktop/src/session/components/session-surface.tsx
+++ b/apps/desktop/src/session/components/session-surface.tsx
@@ -32,8 +32,12 @@ export function SessionSurface({
       mergeAfterBorder={mergeAfterBorder}
     >
       <div className="flex h-full flex-col">
-        {header ? <div className="pr-1 pl-3">{header}</div> : null}
-        <div className="mt-2 min-h-0 flex-1 px-2">{children}</div>
+        {header ? (
+          <div data-tauri-drag-region className="pr-1 pl-3">
+            {header}
+          </div>
+        ) : null}
+        <div className="min-h-0 flex-1 px-2">{children}</div>
       </div>
     </StandardTabWrapper>
   );

--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -97,6 +97,17 @@ describe("TitleInput", () => {
     ).toBeNull();
   });
 
+  it("keeps the title field out of the header drag region", () => {
+    renderTitleInput();
+
+    const input = screen.getByPlaceholderText("Untitled");
+
+    expect(input.getAttribute("data-tauri-drag-region")).toBe("false");
+    expect(input.parentElement?.getAttribute("data-tauri-drag-region")).toBe(
+      "false",
+    );
+  });
+
   it("uses the flexible title layout for whitespace-only titles", () => {
     hoisted.store.getCell.mockReturnValueOnce("          ");
 

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -77,7 +77,10 @@ export const TitleInput = forwardRef<
 
     if (isGenerating) {
       return (
-        <div className="flex h-8 w-full items-center justify-start">
+        <div
+          data-tauri-drag-region="false"
+          className="flex h-8 w-full items-center justify-start"
+        >
           <span className="text-muted-foreground animate-pulse text-xl font-semibold">
             Generating title...
           </span>
@@ -87,7 +90,10 @@ export const TitleInput = forwardRef<
 
     if (showRevealAnimation && generatedTitle) {
       return (
-        <div className="flex h-8 w-full items-center justify-start overflow-hidden">
+        <div
+          data-tauri-drag-region="false"
+          className="flex h-8 w-full items-center justify-start overflow-hidden"
+        >
           <span className="animate-reveal-left text-xl font-semibold whitespace-nowrap">
             {generatedTitle}
           </span>
@@ -341,10 +347,12 @@ const TitleInputInner = memo(
 
       return (
         <div
+          data-tauri-drag-region="false"
           style={titleFadeStyle}
           className="group/title-input relative flex h-8 w-full items-center overflow-hidden"
         >
           <input
+            data-tauri-drag-region="false"
             ref={setInputRef}
             id={`title-input-${sessionId}-${editorId}`}
             placeholder="Untitled"


### PR DESCRIPTION
Pull the note tab row closer to the top session toolbar by removing the session content spacer and tightening the local note-tab margins. Add a focused spacing regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI layout and Tauri drag-attribute changes only, covered by focused component tests; no auth, data, or backend impact.
> 
> **Overview**
> Tightens vertical spacing between the session toolbar and note tabs by removing the content `mt-2` spacer, zeroing note-tab vertical margins, and slimming the collapsed-sidebar outer header (`h-11`, no `pb-1` / title `-translate-y-1`).
> 
> Separately wires **Tauri window dragging** on the session header wrapper (`data-tauri-drag-region` on `SessionSurface`) while marking interactive chrome—title field, note tabs, stop/join/metadata/overflow controls—with `data-tauri-drag-region="false"` (and `data-main-area-window-drag-region` on tabs) so clicks still work. Regression tests cover spacing, drag attributes, and header layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78f8ab1df7ae033788a8e1c9f391cdb728e7e758. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->