### PR TITLE
Recover related meeting regeneration failures

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/past-note-regenerate.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/past-note-regenerate.test.tsx
@@ -1,7 +1,50 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { buildPastSessionNotes } from "./past-notes";
+const hoisted = vi.hoisted(() => ({
+  store: null as ReturnType<typeof makeStore> | null,
+  userId: "self",
+  generateText: vi.fn(),
+  showTransientToast: vi.fn(),
+}));
+
+vi.mock("ai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("ai")>()),
+  generateText: hoisted.generateText,
+}));
+
+vi.mock("@hypr/plugin-template", () => ({
+  commands: {
+    renderCustom: vi.fn(async (template: string) => ({
+      status: "ok",
+      data: template,
+    })),
+  },
+}));
+
+vi.mock("~/ai/hooks", () => ({
+  useLanguageModel: () => ({ id: "model-1" }),
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useStore: () => hoisted.store,
+    useTable: () => ({}),
+    useValue: () => hoisted.userId,
+  },
+}));
+
+import { buildPastSessionNotes, usePastSessionNotes } from "./past-notes";
 import { PostSessionAccessory } from "./post-session";
 
 vi.mock("@hypr/plugin-fs-sync", () => ({
@@ -62,7 +105,7 @@ vi.mock("~/session/components/note-input/transcript/state", () => ({
 }));
 
 vi.mock("~/sidebar/toast/transient", () => ({
-  showTransientToast: vi.fn(),
+  showTransientToast: hoisted.showTransientToast,
 }));
 
 vi.mock("~/stt/contexts", () => ({
@@ -74,6 +117,13 @@ vi.mock("~/stt/useRunBatch", () => ({
   useRunBatch: () => vi.fn(),
   isStoppedTranscriptionError: vi.fn(() => false),
 }));
+
+beforeEach(() => {
+  hoisted.store = null;
+  hoisted.userId = "self";
+  hoisted.generateText.mockReset();
+  hoisted.showTransientToast.mockReset();
+});
 
 afterEach(() => {
   cleanup();
@@ -229,6 +279,106 @@ describe("past note regeneration", () => {
       "previous",
     ]);
   });
+
+  it("recovers from failed related meeting fact regeneration", async () => {
+    hoisted.store = makeStore({
+      sessions: {
+        current: {
+          title: "Weekly Product Sync",
+          created_at: "2026-06-03T10:00:00.000Z",
+          event_json: "",
+          raw_md: "",
+        },
+        previous: {
+          title: "Weekly Product Sync",
+          created_at: "2026-05-28T10:00:00.000Z",
+          event_json: "",
+          raw_md: "Alex committed to send pricing by Friday.",
+        },
+      },
+      mapping_session_participant: {
+        current_alex: {
+          session_id: "current",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+        previous_alex: {
+          session_id: "previous",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+      },
+    });
+    const first = buildPastSessionNotes(hoisted.store, "current", "self");
+    const request = first.requests[0]!;
+    hoisted.store.setRow("session_key_facts", "previous", {
+      user_id: "self",
+      session_id: "previous",
+      created_at: "2026-05-28T11:00:00.000Z",
+      updated_at: "2026-05-28T11:00:00.000Z",
+      content: "Alex committed to send pricing by Friday.",
+      source_hash: request.sourceHash,
+    });
+    hoisted.generateText.mockRejectedValueOnce(new Error("timed out"));
+    hoisted.generateText.mockResolvedValueOnce({
+      output: {
+        facts: ["Alex will send pricing by Friday."],
+      },
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: {
+          retry: false,
+        },
+      },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(
+      () => usePastSessionNotes("current", { enabled: true }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.regenerate("previous");
+    });
+
+    await waitFor(() => {
+      expect(hoisted.showTransientToast).toHaveBeenCalledWith({
+        id: "past-note-key-facts-error",
+        description: "Could not generate related meeting facts. Try again.",
+        variant: "error",
+      });
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to generate related meeting facts",
+      expect.any(Error),
+    );
+    await waitFor(() => {
+      expect(result.current.isGenerating).toBe(false);
+    });
+
+    act(() => {
+      result.current.regenerate("previous");
+    });
+
+    await waitFor(() => {
+      expect(hoisted.generateText).toHaveBeenCalledTimes(2);
+    });
+    expect(hoisted.generateText.mock.calls[1]?.[0]).toMatchObject({
+      timeout: {
+        totalMs: 30_000,
+      },
+    });
+    consoleError.mockRestore();
+  });
 });
 
 function makeStore(
@@ -251,6 +401,9 @@ function makeStore(
         ...(tables[tableId] ?? {}),
         [rowId]: row,
       };
+    },
+    transaction: (callback: () => void) => {
+      callback();
     },
   } as any;
 }

--- a/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
+++ b/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
@@ -15,6 +15,7 @@ import userPromptTemplate from "./past-note-key-facts.user.md.jinja?raw";
 import { useLanguageModel } from "~/ai/hooks";
 import { extractPlainText } from "~/search/contexts/engine/utils";
 import { getSessionEvent } from "~/session/utils";
+import { showTransientToast } from "~/sidebar/toast/transient";
 import * as main from "~/store/tinybase/store/main";
 
 export type PastSessionNote = {
@@ -49,6 +50,7 @@ type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
 const MAX_PAST_NOTES = 8;
 const MAX_SOURCE_LENGTH = 6000;
 const MAX_KEY_FACTS = 3;
+const KEY_FACTS_GENERATION_TIMEOUT_MS = 30_000;
 const SPACE_REGEX = /\s+/g;
 const GENERIC_TITLE_KEYS = new Set(["new note", "untitled"]);
 
@@ -119,6 +121,14 @@ export function usePastSessionNotes(
         requests,
       });
     },
+    onError: (error) => {
+      console.error("Failed to generate related meeting facts", error);
+      showTransientToast({
+        id: "past-note-key-facts-error",
+        description: "Could not generate related meeting facts. Try again.",
+        variant: "error",
+      });
+    },
   });
 
   const generatingIds = useMemo(
@@ -149,7 +159,7 @@ export function usePastSessionNotes(
       return;
     }
 
-    void mutation.mutateAsync(built.missing);
+    mutation.mutate(built.missing);
   }, [built.missing, enabled, model, mutation]);
 
   const regenerate = useCallback(
@@ -165,7 +175,7 @@ export function usePastSessionNotes(
         return;
       }
 
-      void mutation.mutateAsync([request]);
+      mutation.mutate([request]);
     },
     [built.requests, enabled, model, mutation],
   );
@@ -368,6 +378,7 @@ async function generatePastSessionKeyFacts({
     output: Output.object({ schema: keyFactsSchema }),
     maxRetries: 2,
     maxOutputTokens: 400,
+    timeout: { totalMs: KEY_FACTS_GENERATION_TIMEOUT_MS },
   });
 
   return normalizeFacts(result.output?.facts ?? []).join("\n");


### PR DESCRIPTION
Add a timeout and visible error path for related meeting key fact generation so failed regenerate attempts re-enable and can be retried.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Session UI and optional AI key-facts generation only; no auth or data-model changes beyond existing session_key_facts writes on success.
> 
> **Overview**
> Improves **related meeting key facts** generation when LLM calls fail or hang: `generateText` now uses a **30s total timeout**, and the React Query mutation has an **`onError`** path that logs and shows an error transient toast so users know to retry.
> 
> **`generateMissing`** and **`regenerate`** now call **`mutation.mutate`** instead of **`mutateAsync`**, so failures settle the mutation (clearing **`isGenerating`** / re-enabling regenerate) instead of leaving the UI stuck.
> 
> Adds an integration test that mocks a failed then successful regenerate and asserts the toast, cleared pending state, and timeout on the retry call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 842040f65991ab7bfabd976c838c7e2e1c3db366. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->