### PR TITLE
Align generating summary preview with final view

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EnhancedEditor } from "./editor";
+
+const hoisted = vi.hoisted(() => ({
+  content: JSON.stringify({ type: "doc", content: [] }),
+  handleChange: vi.fn(),
+  noteEditorProps: [] as Record<string, unknown>[],
+}));
+
+vi.mock("@hypr/editor/markdown", () => ({
+  parseJsonContent: (value: string) => JSON.parse(value),
+}));
+
+vi.mock("@hypr/editor/note", () => ({
+  NoteEditor: (props: Record<string, unknown>) => {
+    hoisted.noteEditorProps.push(props);
+
+    return <div>Note editor</div>;
+  },
+}));
+
+vi.mock("~/editor-bridge/app-link-view", () => ({
+  AppLinkView: () => null,
+}));
+
+vi.mock("~/editor-bridge/mention-config", () => ({
+  useMentionConfig: () => ({ users: [] }),
+}));
+
+vi.mock("~/editor-bridge/open-editor-link", () => ({
+  openEditorLink: vi.fn(),
+}));
+
+vi.mock("~/editor-bridge/session-mention-drop", () => ({
+  sessionMentionDropConfig: { read: () => null },
+}));
+
+vi.mock("~/editor-bridge/session-view", () => ({
+  SessionNodeView: () => null,
+}));
+
+vi.mock("~/shared/hooks/useFileUpload", () => ({
+  useFileUpload: () => vi.fn(),
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useCell: () => hoisted.content,
+    useSetPartialRowCallback: () => hoisted.handleChange,
+  },
+}));
+
+describe("EnhancedEditor", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    hoisted.noteEditorProps = [];
+    hoisted.content = JSON.stringify({ type: "doc", content: [] });
+    hoisted.handleChange = vi.fn();
+  });
+
+  it("keeps persisted notes from syncing external content while focused", () => {
+    render(<EnhancedEditor sessionId="session-1" enhancedNoteId="note-1" />);
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+
+    expect(props?.syncContentWhenFocused).toBe(false);
+    expect(props?.handleChange).toBe(hoisted.handleChange);
+    expect(props?.taskSource).toEqual({ type: "enhanced_note", id: "note-1" });
+  });
+
+  it("keeps streamed previews syncing while focused", () => {
+    const contentOverride = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "Generating" }] },
+      ],
+    };
+
+    render(
+      <EnhancedEditor
+        sessionId="session-1"
+        enhancedNoteId="note-1"
+        contentOverride={contentOverride}
+      />,
+    );
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+
+    expect(props?.syncContentWhenFocused).toBe(true);
+    expect(props?.handleChange).toBeUndefined();
+    expect(props?.taskSource).toBeUndefined();
+    expect(props?.initialContent).toBe(contentOverride);
+  });
+});

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -23,6 +23,7 @@ export const EnhancedEditor = forwardRef<
   {
     sessionId: string;
     enhancedNoteId: string;
+    contentOverride?: JSONContent;
     onNavigateToTitle?: (pixelWidth?: number) => void;
     onViewReady?: (view: EditorView) => void;
     onViewDisposed?: (view: EditorView) => void;
@@ -32,6 +33,7 @@ export const EnhancedEditor = forwardRef<
     {
       sessionId,
       enhancedNoteId,
+      contentOverride,
       onNavigateToTitle,
       onViewReady,
       onViewDisposed,
@@ -47,9 +49,13 @@ export const EnhancedEditor = forwardRef<
     );
 
     const initialContent = useMemo<JSONContent>(
-      () => parseJsonContent(content as string),
-      [content],
+      () => contentOverride ?? parseJsonContent(content as string),
+      [content, contentOverride],
     );
+    const persistChanges = contentOverride === undefined;
+    const editorKey = persistChanges
+      ? `enhanced-note-${enhancedNoteId}`
+      : `enhanced-note-${enhancedNoteId}-preview`;
 
     const handleChange = main.UI.useSetPartialRowCallback(
       "enhanced_notes",
@@ -67,18 +73,23 @@ export const EnhancedEditor = forwardRef<
         <NoteEditor
           ref={ref}
           className="enhanced-summary-editor"
-          key={`enhanced-note-${enhancedNoteId}`}
+          key={editorKey}
           initialContent={initialContent}
-          handleChange={handleChange}
+          handleChange={persistChanges ? handleChange : undefined}
           mentionConfig={mentionConfig}
           sessionMentionDropConfig={sessionMentionDropConfig}
           onNavigateToTitle={onNavigateToTitle}
           onLinkOpen={openEditorLink}
           fileHandlerConfig={fileHandlerConfig}
-          taskSource={{ type: "enhanced_note", id: enhancedNoteId }}
+          taskSource={
+            persistChanges
+              ? { type: "enhanced_note", id: enhancedNoteId }
+              : undefined
+          }
           extraNodeViews={extraNodeViews}
           onViewReady={onViewReady}
           onViewDisposed={onViewDisposed}
+          syncContentWhenFocused={!persistChanges}
         />
       </div>
     );

--- a/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
@@ -23,10 +23,6 @@ const hoisted = vi.hoisted(() => ({
   content: "",
 }));
 
-vi.mock("streamdown", () => ({
-  Streamdown: ({ children }: { children: string }) => <div>{children}</div>,
-}));
-
 vi.mock("@hypr/ui/components/ui/spinner", () => ({
   Spinner: () => <span data-testid="spinner" />,
 }));
@@ -55,7 +51,34 @@ vi.mock("./config-error", () => ({
 }));
 
 vi.mock("./editor", () => ({
-  EnhancedEditor: () => <div>Enhanced editor</div>,
+  EnhancedEditor: ({
+    contentOverride,
+  }: {
+    contentOverride?: { content?: unknown[] };
+  }) => {
+    const collectText = (value: unknown): string => {
+      if (!value || typeof value !== "object") {
+        return "";
+      }
+
+      const node = value as {
+        text?: unknown;
+        content?: unknown[];
+      };
+
+      return [
+        typeof node.text === "string" ? node.text : "",
+        ...(node.content?.map(collectText) ?? []),
+      ].join("");
+    };
+
+    return (
+      <div>
+        <span>Enhanced editor</span>
+        {contentOverride ? <span>{collectText(contentOverride)}</span> : null}
+      </div>
+    );
+  },
 }));
 
 vi.mock("./enhance-error", () => ({
@@ -86,23 +109,20 @@ describe("Enhanced", () => {
     expect(screen.queryByTestId("spinner")).toBeNull();
   });
 
-  it("shows an inline analyzing state until summary text streams", () => {
+  it("renders a generating summary through the editor preview", () => {
     hoisted.task = {
       status: "generating",
       error: undefined,
-      streamedText: "",
+      streamedText: "Streaming summary",
       currentStep: undefined,
       isGenerating: true,
     };
 
     render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
 
-    expect(screen.getByRole("status")).not.toBeNull();
-    expect(screen.getByText("Analyzing structure...")).not.toBeNull();
-    expect(
-      screen.getByText("Tip: The Anarlog team loves our users!"),
-    ).not.toBeNull();
-    expect(screen.queryByText("Enhanced editor")).toBeNull();
+    expect(screen.getByText("Enhanced editor")).not.toBeNull();
+    expect(screen.getByText("Streaming summary")).not.toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
   });
 
   it("renders the editor after an empty enhance task returns idle", () => {

--- a/apps/desktop/src/session/components/note-input/enhanced/index.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.tsx
@@ -1,12 +1,12 @@
 import type { EditorView } from "prosemirror-view";
-import { forwardRef } from "react";
+import { forwardRef, useMemo } from "react";
 
+import { md2json } from "@hypr/editor/markdown";
 import type { NoteEditorRef } from "@hypr/editor/note";
 
 import { ConfigError } from "./config-error";
 import { EnhancedEditor } from "./editor";
 import { EnhanceError } from "./enhance-error";
-import { StreamingView } from "./streaming";
 
 import { useAITaskTask } from "~/ai/hooks";
 import { useLLMConnectionStatus } from "~/ai/hooks";
@@ -36,12 +36,16 @@ export const Enhanced = forwardRef<
   ) => {
     const taskId = createTaskId(enhancedNoteId, "enhance");
     const llmStatus = useLLMConnectionStatus();
-    const { status, error } = useAITaskTask(taskId, "enhance");
+    const { status, error, streamedText } = useAITaskTask(taskId, "enhance");
     const content = main.UI.useCell(
       "enhanced_notes",
       enhancedNoteId,
       "content",
       main.STORE_ID,
+    );
+    const streamingPreviewContent = useMemo(
+      () => (status === "generating" ? md2json(streamedText) : undefined),
+      [status, streamedText],
     );
 
     const hasContent = typeof content === "string" && content.trim().length > 0;
@@ -62,15 +66,12 @@ export const Enhanced = forwardRef<
       );
     }
 
-    if (status === "generating") {
-      return <StreamingView enhancedNoteId={enhancedNoteId} />;
-    }
-
     return (
       <EnhancedEditor
         ref={ref}
         sessionId={sessionId}
         enhancedNoteId={enhancedNoteId}
+        contentOverride={streamingPreviewContent}
         onNavigateToTitle={onNavigateToTitle}
         onViewReady={onViewReady}
         onViewDisposed={onViewDisposed}

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -224,7 +224,7 @@ function HeaderTabEnhanced({
   canRemove?: boolean;
   onRemove?: () => void;
 }) {
-  const { isGenerating, isError, onRegenerate, onCancel } = useEnhanceLogic(
+  const { isGenerating, isError, onRegenerate } = useEnhanceLogic(
     sessionId,
     enhancedNoteId,
   );
@@ -268,9 +268,12 @@ function HeaderTabEnhanced({
   const handleRegenerateClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
+      if (isGenerating) {
+        return;
+      }
       handleRegenerate();
     },
-    [handleRegenerate],
+    [handleRegenerate, isGenerating],
   );
   const handleExploreTemplatesClick = useCallback(
     (e: React.MouseEvent) => {
@@ -370,57 +373,6 @@ function HeaderTabEnhanced({
     onRemove,
   ]);
   const showContextMenu = useNativeContextMenu(contextMenu);
-
-  if (isGenerating) {
-    const handleCancelClick = (e: React.MouseEvent) => {
-      e.stopPropagation();
-      onCancel();
-    };
-
-    return wrapWithTemplateTooltip(
-      <div
-        data-main-area-window-drag-region
-        data-tauri-drag-region="false"
-        role="button"
-        tabIndex={0}
-        onClick={onClick}
-        onContextMenu={showContextMenu}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            onClick();
-          }
-        }}
-        className={cn([
-          "group/tab relative shrink-0 cursor-pointer border-b-2 px-1 py-0.5 text-xs font-medium transition-all duration-200 select-none",
-          SESSION_NOTE_TAB_CLASSNAME,
-          isActive
-            ? ["text-foreground", "border-foreground"]
-            : [
-                "text-muted-foreground",
-                "border-transparent",
-                "hover:text-foreground",
-              ],
-        ])}
-      >
-        <span className="flex h-5 items-center gap-1">
-          <TruncatedTitle title={tabTitle} isActive={isActive} />
-          <button
-            type="button"
-            data-tauri-drag-region="false"
-            onClick={handleCancelClick}
-            className={cn([
-              "hover:bg-accent inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-xs",
-              !isActive && "opacity-50",
-            ])}
-            aria-label="Cancel enhancement"
-          >
-            <XIcon className="flex size-4 items-center justify-center" />
-          </button>
-        </span>
-      </div>,
-    );
-  }
 
   const regenerateIcon = (
     <span

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -162,6 +162,7 @@ export interface NoteEditorProps {
   showFormatToolbar?: boolean;
   onViewReady?: (view: EditorView) => void;
   onViewDisposed?: (view: EditorView) => void;
+  syncContentWhenFocused?: boolean;
 }
 
 const baseNodeViews = {
@@ -473,6 +474,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       showFormatToolbar = true,
       onViewReady: onViewReadyProp,
       onViewDisposed,
+      syncContentWhenFocused = false,
     } = props;
 
     const taskStorage = useTaskStorageOptional();
@@ -618,7 +620,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         return;
       }
 
-      if (view.hasFocus()) {
+      if (view.hasFocus() && !syncContentWhenFocused) {
         previousContentRef.current = reconciledInitialContent;
         return;
       }
@@ -634,7 +636,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       } catch {
         // invalid content
       }
-    }, [reconciledInitialContent]);
+    }, [reconciledInitialContent, syncContentWhenFocused]);
 
     const onViewReady = useCallback(
       (view: EditorView) => {


### PR DESCRIPTION
Render streaming summary content through the finalized editor surface and keep the summary tab chrome consistent while generation is in progress.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared `NoteEditor` content-reconciliation while focused, which could affect other editors if misused; preview mode correctly disables persistence and task sync.
> 
> **Overview**
> While an enhance task is **generating**, streamed markdown is converted with `md2json` and shown in the same **enhanced summary editor** as the final note, instead of the separate `StreamingView` / analyzing UI.
> 
> **`EnhancedEditor`** gains optional `contentOverride`. When set, it runs in read-only preview mode: no persistence or `taskSource`, a distinct remount key, and **`syncContentWhenFocused`** so incoming stream updates still apply even if the view is focused. Normal editing keeps the previous behavior (no external sync while focused).
> 
> **`NoteEditor`** adds **`syncContentWhenFocused`** (default `false`) so external `initialContent` reconciliation can continue during focused preview updates.
> 
> The **summary tab header** no longer swaps to a cancel-only generating layout; regenerate is ignored while generating. Tests cover preview vs persisted editor props and the updated `Enhanced` generating flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95e6d144b6345fc9269fb476ffbec5e3d3658179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->