### PR TITLE
Fix related meeting list indentation

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -451,7 +451,8 @@ describe("PostSessionAccessory", () => {
     );
     const factsList = screen.getByRole("list");
     expect(factsList.className).toContain("list-disc");
-    expect(factsList.className).toContain("list-inside");
+    expect(factsList.className).not.toContain("list-inside");
+    expect(factsList.className).toContain("pl-5");
     expect(factsList.className).not.toContain("overflow-hidden");
     const facts = screen.getAllByRole("listitem");
     expect(facts).toHaveLength(3);

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -182,7 +182,7 @@ function PastNotesPanel({
                   ) : null}
                 </div>
                 {note.summary ? (
-                  <ul className="text-muted-foreground min-w-0 list-inside list-disc space-y-1 pr-1 text-xs leading-5">
+                  <ul className="text-muted-foreground min-w-0 list-disc space-y-1 pr-1 pl-5 text-xs leading-5">
                     {splitKeyFacts(note.summary).map((fact) => (
                       <li key={fact} className="min-w-0 break-words">
                         {fact}


### PR DESCRIPTION
Render related meeting facts with outside list markers so wrapped lines align under the fact text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only change in the post-session past-notes panel with a matching test update; no logic or data paths affected.
> 
> **Overview**
> **Related meetings** key-facts bullets no longer use `list-inside`; the `<ul>` now uses `list-disc` with `pl-5` so markers sit outside the text block and wrapped lines align under the fact copy instead of under the bullet.
> 
> The past-notes timeline test was updated to assert the new classes (`pl-5`, no `list-inside`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6152a3207bcea17378635e9a6de7f5b5a6bb83b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->