### PR TITLE
Add desktop changelog for 1.0.45

### DIFF
--- a/packages/changelog/content/1.0.45.md
+++ b/packages/changelog/content/1.0.45.md
@@ -1,0 +1,37 @@
+---
+date: "2026-06-17"
+summary: "Anarlog now supports Cloudflare Workers AI, improves transcript status and live STT defaults, keeps meeting surfaces steadier, and makes downloaded updates easier to install."
+---
+
+## Meetings
+
+- The sidebar now shows when a scheduled meeting is about to start
+- Sidebar session previews now load on hover so startup stays smoother
+- The meeting timeline no longer jumps to the current-time fallback when there is no Today section
+- The floating Now chip no longer reserves extra sidebar space when it overlays the timeline
+- Starting chat during an active meeting now opens the chat panel more reliably
+- Mic-detected meeting prompts now show clearer app names and icons for iPhone calls, FaceTime, and KakaoTalk
+- KakaoTalk screen sharing no longer stops listening unexpectedly
+- The tucked floating chat button no longer blocks nearby click targets
+
+## Notes and Transcripts
+
+- Summaries regenerate after resumed listening adds or replaces transcript content
+- Streaming summary generation now previews in the final editor layout instead of a separate loading view
+- Batch transcript progress now uses a simpler phase label and hover-to-stop control
+- Soniox realtime transcription now defaults to v5 while preserving existing v4 settings
+- Inline enhanced-note loading is visible again while Anarlog analyzes a note
+- Related meeting facts now recover more clearly after failures and keep wrapped bullets aligned
+
+## Contacts and Chat
+
+- Contact enhancement now shows visible progress on participant chips
+- Calendar-derived contacts can capture company names and match more email-only invitees
+- Chat replies now follow the app's configured response language more consistently
+
+## Updates and Settings
+
+- Cloudflare Workers AI is now available as a selectable AI provider with setup guidance
+- Downloaded updates now stay visible in the sidebar so you can restart and install them
+- Checking for updates from the tray now recognizes updates that are already downloaded
+- Dock and menu bar icon settings now apply immediately after saving


### PR DESCRIPTION
Create a user-facing changelog entry covering timeline, summary, chat, contact, update, and settings polish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition of a changelog file; no runtime or security-sensitive code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.0.45.md`**, a new desktop changelog entry for **1.0.45** (dated 2026-06-17) with frontmatter summary and bullet sections for **Meetings**, **Notes and Transcripts**, **Contacts and Chat**, and **Updates and Settings**.
> 
> The copy documents shipped polish in this release—e.g. upcoming-meeting sidebar cues, timeline/Now chip behavior, summary regeneration and streaming preview, Soniox v5 default, contact enhancement progress, Cloudflare Workers AI as a provider, and sidebar/tray update install flows—without changing application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11099fd731a7044020873bc1704f768fe8336ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->