### PR TITLE
Respect main language in chat replies

### DIFF
--- a/apps/desktop/src/chat/transport/use-transport.ts
+++ b/apps/desktop/src/chat/transport/use-transport.ts
@@ -10,6 +10,7 @@ import { useLanguageModel } from "~/ai/hooks";
 import type { ContextRef } from "~/chat/context/entities";
 import { hydrateSessionContextFromFs } from "~/chat/context/session-context-hydrator";
 import { useToolRegistry } from "~/contexts/tool";
+import { useConfigValue } from "~/shared/config";
 import * as main from "~/store/tinybase/store/main";
 
 const FILE_CONTEXT_TOOL_GUIDANCE = `
@@ -109,7 +110,7 @@ export function useTransport(
   const registry = useToolRegistry();
   const configuredModel = useLanguageModel("chat");
   const model = modelOverride ?? configuredModel;
-  const language = main.UI.useValue("ai_language", main.STORE_ID) ?? "en";
+  const language = useConfigValue("ai_language") || "en";
   const [systemPrompt, setSystemPrompt] = useState<string | undefined>();
 
   useEffect(() => {

--- a/crates/template-app/assets/chat.system.md.jinja
+++ b/crates/template-app/assets/chat.system.md.jinja
@@ -7,6 +7,7 @@ Current date: {{ ""|current_date }}
 - You are Anarlog AI, a helpful AI meeting assistant in Anarlog, an intelligent meeting platform that transcribes and analyzes meetings. Your purpose is to help users understand their meeting content better.
 - If the user asks for your name or identity, say your name is Anarlog AI.
 - Always respond in {{ language | language }}, unless the user explicitly asks for a different language.
+- Transcript language, source-note language, quoted text, previous assistant messages, and additional spoken-language settings are context only; do not use them to choose your response language.
 - Always keep your responses concise, professional, and directly relevant to the user's questions.
 - Your primary source of truth is the meeting transcript. Try to generate responses primarily from the transcript, and then the summary or other information (unless the user asks for something specific).
 

--- a/crates/template-app/src/chat.rs
+++ b/crates/template-app/src/chat.rs
@@ -50,6 +50,7 @@ mod tests {
     - You are Anarlog AI, a helpful AI meeting assistant in Anarlog, an intelligent meeting platform that transcribes and analyzes meetings. Your purpose is to help users understand their meeting content better.
     - If the user asks for your name or identity, say your name is Anarlog AI.
     - Always respond in English, unless the user explicitly asks for a different language.
+    - Transcript language, source-note language, quoted text, previous assistant messages, and additional spoken-language settings are context only; do not use them to choose your response language.
     - Always keep your responses concise, professional, and directly relevant to the user's questions.
     - Your primary source of truth is the meeting transcript. Try to generate responses primarily from the transcript, and then the summary or other information (unless the user asks for something specific).
 


### PR DESCRIPTION
Read chat language from settings and reinforce that note context should not override the configured response language.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small prompt and config-read path change with no auth, data, or API surface impact.
> 
> **Overview**
> Chat now reads **`ai_language`** through **`useConfigValue`** (settings) instead of the main TinyBase store, so the rendered system prompt matches the language chosen in general settings—the same path used elsewhere for **`ai_language`**.
> 
> The chat system template adds an explicit rule: transcript language, note language, quotes, prior assistant text, and extra spoken-language settings are **context only** and must not drive the reply language unless the user asks otherwise. The Rust template snapshot test is updated for that wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8f9c8639998eecbeaa38a23964f68f374b4d1f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->