### PR TITLE
Remove raw note placeholder

### DIFF
--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -6,7 +6,6 @@ import {
   NoteEditor,
   type JSONContent,
   type NoteEditorRef,
-  type PlaceholderFunction,
 } from "@hypr/editor/note";
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 
@@ -116,7 +115,6 @@ export const RawEditor = forwardRef<
         handleChange={handleChange}
         mentionConfig={mentionConfig}
         sessionMentionDropConfig={sessionMentionDropConfig}
-        placeholderComponent={Placeholder}
         onNavigateToTitle={onNavigateToTitle}
         onLinkOpen={openEditorLink}
         fileHandlerConfig={fileHandlerConfig}
@@ -140,15 +138,3 @@ function useRawEditorSyncSourceId() {
 
   return sourceIdRef.current;
 }
-
-const Placeholder: PlaceholderFunction = ({ node, pos }) => {
-  if (node.type.name !== "paragraph") {
-    return "";
-  }
-
-  if (pos === 0) {
-    return "Take notes to guide Anarlog's meeting notes. Press / for commands.";
-  }
-
-  return "Press / for commands.";
-};


### PR DESCRIPTION
Remove the raw editor placeholder so empty notes render without prompt text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change limited to raw note empty-state copy; no data, auth, or editor behavior changes beyond hiding placeholder text.
> 
> **Overview**
> Removes empty-state placeholder text from the session **raw note** editor so blank notes show no prompt.
> 
> The `RawEditor` no longer passes `placeholderComponent` to `NoteEditor` and deletes the local `Placeholder` helper that showed “Take notes to guide Anarlog's meeting notes…” at the first paragraph and “Press / for commands.” elsewhere. Other editors (chat, composer) still use their own placeholders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbdf572a32559524a1cb68e2355caeca78d773ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->