### PR TITLE
Enhance contact chips with feedback

### DIFF
--- a/apps/desktop/src/session/components/outer-header/metadata/participants/chip.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/chip.tsx
@@ -8,6 +8,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@hypr/ui/components/ui/tooltip";
+import { cn } from "@hypr/utils";
 
 import * as main from "~/store/tinybase/store/main";
 import { useTabs } from "~/store/zustand/tabs/index";
@@ -55,10 +56,19 @@ export function ParticipantChip({
   return (
     <Badge
       variant="secondary"
-      className="bg-muted hover:bg-muted/80 flex cursor-pointer items-center gap-1 px-2 py-0.5 text-xs"
+      className={cn([
+        "bg-muted hover:bg-muted/80 relative flex cursor-pointer items-center gap-1 overflow-hidden px-2 py-0.5 text-xs",
+        isEnhancing && "ring-ring/20 ring-1",
+      ])}
       onClick={handleClick}
     >
-      {humanName || "Unknown"}
+      {isEnhancing && (
+        <span
+          aria-hidden="true"
+          className="animate-shimmer pointer-events-none absolute inset-0 -translate-x-full bg-linear-to-r from-transparent via-white/60 to-transparent"
+        />
+      )}
+      <span className="relative z-10">{humanName || "Unknown"}</span>
       {canEnhance && (
         <EnhanceContactButton
           isEnhancing={isEnhancing}
@@ -75,7 +85,7 @@ export function ParticipantChip({
         type="button"
         variant="ghost"
         size="sm"
-        className="ml-0.5 h-3 w-3 p-0 hover:bg-transparent"
+        className="relative z-10 ml-0.5 h-3 w-3 p-0 hover:bg-transparent"
         onClick={(e) => {
           e.stopPropagation();
           handleRemove();
@@ -106,7 +116,7 @@ function EnhanceContactButton({
           variant="ghost"
           size="sm"
           aria-label={`Enhance contact ${label}`}
-          className="text-muted-foreground hover:text-foreground ml-0.5 h-3.5 w-3.5 p-0 hover:bg-transparent"
+          className="text-muted-foreground hover:text-foreground relative z-10 ml-0.5 h-3.5 w-3.5 p-0 hover:bg-transparent"
           disabled={isDisabled}
           onClick={(e) => {
             e.stopPropagation();

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
@@ -1,14 +1,29 @@
-import { describe, expect, test } from "vitest";
+import { generateText } from "ai";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
   applyExtractedContactToHuman,
   applyExtractedContacts,
   buildEventContactExtractionContext,
-  extractDeterministicContactHints,
+  extractEventContacts,
 } from "./event-contact-extraction";
 
 import { createTestMainStore } from "~/store/tinybase/persister/testing/mocks";
 import type { Store } from "~/store/tinybase/store/main";
+
+const mocks = vi.hoisted(() => ({
+  renderTemplate: vi.fn(),
+}));
+
+vi.mock("ai", () => ({
+  generateText: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-template", () => ({
+  commands: {
+    render: mocks.renderTemplate,
+  },
+}));
 
 function createStore(): Store {
   const store = createTestMainStore() as Store;
@@ -53,7 +68,31 @@ function createStore(): Store {
 }
 
 describe("event contact extraction", () => {
-  test("extracts screenshot-style name hints and matches the participant email", () => {
+  beforeEach(() => {
+    vi.mocked(generateText).mockReset();
+    mocks.renderTemplate.mockReset();
+    mocks.renderTemplate.mockImplementation(async (template: unknown) => {
+      if (
+        template &&
+        typeof template === "object" &&
+        "eventContactSystem" in template
+      ) {
+        return { status: "success", data: "# System prompt" };
+      }
+
+      if (
+        template &&
+        typeof template === "object" &&
+        "eventContactUser" in template
+      ) {
+        return { status: "success", data: "# User prompt" };
+      }
+
+      return { status: "error", error: "Unexpected template" };
+    });
+  });
+
+  test("extracts contacts from model JSON and matches the participant email", async () => {
     const store = createStore();
     store.setRow("humans", "human-1", {
       user_id: "user-1",
@@ -86,12 +125,220 @@ describe("event contact extraction", () => {
         "What:\nYongkyun (Daniel) Lee <> john\n\nWho:\nJohn Jeong - Organizer",
     });
 
-    expect(extractDeterministicContactHints(context)).toEqual([
+    vi.mocked(generateText).mockResolvedValue({
+      text: JSON.stringify({
+        contacts: [{ name: "Yongkyun (Daniel) Lee", email: null }],
+      }),
+    } as any);
+
+    await expect(
+      extractEventContacts({ model: {} as any, context }),
+    ).resolves.toEqual({
+      source: "model",
+      contacts: [
+        {
+          name: "Yongkyun (Daniel) Lee",
+          email: "yongkyun.daniel.lee@gmail.com",
+        },
+      ],
+    });
+    expect(generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: {},
+        system: "# System prompt",
+        prompt: "# User prompt",
+      }),
+    );
+    expect(vi.mocked(generateText).mock.calls[0]?.[0]).not.toHaveProperty(
+      "output",
+    );
+  });
+
+  test("enhances an invite title name from model JSON when it matches one participant email", async () => {
+    const store = createStore();
+    store.setRow("sessions", "session-1", {
+      user_id: "user-1",
+      created_at: "2026-06-16T05:00:00.000Z",
+      title: "Tom Yang <> john",
+      raw_md: "",
+      event_json: JSON.stringify({
+        tracking_id: "event-tracking-1",
+        calendar_id: "calendar-1",
+        title: "Tom Yang <> john",
+        started_at: "2026-06-16T05:00:00.000Z",
+        ended_at: "2026-06-16T05:20:00.000Z",
+        is_all_day: false,
+        has_recurrence_rules: false,
+        description: "What:\nTom Yang <> john\n\nWho:\nJohn Jeong - Organizer",
+      }),
+    });
+    store.setRow("humans", "human-1", {
+      user_id: "user-1",
+      created_at: "2026-06-16T05:00:00.000Z",
+      name: "tom@kestroll.com",
+      email: "tom@kestroll.com",
+      phone: "",
+      org_id: "",
+      job_title: "",
+      linkedin_username: "",
+      memo: "",
+      pinned: false,
+    });
+    store.setRow("mapping_session_participant", "mapping-1", {
+      user_id: "user-1",
+      session_id: "session-1",
+      human_id: "human-1",
+      source: "auto",
+    });
+
+    const context = buildEventContactExtractionContext(store, "session-1", {
+      tracking_id: "event-tracking-1",
+      calendar_id: "calendar-1",
+      title: "Tom Yang <> john",
+      started_at: "2026-06-16T05:00:00.000Z",
+      ended_at: "2026-06-16T05:20:00.000Z",
+      is_all_day: false,
+      has_recurrence_rules: false,
+      description: "What:\nTom Yang <> john\n\nWho:\nJohn Jeong - Organizer",
+    });
+
+    vi.mocked(generateText).mockResolvedValue({
+      text: JSON.stringify({
+        contacts: [{ name: "Tom Yang", email: null, companyName: "Kestroll" }],
+      }),
+    } as any);
+
+    const extraction = await extractEventContacts({
+      model: {} as any,
+      context,
+    });
+    const result = applyExtractedContactToHuman(
+      store,
+      "session-1",
+      "human-1",
+      extraction.contacts,
+      { userId: "user-1" },
+    );
+
+    expect(extraction.contacts).toEqual([
       {
-        name: "Yongkyun (Daniel) Lee",
-        email: "yongkyun.daniel.lee@gmail.com",
+        name: "Tom Yang",
+        email: "tom@kestroll.com",
+        companyName: "Kestroll",
       },
     ]);
+    expect(result).toMatchObject({
+      updated: 1,
+      matched: true,
+    });
+    expect(store.getCell("humans", "human-1", "name")).toBe("Tom Yang");
+    const organizations = store.getTable("organizations");
+    const organizationEntry = Object.entries(organizations).find(
+      ([, organization]) => organization.name === "Kestroll",
+    );
+    expect(organizationEntry).toBeTruthy();
+    expect(store.getCell("humans", "human-1", "org_id")).toBe(
+      organizationEntry?.[0],
+    );
+  });
+
+  test("reuses an existing organization when applying extracted company", () => {
+    const store = createStore();
+    store.setRow("organizations", "org-1", {
+      user_id: "user-1",
+      created_at: "2026-04-01T00:00:00.000Z",
+      name: "Kestroll",
+      pinned: false,
+    });
+    store.setRow("humans", "human-1", {
+      user_id: "user-1",
+      created_at: "2026-04-01T00:00:00.000Z",
+      name: "tom@kestroll.com",
+      email: "tom@kestroll.com",
+      phone: "",
+      org_id: "",
+      job_title: "",
+      linkedin_username: "",
+      memo: "",
+      pinned: false,
+    });
+    store.setRow("mapping_session_participant", "mapping-1", {
+      user_id: "user-1",
+      session_id: "session-1",
+      human_id: "human-1",
+      source: "auto",
+    });
+
+    const result = applyExtractedContactToHuman(
+      store,
+      "session-1",
+      "human-1",
+      [
+        {
+          name: "Tom Yang",
+          email: "tom@kestroll.com",
+          companyName: "Kestroll",
+        },
+      ],
+      { userId: "user-1" },
+    );
+
+    expect(result).toMatchObject({
+      updated: 1,
+      matched: true,
+    });
+    expect(store.getCell("humans", "human-1", "org_id")).toBe("org-1");
+    expect(Object.keys(store.getTable("organizations"))).toHaveLength(1);
+  });
+
+  test("does not create an unused organization when bulk updating a contact that already has one", () => {
+    const store = createStore();
+    store.setRow("organizations", "org-existing", {
+      user_id: "user-1",
+      created_at: "2026-04-01T00:00:00.000Z",
+      name: "Existing Co",
+      pinned: false,
+    });
+    store.setRow("humans", "human-1", {
+      user_id: "user-1",
+      created_at: "2026-04-01T00:00:00.000Z",
+      name: "tom@kestroll.com",
+      email: "tom@kestroll.com",
+      phone: "",
+      org_id: "org-existing",
+      job_title: "",
+      linkedin_username: "",
+      memo: "",
+      pinned: false,
+    });
+    store.setRow("mapping_session_participant", "mapping-1", {
+      user_id: "user-1",
+      session_id: "session-1",
+      human_id: "human-1",
+      source: "auto",
+    });
+
+    const result = applyExtractedContacts(
+      store,
+      "session-1",
+      [
+        {
+          name: "Tom Yang",
+          email: "tom@kestroll.com",
+          companyName: "Kestroll",
+        },
+      ],
+      { userId: "user-1", createdAt: "2026-04-21T20:00:00.000Z" },
+    );
+
+    expect(result).toMatchObject({
+      created: 0,
+      updated: 1,
+      linked: 0,
+    });
+    expect(store.getCell("humans", "human-1", "name")).toBe("Tom Yang");
+    expect(store.getCell("humans", "human-1", "org_id")).toBe("org-existing");
+    expect(Object.keys(store.getTable("organizations"))).toHaveLength(1);
   });
 
   test("updates an existing email-only contact without creating a duplicate mapping", () => {
@@ -263,6 +510,56 @@ describe("event contact extraction", () => {
     expect(
       Object.keys(store.getTable("mapping_session_participant")),
     ).toHaveLength(3);
+  });
+
+  test("does not create an unused organization when enhancing a contact that already has one", () => {
+    const store = createStore();
+    store.setRow("organizations", "org-existing", {
+      user_id: "user-1",
+      created_at: "2026-04-01T00:00:00.000Z",
+      name: "Existing Co",
+      pinned: false,
+    });
+    store.setRow("humans", "human-1", {
+      user_id: "user-1",
+      created_at: "2026-04-01T00:00:00.000Z",
+      name: "tom@kestroll.com",
+      email: "tom@kestroll.com",
+      phone: "",
+      org_id: "org-existing",
+      job_title: "",
+      linkedin_username: "",
+      memo: "",
+      pinned: false,
+    });
+    store.setRow("mapping_session_participant", "mapping-1", {
+      user_id: "user-1",
+      session_id: "session-1",
+      human_id: "human-1",
+      source: "auto",
+    });
+
+    const result = applyExtractedContactToHuman(
+      store,
+      "session-1",
+      "human-1",
+      [
+        {
+          name: "Tom Yang",
+          email: "tom@kestroll.com",
+          companyName: "Kestroll",
+        },
+      ],
+      { userId: "user-1" },
+    );
+
+    expect(result).toMatchObject({
+      updated: 1,
+      matched: true,
+    });
+    expect(store.getCell("humans", "human-1", "name")).toBe("Tom Yang");
+    expect(store.getCell("humans", "human-1", "org_id")).toBe("org-existing");
+    expect(Object.keys(store.getTable("organizations"))).toHaveLength(1);
   });
 
   test("does not enhance a selected participant from a loose first-name alias", () => {

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
@@ -1,4 +1,4 @@
-import { generateText, type LanguageModel, Output } from "ai";
+import { generateText, type LanguageModel } from "ai";
 import { z } from "zod";
 
 import {
@@ -9,6 +9,7 @@ import type {
   EventParticipant,
   HumanStorage,
   MappingSessionParticipantStorage,
+  OrganizationStorage,
   SessionEvent,
 } from "@hypr/store";
 
@@ -37,11 +38,12 @@ export type EventContactExtractionContext = {
 export type ExtractedEventContact = {
   name: string;
   email?: string;
+  companyName?: string;
 };
 
 export type ExtractEventContactsResult = {
   contacts: ExtractedEventContact[];
-  source: "hint" | "model";
+  source: "model";
 };
 
 export type ApplyExtractedContactsResult = {
@@ -62,6 +64,7 @@ const aiExtractionSchema = z.object({
       z.object({
         name: z.string(),
         email: z.union([z.string(), z.null()]).optional(),
+        companyName: z.union([z.string(), z.null()]).optional(),
       }),
     )
     .max(MAX_CONTACTS_TO_EXTRACT),
@@ -92,11 +95,6 @@ export async function extractEventContacts({
   model: LanguageModel | null;
   context: EventContactExtractionContext;
 }): Promise<ExtractEventContactsResult> {
-  const hintedContacts = extractDeterministicContactHints(context);
-  if (hintedContacts.length > 0) {
-    return { contacts: hintedContacts, source: "hint" };
-  }
-
   if (!model) {
     throw new Error("Language model needed");
   }
@@ -111,13 +109,12 @@ export async function extractEventContacts({
     temperature: 0,
     maxRetries: 2,
     maxOutputTokens: 384,
-    output: Output.object({ schema: aiExtractionSchema }),
     system,
     prompt,
   });
 
   const contacts = normalizeExtractedContacts(
-    result.output?.contacts ?? [],
+    parseExtractionJson(result.text).contacts,
     context.candidates,
   );
 
@@ -152,6 +149,7 @@ export function applyExtractedContacts(
   store.transaction(() => {
     const humansByEmail = buildHumansByEmailIndex(store);
     const humansByName = buildHumansByNameIndex(store);
+    const organizationsByName = buildOrganizationsByNameIndex(store);
     const sessionMappings = buildSessionMappingsByHuman(store, sessionId);
     const sessionHumansByName = buildSessionHumansByNameIndex(
       store,
@@ -177,6 +175,14 @@ export function applyExtractedContacts(
       }
 
       if (!humanId) {
+        const orgId = getOrCreateOrganizationId(
+          store,
+          organizationsByName,
+          userId,
+          contact.companyName,
+          createdAt,
+        );
+
         humanId = id();
         store.setRow("humans", humanId, {
           user_id: userId,
@@ -184,7 +190,7 @@ export function applyExtractedContacts(
           name: contact.name,
           email: contact.email ?? "",
           phone: "",
-          org_id: "",
+          org_id: orgId ?? "",
           job_title: "",
           linkedin_username: "",
           memo: "",
@@ -201,6 +207,17 @@ export function applyExtractedContacts(
         const human = store.getRow("humans", humanId);
         const existingName = stringCell(human?.name);
         const existingEmail = stringCell(human?.email);
+        const existingOrgId = stringCell(human?.org_id);
+        const orgId = existingOrgId
+          ? undefined
+          : getOrCreateOrganizationId(
+              store,
+              organizationsByName,
+              userId,
+              contact.companyName,
+              createdAt,
+            );
+        const shouldUpdateOrg = shouldUpdateHumanOrg(existingOrgId, orgId);
         const shouldUpdateName = shouldUpdateHumanName(
           existingName,
           contact.email,
@@ -221,7 +238,10 @@ export function applyExtractedContacts(
             humansByEmail.set(emailLower, humanId);
           }
         }
-        if (shouldUpdateName || shouldUpdateEmail) {
+        if (shouldUpdateOrg) {
+          store.setCell("humans", humanId, "org_id", orgId ?? "");
+        }
+        if (shouldUpdateName || shouldUpdateEmail || shouldUpdateOrg) {
           result.updated += 1;
           result.contacts.push(contact);
         }
@@ -305,11 +325,23 @@ export function applyExtractedContactToHuman(
 
     const existingName = stringCell(human.name);
     const existingEmail = stringCell(human.email);
+    const existingOrgId = stringCell(human.org_id);
+    const organizationsByName = buildOrganizationsByNameIndex(store);
+    const orgId = existingOrgId
+      ? undefined
+      : getOrCreateOrganizationId(
+          store,
+          organizationsByName,
+          userId,
+          contact.companyName,
+          new Date().toISOString(),
+        );
     const shouldUpdateName = shouldUpdateHumanName(existingName, contact.email);
     const shouldUpdateEmail = shouldUpdateHumanEmail(
       existingEmail,
       contact.email,
     );
+    const shouldUpdateOrg = shouldUpdateHumanOrg(existingOrgId, orgId);
 
     if (shouldUpdateName) {
       store.setCell("humans", humanId, "name", contact.name);
@@ -317,42 +349,15 @@ export function applyExtractedContactToHuman(
     if (shouldUpdateEmail) {
       store.setCell("humans", humanId, "email", contact.email ?? "");
     }
-    if (shouldUpdateName || shouldUpdateEmail) {
+    if (shouldUpdateOrg) {
+      store.setCell("humans", humanId, "org_id", orgId ?? "");
+    }
+    if (shouldUpdateName || shouldUpdateEmail || shouldUpdateOrg) {
       result.updated += 1;
     }
   });
 
   return result;
-}
-
-export function extractDeterministicContactHints(
-  context: EventContactExtractionContext,
-): ExtractedEventContact[] {
-  const contacts: ExtractedEventContact[] = [];
-
-  for (const line of getEventTextLines(context)) {
-    const match = line.match(/^(.{2,120}?)\s+<>\s+(.{1,120})$/);
-    if (!match) {
-      continue;
-    }
-
-    const sides = [match[1], match[2]]
-      .map(cleanNameHint)
-      .filter((name) => isLikelyPersonName(name));
-
-    for (const name of sides) {
-      if (isSelfReference(name, context.candidates)) {
-        continue;
-      }
-
-      contacts.push({
-        name,
-        email: matchCandidateEmail(name, context.candidates),
-      });
-    }
-  }
-
-  return normalizeExtractedContacts(contacts, context.candidates);
 }
 
 function collectContactCandidates(
@@ -481,14 +486,6 @@ function dedupeCandidates(
   return Array.from(byKey.values());
 }
 
-function getEventTextLines(context: EventContactExtractionContext): string[] {
-  return [context.title, context.description]
-    .filter((value): value is string => Boolean(value?.trim()))
-    .flatMap((value) => stripHtml(value).split(/\r?\n/))
-    .map((line) => line.trim())
-    .filter(Boolean);
-}
-
 async function getSystemPrompt(): Promise<string> {
   const result = await templateCommands.render({ eventContactSystem: {} });
   if (result.status === "error") {
@@ -496,6 +493,20 @@ async function getSystemPrompt(): Promise<string> {
   }
 
   return result.data;
+}
+
+function parseExtractionJson(text: string): z.infer<typeof aiExtractionSchema> {
+  try {
+    return aiExtractionSchema.parse(JSON.parse(stripJsonFence(text)));
+  } catch {
+    throw new Error("Invalid contact extraction JSON");
+  }
+}
+
+function stripJsonFence(text: string): string {
+  const trimmed = text.trim();
+  const match = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return match ? match[1].trim() : trimmed;
 }
 
 async function getUserPrompt(
@@ -547,7 +558,11 @@ function stripHtml(value: string): string {
 }
 
 function normalizeExtractedContacts(
-  contacts: Array<{ name?: string | null; email?: string | null }>,
+  contacts: Array<{
+    name?: string | null;
+    email?: string | null;
+    companyName?: string | null;
+  }>,
   candidates: EventContactCandidate[],
 ): ExtractedEventContact[] {
   const deduped = new Map<string, ExtractedEventContact>();
@@ -560,10 +575,16 @@ function normalizeExtractedContacts(
     }
 
     const matchedEmail = email || matchCandidateEmail(name, candidates);
-    const normalizedContact = {
+    const companyName = normalizeCompanyName(contact.companyName);
+    const normalizedContact: ExtractedEventContact = {
       name,
-      email: matchedEmail,
     };
+    if (matchedEmail) {
+      normalizedContact.email = matchedEmail;
+    }
+    if (companyName) {
+      normalizedContact.companyName = companyName;
+    }
 
     if (isSelfContactFromCandidates(normalizedContact, candidates)) {
       continue;
@@ -574,6 +595,18 @@ function normalizeExtractedContacts(
       : `name:${normalizeName(name)}`;
     if (!deduped.has(key)) {
       deduped.set(key, normalizedContact);
+    } else if (
+      !deduped.get(key)?.companyName &&
+      normalizedContact.companyName
+    ) {
+      const existingContact = deduped.get(key);
+      if (!existingContact) {
+        continue;
+      }
+      deduped.set(key, {
+        ...existingContact,
+        companyName: normalizedContact.companyName,
+      });
     }
   }
 
@@ -628,6 +661,9 @@ function matchCandidateEmail(
   }
 
   let best: { email: string; score: number } | null = null;
+  const firstNameMatches: string[] = [];
+  const firstNameToken = nameTokens[0];
+
   for (const candidate of candidates) {
     const email = normalizeEmail(candidate.email);
     if (!email || candidate.isCurrentUser) {
@@ -651,10 +687,20 @@ function matchCandidateEmail(
 
     if (enoughSignal && (!best || score > best.score)) {
       best = { email, score };
+    } else if (
+      firstNameToken &&
+      nameTokens.length > 1 &&
+      matched.length === 1 &&
+      matched[0] === firstNameToken
+    ) {
+      firstNameMatches.push(email);
     }
   }
 
-  return best?.email;
+  return (
+    best?.email ??
+    (firstNameMatches.length === 1 ? firstNameMatches[0] : undefined)
+  );
 }
 
 function isSelfReference(
@@ -820,6 +866,13 @@ function shouldUpdateHumanEmail(
   return Boolean(normalizeEmail(email) && !normalizeEmail(existingEmail));
 }
 
+function shouldUpdateHumanOrg(
+  existingOrgId: string | undefined,
+  orgId: string | undefined,
+): boolean {
+  return Boolean(orgId && !existingOrgId);
+}
+
 function buildHumansByEmailIndex(store: Store): Map<string, string> {
   const humansByEmail = new Map<string, string>();
   store.forEachRow("humans", (humanId, _forEachCell) => {
@@ -842,6 +895,46 @@ function buildHumansByNameIndex(store: Store): Map<string, string> {
     }
   });
   return humansByName;
+}
+
+function buildOrganizationsByNameIndex(store: Store): Map<string, string> {
+  const organizationsByName = new Map<string, string>();
+  store.forEachRow("organizations", (orgId, _forEachCell) => {
+    const organization = store.getRow("organizations", orgId);
+    const name = normalizeName(stringCell(organization?.name) ?? "");
+    if (name) {
+      organizationsByName.set(name, orgId);
+    }
+  });
+  return organizationsByName;
+}
+
+function getOrCreateOrganizationId(
+  store: Store,
+  organizationsByName: Map<string, string>,
+  userId: string,
+  companyName: string | undefined,
+  createdAt: string,
+): string | undefined {
+  if (!companyName) {
+    return undefined;
+  }
+
+  const nameKey = normalizeName(companyName);
+  const existingOrgId = organizationsByName.get(nameKey);
+  if (existingOrgId) {
+    return existingOrgId;
+  }
+
+  const orgId = id();
+  store.setRow("organizations", orgId, {
+    user_id: userId,
+    created_at: createdAt,
+    name: companyName,
+    pinned: false,
+  } satisfies OrganizationStorage);
+  organizationsByName.set(nameKey, orgId);
+  return orgId;
 }
 
 function buildSessionHumansByNameIndex(
@@ -894,6 +987,21 @@ function normalizeEmail(value: string | undefined | null): string | undefined {
   }
 
   return email;
+}
+
+function normalizeCompanyName(
+  value: string | undefined | null,
+): string | undefined {
+  const name = value?.trim().replace(/\s+/g, " ");
+  if (!name || name.length < 2 || name.length > 80) {
+    return undefined;
+  }
+
+  if (name.includes("@") || /^https?:\/\//i.test(name)) {
+    return undefined;
+  }
+
+  return name;
 }
 
 function normalizeName(value: string): string {

--- a/crates/template-app/assets/event-contact.system.md.jinja
+++ b/crates/template-app/assets/event-contact.system.md.jinja
@@ -8,3 +8,21 @@ Extract contacts from calendar event metadata.
 - Prefer matching hinted names to candidate participant emails.
 - Exclude the organizer, current user, meeting platforms, bots, companies, URLs, and labels.
 - If unsure, return an empty contacts array.
+
+# Format Requirements
+
+Return only valid JSON matching this shape:
+
+```json
+{
+  "contacts": [
+    {
+      "name": "Full Name",
+      "email": "person@example.com",
+      "companyName": "Company"
+    }
+  ]
+}
+```
+
+Use `null` for `email` when the event identifies the person but no candidate email matches. Use `null` for `companyName` when no company is clear. Infer obvious company names from non-personal email domains, for example `tom@kestroll.com` means `Kestroll`. Use `{"contacts":[]}` when no contact should be extracted.

--- a/crates/template-app/src/event_contact.rs
+++ b/crates/template-app/src/event_contact.rs
@@ -45,6 +45,24 @@ mod tests {
     - Prefer matching hinted names to candidate participant emails.
     - Exclude the organizer, current user, meeting platforms, bots, companies, URLs, and labels.
     - If unsure, return an empty contacts array.
+
+    # Format Requirements
+
+    Return only valid JSON matching this shape:
+
+    ```json
+    {
+      "contacts": [
+        {
+          "name": "Full Name",
+          "email": "person@example.com",
+          "companyName": "Company"
+        }
+      ]
+    }
+    ```
+
+    Use `null` for `email` when the event identifies the person but no candidate email matches. Use `null` for `companyName` when no company is clear. Infer obvious company names from non-personal email domains, for example `tom@kestroll.com` means `Kestroll`. Use `{"contacts":[]}` when no contact should be extracted.
     "#);
 
     tpl_snapshot!(


### PR DESCRIPTION
Show a shimmer while contact enhancement runs and let screenshot-style invite names update matching email-only participant contacts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how contacts and organizations are written in the local store and depend on LLM JSON parsing instead of deterministic hints, which can affect matching quality if model output is malformed.
> 
> **Overview**
> Participant chips now show a **shimmer overlay** and subtle ring while contact enhancement runs, with chip controls layered above the animation.
> 
> Event contact extraction no longer uses deterministic invite-title parsing; it **always calls the language model** and parses **JSON from plain text** (no structured `output` schema). Extracted contacts can include **`companyName`**, and apply/enhance paths **create or reuse organizations by name** and set `org_id` only when the human has no org yet. Email matching for invite-style names is tightened so a lone first-name token only maps when it uniquely matches one participant. Prompt templates document the JSON shape including optional company.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 677c4ac606534019616d05bc4a76c517d01e9729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->