### PR TITLE
Overlay sidebar Now chip

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
   addDeletion: vi.fn(),
   configValue: undefined as string | undefined,
   currentTimeMs: undefined as number | undefined,
+  isAnchorVisible: true,
+  isScrolledPastAnchor: false,
   isIgnored: vi.fn(() => false),
   liveSessionId: null as string | null,
   liveStatus: "inactive" as "inactive" | "active" | "finalizing",
@@ -123,8 +125,8 @@ vi.mock("./anchor", async () => {
     useAnchor: () => ({
       anchorNode: mocks.anchorNode,
       containerRef: React.useRef<HTMLDivElement>(null),
-      isAnchorVisible: true,
-      isScrolledPastAnchor: false,
+      isAnchorVisible: mocks.isAnchorVisible,
+      isScrolledPastAnchor: mocks.isScrolledPastAnchor,
       registerAnchor: mocks.registerAnchor,
       scrollToAnchor: vi.fn(),
     }),
@@ -160,6 +162,8 @@ describe("TimelineView", () => {
     mocks.anchorNode = null;
     mocks.configValue = undefined;
     mocks.currentTimeMs = undefined;
+    mocks.isAnchorVisible = true;
+    mocks.isScrolledPastAnchor = false;
     mocks.isIgnored.mockReturnValue(false);
     mocks.liveSessionId = null;
     mocks.liveStatus = "inactive";
@@ -479,6 +483,29 @@ describe("TimelineView", () => {
     expect(getSidebarActionTabsOrNull()).toBeNull();
     expect(getTopFade(container).className).toContain("h-16");
     expect(getTopFade(container).className).toContain("from-60%");
+  });
+
+  it("overlays the top now chip without reserving sidebar space", () => {
+    mocks.isAnchorVisible = false;
+    mocks.isScrolledPastAnchor = true;
+    mocks.timelineSessionsTable = {
+      past: {
+        title: "Design sync",
+        created_at: "2024-01-14T12:00:00.000Z",
+      },
+    };
+
+    const { container } = render(<TimelineView topChromeInset />);
+
+    expect(screen.getByRole("button", { name: "Go back to now" })).toBeTruthy();
+    expect(
+      container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
+    ).toContain("h-12");
+    expect(
+      container.querySelector("[data-sidebar-timeline-bucket-header]")
+        ?.className,
+    ).toContain("top-12");
+    expect(getTopFade(container).className).toContain("h-16");
   });
 
   it("places the fallback now indicator between future and past buckets", () => {

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -146,22 +146,21 @@ export function TimelineView({
     anchorNode: todayAnchorNode,
   } = useAnchor();
   const showTopNowChip = !isTodayVisible && isScrolledPastToday;
-  const topChromeChipCount = [
+  const reservedTopChromeChipCount = [
     showOpenCalendarChip,
     topChromeInset && showCalendarSyncStatus,
-    topChromeInset && showTopNowChip,
   ].filter(Boolean).length;
   const topSpacerClassName = topChromeInset
-    ? topChromeChipCount > 1
+    ? reservedTopChromeChipCount > 1
       ? "h-28"
-      : topChromeChipCount === 1
+      : reservedTopChromeChipCount === 1
         ? "h-20"
         : "h-12"
     : "h-10";
   const bucketHeaderTopClassName = topChromeInset
-    ? topChromeChipCount > 1
+    ? reservedTopChromeChipCount > 1
       ? "top-28"
-      : topChromeChipCount === 1
+      : reservedTopChromeChipCount === 1
         ? "top-20"
         : "top-12"
     : "top-0";
@@ -437,9 +436,9 @@ export function TimelineView({
           data-sidebar-timeline-top-fade
           className={cn([
             "pointer-events-none absolute inset-x-0 top-0 z-[15]",
-            topChromeChipCount > 1
+            reservedTopChromeChipCount > 1
               ? "bg-background h-28"
-              : topChromeChipCount === 1
+              : reservedTopChromeChipCount === 1
                 ? "bg-background h-20"
                 : "from-background via-background/95 to-background/0 h-16 bg-linear-to-b from-60% via-85%",
           ])}


### PR DESCRIPTION
Keep the floating Now chip out of reserved sidebar timeline spacing and cover the scrolled-past-anchor state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout change in the sidebar timeline with a focused test; no auth, data, or API impact.
> 
> **Overview**
> When users scroll past the “today” anchor, the floating **Go back to now** chip still appears in the sidebar top chrome, but it no longer counts toward reserved timeline spacing.
> 
> **Reserved top chrome** (`topSpacerClassName`, sticky bucket headers, and the top fade) now only accounts for the open-calendar chip and calendar sync status—not `showTopNowChip`. That keeps the default `h-12` / `top-12` layout when only the Now chip is visible, so the chip overlays the list instead of pushing content down.
> 
> Tests mock `isAnchorVisible` / `isScrolledPastAnchor` and assert the scrolled-past-anchor state shows the Now button while spacer and bucket headers stay at the compact inset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 404a9dfb368f2c2c5ce8a13546432f8ca1cbaf94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->