### PR TITLE
Regenerate summaries after resumed listening

### DIFF
--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -5,7 +5,9 @@ import { getPostCaptureAction } from "./useStartListening";
 import { useStartListening } from "./useStartListening";
 
 const {
+  queueAutoEnhanceMock,
   queueAutoEnhanceIfSummaryEmptyMock,
+  resetEnhanceTasksMock,
   startMock,
   runBatchMock,
   useListenerMock,
@@ -21,7 +23,9 @@ const {
   mainStoreMock,
   settingsStoreMock,
 } = vi.hoisted(() => ({
+  queueAutoEnhanceMock: vi.fn(),
   queueAutoEnhanceIfSummaryEmptyMock: vi.fn(),
+  resetEnhanceTasksMock: vi.fn(),
   startMock: vi.fn(),
   runBatchMock: vi.fn(),
   useListenerMock: vi.fn(),
@@ -35,9 +39,10 @@ const {
   settingsUseStoreMock: vi.fn(),
   deleteProcessedAudioForRetentionMock: vi.fn(),
   mainStoreMock: {
-    getCell: vi.fn(() => ""),
+    getCell: vi.fn((_table: string, _rowId: string, _cell: string) => ""),
     forEachRow: vi.fn(),
     setRow: vi.fn(),
+    setCell: vi.fn(),
     delRow: vi.fn(),
     transaction: vi.fn((fn: () => void) => fn()),
   },
@@ -75,7 +80,9 @@ vi.mock("./useSTTConnection", () => ({
 
 vi.mock("~/services/enhancer", () => ({
   getEnhancerService: vi.fn(() => ({
+    queueAutoEnhance: queueAutoEnhanceMock,
     queueAutoEnhanceIfSummaryEmpty: queueAutoEnhanceIfSummaryEmptyMock,
+    resetEnhanceTasks: resetEnhanceTasksMock,
   })),
 }));
 
@@ -187,6 +194,8 @@ describe("useStartListening", () => {
       key === "ai_language" ? "en" : [],
     );
     settingsUseStoreMock.mockReturnValue(settingsStoreMock);
+    mainStoreMock.getCell.mockImplementation(() => "");
+    mainStoreMock.forEachRow.mockImplementation(() => {});
     useSTTConnectionMock.mockReturnValue({
       conn: {
         provider: "hyprnote",
@@ -283,6 +292,110 @@ describe("useStartListening", () => {
       settingsStoreMock,
       "session-1",
     );
+  });
+
+  test("regenerates the summary after resumed live capture writes transcript", async () => {
+    useIndexesMock.mockReturnValue({
+      getSliceRowIds: vi.fn(() => ["existing-transcript"]),
+    });
+    mainStoreMock.getCell.mockImplementation((table, _rowId, cell) => {
+      if (table === "transcripts" && cell === "words") {
+        return JSON.stringify([
+          {
+            id: "existing-word",
+            text: "existing",
+            start_ms: 0,
+            end_ms: 100,
+            channel: 0,
+          },
+        ]);
+      }
+
+      return "";
+    });
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    const handlePersist = startMock.mock.calls[0]?.[1]?.handlePersist;
+    expect(handlePersist).toBeTypeOf("function");
+
+    act(() => {
+      handlePersist?.({
+        new_words: [
+          {
+            id: "new-word",
+            text: "new",
+            start_ms: 100,
+            end_ms: 200,
+            channel: 0,
+          },
+        ],
+        replaced_ids: [],
+        partials: [],
+      });
+    });
+
+    const onStopped = startMock.mock.calls[0]?.[1]?.onStopped;
+
+    await act(async () => {
+      await onStopped?.("session-1", {
+        durationSeconds: 42,
+        audioPath: "/tmp/session.wav",
+        requestedLiveTranscription: true,
+        liveTranscriptionActive: true,
+      });
+    });
+
+    expect(resetEnhanceTasksMock).toHaveBeenCalledWith("session-1");
+    expect(queueAutoEnhanceMock).toHaveBeenCalledWith("session-1");
+    expect(queueAutoEnhanceIfSummaryEmptyMock).not.toHaveBeenCalled();
+  });
+
+  test("regenerates the summary after resumed batch capture completes", async () => {
+    useIndexesMock.mockReturnValue({
+      getSliceRowIds: vi.fn(() => ["existing-transcript"]),
+    });
+    mainStoreMock.getCell.mockImplementation((table, _rowId, cell) => {
+      if (table === "transcripts" && cell === "words") {
+        return JSON.stringify([
+          {
+            id: "existing-word",
+            text: "existing",
+            start_ms: 0,
+            end_ms: 100,
+            channel: 0,
+          },
+        ]);
+      }
+
+      return "";
+    });
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    const onStopped = startMock.mock.calls[0]?.[1]?.onStopped;
+
+    await act(async () => {
+      await onStopped?.("session-1", {
+        durationSeconds: 42,
+        audioPath: "/tmp/session.wav",
+        requestedLiveTranscription: false,
+        liveTranscriptionActive: false,
+      });
+    });
+
+    expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav");
+    expect(resetEnhanceTasksMock).toHaveBeenCalledWith("session-1");
+    expect(queueAutoEnhanceMock).toHaveBeenCalledWith("session-1");
+    expect(queueAutoEnhanceIfSummaryEmptyMock).not.toHaveBeenCalled();
   });
 
   test("forces batch transcription for batch-only local models with realtime stored", async () => {

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -30,8 +30,22 @@ import {
 } from "~/stt/capabilities";
 import {
   createTranscriptAccumulator,
+  parseTranscriptWords,
   type TranscriptAccumulator,
 } from "~/stt/utils";
+
+function hasTranscriptContent(
+  store: main.Store,
+  indexes: ReturnType<typeof main.UI.useIndexes> | undefined,
+  sessionId: string,
+) {
+  const transcriptIds =
+    indexes?.getSliceRowIds(main.INDEXES.transcriptBySession, sessionId) ?? [];
+
+  return transcriptIds.some(
+    (transcriptId) => parseTranscriptWords(store, transcriptId).length > 0,
+  );
+}
 
 export function getPostCaptureAction(
   details: {
@@ -81,6 +95,11 @@ export function useStartListening(sessionId: string) {
     const startedAt = Date.now();
     const memoMd = store.getCell("sessions", sessionId, "raw_md");
     const createdAt = new Date().toISOString();
+    const hadTranscriptBeforeStart = hasTranscriptContent(
+      store as main.Store,
+      indexes ?? undefined,
+      sessionId,
+    );
     const transcriptAccumulatorRef: {
       current: TranscriptAccumulator | null;
     } = { current: null };
@@ -113,7 +132,16 @@ export function useStartListening(sessionId: string) {
         return;
       }
 
-      getEnhancerService()?.queueAutoEnhanceIfSummaryEmpty(sessionId);
+      const service = getEnhancerService();
+      const shouldRegenerateExistingSummary =
+        hadTranscriptBeforeStart &&
+        (transcriptId !== null || postCaptureAction === "batch_then_enhance");
+      if (shouldRegenerateExistingSummary) {
+        service?.resetEnhanceTasks(sessionId);
+        service?.queueAutoEnhance(sessionId);
+      } else {
+        service?.queueAutoEnhanceIfSummaryEmpty(sessionId);
+      }
 
       if (settingsStore) {
         await deleteProcessedAudioForRetention(


### PR DESCRIPTION
Force auto-enhance to rerun when a resumed capture adds or replaces transcript data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when AI summaries are regenerated after listening stops; mistakes could overwrite or skip summaries, but logic is limited to sessions with pre-existing transcript.
> 
> **Overview**
> **Resumed listening** now triggers a **full summary regeneration** when the session already had transcript text before capture started, instead of only auto-enhancing when the summary is empty.
> 
> `useStartListening` records whether the session had transcript at start via `hasTranscriptContent`, then on stop chooses **`resetEnhanceTasks` + `queueAutoEnhance`** when that was true and new live transcript was persisted or batch transcription ran; otherwise behavior stays **`queueAutoEnhanceIfSummaryEmpty`**.
> 
> Tests cover resumed **live** (with `handlePersist`) and **batch** stop paths asserting the new enhancer calls and that the empty-summary path is skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49ffdf97d74c2bf52d3582b24fb6aabb70f42e93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->