### PR TITLE
Show upcoming meeting chip in sidebar

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -485,6 +485,96 @@ describe("TimelineView", () => {
     expect(getTopFade(container).className).toContain("from-60%");
   });
 
+  it("shows an imminent meeting chip over the sidebar timeline", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.smartCurrentTimeMs = Date.now();
+    mocks.timelineEventsTable = {
+      standup: {
+        title: "Team standup",
+        started_at: "2024-01-15T12:00:51.000Z",
+        ended_at: "2024-01-15T12:30:00.000Z",
+        tracking_id_event: "event-standup",
+        has_recurrence_rules: false,
+      },
+    };
+
+    const { container } = render(<TimelineView topChromeInset />);
+    const chip = container.querySelector(
+      "[data-sidebar-upcoming-meeting-status]",
+    );
+
+    expect(chip?.textContent).toBe("Starts in 51s");
+    expect(chip?.className).toContain("bg-destructive");
+    expect(chip?.getAttribute("aria-label")).toBe("Team standup starts in 51s");
+    expect(
+      container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
+    ).toContain("h-12");
+  });
+
+  it("rounds upcoming meeting minutes down to elapsed whole minutes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.smartCurrentTimeMs = Date.now();
+    mocks.timelineEventsTable = {
+      standup: {
+        title: "Team standup",
+        started_at: "2024-01-15T12:01:01.000Z",
+        ended_at: "2024-01-15T12:30:00.000Z",
+        tracking_id_event: "event-standup",
+        has_recurrence_rules: false,
+      },
+    };
+
+    const { container } = render(<TimelineView topChromeInset />);
+
+    expect(
+      container.querySelector("[data-sidebar-upcoming-meeting-status]")
+        ?.textContent,
+    ).toBe("Starts in 1m");
+  });
+
+  it("hides the imminent meeting chip outside the start window", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.smartCurrentTimeMs = Date.now();
+    mocks.timelineEventsTable = {
+      later: {
+        title: "Roadmap review",
+        started_at: "2024-01-15T12:06:00.000Z",
+        ended_at: "2024-01-15T12:30:00.000Z",
+        tracking_id_event: "event-later",
+        has_recurrence_rules: false,
+      },
+    };
+
+    const { container, rerender } = render(<TimelineView topChromeInset />);
+
+    expect(
+      container.querySelector("[data-sidebar-upcoming-meeting-status]"),
+    ).toBeNull();
+
+    vi.setSystemTime(new Date("2024-01-15T12:01:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    rerender(<TimelineView topChromeInset />);
+
+    expect(
+      container.querySelector("[data-sidebar-upcoming-meeting-status]")
+        ?.textContent,
+    ).toBe("Starts in 5m");
+
+    vi.setSystemTime(new Date("2024-01-15T12:06:01.000Z"));
+    mocks.currentTimeMs = Date.now();
+    rerender(<TimelineView topChromeInset />);
+
+    expect(
+      container.querySelector("[data-sidebar-upcoming-meeting-status]"),
+    ).toBeNull();
+  });
+
   it("overlays the top now chip without reserving sidebar space", () => {
     mocks.isAnchorVisible = false;
     mocks.isScrolledPastAnchor = true;

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -60,6 +60,7 @@ import { useListener } from "~/stt/contexts";
 
 const DUE_CALENDAR_SYNC_VISIBLE_WINDOW_MS = 1000;
 const CALENDAR_SYNC_STATUS_TICK_MS = 500;
+const UPCOMING_MEETING_VISIBLE_WINDOW_MS = 5 * 60 * 1000;
 type SidebarCalendarSyncStatus = "idle" | "scheduled" | "syncing";
 
 export function TimelineView({
@@ -96,7 +97,11 @@ export function TimelineView({
     () => buckets.some((bucket) => bucket.label === "Today"),
     [buckets],
   );
-  const currentTimeMs = useCurrentTimeMs();
+  const currentTimeMs = useCurrentTimeMs(1000);
+  const upcomingMeetingStatus = useMemo(
+    () => getUpcomingMeetingStatus(buckets, currentTimeMs),
+    [buckets, currentTimeMs],
+  );
   const activeSessionId = useListener((state) =>
     state.live.status === "active" || state.live.status === "finalizing"
       ? state.live.sessionId
@@ -447,6 +452,7 @@ export function TimelineView({
 
       {(showOpenCalendarChip ||
         (topChromeInset && showCalendarSyncStatus) ||
+        upcomingMeetingStatus ||
         showTopNowChip) && (
         <div
           className={cn([
@@ -466,6 +472,12 @@ export function TimelineView({
           {topChromeInset && showCalendarSyncStatus && (
             <SidebarCalendarSyncStatus status={calendarSyncStatus} />
           )}
+          {upcomingMeetingStatus && (
+            <SidebarUpcomingMeetingStatus
+              label={upcomingMeetingStatus.label}
+              title={upcomingMeetingStatus.title}
+            />
+          )}
           {showTopNowChip && (
             <TimelineNowChip direction="up" onClick={scrollToToday} />
           )}
@@ -483,6 +495,32 @@ export function TimelineView({
         />
       )}
     </div>
+  );
+}
+
+function SidebarUpcomingMeetingStatus({
+  label,
+  title,
+}: {
+  label: string;
+  title: string;
+}) {
+  return (
+    <TimelineTopChip
+      role="status"
+      aria-live="polite"
+      ariaLabel={`${title || "Meeting"} ${label.toLowerCase()}`}
+      data-sidebar-upcoming-meeting-status
+      className="border-destructive bg-destructive text-destructive-foreground shadow-md"
+      icon={
+        <span
+          aria-hidden
+          className="bg-destructive-foreground size-2 rounded-full"
+        />
+      }
+    >
+      {label}
+    </TimelineTopChip>
   );
 }
 
@@ -530,6 +568,7 @@ function TimelineTopChip({
   role?: string;
   "aria-live"?: "off" | "polite" | "assertive";
   "data-sidebar-calendar-sync-status"?: true;
+  "data-sidebar-upcoming-meeting-status"?: true;
   onClick?: () => void;
 }) {
   const className = cn([
@@ -600,6 +639,56 @@ function isFutureBucketLabel(label: string) {
     label === "next month" ||
     label.startsWith("in ")
   );
+}
+
+function getUpcomingMeetingStatus(
+  buckets: TimelineBucket[],
+  currentTimeMs: number,
+): { label: string; title: string } | null {
+  let nearest: { title: string; diffMs: number } | null = null;
+
+  for (const bucket of buckets) {
+    for (const item of bucket.items) {
+      if (item.type === "event" && item.data.is_all_day) {
+        continue;
+      }
+
+      const timestamp = getItemTimestamp(item);
+      if (!timestamp) {
+        continue;
+      }
+
+      const diffMs = timestamp.getTime() - currentTimeMs;
+      if (diffMs <= 0 || diffMs > UPCOMING_MEETING_VISIBLE_WINDOW_MS) {
+        continue;
+      }
+
+      if (!nearest || diffMs < nearest.diffMs) {
+        nearest = {
+          title: item.data.title || "Untitled",
+          diffMs,
+        };
+      }
+    }
+  }
+
+  if (!nearest) {
+    return null;
+  }
+
+  return {
+    label: formatUpcomingMeetingLabel(nearest.diffMs),
+    title: nearest.title,
+  };
+}
+
+function formatUpcomingMeetingLabel(diffMs: number): string {
+  const totalSeconds = Math.max(1, Math.floor(diffMs / 1000));
+  if (totalSeconds < 60) {
+    return `Starts in ${totalSeconds}s`;
+  }
+
+  return `Starts in ${Math.floor(totalSeconds / 60)}m`;
 }
 
 function TimelineNowChip({


### PR DESCRIPTION
Render a red sidebar overlay chip for meetings starting within five minutes and cover the visibility window in timeline tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar timeline change with localized time logic; no auth, data, or API impact.
> 
> **Overview**
> Adds a **destructive-styled overlay chip** on the sidebar timeline when a timed calendar event starts within **five minutes**, showing the nearest match as `Starts in Xs` or `Starts in Xm` (all-day events excluded).
> 
> **`getUpcomingMeetingStatus`** scans timeline buckets for the closest future start; the chip uses `role="status"`, polite live region, and an aria-label that includes the meeting title. Timeline time in this path ticks every **1s** via `useCurrentTimeMs(1000)` so second-level countdowns update.
> 
> Tests cover imminent display, minute rounding, and hiding outside the window (including after start).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e4ef50f54a4148b00492569e59eaf779deeb346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->