### PR TITLE
Fix floating chat button hit area

### DIFF
--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -183,6 +183,7 @@ describe("FloatingActionButton", () => {
     expect(hoverZone?.className).not.toContain("w-96");
     expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
     expect(wrapper?.className).toContain("pointer-events-none");
+    expect(wrapper?.className).toContain("before:pointer-events-none");
     expect(wrapper?.className).toContain("before:-inset-x-8");
     expect(wrapper?.className).toContain("before:-inset-y-8");
     expect(wrapper?.className).toContain(
@@ -191,6 +192,7 @@ describe("FloatingActionButton", () => {
     expect(wrapper?.style.getPropertyValue("--floating-fab-tuck-offset")).toBe(
       "calc(100% - 0.5rem + 18px)",
     );
+    expect(wrapper?.className).toContain("before:pointer-events-none");
     expect(wrapper?.className).toContain("group-hover:pointer-events-auto");
     expect(wrapper?.className).toContain("group-hover:translate-y-0");
     expect(wrapper?.className).toContain("hover:pointer-events-auto");
@@ -240,6 +242,7 @@ describe("FloatingActionButton", () => {
       "calc(100% - 0.5rem + 18px)",
     );
     expect(wrapper?.className).toContain("pointer-events-none");
+    expect(wrapper?.className).toContain("before:pointer-events-none");
     expect(wrapper?.className).toContain("group-hover:pointer-events-auto");
     expect(wrapper?.className).toContain("group-hover:translate-y-0");
     expect(wrapper?.className).toContain("hover:pointer-events-auto");

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -85,7 +85,7 @@ export function FloatingActionButton({
             className={cn([
               "relative max-w-full translate-y-[var(--floating-fab-tuck-offset)] transition-transform duration-200 ease-out",
               tuckAction
-                ? "pointer-events-none visible group-hover:pointer-events-auto group-hover:translate-y-0 before:absolute before:-inset-x-8 before:-inset-y-8 before:content-[''] hover:pointer-events-auto hover:translate-y-0"
+                ? "pointer-events-none visible group-hover:pointer-events-auto group-hover:translate-y-0 before:pointer-events-none before:absolute before:-inset-x-8 before:-inset-y-8 before:content-[''] hover:pointer-events-auto hover:translate-y-0"
                 : "pointer-events-auto visible",
             ])}
           >


### PR DESCRIPTION
Let the tucked chat FAB hover pseudo-element pass clicks through to the underlying CTA and cover the behavior with focused assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only pointer-events tweak on the floating session FAB with matching unit tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes the tucked floating chat FAB so its enlarged **`::before`** hover hit area no longer intercepts clicks meant for the actual CTA.
> 
> When the FAB is tucked (`tuckAction`), the wrapper now includes **`before:pointer-events-none`** alongside the existing expanded inset pseudo-element, so pointer events reach the button while **group-hover** / **hover** still re-enable interaction on the wrapper as before.
> 
> Tests assert **`before:pointer-events-none`** on the wrapper in tucked/hidden and active-meeting scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff1874716fe211f9620c44b3e5f0a56261aaff8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->