### PR TITLE
Improve sidebar startup performance

### DIFF
--- a/apps/desktop/src/session/components/session-preview-card.test.tsx
+++ b/apps/desktop/src/session/components/session-preview-card.test.tsx
@@ -1,0 +1,119 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  contentOpen: false,
+  enhancedNoteIds: [] as string[],
+  useCell: vi.fn(
+    (_table: string, _rowId: string, cellId: string) =>
+      (
+        ({
+          title: "Design sync",
+          raw_md: "Discussed launch readiness and owner follow-ups.",
+          created_at: "2024-01-15T10:30:00.000Z",
+          event_json: undefined,
+        }) as Record<string, string | undefined>
+      )[cellId],
+  ),
+  useEnhancedNote: vi.fn(() => ({ content: undefined, title: undefined })),
+  useEnhancedNotes: vi.fn(() => mocks.enhancedNoteIds),
+  useResultTable: vi.fn(() => ({})),
+  useSliceRowIds: vi.fn(() => []),
+}));
+
+vi.mock("@hypr/editor/markdown", () => ({
+  isValidContent: () => false,
+  json2md: () => "",
+}));
+
+vi.mock("@hypr/editor/node-views", () => ({
+  parseImageMetadata: () => ({ editorWidth: undefined, title: undefined }),
+}));
+
+vi.mock("@hypr/ui/components/ui/hover-card", () => ({
+  HoverCard: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  HoverCardContent: ({ children }: { children: ReactNode }) =>
+    mocks.contentOpen ? (
+      <div data-testid="preview-content">{children}</div>
+    ) : null,
+  HoverCardTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("~/search/contexts/engine/utils", () => ({
+  extractPlainText: (value: string) => value,
+}));
+
+vi.mock("~/session/components/streamdown", () => ({
+  streamdownComponents: {},
+}));
+
+vi.mock("~/session/hooks/useEnhancedNotes", () => ({
+  useEnhancedNote: mocks.useEnhancedNote,
+  useEnhancedNotes: mocks.useEnhancedNotes,
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  INDEXES: {
+    sessionParticipantsBySession: "sessionParticipantsBySession",
+  },
+  QUERIES: {
+    sessionParticipantsWithDetails: "sessionParticipantsWithDetails",
+  },
+  STORE_ID: "main",
+  UI: {
+    useCell: mocks.useCell,
+    useResultTable: mocks.useResultTable,
+    useSliceRowIds: mocks.useSliceRowIds,
+  },
+}));
+
+import { SessionPreviewCard } from "./session-preview-card";
+
+describe("SessionPreviewCard", () => {
+  beforeEach(() => {
+    mocks.contentOpen = false;
+    mocks.enhancedNoteIds = [];
+    mocks.useCell.mockClear();
+    mocks.useEnhancedNote.mockClear();
+    mocks.useEnhancedNotes.mockClear();
+    mocks.useResultTable.mockClear();
+    mocks.useSliceRowIds.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("defers preview data subscriptions until the hover content mounts", () => {
+    const { rerender } = render(
+      <SessionPreviewCard sessionId="session-1" side="right">
+        <button type="button">Open note</button>
+      </SessionPreviewCard>,
+    );
+
+    expect(screen.getByRole("button", { name: "Open note" })).toBeTruthy();
+    expect(mocks.useCell).not.toHaveBeenCalled();
+    expect(mocks.useEnhancedNotes).not.toHaveBeenCalled();
+    expect(mocks.useSliceRowIds).not.toHaveBeenCalled();
+
+    mocks.contentOpen = true;
+    rerender(
+      <SessionPreviewCard sessionId="session-1" side="right">
+        <button type="button">Open note</button>
+      </SessionPreviewCard>,
+    );
+
+    expect(screen.getByTestId("preview-content")).toBeTruthy();
+    expect(screen.getByText("Design sync")).toBeTruthy();
+    expect(mocks.useCell).toHaveBeenCalled();
+    expect(mocks.useEnhancedNotes).toHaveBeenCalledWith("session-1");
+    expect(mocks.useSliceRowIds).toHaveBeenCalledWith(
+      "sessionParticipantsBySession",
+      "session-1",
+      "main",
+    );
+  });
+});

--- a/apps/desktop/src/session/components/session-preview-card.tsx
+++ b/apps/desktop/src/session/components/session-preview-card.tsx
@@ -297,20 +297,6 @@ export function SessionPreviewCard({
   children: React.ReactNode;
   enabled?: boolean;
 }) {
-  const {
-    title,
-    previewMarkdown,
-    previewPlainText,
-    dateDisplay,
-    participantMappingIds,
-  } = useSessionPreviewData(sessionId);
-  const previewHasImage =
-    !!previewMarkdown && MARKDOWN_IMAGE_REGEX.test(previewMarkdown);
-  const previewImage = useMemo(
-    () => extractPreviewImage(previewMarkdown),
-    [previewMarkdown],
-  );
-
   const followAxis = side === "right" ? "y" : "x";
   const { triggerRef, handleMouseMove, handleMouseLeave, style } =
     useCursorFollow(followAxis);
@@ -359,43 +345,61 @@ export function SessionPreviewCard({
         followStyle={style}
         className={cn(["w-[228px] pb-0!", "pointer-events-none"])}
       >
-        <div className="flex flex-col gap-1">
-          {dateDisplay && (
-            <div className="text-muted-foreground text-xs">{dateDisplay}</div>
-          )}
-
-          <div className="text-sm font-medium">{title || "Untitled"}</div>
-          <ParticipantsList mappingIds={participantMappingIds} />
-
-          {previewMarkdown || previewPlainText ? (
-            <div className="text-muted-foreground mt-1 flex max-h-32 flex-col overflow-hidden mask-[linear-gradient(to_bottom,black_60%,transparent)]">
-              {previewHasImage && previewImage ? (
-                <img
-                  src={previewImage.src}
-                  alt={previewImage.alt}
-                  title={previewImage.title}
-                  className="block w-full object-cover object-top"
-                />
-              ) : previewMarkdown ? (
-                <Streamdown
-                  components={previewCardComponents}
-                  className="flex flex-col text-xs"
-                  isAnimating={false}
-                  rehypePlugins={previewCardRehypePlugins}
-                >
-                  {previewMarkdown}
-                </Streamdown>
-              ) : (
-                <div className="text-xs leading-relaxed">
-                  {previewPlainText}
-                </div>
-              )}
-            </div>
-          ) : (
-            <div className="h-4" />
-          )}
-        </div>
+        <SessionPreviewCardContent sessionId={sessionId} />
       </HoverCardContent>
     </HoverCard>
+  );
+}
+
+function SessionPreviewCardContent({ sessionId }: { sessionId: string }) {
+  const {
+    title,
+    previewMarkdown,
+    previewPlainText,
+    dateDisplay,
+    participantMappingIds,
+  } = useSessionPreviewData(sessionId);
+  const previewHasImage =
+    !!previewMarkdown && MARKDOWN_IMAGE_REGEX.test(previewMarkdown);
+  const previewImage = useMemo(
+    () => extractPreviewImage(previewMarkdown),
+    [previewMarkdown],
+  );
+
+  return (
+    <div className="flex flex-col gap-1">
+      {dateDisplay && (
+        <div className="text-muted-foreground text-xs">{dateDisplay}</div>
+      )}
+
+      <div className="text-sm font-medium">{title || "Untitled"}</div>
+      <ParticipantsList mappingIds={participantMappingIds} />
+
+      {previewMarkdown || previewPlainText ? (
+        <div className="text-muted-foreground mt-1 flex max-h-32 flex-col overflow-hidden mask-[linear-gradient(to_bottom,black_60%,transparent)]">
+          {previewHasImage && previewImage ? (
+            <img
+              src={previewImage.src}
+              alt={previewImage.alt}
+              title={previewImage.title}
+              className="block w-full object-cover object-top"
+            />
+          ) : previewMarkdown ? (
+            <Streamdown
+              components={previewCardComponents}
+              className="flex flex-col text-xs"
+              isAnimating={false}
+              rehypePlugins={previewCardRehypePlugins}
+            >
+              {previewMarkdown}
+            </Streamdown>
+          ) : (
+            <div className="text-xs leading-relaxed">{previewPlainText}</div>
+          )}
+        </div>
+      ) : (
+        <div className="h-4" />
+      )}
+    </div>
   );
 }

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -427,11 +427,14 @@ const SessionItem = memo(
     ) as string | undefined;
     const title = useSessionTitle(sessionId, storeTitle);
 
-    const { sessionMode, stop, amplitude } = useListener((state) => ({
-      sessionMode: state.getSessionMode(sessionId),
-      stop: state.stop,
-      amplitude: state.live.amplitude,
-    }));
+    const { sessionMode, stop, amplitude } = useListener((state) => {
+      const sessionMode = state.getSessionMode(sessionId);
+      return {
+        sessionMode,
+        stop: state.stop,
+        amplitude: sessionMode === "active" ? state.live.amplitude : null,
+      };
+    });
     const isEnhancing = useIsSessionEnhancing(sessionId);
     const isLive = sessionMode === "active";
     const isFinalizing = sessionMode === "finalizing";
@@ -557,7 +560,10 @@ const SessionItem = memo(
           isLive={isLive}
           amplitude={Math.max(
             0.25,
-            Math.min(Math.hypot(amplitude.mic, amplitude.speaker), 1),
+            Math.min(
+              Math.hypot(amplitude?.mic ?? 0, amplitude?.speaker ?? 0),
+              1,
+            ),
           )}
           showSpinner={showSpinner}
           selected={selected}


### PR DESCRIPTION
Defer session preview subscriptions until hover and avoid amplitude updates waking inactive timeline rows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-focused refactors with behavior preserved for open previews and the single active live session; risk is mainly regression in hover preview content or live meter display.
> 
> **Overview**
> Improves sidebar startup and scroll performance by cutting unnecessary store and listener subscriptions on timeline session rows.
> 
> **Session hover previews** no longer call `useSessionPreviewData` (Tinybase cells, enhanced notes, participants) from the outer card. That work moves into `SessionPreviewCardContent`, which only mounts inside `HoverCardContent`, so subscriptions start when the preview actually opens. A Vitest test asserts preview hooks stay idle until hover content is shown.
> 
> **Timeline session rows** change their `useListener` selector so `state.live.amplitude` is only read when that row’s session is **active**. Inactive rows still get mode/stop but stop re-rendering on every amplitude tick; live visualization uses null-safe mic/speaker values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d8cfa4fafa38b0be1b5300eca71fa5df8c5f53a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->