### PR TITLE
Restore inline enhanced-note loading

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
@@ -86,7 +86,7 @@ describe("Enhanced", () => {
     expect(screen.queryByTestId("spinner")).toBeNull();
   });
 
-  it("keeps the generating view quiet until summary text streams", () => {
+  it("shows an inline analyzing state until summary text streams", () => {
     hoisted.task = {
       status: "generating",
       error: undefined,
@@ -97,8 +97,11 @@ describe("Enhanced", () => {
 
     render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
 
-    expect(screen.queryByRole("status")).toBeNull();
-    expect(screen.queryByText("Preparing summary...")).toBeNull();
+    expect(screen.getByRole("status")).not.toBeNull();
+    expect(screen.getByText("Analyzing structure...")).not.toBeNull();
+    expect(
+      screen.getByText("Tip: The Anarlog team loves our users!"),
+    ).not.toBeNull();
     expect(screen.queryByText("Enhanced editor")).toBeNull();
   });
 

--- a/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
@@ -11,6 +11,25 @@ export function StreamingView({ enhancedNoteId }: { enhancedNoteId: string }) {
   const taskId = createTaskId(enhancedNoteId, "enhance");
   const { streamedText, isGenerating } = useAITaskTask(taskId, "enhance");
 
+  if (streamedText.trim().length === 0) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="text-muted-foreground flex flex-col gap-0.5 pb-2 text-sm"
+      >
+        <p className="leading-5">Analyzing structure...</p>
+        <p className="flex items-start gap-1.5 pl-4 text-xs leading-5">
+          <span
+            aria-hidden="true"
+            className="border-muted-foreground/60 mt-[5px] h-2 w-2 shrink-0 rounded-bl-[2px] border-b border-l"
+          />
+          <span>Tip: The Anarlog team loves our users!</span>
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="pb-2">
       <div className="flex flex-col gap-1">

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -24,7 +24,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@hypr/ui/components/ui/popover";
-import { Spinner } from "@hypr/ui/components/ui/spinner";
 import { sonnerToast } from "@hypr/ui/components/ui/toast";
 import { cn } from "@hypr/utils";
 
@@ -47,7 +46,6 @@ import {
 import { useWebResources } from "~/shared/ui/resource-list";
 import * as main from "~/store/tinybase/store/main";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
-import { type TaskStepInfo } from "~/store/zustand/ai-task/tasks";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { type EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
@@ -226,8 +224,10 @@ function HeaderTabEnhanced({
   canRemove?: boolean;
   onRemove?: () => void;
 }) {
-  const { isGenerating, isError, onRegenerate, onCancel, currentStep } =
-    useEnhanceLogic(sessionId, enhancedNoteId);
+  const { isGenerating, isError, onRegenerate, onCancel } = useEnhanceLogic(
+    sessionId,
+    enhancedNoteId,
+  );
   const content = main.UI.useCell(
     "enhanced_notes",
     enhancedNoteId,
@@ -372,8 +372,6 @@ function HeaderTabEnhanced({
   const showContextMenu = useNativeContextMenu(contextMenu);
 
   if (isGenerating) {
-    const step = currentStep as TaskStepInfo<"enhance"> | undefined;
-
     const handleCancelClick = (e: React.MouseEvent) => {
       e.stopPropagation();
       onCancel();
@@ -417,27 +415,7 @@ function HeaderTabEnhanced({
             ])}
             aria-label="Cancel enhancement"
           >
-            <span className="flex items-center justify-center group-hover/tab:hidden">
-              {step?.type === "generating" ? (
-                <>
-                  <img
-                    src="/assets/write-animation.gif"
-                    alt=""
-                    aria-hidden="true"
-                    className="size-3 dark:hidden"
-                  />
-                  <img
-                    src="/assets/write-animation-white.gif"
-                    alt=""
-                    aria-hidden="true"
-                    className="hidden size-3 dark:block"
-                  />
-                </>
-              ) : (
-                <Spinner size={14} />
-              )}
-            </span>
-            <XIcon className="hidden size-4 items-center justify-center group-hover/tab:flex" />
+            <XIcon className="flex size-4 items-center justify-center" />
           </button>
         </span>
       </div>,
@@ -1241,7 +1219,6 @@ function useEnhanceLogic(sessionId: string, enhancedNoteId: string) {
     error,
     onRegenerate,
     onCancel: enhanceTask.cancel,
-    currentStep: enhanceTask.currentStep,
   };
 }
 


### PR DESCRIPTION
Show the analyzing status beneath the note tabs and keep the generating tab cancel affordance visible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Session note UI and loading affordances only; no auth, data, or enhance pipeline logic changes.
> 
> **Overview**
> Restores visible feedback in the enhanced note body while enhancement runs but **no summary text has streamed yet**. `StreamingView` now shows an accessible **`role="status"`** block with **“Analyzing structure…”** and a short tip instead of a blank area.
> 
> The **generating enhanced tab** is simplified: cancel is always a visible **X** (no step-based spinner or write animation), and tab logic no longer depends on **`currentStep`** from the enhance task. Tests are updated to expect the inline analyzing state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09dc70172eb88095da00ce376fd6f0f6f9f26878. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->