### PR TITLE
Use Soniox real-time v5

### DIFF
--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -401,11 +401,11 @@ function getProviderModelMode(
   }
 
   if (providerId === "soniox") {
-    if (model === "stt-v5" || model === "stt-async-v5") {
+    if (model === "stt-async-v5") {
       return "batch";
     }
 
-    if (model === "stt-v4" || model === "stt-rt-v4") {
+    if (model === "stt-rt-v5" || model === "stt-v4" || model === "stt-rt-v4") {
       return "realtime";
     }
   }

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -46,7 +46,7 @@ export const displayModelId = (model: string) => {
     return "Whisper RT";
   }
 
-  if (model === "stt-v5" || model === "stt-async-v5") {
+  if (model === "stt-v5" || model === "stt-rt-v5" || model === "stt-async-v5") {
     return "Soniox v5";
   }
 
@@ -205,7 +205,7 @@ const _PROVIDERS = [
       />
     ),
     baseUrl: "https://api.soniox.com",
-    models: ["stt-v5", "stt-v4"],
+    models: ["stt-v5", "stt-rt-v5"],
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
   },
   {

--- a/crates/owhisper-client/src/adapter/soniox/mod.rs
+++ b/crates/owhisper-client/src/adapter/soniox/mod.rs
@@ -10,7 +10,11 @@ use super::LanguageSupport;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, strum::EnumString, strum::AsRefStr)]
 pub enum SonioxModel {
     #[default]
-    #[strum(serialize = "stt-v5", serialize = "stt-async-v5")]
+    #[strum(
+        serialize = "stt-v5",
+        serialize = "stt-rt-v5",
+        serialize = "stt-async-v5"
+    )]
     V5,
     #[strum(
         serialize = "stt-v4",
@@ -33,7 +37,7 @@ pub enum SonioxModel {
 impl SonioxModel {
     pub fn live_model(&self) -> &'static str {
         match self {
-            Self::V5 => "stt-rt-v4",
+            Self::V5 => "stt-rt-v5",
             Self::V4 => "stt-rt-v4",
             Self::V3 => "stt-rt-v3",
         }
@@ -125,19 +129,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn v5_uses_async_v5_for_batch_and_rt_v4_for_live() {
+    fn v5_uses_async_v5_for_batch_and_rt_v5_for_live() {
         let model = SonioxAdapter::resolve_model(Some("stt-v5"));
 
         assert_eq!(model.batch_model(), "stt-async-v5");
-        assert_eq!(model.live_model(), "stt-rt-v4");
+        assert_eq!(model.live_model(), "stt-rt-v5");
     }
 
     #[test]
-    fn async_v5_model_resolves_to_v5() {
-        let model = SonioxAdapter::resolve_model(Some("stt-async-v5"));
+    fn explicit_v5_models_resolve_to_v5() {
+        let async_model = SonioxAdapter::resolve_model(Some("stt-async-v5"));
+        let live_model = SonioxAdapter::resolve_model(Some("stt-rt-v5"));
 
-        assert_eq!(model, SonioxModel::V5);
-        assert_eq!(model.batch_model(), "stt-async-v5");
+        assert_eq!(async_model, SonioxModel::V5);
+        assert_eq!(async_model.batch_model(), "stt-async-v5");
+        assert_eq!(live_model, SonioxModel::V5);
+        assert_eq!(live_model.live_model(), "stt-rt-v5");
     }
 
     #[test]

--- a/crates/owhisper-client/src/providers.rs
+++ b/crates/owhisper-client/src/providers.rs
@@ -298,7 +298,7 @@ impl Provider {
         match self {
             Self::AquaVoice => "avalon-v1-en",
             Self::Deepgram => "nova-3",
-            Self::Soniox => "stt-rt-v4",
+            Self::Soniox => "stt-rt-v5",
             Self::AssemblyAI => "u3-rt-pro",
             Self::Fireworks => "whisper-v3-turbo",
             Self::OpenAI => "gpt-4o-transcribe",

--- a/crates/transcribe-proxy/src/routes/streaming/hyprnote.rs
+++ b/crates/transcribe-proxy/src/routes/streaming/hyprnote.rs
@@ -449,7 +449,7 @@ mod tests {
         let msg = initial_msg.unwrap();
         assert!(msg.contains("api_key"));
         assert!(msg.contains("test-key"));
-        assert!(msg.contains("stt-rt-v4"));
+        assert!(msg.contains("stt-rt-v5"));
     }
 
     #[test]

--- a/plugins/transcription/src/api.rs
+++ b/plugins/transcription/src/api.rs
@@ -346,7 +346,7 @@ mod tests {
 
     #[test]
     fn defaults_soniox_capture_to_live_mode_without_languages() {
-        let params = capture_params("https://api.soniox.com", "stt-rt-v4");
+        let params = capture_params("https://api.soniox.com", "stt-rt-v5");
 
         assert_eq!(params.default_transcription_mode(), TranscriptionMode::Live);
     }
@@ -355,7 +355,7 @@ mod tests {
     fn defaults_soniox_capture_to_live_mode_with_selected_language() {
         let params = capture_params_with_languages(
             "https://api.soniox.com",
-            "stt-rt-v4",
+            "stt-rt-v5",
             vec![ISO639::Ko.into()],
         );
 


### PR DESCRIPTION
## Summary
- Update Soniox live model resolution and provider defaults to use `stt-rt-v5`.
- Keep v4 model aliases for existing saved configs.
- Update desktop STT settings to expose the v5 real-time option.

## Validation
- `pnpm exec dprint fmt`
- `pnpm -F desktop typecheck`
- `pnpm -F desktop test src/settings/ai/stt/selection.test.ts`
- `cargo test -p owhisper-client soniox::tests`
- `cargo test -p transcribe-proxy routes::streaming::hyprnote::tests::test_build_initial_message_soniox`
- `cargo test -p tauri-plugin-transcription defaults_soniox_capture_to_live_mode`
- `cargo check -p owhisper-client -p transcribe-proxy -p tauri-plugin-transcription`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which upstream model ID is used for live Soniox v5 sessions (client, proxy, defaults); v4 aliases remain but wrong resolution could break streaming for some saved settings.
> 
> **Overview**
> Soniox **v5 live transcription** now targets **`stt-rt-v5`** instead of routing v5 through **`stt-rt-v4`**. The Rust `SonioxModel` adapter, provider default live model, transcribe-proxy initial WebSocket payload, and related tests were updated to match.
> 
> On desktop STT settings, Soniox exposes **`stt-v5`** and **`stt-rt-v5`** (replacing **`stt-v4`** in the picker), with realtime/batch badges and display names adjusted for **`stt-rt-v5`**. **v4 model IDs** (`stt-v4`, `stt-rt-v4`, etc.) still resolve and show as realtime where applicable for existing saved configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa8d45f411202f914afae1ceea4a634f692af42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->