### PR TITLE
Open chat during active meetings

### DIFF
--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FloatingActionButton } from "./index";
@@ -23,6 +23,7 @@ const hoisted = vi.hoisted(() => ({
   } as LLMConnectionStatus,
   isCaretNearBottom: false,
   sessionMode: "inactive",
+  sendEvent: vi.fn(),
 }));
 
 vi.mock("./listen", () => ({
@@ -30,7 +31,11 @@ vi.mock("./listen", () => ({
 }));
 
 vi.mock("~/shared/chat-cta", () => ({
-  ChatCTA: () => <button type="button">Ask Anarlog anything</button>,
+  ChatCTA: () => (
+    <button type="button" onClick={() => hoisted.sendEvent({ type: "OPEN" })}>
+      Ask Anarlog anything
+    </button>
+  ),
 }));
 
 vi.mock("~/session/components/shared", () => ({
@@ -99,6 +104,7 @@ describe("FloatingActionButton", () => {
     };
     hoisted.isCaretNearBottom = false;
     hoisted.sessionMode = "inactive";
+    hoisted.sendEvent.mockClear();
   });
 
   afterEach(() => {
@@ -168,6 +174,7 @@ describe("FloatingActionButton", () => {
 
     expect(hoverZone?.className).toContain("group");
     expect(hoverZone?.className).toContain("pointer-events-auto");
+    expect(hoverZone?.className).toContain("z-30");
     expect(hoverZone?.className).toContain("bottom-0");
     expect(hoverZone?.className).not.toContain("-bottom-4");
     expect(hoverZone?.className).toContain("h-32");
@@ -228,7 +235,7 @@ describe("FloatingActionButton", () => {
     expect(hoverZone?.className).not.toContain("-bottom-4");
     expect(hoverZone?.className).toContain("h-32");
     expect(hoverZone?.className).toContain("pb-4");
-    expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
+    expect(wrapper?.getAttribute("aria-hidden")).toBe("false");
     expect(wrapper?.style.getPropertyValue("--floating-fab-tuck-offset")).toBe(
       "calc(100% - 0.5rem + 18px)",
     );
@@ -250,10 +257,22 @@ describe("FloatingActionButton", () => {
     expect(
       screen.queryByRole("button", { name: "Start listening" }),
     ).toBeNull();
-    expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
+    expect(wrapper?.getAttribute("aria-hidden")).toBe("false");
     expect(wrapper?.style.getPropertyValue("--floating-fab-tuck-offset")).toBe(
       "calc(100% - 0.5rem + 18px)",
     );
+  });
+
+  it("opens chat from the tucked active meeting FAB", () => {
+    hoisted.sessionMode = "active";
+
+    render(<FloatingActionButton tab={tab} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Ask Anarlog anything" }),
+    );
+
+    expect(hoisted.sendEvent).toHaveBeenCalledWith({ type: "OPEN" });
   });
 
   it("tucks the listen FAB near the editor caret instead of scroll state", () => {

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -46,7 +46,7 @@ export function FloatingActionButton({
   return (
     <div
       className={cn([
-        "absolute left-1/2 z-20 flex max-w-[calc(100%-2rem)] -translate-x-1/2 items-end justify-center",
+        "absolute left-1/2 z-30 flex max-w-[calc(100%-2rem)] -translate-x-1/2 items-end justify-center",
         tuckAction
           ? "group pointer-events-auto bottom-0 h-32 pb-4"
           : "pointer-events-none bottom-0 h-14 pb-4",
@@ -68,7 +68,9 @@ export function FloatingActionButton({
         ) : (
           <motion.div
             key={shouldShowListen ? "listen" : "chat"}
-            aria-hidden={tuckAction}
+            aria-hidden={
+              tuckAction && (shouldShowListen || !isLiveSessionActive)
+            }
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}


### PR DESCRIPTION
Keep the tucked active-meeting chat CTA above the live handle and cover the open path with a regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/a11y layering tweak in the session FAB with test coverage; no auth, data, or backend changes.
> 
> **Overview**
> During **active meetings**, the tucked chat FAB stays exposed to assistive tech and pointer interaction instead of inheriting the same `aria-hidden` behavior as the listen/caret-tucked states.
> 
> **`FloatingActionButton`** now sets `aria-hidden` only when tucked **and** (showing listen **or** session is not live). The hover zone stacking order is raised from `z-20` to **`z-30`** so the peek CTA sits above the live session handle.
> 
> Tests assert the new `aria-hidden` values for active-meeting cases, expect `z-30` on the hidden peek layout, and add a regression that clicking the tucked chat CTA dispatches **`OPEN`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1bee39c75c7a16d8d809a1216e1b325ac31891e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->