### PR TITLE
Keep KakaoTalk screen sharing from stopping listening

### DIFF
--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -312,6 +312,125 @@ describe("ListenerProvider detect events", () => {
     expect(stopSpy).not.toHaveBeenCalled();
   });
 
+  test.each([
+    [[{ id: "com.kakao.KakaoTalkMac", name: "KakaoTalk" }]],
+    [[{ id: "pid:42", name: "KakaoTalk Helper" }]],
+  ])(
+    "does not auto-stop KakaoTalk sessions from screen-share mic transitions",
+    async (stoppedApps) => {
+      const store = createListenerStore();
+      const stopSpy = vi.fn();
+
+      store.setState({ stop: stopSpy });
+      store.getState().setTriggerAppIds(["com.kakao.KakaoTalkMac"]);
+      setStoreActive(store);
+
+      render(
+        <ListenerProvider store={store}>
+          <div>child</div>
+        </ListenerProvider>,
+      );
+
+      await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+      const handler = listenMock.mock.calls[0]?.[0];
+      expect(handler).toBeTypeOf("function");
+
+      vi.useFakeTimers();
+      listMicUsingApplicationsMock.mockClear();
+
+      handler({
+        payload: {
+          type: "micStopped",
+          apps: stoppedApps,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+
+      expect(listMicUsingApplicationsMock).not.toHaveBeenCalled();
+      expect(stopSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  test("does not auto-stop co-trigger sessions while KakaoTalk remains active after a helper stop", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    store
+      .getState()
+      .setTriggerAppIds(["com.kakao.KakaoTalkMac", "us.zoom.xos"]);
+    setStoreActive(store);
+    listMicUsingApplicationsMock.mockResolvedValue({
+      status: "ok",
+      data: [{ id: "com.kakao.KakaoTalkMac", name: "KakaoTalk" }],
+    });
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+    listMicUsingApplicationsMock.mockClear();
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "pid:42", name: "KakaoTalk Helper" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+
+    expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  test("auto-stops co-trigger sessions after a helper stop when no trigger app remains active", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    store
+      .getState()
+      .setTriggerAppIds(["com.kakao.KakaoTalkMac", "us.zoom.xos"]);
+    setStoreActive(store);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+    listMicUsingApplicationsMock.mockClear();
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "pid:42", name: "KakaoTalk Helper" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+
+    expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
   test("auto-stops when MicStopped omits the trigger app and no trigger app remains active (regression: #5436)", async () => {
     const store = createListenerStore();
     const stopSpy = vi.fn();

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -61,6 +61,8 @@ const BROWSER_AUTO_STOP_APP_IDS = new Set([
   "org.torproject.torbrowser",
 ]);
 
+const UNRELIABLE_AUTO_STOP_APP_IDS = new Set(["com.kakao.KakaoTalkMac"]);
+
 type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
 
 function getIgnorableApps(apps: { id: string; name: string }[]) {
@@ -176,8 +178,20 @@ function getAutoStopCandidateAppIds(
   const trigger = triggerAppIds ?? [];
   const stoppedIds = new Set(stoppedApps.map((app) => app.id));
   const stoppedTriggerAppIds = trigger.filter((id) => stoppedIds.has(id));
+  const candidateAppIds =
+    stoppedTriggerAppIds.length > 0 ? stoppedTriggerAppIds : trigger;
 
-  return stoppedTriggerAppIds.length > 0 ? stoppedTriggerAppIds : trigger;
+  return candidateAppIds.filter((id) => !UNRELIABLE_AUTO_STOP_APP_IDS.has(id));
+}
+
+function getAutoStopActiveCheckAppIds(
+  triggerAppIds: string[] | null | undefined,
+  candidateAppIds: string[],
+) {
+  const unreliableTriggerAppIds =
+    triggerAppIds?.filter((id) => UNRELIABLE_AUTO_STOP_APP_IDS.has(id)) ?? [];
+
+  return [...new Set([...candidateAppIds, ...unreliableTriggerAppIds])];
 }
 
 function getStoppedAppLabel(app: { name: string } | null) {
@@ -321,13 +335,20 @@ const useHandleDetectEvents = (store: ListenerStore) => {
         return;
       }
 
+      const activeCheckAppIds = getAutoStopActiveCheckAppIds(
+        currentTrigger,
+        candidateAppIds,
+      );
+      const hasUnreliableActiveCheckApp = activeCheckAppIds.some(
+        (id) => !candidateAppIds.includes(id),
+      );
       const result = await detectCommands.listMicUsingApplications();
       if (result.status === "ok") {
         const activeAppIds = new Set(result.data.map((app) => app.id));
-        if (candidateAppIds.some((id) => activeAppIds.has(id))) {
+        if (activeCheckAppIds.some((id) => activeAppIds.has(id))) {
           return;
         }
-      } else if (requireMicSnapshot) {
+      } else if (requireMicSnapshot || hasUnreliableActiveCheckApp) {
         return;
       }
 


### PR DESCRIPTION
Ignore KakaoTalk mic-stop events when selecting auto-stop candidates and cover direct/helper stop regressions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core meeting auto-stop logic in `ListenerProvider`; behavior is narrowed to KakaoTalk and co-trigger edge cases but could affect when sessions end for those users.
> 
> **Overview**
> **KakaoTalk** (`com.kakao.KakaoTalkMac`) is treated as an unreliable auto-stop trigger so screen-share mic transitions no longer end listening when it is the only trigger.
> 
> Auto-stop **candidates** exclude that bundle id, but the post-delay mic snapshot still checks whether KakaoTalk (and any other “unreliable” triggers) remain active. If the snapshot fails while an unreliable trigger is in play, auto-stop is skipped instead of stopping blindly.
> 
> For **co-trigger** sessions (e.g. KakaoTalk + Zoom), a helper-only `micStopped` keeps the session running when KakaoTalk is still on the mic list; auto-stop still runs when no trigger app is left active. New tests cover direct/helper stops and those co-trigger cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b00524947cb4efe2bdf6212a9f2fc9d340d1535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->