### PR TITLE
Show ready app updates in sidebar chrome

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -298,7 +298,7 @@ function SidebarTimelineChrome({
   update: DesktopUpdateControl;
 }) {
   const updateVisible = Boolean(update.status && update.version);
-  const showDownloadButton = sidebarExpanded && update.status === "available";
+  const showUpdateButton = sidebarExpanded && updateVisible;
 
   return (
     <div
@@ -328,7 +328,7 @@ function SidebarTimelineChrome({
           </>
         ) : null}
       </div>
-      {showDownloadButton ? (
+      {showUpdateButton ? (
         <SidebarTimelineUpdateButton update={update} />
       ) : null}
     </div>

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -291,13 +291,13 @@ describe("ClassicMainBody", () => {
     ).toBeNull();
   });
 
-  it("only shows downloadable updates in the far-right sidebar chrome slot", () => {
+  it("shows ready updates in the far-right sidebar chrome slot", () => {
     mocks.sidebarUpdateControl.status = "ready";
     mocks.sidebarUpdateControl.version = "1.0.34";
 
     render(<ClassicMainBody />);
 
-    expect(screen.queryByTestId("sidebar-update-button")).toBeNull();
+    expect(screen.getByTestId("sidebar-update-button")).toBeTruthy();
   });
 
   it("shows an update badge on the collapsed sidebar toggle", () => {

--- a/plugins/tray/src/menu_items/tray_check_update.rs
+++ b/plugins/tray/src/menu_items/tray_check_update.rs
@@ -9,6 +9,7 @@ use tauri::{
 };
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 use tauri_plugin_updater2::Updater2PluginExt;
+use tauri_specta::Event;
 
 use super::{MenuItemHandler, TrayOpen, TrayQuit, TrayStart, TrayVersion};
 
@@ -75,6 +76,25 @@ impl TrayCheckUpdate {
     fn pending_version() -> Option<String> {
         PENDING_VERSION.lock().unwrap().clone()
     }
+
+    async fn apply_update(app: AppHandle<tauri::Wry>, version: String) {
+        match app.updater2().install(&version).await {
+            Ok(result) => {
+                if let Err(e) = app.updater2().postinstall(result).await {
+                    app.dialog()
+                        .message(format!("Failed to apply update: {}", e))
+                        .title("Update Failed")
+                        .show(|_| {});
+                }
+            }
+            Err(e) => {
+                app.dialog()
+                    .message(format!("Failed to install update: {}", e))
+                    .title("Update Failed")
+                    .show(|_| {});
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -106,22 +126,7 @@ impl MenuItemHandler for TrayCheckUpdate {
             if let Some(version) = Self::pending_version() {
                 let app = app.clone();
                 tauri::async_runtime::spawn(async move {
-                    match app.updater2().install(&version).await {
-                        Ok(result) => {
-                            if let Err(e) = app.updater2().postinstall(result).await {
-                                app.dialog()
-                                    .message(format!("Failed to apply update: {}", e))
-                                    .title("Update Failed")
-                                    .show(|_| {});
-                            }
-                        }
-                        Err(e) => {
-                            app.dialog()
-                                .message(format!("Failed to install update: {}", e))
-                                .title("Update Failed")
-                                .show(|_| {});
-                        }
-                    }
+                    Self::apply_update(app, version).await;
                 });
             }
             return;
@@ -135,6 +140,14 @@ impl MenuItemHandler for TrayCheckUpdate {
         tauri::async_runtime::spawn(async move {
             match app.updater2().check().await {
                 Ok(Some(version)) => {
+                    if app.updater2().has_cached_update(&version) {
+                        let event = tauri_plugin_updater2::UpdateReadyEvent { version };
+                        if let Err(e) = event.emit(&app) {
+                            tracing::warn!("failed_emit_update_ready_event: {e}");
+                        }
+                        return;
+                    }
+
                     let app_for_dialog = app.clone();
                     let version_for_download = version.clone();
                     app.dialog()


### PR DESCRIPTION
Keep the update control visible after the stable updater has already downloaded an update so users can restart to install it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI visibility and tray update-check branching only; install paths reuse existing updater2 APIs with no new auth or data handling.
> 
> **Overview**
> Keeps the **sidebar update control** visible whenever an update has a status and version—not only while status is `available`—so users who already downloaded an update can still use the far-right chrome slot to restart and install.
> 
> **Tray “Check for Updates”** now skips the download prompt when `has_cached_update` is true and instead emits **`UpdateReadyEvent`**, aligning the tray path with the in-app “ready” state. Install/restart logic is moved into a shared **`apply_update`** helper used from the restart menu action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b61a77413ea95584e8e82fd758b56129142f355d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->