### PR TITLE
Simplify batch transcript status

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -333,7 +333,7 @@ describe("PostSessionAccessory", () => {
     expect(screen.queryByTestId("transcript")).toBeNull();
   });
 
-  it("keeps batch progress visible while the transcript panel is collapsed", () => {
+  it("keeps batch status visible while the transcript panel is collapsed", () => {
     useTranscriptScreenMock.mockReturnValue({
       kind: "running_batch",
       percentage: 0.25,
@@ -349,9 +349,35 @@ describe("PostSessionAccessory", () => {
       />,
     );
 
-    expect(screen.getByText("25%")).toBeTruthy();
-    expect(screen.getByText("Transcribing")).toBeTruthy();
+    expect(screen.queryByText("25%")).toBeNull();
+    expect(screen.getByText("Transcribing...")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Stop transcription" }),
+    ).toBeTruthy();
     expect(screen.queryByTestId("transcript")).toBeNull();
+  });
+
+  it("shows uploading state without a stop action while importing audio", () => {
+    useTranscriptScreenMock.mockReturnValue({
+      kind: "running_batch",
+      percentage: 0.25,
+      phase: "importing",
+    });
+
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio
+        hasTranscript
+        isTranscriptExpanded={false}
+      />,
+    );
+
+    expect(screen.getByText("Uploading...")).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Stop transcription" }),
+    ).toBeNull();
+    expect(screen.queryByText("25%")).toBeNull();
   });
 
   it("keeps the audio timeline slot height stable when expanded", () => {
@@ -397,7 +423,7 @@ describe("PostSessionAccessory", () => {
     expect(transcriptSlot?.className).toContain("min-h-[114px]");
   });
 
-  it("shows transcript skeletons instead of duplicating batch progress in the body", () => {
+  it("shows transcript skeletons with simple batch status in the body", () => {
     useTranscriptScreenMock.mockReturnValue({
       kind: "running_batch",
       percentage: 0.25,
@@ -414,7 +440,8 @@ describe("PostSessionAccessory", () => {
     );
 
     expect(screen.getByText("Transcript")).toBeTruthy();
-    expect(screen.getAllByText("Transcribing...")).toHaveLength(1);
+    expect(screen.getAllByText("Transcribing...")).toHaveLength(2);
+    expect(screen.queryByText("25%")).toBeNull();
     expect(screen.getAllByTestId("spinner")).toHaveLength(2);
     expect(screen.getByTestId("transcript-skeleton")).toBeTruthy();
     expect(screen.queryByTestId("transcript")).toBeNull();

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -356,8 +356,8 @@ function BatchingTranscriptPanel({
   const handleStop = useCallback(() => {
     void stopTranscription(sessionId);
   }, [sessionId, stopTranscription]);
-  const { percentage, phase } = screen;
-  const phaseLabel = phase === "importing" ? "Importing..." : "Transcribing...";
+  const { phase } = screen;
+  const phaseLabel = getBatchPhaseLabel(phase);
   const canStopTranscription = phase !== "importing";
 
   if (!isExpanded) {
@@ -371,18 +371,13 @@ function BatchingTranscriptPanel({
           Transcript
         </span>
         <div className="flex items-center gap-1 px-1 py-0.5">
-          <Spinner size={10} />
+          <BatchStatusControl
+            onStop={canStopTranscription ? handleStop : undefined}
+            compact
+          />
           <span className="text-muted-foreground text-[11px]">
             {phaseLabel}
-            {typeof percentage === "number" && percentage > 0 && (
-              <span className="text-muted-foreground ml-1 tabular-nums">
-                {Math.round(percentage * 100)}%
-              </span>
-            )}
           </span>
-          {canStopTranscription ? (
-            <StopTranscriptionButton onClick={handleStop} compact />
-          ) : null}
         </div>
       </div>
 
@@ -473,62 +468,57 @@ function BatchProgressTimeline({
   const handleStop = useCallback(() => {
     void stopTranscription(sessionId);
   }, [sessionId, stopTranscription]);
-  const phaseLabel =
-    screen.phase === "importing" ? "Importing" : "Transcribing";
+  const phaseLabel = getBatchPhaseLabel(screen.phase);
   const canStopTranscription = screen.phase !== "importing";
-  const progress = Math.max(0, Math.min(screen.percentage ?? 0, 1));
-  const progressText =
-    typeof screen.percentage === "number" && screen.percentage > 0
-      ? `${Math.round(screen.percentage * 100)}%`
-      : "...";
 
   return (
     <AudioPlayer.TimelineShell
       leading={
-        <div
-          className={cn([
-            "flex h-7 w-7 items-center justify-center rounded-full",
-            "border-border bg-card border shadow-xs",
-            "shrink-0",
-          ])}
-        >
-          <Spinner size={12} />
-        </div>
-      }
-      meta={
-        <AudioPlayer.TimelineMeta>
-          <span>{progressText}</span>
-          {canStopTranscription ? (
-            <StopTranscriptionButton onClick={handleStop} />
-          ) : null}
-        </AudioPlayer.TimelineMeta>
+        <BatchStatusControl
+          onStop={canStopTranscription ? handleStop : undefined}
+        />
       }
       main={
-        <div className="flex h-6 items-center">
-          <div className="bg-accent/80 relative h-2 w-full overflow-hidden rounded-full">
-            <div
-              className="bg-muted-foreground absolute inset-y-0 left-0 rounded-full transition-[width] duration-300 ease-out"
-              style={{ width: `${Math.max(progress * 100, 8)}%` }}
-            />
-            <div className="absolute inset-0 flex items-center justify-center">
-              <span className="text-muted-foreground px-2 text-[10px] font-medium tracking-[0.02em]">
-                {phaseLabel}
-              </span>
-            </div>
-          </div>
+        <div className="flex h-6 items-center justify-center">
+          <span className="text-muted-foreground text-[11px] font-medium">
+            {phaseLabel}
+          </span>
         </div>
       }
     />
   );
 }
 
-function StopTranscriptionButton({
-  onClick,
-  compact = false,
+function getBatchPhaseLabel(phase?: "importing" | "transcribing") {
+  return phase === "importing" ? "Uploading..." : "Transcribing...";
+}
+
+function BatchStatusControl({
+  onStop,
+  compact,
 }: {
-  onClick: () => void;
+  onStop?: () => void;
   compact?: boolean;
 }) {
+  const sizeClassName = compact ? "h-5 w-5" : "h-7 w-7";
+  const spinnerSize = compact ? 10 : 12;
+  const iconSize = compact ? 9 : 10;
+
+  if (!onStop) {
+    return (
+      <div
+        className={cn([
+          "flex items-center justify-center rounded-full",
+          "border-border bg-card border shadow-xs",
+          "shrink-0",
+          sizeClassName,
+        ])}
+      >
+        <Spinner size={spinnerSize} />
+      </div>
+    );
+  }
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -537,13 +527,22 @@ function StopTranscriptionButton({
           variant="ghost"
           size="icon"
           className={cn([
-            "text-muted-foreground hover:text-muted-foreground",
-            compact ? "h-5 w-5" : "h-6 w-6",
+            "group rounded-full",
+            "border-border bg-card border shadow-xs",
+            "text-muted-foreground hover:bg-accent hover:text-muted-foreground",
+            "shrink-0 transition-colors",
+            sizeClassName,
           ])}
-          onClick={onClick}
+          onClick={onStop}
           aria-label="Stop transcription"
         >
-          <SquareIcon size={compact ? 9 : 10} className="fill-current" />
+          <span className="group-hover:hidden">
+            <Spinner size={spinnerSize} />
+          </span>
+          <SquareIcon
+            size={iconSize}
+            className="hidden fill-current group-hover:block"
+          />
         </Button>
       </TooltipTrigger>
       <TooltipContent side="bottom">


### PR DESCRIPTION
Replace the collapsed batch progress rail with a simple phase label and a hover-to-stop spinner control.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes in the post-session transcript accessory; stop transcription wiring is preserved for the transcribing phase only.
> 
> **Overview**
> **Batch transcription/import** in the post-session bottom accessory no longer shows **percentage or a progress bar**; users only see phase text (**Uploading...** vs **Transcribing...**) in the collapsed timeline rail and expanded transcript header.
> 
> **Stop** is consolidated into **`BatchStatusControl`**: during upload/import it is a **spinner-only** control with no stop action; while transcribing it is a circular control that shows a spinner by default and reveals **Stop transcription** on hover (replacing the separate stop button and timeline meta).
> 
> Expanded batch state still uses transcript skeletons; tests were updated for the new labels, absent **25%**, and importing vs transcribing stop behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 001a98d7a22d3da863ee38d0776a51a81795053f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->