### PR TITLE
Add Cloudflare Workers AI provider

### DIFF
--- a/apps/desktop/src/settings/ai/llm/configure.tsx
+++ b/apps/desktop/src/settings/ai/llm/configure.tsx
@@ -50,7 +50,9 @@ function ProviderContext({ providerId }: { providerId: ProviderId }) {
                 ? "Enter your **Azure AI Foundry endpoint** as the Base URL and your **API key**. Supports Claude and other models deployed via Azure AI Foundry. [Report issues](https://github.com/fastrepl/char/issues/3928)"
                 : providerId === "google_generative_ai"
                   ? "Visit [AI Studio](https://aistudio.google.com/api-keys) to create an API key."
-                  : "";
+                  : providerId === "cloudflare_workers_ai"
+                    ? "Enter the Workers AI **OpenAI-compatible base URL** as `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1` and use a Cloudflare API token with Workers AI access."
+                    : "";
 
   if (!content) {
     return null;

--- a/apps/desktop/src/settings/ai/llm/select.tsx
+++ b/apps/desktop/src/settings/ai/llm/select.tsx
@@ -24,6 +24,7 @@ import {
 import { listAnthropicModels } from "~/settings/ai/shared/list-anthropic";
 import { listAzureAIModels } from "~/settings/ai/shared/list-azure-ai";
 import { listAzureOpenAIModels } from "~/settings/ai/shared/list-azure-openai";
+import { listCloudflareWorkersAIModels } from "~/settings/ai/shared/list-cloudflare-workers-ai";
 import {
   type InputModality,
   type ListModelsResult,
@@ -300,6 +301,10 @@ function useConfiguredMapping(): Record<string, ProviderStatus> {
         switch (provider.id) {
           case "openai":
             listModelsFunc = () => listOpenAIModels(baseUrl, apiKey);
+            break;
+          case "cloudflare_workers_ai":
+            listModelsFunc = () =>
+              listCloudflareWorkersAIModels(baseUrl, apiKey);
             break;
           case "anthropic":
             listModelsFunc = () => listAnthropicModels(baseUrl, apiKey);

--- a/apps/desktop/src/settings/ai/llm/shared.tsx
+++ b/apps/desktop/src/settings/ai/llm/shared.tsx
@@ -97,6 +97,26 @@ const _PROVIDERS = [
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
   },
   {
+    id: "cloudflare_workers_ai",
+    displayName: "Cloudflare Workers AI",
+    badge: null,
+    icon: <Icon icon="simple-icons:cloudflare" width={16} />,
+    baseUrl: undefined,
+    requirements: [
+      { kind: "requires_config", fields: ["base_url", "api_key"] },
+    ],
+    links: {
+      models: {
+        label: "Available models",
+        url: "https://developers.cloudflare.com/workers-ai/models/",
+      },
+      setup: {
+        label: "Setup guide",
+        url: "https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/",
+      },
+    },
+  },
+  {
     id: "anthropic",
     displayName: "Anthropic",
     badge: null,

--- a/apps/desktop/src/settings/ai/shared/list-cloudflare-workers-ai.test.ts
+++ b/apps/desktop/src/settings/ai/shared/list-cloudflare-workers-ai.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  CLOUDFLARE_WORKERS_AI_MODELS,
+  createStaticCloudflareWorkersAIModelResult,
+} from "./list-cloudflare-workers-ai";
+
+describe("createStaticCloudflareWorkersAIModelResult", () => {
+  test("keeps a selectable fallback for Workers AI chat models", () => {
+    const result = createStaticCloudflareWorkersAIModelResult();
+
+    expect(result.models).toEqual([...CLOUDFLARE_WORKERS_AI_MODELS]);
+    expect(result.models[0]).toBe("@cf/moonshotai/kimi-k2.6");
+    expect(result.metadata["@cf/moonshotai/kimi-k2.6"]).toEqual({
+      input_modalities: ["text", "image"],
+    });
+    expect(result.metadata["@cf/openai/gpt-oss-120b"]).toEqual({
+      input_modalities: ["text"],
+    });
+  });
+});

--- a/apps/desktop/src/settings/ai/shared/list-cloudflare-workers-ai.ts
+++ b/apps/desktop/src/settings/ai/shared/list-cloudflare-workers-ai.ts
@@ -1,0 +1,64 @@
+import type { ListModelsResult, ModelMetadata } from "./list-common";
+import { DEFAULT_RESULT } from "./list-common";
+
+export const CLOUDFLARE_WORKERS_AI_MODELS = [
+  "@cf/moonshotai/kimi-k2.6",
+  "@cf/zai-org/glm-4.7-flash",
+  "@cf/openai/gpt-oss-120b",
+  "@cf/meta/llama-4-scout-17b-16e-instruct",
+  "@cf/google/gemma-4-26b-a4b-it",
+  "@cf/nvidia/nemotron-3-120b-a12b",
+  "@cf/openai/gpt-oss-20b",
+  "@cf/qwen/qwen3-30b-a3b-fp8",
+  "@cf/mistralai/mistral-small-3.1-24b-instruct",
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+] as const;
+
+const VISION_MODELS = new Set<string>([
+  "@cf/moonshotai/kimi-k2.6",
+  "@cf/meta/llama-4-scout-17b-16e-instruct",
+  "@cf/google/gemma-4-26b-a4b-it",
+]);
+
+function isCloudflareWorkersAIModel(
+  model: string,
+): model is (typeof CLOUDFLARE_WORKERS_AI_MODELS)[number] {
+  return (CLOUDFLARE_WORKERS_AI_MODELS as readonly string[]).includes(model);
+}
+
+export function getCloudflareWorkersAIModelMetadata(
+  model: string | undefined,
+): ModelMetadata | undefined {
+  if (!model || !isCloudflareWorkersAIModel(model)) {
+    return undefined;
+  }
+
+  return {
+    input_modalities: VISION_MODELS.has(model) ? ["text", "image"] : ["text"],
+  };
+}
+
+export function createStaticCloudflareWorkersAIModelResult(): ListModelsResult {
+  const metadata: Record<string, ModelMetadata> = {};
+
+  for (const model of CLOUDFLARE_WORKERS_AI_MODELS) {
+    metadata[model] = getCloudflareWorkersAIModelMetadata(model)!;
+  }
+
+  return {
+    models: [...CLOUDFLARE_WORKERS_AI_MODELS],
+    ignored: [],
+    metadata,
+  };
+}
+
+export async function listCloudflareWorkersAIModels(
+  baseUrl: string,
+  _apiKey: string,
+): Promise<ListModelsResult> {
+  if (!baseUrl) {
+    return DEFAULT_RESULT;
+  }
+
+  return createStaticCloudflareWorkersAIModelResult();
+}

--- a/apps/desktop/src/settings/ai/shared/model-capabilities.test.ts
+++ b/apps/desktop/src/settings/ai/shared/model-capabilities.test.ts
@@ -30,4 +30,19 @@ describe("modelSupportsImageInput", () => {
     expect(modelSupportsImageInput("ollama", "llava:latest")).toBe(true);
     expect(modelSupportsImageInput("custom", "llama-3.1-8b")).toBe(false);
   });
+
+  it("uses Workers AI model metadata for image input support", () => {
+    expect(
+      modelSupportsImageInput(
+        "cloudflare_workers_ai",
+        "@cf/moonshotai/kimi-k2.6",
+      ),
+    ).toBe(true);
+    expect(
+      modelSupportsImageInput(
+        "cloudflare_workers_ai",
+        "@cf/openai/gpt-oss-120b",
+      ),
+    ).toBe(false);
+  });
 });

--- a/apps/desktop/src/settings/ai/shared/model-capabilities.ts
+++ b/apps/desktop/src/settings/ai/shared/model-capabilities.ts
@@ -1,3 +1,5 @@
+import { getCloudflareWorkersAIModelMetadata } from "./list-cloudflare-workers-ai";
+
 const TEXT_ONLY_MODEL_RE =
   /(?:^|[/:\-.])(?:gpt-3\.5|claude-2|claude-instant|davinci|babbage|curie|ada|dall-e|sora|gpt-image|image-generation|embed|embedding|whisper|tts|transcribe|moderation|realtime|computer)(?:$|[/:\-.])/i;
 
@@ -10,6 +12,13 @@ export function modelSupportsImageInput(
 ): boolean {
   if (!providerId || !modelId) {
     return false;
+  }
+
+  if (providerId === "cloudflare_workers_ai") {
+    const metadata = getCloudflareWorkersAIModelMetadata(modelId);
+    if (metadata?.input_modalities) {
+      return metadata.input_modalities.includes("image");
+    }
   }
 
   if (TEXT_ONLY_MODEL_RE.test(modelId)) {


### PR DESCRIPTION
Add Cloudflare Workers AI as a selectable OpenAI-compatible LLM provider with setup guidance and seeded model fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop settings-only addition following existing provider patterns; no auth or backend changes, with behavior covered by small unit tests.
> 
> **Overview**
> Adds **Cloudflare Workers AI** as a new OpenAI-compatible LLM provider in desktop AI settings. Users configure a **base URL** (account-scoped Workers AI v1 endpoint) and **API token**, with in-app setup copy and links to Cloudflare docs.
> 
> Model selection uses a **static seeded list** of `@cf/...` chat models (with per-model **input modality** metadata) when a base URL is set, instead of calling a remote models API. **Image input** support for Workers AI models is driven by that metadata in `modelSupportsImageInput`, with unit tests for the list and capabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e54e3a4fa8f79549608161f4d85258858d1037b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->