### PR TITLE
Show call source icons in mic notifications

### DIFF
--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -589,10 +589,103 @@ describe("ListenerProvider detect events", () => {
             bundle_id: "us.zoom.xos",
           },
         },
-        icon: null,
+        icon: {
+          type: "bundle_id",
+          bundle_id: "us.zoom.xos",
+        },
       }),
     );
   });
+
+  test("shows iPhone call icon and label for AV Capture mic notifications", async () => {
+    const store = createListenerStore();
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "micDetected",
+        key: "mic-1",
+        apps: [{ id: "pid:42", name: "AV Capture" }],
+        duration_secs: 15,
+      },
+    });
+
+    expect(showNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: {
+          type: "mic_detected",
+          app_names: ["iPhone Call"],
+          app_ids: [],
+          event_ids: [],
+        },
+        footer: null,
+        icon: {
+          type: "system_symbol",
+          name: "phone.fill",
+        },
+      }),
+    );
+  });
+
+  test.each([
+    {
+      app: { id: "com.apple.FaceTime", name: "FaceTime" },
+      icon: { type: "bundle_id", bundle_id: "com.apple.FaceTime" },
+    },
+    {
+      app: { id: "com.kakao.KakaoTalkMac", name: "KakaoTalk" },
+      icon: { type: "bundle_id", bundle_id: "com.kakao.KakaoTalkMac" },
+    },
+  ])(
+    "uses app-specific icons for $app.name mic notifications",
+    async ({ app, icon }) => {
+      const store = createListenerStore();
+
+      render(
+        <ListenerProvider store={store}>
+          <div>child</div>
+        </ListenerProvider>,
+      );
+
+      await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+      const handler = listenMock.mock.calls[0]?.[0];
+      expect(handler).toBeTypeOf("function");
+
+      handler({
+        payload: {
+          type: "micDetected",
+          key: "mic-1",
+          apps: [app],
+          duration_secs: 15,
+        },
+      });
+
+      expect(showNotificationMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: expect.objectContaining({
+            app_names: [app.name],
+            app_ids: [app.id],
+          }),
+          footer: expect.objectContaining({
+            text: `Ignore ${app.name}?`,
+            icon,
+          }),
+          icon,
+        }),
+      );
+    },
+  );
 
   test("records trigger app ids from micDetected while already listening", async () => {
     const store = createListenerStore();

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -64,18 +64,50 @@ const BROWSER_AUTO_STOP_APP_IDS = new Set([
 const UNRELIABLE_AUTO_STOP_APP_IDS = new Set(["com.kakao.KakaoTalkMac"]);
 
 type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
+type MicApp = { id: string; name: string };
 
-function getIgnorableApps(apps: { id: string; name: string }[]) {
-  const seen = new Set<string>();
+const IPHONE_CALL_ICON: NotificationIcon = {
+  type: "system_symbol",
+  name: "phone.fill",
+};
 
-  return apps.filter((app) => {
-    if (!app.id || app.id.startsWith("pid:") || seen.has(app.id)) {
-      return false;
-    }
+const MIC_APP_NOTIFICATION_OVERRIDES = [
+  {
+    ids: new Set([
+      "com.apple.avconferenced",
+      "com.apple.TelephonyUtilities",
+      "com.apple.TelephonyUtilities.callservicesd",
+    ]),
+    names: new Set(["av capture", "avcapture", "iphone call"]),
+    displayName: "iPhone Call",
+    icon: IPHONE_CALL_ICON,
+  },
+  {
+    ids: new Set(["com.apple.FaceTime"]),
+    names: new Set(["facetime"]),
+    displayName: "FaceTime",
+    icon: {
+      type: "bundle_id",
+      bundle_id: "com.apple.FaceTime",
+    } satisfies NotificationIcon,
+  },
+  {
+    ids: new Set(["com.kakao.KakaoTalkMac"]),
+    names: new Set(["kakaotalk", "kakaotalk helper"]),
+    displayName: "KakaoTalk",
+    icon: {
+      type: "bundle_id",
+      bundle_id: "com.kakao.KakaoTalkMac",
+    } satisfies NotificationIcon,
+  },
+];
 
-    seen.add(app.id);
-    return true;
-  });
+function getMicAppNotificationOverride(app: MicApp) {
+  const normalizedName = app.name.trim().toLowerCase();
+  return MIC_APP_NOTIFICATION_OVERRIDES.find(
+    (override) =>
+      override.ids.has(app.id) || override.names.has(normalizedName),
+  );
 }
 
 function getNotificationIconForAppId(appId: string): NotificationIcon | null {
@@ -90,8 +122,43 @@ function getNotificationIconForAppId(appId: string): NotificationIcon | null {
   return { type: "bundle_id", bundle_id: appId };
 }
 
-function getIgnoreAppsFooterText(apps: { name: string }[]) {
-  const firstName = apps[0]?.name.trim();
+function getNotificationIconForApp(app: MicApp): NotificationIcon | null {
+  return (
+    getMicAppNotificationOverride(app)?.icon ??
+    getNotificationIconForAppId(app.id)
+  );
+}
+
+function getNotificationIconForApps(apps: MicApp[]): NotificationIcon | null {
+  for (const app of apps) {
+    const icon = getNotificationIconForApp(app);
+    if (icon) {
+      return icon;
+    }
+  }
+
+  return null;
+}
+
+function getNotificationAppName(app: MicApp) {
+  return getMicAppNotificationOverride(app)?.displayName ?? app.name;
+}
+
+function getIgnorableApps(apps: MicApp[]) {
+  const seen = new Set<string>();
+
+  return apps.filter((app) => {
+    if (!app.id || app.id.startsWith("pid:") || seen.has(app.id)) {
+      return false;
+    }
+
+    seen.add(app.id);
+    return true;
+  });
+}
+
+function getIgnoreAppsFooterText(apps: MicApp[]) {
+  const firstName = apps[0] ? getNotificationAppName(apps[0]).trim() : "";
 
   if (apps.length === 1) {
     return firstName ? `Ignore ${firstName}?` : "Ignore this app?";
@@ -101,7 +168,7 @@ function getIgnoreAppsFooterText(apps: { name: string }[]) {
     return "Ignore these apps?";
   }
 
-  const secondName = apps[1]?.name.trim();
+  const secondName = apps[1] ? getNotificationAppName(apps[1]).trim() : "";
   if (apps.length === 2 && secondName) {
     return `Ignore ${firstName} and ${secondName}?`;
   }
@@ -194,8 +261,8 @@ function getAutoStopActiveCheckAppIds(
   return [...new Set([...candidateAppIds, ...unreliableTriggerAppIds])];
 }
 
-function getStoppedAppLabel(app: { name: string } | null) {
-  const name = app?.name.trim();
+function getStoppedAppLabel(app: MicApp | null) {
+  const name = app ? getNotificationAppName(app).trim() : "";
   return name || "The meeting app";
 }
 
@@ -223,7 +290,7 @@ function showMeetingEndedPrompt({
     action_variant: "destructive",
     options: null,
     footer: null,
-    icon: app ? getNotificationIconForAppId(app.id) : null,
+    icon: app ? getNotificationIconForApp(app) : null,
   });
 }
 
@@ -410,7 +477,7 @@ const useHandleDetectEvents = (store: ListenerStore) => {
               ? {
                   text: getIgnoreAppsFooterText(ignorableApps),
                   actionLabel: "Yes",
-                  icon: getNotificationIconForAppId(ignorableApps[0]!.id),
+                  icon: getNotificationIconForApp(ignorableApps[0]!),
                 }
               : null;
 
@@ -421,7 +488,7 @@ const useHandleDetectEvents = (store: ListenerStore) => {
             timeout: { secs: 15, nanos: 0 },
             source: {
               type: "mic_detected",
-              app_names: payload.apps.map((a) => a.name),
+              app_names: payload.apps.map((app) => getNotificationAppName(app)),
               app_ids: appIds,
               event_ids: nearbyEvents.map((e) => e.id),
             },
@@ -432,7 +499,7 @@ const useHandleDetectEvents = (store: ListenerStore) => {
             action_variant: null,
             options,
             footer,
-            icon: null,
+            icon: getNotificationIconForApps(payload.apps),
           });
         } else if (payload.type === "micStopped") {
           const autoStopEnabled =

--- a/crates/notification-interface/src/lib.rs
+++ b/crates/notification-interface/src/lib.rs
@@ -121,6 +121,8 @@ pub enum NotificationIconAsset {
     AppIcon,
     #[serde(rename = "calendar")]
     Calendar,
+    #[serde(rename = "system_symbol")]
+    SystemSymbol { name: String },
     #[serde(rename = "bundle_id")]
     BundleId { bundle_id: String },
     #[serde(rename = "path")]
@@ -134,6 +136,8 @@ pub enum NotificationIcon {
     Hidden,
     #[serde(rename = "bundle_id")]
     BundleId { bundle_id: String },
+    #[serde(rename = "system_symbol")]
+    SystemSymbol { name: String },
     #[serde(rename = "path")]
     Path { path: String },
     #[serde(rename = "overlay")]
@@ -213,6 +217,10 @@ impl NotificationIcon {
         Some(Self::BundleId {
             bundle_id: app_id.to_string(),
         })
+    }
+
+    pub fn system_symbol(name: impl Into<String>) -> Self {
+        Self::SystemSymbol { name: name.into() }
     }
 }
 
@@ -355,6 +363,16 @@ mod tests {
             Some(NotificationIcon::BundleId {
                 bundle_id: "us.zoom.xos".to_string(),
             })
+        );
+    }
+
+    #[test]
+    fn system_symbol_icons_are_supported() {
+        assert_eq!(
+            NotificationIcon::system_symbol("phone.fill"),
+            NotificationIcon::SystemSymbol {
+                name: "phone.fill".to_string(),
+            }
         );
     }
 

--- a/crates/notification-macos/swift-lib/src/Models.swift
+++ b/crates/notification-macos/swift-lib/src/Models.swift
@@ -21,11 +21,13 @@ struct NotificationFooter: Codable {
 enum NotificationIconAsset: Codable {
   case appIcon
   case calendar
+  case systemSymbol(name: String)
   case bundleId(bundleId: String)
   case path(path: String)
 
   private enum CodingKeys: String, CodingKey {
     case type
+    case name
     case bundleId = "bundle_id"
     case path
   }
@@ -33,6 +35,7 @@ enum NotificationIconAsset: Codable {
   private enum IconType: String, Codable {
     case appIcon = "app_icon"
     case calendar
+    case systemSymbol = "system_symbol"
     case bundleId = "bundle_id"
     case path
   }
@@ -45,6 +48,8 @@ enum NotificationIconAsset: Codable {
       self = .appIcon
     case .calendar:
       self = .calendar
+    case .systemSymbol:
+      self = .systemSymbol(name: try container.decode(String.self, forKey: .name))
     case .bundleId:
       self = .bundleId(bundleId: try container.decode(String.self, forKey: .bundleId))
     case .path:
@@ -60,6 +65,9 @@ enum NotificationIconAsset: Codable {
       try container.encode(IconType.appIcon, forKey: .type)
     case .calendar:
       try container.encode(IconType.calendar, forKey: .type)
+    case .systemSymbol(let name):
+      try container.encode(IconType.systemSymbol, forKey: .type)
+      try container.encode(name, forKey: .name)
     case .bundleId(let bundleId):
       try container.encode(IconType.bundleId, forKey: .type)
       try container.encode(bundleId, forKey: .bundleId)
@@ -73,11 +81,13 @@ enum NotificationIconAsset: Codable {
 enum NotificationIcon: Codable {
   case hidden
   case bundleId(bundleId: String)
+  case systemSymbol(name: String)
   case path(path: String)
   case overlay(base: NotificationIconAsset, badge: NotificationIconAsset)
 
   private enum CodingKeys: String, CodingKey {
     case type
+    case name
     case bundleId = "bundle_id"
     case path
     case base
@@ -87,6 +97,7 @@ enum NotificationIcon: Codable {
   private enum IconType: String, Codable {
     case hidden
     case bundleId = "bundle_id"
+    case systemSymbol = "system_symbol"
     case path
     case overlay
   }
@@ -99,6 +110,8 @@ enum NotificationIcon: Codable {
       self = .hidden
     case .bundleId:
       self = .bundleId(bundleId: try container.decode(String.self, forKey: .bundleId))
+    case .systemSymbol:
+      self = .systemSymbol(name: try container.decode(String.self, forKey: .name))
     case .path:
       self = .path(path: try container.decode(String.self, forKey: .path))
     case .overlay:
@@ -118,6 +131,9 @@ enum NotificationIcon: Codable {
     case .bundleId(let bundleId):
       try container.encode(IconType.bundleId, forKey: .type)
       try container.encode(bundleId, forKey: .bundleId)
+    case .systemSymbol(let name):
+      try container.encode(IconType.systemSymbol, forKey: .type)
+      try container.encode(name, forKey: .name)
     case .path(let path):
       try container.encode(IconType.path, forKey: .type)
       try container.encode(path, forKey: .path)

--- a/crates/notification-macos/swift-lib/src/NotificationManager+Creation.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationManager+Creation.swift
@@ -136,12 +136,18 @@ extension NotificationManager {
     resolveNotificationBundleIcon("com.apple.iCal")
   }
 
+  func systemSymbolNotificationIcon(_ name: String) -> NSImage? {
+    NSImage(systemSymbolName: name, accessibilityDescription: nil)
+  }
+
   func resolveNotificationIconAsset(_ asset: NotificationIconAsset) -> NSImage? {
     switch asset {
     case .appIcon:
       return defaultNotificationIcon()
     case .calendar:
       return calendarNotificationIcon()
+    case .systemSymbol(let name):
+      return systemSymbolNotificationIcon(name)
     case .bundleId(let bundleId):
       return resolveNotificationBundleIcon(bundleId)
     case .path(let path):
@@ -210,6 +216,8 @@ extension NotificationManager {
       return nil
     case .bundleId(let bundleId):
       return resolveNotificationBundleIcon(bundleId) ?? fallbackIcon
+    case .systemSymbol(let name):
+      return systemSymbolNotificationIcon(name) ?? fallbackIcon
     case .path(let path):
       return resolveNotificationPathIcon(path) ?? fallbackIcon
     case .overlay(let base, let badge):

--- a/plugins/notification/js/bindings.gen.ts
+++ b/plugins/notification/js/bindings.gen.ts
@@ -104,6 +104,7 @@ export type NotificationFooter = {
 export type NotificationIcon =
   | { type: "hidden" }
   | { type: "bundle_id"; bundle_id: string }
+  | { type: "system_symbol"; name: string }
   | { type: "path"; path: string }
   | {
       type: "overlay";
@@ -113,6 +114,7 @@ export type NotificationIcon =
 export type NotificationIconAsset =
   | { type: "app_icon" }
   | { type: "calendar" }
+  | { type: "system_symbol"; name: string }
   | { type: "bundle_id"; bundle_id: string }
   | { type: "path"; path: string };
 export type NotificationSource =


### PR DESCRIPTION
Normalize AV Capture, FaceTime, and KakaoTalk mic-detected notifications to clearer labels and icons while keeping raw app ids for listener routing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer notification mapping and a backward-compatible icon variant; listener `app_ids` behavior is unchanged aside from display names in `app_names`.
> 
> **Overview**
> Mic-detected **“Are you in a meeting?”** prompts now show a **primary notification icon** (not only footer icons) and use **friendlier labels** for common call sources, while **`app_ids` in the notification source stay unchanged** for listener routing.
> 
> A new **`system_symbol`** notification icon type is added end-to-end (Rust interface, generated TS bindings, macOS Swift decode/render via `NSImage(systemSymbolName:)`). **AV Capture** / telephony helpers map to **“iPhone Call”** with `phone.fill`; **FaceTime** and **KakaoTalk** get explicit bundle icons and matching ignore-footer copy. **Zoom-style** cases now pass the bundle icon on the main notification as well as the footer.
> 
> Tests cover iPhone Call, FaceTime, KakaoTalk, and the updated Zoom mic-detected payload expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aff02ec5dcc927a08fb704ff14c952540b5706e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->