### PR TITLE
Show available update action

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -144,9 +144,10 @@ pub async fn main() {
         .plugin(tauri_plugin_notify::init())
         .plugin(tauri_plugin_overlay::init())
         .plugin(tauri_plugin_clipboard_manager::init())
-        .plugin(tauri_plugin_tray::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_store2::init())
+        .plugin(tauri_plugin_updater2::init())
+        .plugin(tauri_plugin_tray::init())
         .plugin(tauri_plugin_settings::init())
         .plugin(tauri_plugin_sfx::init())
         .plugin(tauri_plugin_shortcut::init())
@@ -169,8 +170,7 @@ pub async fn main() {
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
             Some(vec!["--background"]),
-        ))
-        .plugin(tauri_plugin_updater2::init());
+        ));
 
     if let Some(client) = sentry_client.as_ref() {
         builder = builder.plugin(tauri_plugin_sentry::init_with_no_injection(client));

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -367,7 +367,7 @@ function LeftSurfaceChromeButton({
         <span
           aria-hidden="true"
           data-testid="collapsed-sidebar-update-badge"
-          className="ring-background pointer-events-none absolute top-1 right-1 size-1.5 rounded-full bg-red-500 ring-2"
+          className="ring-background pointer-events-none absolute top-1 right-1 size-1.5 rounded-full bg-blue-500 ring-2"
         />
       ) : null}
     </button>

--- a/apps/desktop/src/main/update-banner.test.tsx
+++ b/apps/desktop/src/main/update-banner.test.tsx
@@ -16,6 +16,7 @@ const {
   installMock,
   isDownloadedMock,
   postinstallMock,
+  updateAvailableListenMock,
   updateDownloadingListenMock,
   updateDownloadProgressListenMock,
   updateReadyListenMock,
@@ -28,12 +29,16 @@ const {
   installMock: vi.fn(),
   isDownloadedMock: vi.fn(),
   postinstallMock: vi.fn(),
+  updateAvailableListenMock: vi.fn(),
   updateDownloadingListenMock: vi.fn(),
   updateDownloadProgressListenMock: vi.fn(),
   updateReadyListenMock: vi.fn(),
   updateDownloadFailedListenMock: vi.fn(),
   updatedListenMock: vi.fn(),
   eventHandlers: {
+    updateAvailable: null as
+      | null
+      | ((event: { payload: { version: string } }) => void),
     updateDownloading: null as
       | null
       | ((event: { payload: { version: string } }) => void),
@@ -69,6 +74,9 @@ vi.mock("@hypr/plugin-updater2", () => ({
     postinstall: postinstallMock,
   },
   events: {
+    updateAvailableEvent: {
+      listen: updateAvailableListenMock,
+    },
     updateDownloadingEvent: {
       listen: updateDownloadingListenMock,
     },
@@ -103,12 +111,14 @@ describe("SidebarTimelineUpdateButton", () => {
     installMock.mockReset();
     isDownloadedMock.mockReset();
     postinstallMock.mockReset();
+    updateAvailableListenMock.mockReset();
     updateDownloadingListenMock.mockReset();
     updateDownloadProgressListenMock.mockReset();
     updateReadyListenMock.mockReset();
     updateDownloadFailedListenMock.mockReset();
     updatedListenMock.mockReset();
 
+    eventHandlers.updateAvailable = null;
     eventHandlers.updateDownloading = null;
     eventHandlers.updateDownloadProgress = null;
     eventHandlers.updateReady = null;
@@ -124,6 +134,10 @@ describe("SidebarTimelineUpdateButton", () => {
     isDownloadedMock.mockResolvedValue({ status: "ok", data: false });
     postinstallMock.mockResolvedValue({ status: "ok", data: null });
 
+    updateAvailableListenMock.mockImplementation(async (handler) => {
+      eventHandlers.updateAvailable = handler;
+      return () => {};
+    });
     updateDownloadingListenMock.mockImplementation(async (handler) => {
       eventHandlers.updateDownloading = handler;
       return () => {};
@@ -167,10 +181,83 @@ describe("SidebarTimelineUpdateButton", () => {
     expect(button.className.split(" ")).toEqual(
       expect.arrayContaining(["h-7", "w-7", "min-h-7", "min-w-7", "p-0"]),
     );
+    expect(button.className.split(" ")).toEqual(
+      expect.arrayContaining(["bg-blue-500", "hover:bg-blue-600"]),
+    );
+    expect(button.className.split(" ")).not.toContain("bg-primary");
 
     fireEvent.click(button);
 
     await waitFor(() => expect(downloadMock).toHaveBeenCalledWith("1.0.34"));
+  });
+
+  it("shows download when an external update check reports an available version", async () => {
+    renderSidebarUpdateButton();
+
+    await waitFor(() =>
+      expect(eventHandlers.updateAvailable).toBeTypeOf("function"),
+    );
+
+    act(() => {
+      eventHandlers.updateAvailable?.({ payload: { version: "1.0.34" } });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Download update" }));
+
+    await waitFor(() => expect(downloadMock).toHaveBeenCalledWith("1.0.34"));
+  });
+
+  it("clears stale available state after a successful check finds no update", async () => {
+    renderSidebarUpdateButton();
+
+    await waitFor(() =>
+      expect(eventHandlers.updateAvailable).toBeTypeOf("function"),
+    );
+
+    act(() => {
+      eventHandlers.updateAvailable?.({ payload: { version: "1.0.34" } });
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Download update" }),
+    ).toBeTruthy();
+
+    await act(async () => {
+      await queryClients[queryClients.length - 1]?.refetchQueries({
+        queryKey: ["updater2", "check"],
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Download update" }),
+      ).toBeNull(),
+    );
+  });
+
+  it("keeps retry visible when a failed update is rechecked", async () => {
+    renderSidebarUpdateButton();
+
+    await waitFor(() =>
+      expect(eventHandlers.updateDownloadFailed).toBeTypeOf("function"),
+    );
+
+    act(() => {
+      eventHandlers.updateDownloadFailed?.({
+        payload: { version: "1.0.34" },
+      });
+    });
+
+    expect(screen.getByRole("button", { name: "Retry update" })).toBeTruthy();
+
+    act(() => {
+      eventHandlers.updateAvailable?.({ payload: { version: "1.0.34" } });
+    });
+
+    expect(screen.getByRole("button", { name: "Retry update" })).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Download update" }),
+    ).toBeNull();
   });
 
   it("shows restart when the checked update is already downloaded", async () => {
@@ -181,6 +268,28 @@ describe("SidebarTimelineUpdateButton", () => {
 
     expect(
       await screen.findByRole("button", { name: "Restart to update" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Download update" }),
+    ).toBeNull();
+  });
+
+  it("keeps restart visible when an already-downloaded update also emits available", async () => {
+    checkMock.mockResolvedValue({ status: "ok", data: "1.0.34" });
+    isDownloadedMock.mockResolvedValue({ status: "ok", data: true });
+
+    renderSidebarUpdateButton();
+
+    expect(
+      await screen.findByRole("button", { name: "Restart to update" }),
+    ).toBeTruthy();
+
+    act(() => {
+      eventHandlers.updateAvailable?.({ payload: { version: "1.0.34" } });
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Restart to update" }),
     ).toBeTruthy();
     expect(
       screen.queryByRole("button", { name: "Download update" }),

--- a/apps/desktop/src/main/update-banner.tsx
+++ b/apps/desktop/src/main/update-banner.tsx
@@ -64,12 +64,29 @@ export function useDesktopUpdateControl(): DesktopUpdateControl {
 
     const listen = async () => {
       const [
+        unlistenAvailable,
         unlistenDownloading,
         unlistenProgress,
         unlistenReady,
         unlistenFailed,
         unlistenUpdated,
       ] = await Promise.all([
+        updaterEvents.updateAvailableEvent.listen(({ payload }) => {
+          setEventState((current) =>
+            current?.version === payload.version &&
+            (current.status === "downloading" ||
+              current.status === "ready" ||
+              current.status === "failed")
+              ? current
+              : {
+                  status: "available",
+                  version: payload.version,
+                  downloadedBytes: 0,
+                  contentLength: null,
+                  errorMessage: null,
+                },
+          );
+        }),
         updaterEvents.updateDownloadingEvent.listen(({ payload }) => {
           setEventState({
             status: "downloading",
@@ -120,6 +137,7 @@ export function useDesktopUpdateControl(): DesktopUpdateControl {
       ]);
 
       if (cancelled) {
+        unlistenAvailable();
         unlistenDownloading();
         unlistenProgress();
         unlistenReady();
@@ -129,6 +147,7 @@ export function useDesktopUpdateControl(): DesktopUpdateControl {
       }
 
       unlistenFns.push(
+        unlistenAvailable,
         unlistenDownloading,
         unlistenProgress,
         unlistenReady,
@@ -151,13 +170,24 @@ export function useDesktopUpdateControl(): DesktopUpdateControl {
       const version = unwrapResult(await updaterCommands.check());
 
       if (!version) {
+        setEventState((current) =>
+          current?.status === "available" ? null : current,
+        );
         return null;
       }
 
-      return {
+      const nextUpdate = {
         version,
         ready: unwrapResult(await updaterCommands.isDownloaded(version)),
       };
+
+      setEventState((current) =>
+        current?.status === "available" && current.version !== version
+          ? null
+          : current,
+      );
+
+      return nextUpdate;
     },
     refetchInterval: UPDATE_CHECK_INTERVAL_MS,
     retry: false,
@@ -221,8 +251,14 @@ export function useDesktopUpdateControl(): DesktopUpdateControl {
       ? updateCheck.data
       : null;
   const version = eventState?.version ?? checkedUpdate?.version ?? null;
-  const status: UpdateBannerStatus | null = eventState
-    ? eventState.status
+  const eventStatus =
+    eventState?.status === "available" &&
+    checkedUpdate?.version === eventState.version &&
+    checkedUpdate.ready
+      ? "ready"
+      : eventState?.status;
+  const status: UpdateBannerStatus | null = eventStatus
+    ? eventStatus
     : checkedUpdate
       ? checkedUpdate.ready
         ? "ready"
@@ -315,9 +351,9 @@ export function SidebarTimelineUpdateButton({
       disabled={isDownloading || update.downloadStarting || update.installing}
       className={cn([
         "relative flex h-7 min-h-7 w-7 min-w-7 shrink-0 items-center justify-center rounded-full p-0",
-        "bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm transition-colors",
+        "bg-blue-500 text-white shadow-sm transition-colors hover:bg-blue-600",
         "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden",
-        "disabled:bg-primary disabled:text-primary-foreground disabled:hover:bg-primary disabled:cursor-default disabled:opacity-70",
+        "disabled:cursor-default disabled:bg-blue-500 disabled:text-white disabled:opacity-70 disabled:hover:bg-blue-500",
       ])}
       onClick={isReady ? update.installUpdate : update.downloadUpdate}
     >

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -312,9 +312,13 @@ describe("ClassicMainBody", () => {
     fireEvent.click(sidebarToggle);
 
     expect(screen.queryByTestId("sidebar-update-button")).toBeNull();
-    expect(
-      within(sidebarToggle).getByTestId("collapsed-sidebar-update-badge"),
-    ).toBeTruthy();
+    const badge = within(sidebarToggle).getByTestId(
+      "collapsed-sidebar-update-badge",
+    );
+
+    expect(badge).toBeTruthy();
+    expect(badge.className.split(" ")).toContain("bg-blue-500");
+    expect(badge.className.split(" ")).not.toContain("bg-red-500");
     expect(mocks.toggleLeftSidebar).toHaveBeenCalledTimes(1);
   });
 

--- a/crates/transcribe-proxy/tests/hyprnote_client_contract_mock.rs
+++ b/crates/transcribe-proxy/tests/hyprnote_client_contract_mock.rs
@@ -253,7 +253,11 @@ async fn streaming_hyprnote_client_surfaces_abnormal_close_without_response() {
     );
     assert_terminal_error_contains(
         &result,
-        &["ResetWithoutClosingHandshake", "Protocol"],
+        &[
+            "ResetWithoutClosingHandshake",
+            "Protocol",
+            "Connection reset",
+        ],
         "abnormal closes without responses should surface as client stream errors",
     );
 }

--- a/plugins/tray/src/lib.rs
+++ b/plugins/tray/src/lib.rs
@@ -25,6 +25,11 @@ fn setup_update_listeners(app: &tauri::AppHandle) {
     use tauri_specta::Event;
 
     let handle = app.clone();
+    tauri_plugin_updater2::UpdateAvailableEvent::listen(app, move |_event| {
+        let _ = handle.tray().set_update_available(true);
+    });
+
+    let handle = app.clone();
     tauri_plugin_updater2::UpdateDownloadingEvent::listen(app, move |_event| {
         let _ = menu_items::TrayCheckUpdate::set_state(&handle, UpdateMenuState::Downloading);
         let _ = handle.tray().set_update_available(true);

--- a/plugins/updater2/js/bindings.gen.ts
+++ b/plugins/updater2/js/bindings.gen.ts
@@ -55,12 +55,14 @@ async maybeEmitUpdated() : Promise<void> {
 
 
 export const events = __makeEvents__<{
+updateAvailableEvent: UpdateAvailableEvent,
 updateDownloadFailedEvent: UpdateDownloadFailedEvent,
 updateDownloadProgressEvent: UpdateDownloadProgressEvent,
 updateDownloadingEvent: UpdateDownloadingEvent,
 updateReadyEvent: UpdateReadyEvent,
 updatedEvent: UpdatedEvent
 }>({
+updateAvailableEvent: "plugin:updater2:update-available-event",
 updateDownloadFailedEvent: "plugin:updater2:update-download-failed-event",
 updateDownloadProgressEvent: "plugin:updater2:update-download-progress-event",
 updateDownloadingEvent: "plugin:updater2:update-downloading-event",
@@ -75,6 +77,7 @@ updatedEvent: "plugin:updater2:updated-event"
 /** user-defined types **/
 
 export type InstallResult = { kind: "relaunch_current" }
+export type UpdateAvailableEvent = { version: string }
 export type UpdateDownloadFailedEvent = { version: string }
 export type UpdateDownloadProgressEvent = { version: string; chunk_length: number; content_length: number | null }
 export type UpdateDownloadingEvent = { version: string }

--- a/plugins/updater2/src/events.rs
+++ b/plugins/updater2/src/events.rs
@@ -1,4 +1,9 @@
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type, tauri_specta::Event)]
+pub struct UpdateAvailableEvent {
+    pub version: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type, tauri_specta::Event)]
 pub struct UpdateDownloadingEvent {
     pub version: String,
 }

--- a/plugins/updater2/src/ext.rs
+++ b/plugins/updater2/src/ext.rs
@@ -6,8 +6,8 @@ use tauri_plugin_updater::UpdaterExt;
 use tauri_specta::Event;
 
 use crate::events::{
-    UpdateDownloadFailedEvent, UpdateDownloadProgressEvent, UpdateDownloadingEvent,
-    UpdateReadyEvent, UpdatedEvent,
+    UpdateAvailableEvent, UpdateDownloadFailedEvent, UpdateDownloadProgressEvent,
+    UpdateDownloadingEvent, UpdateReadyEvent, UpdatedEvent,
 };
 
 static DOWNLOAD_MUTEX: LazyLock<tokio::sync::Mutex<()>> =
@@ -101,7 +101,23 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Updater2<'a, R, M> {
     pub async fn check(&self) -> Result<Option<String>, crate::Error> {
         let updater = self.manager.updater()?;
         let update = updater.check().await?;
-        Ok(update.map(|u| u.version))
+        let version = update.map(|u| u.version);
+
+        if let Some(version) = &version {
+            if self.has_cached_update(version) {
+                let _ = UpdateReadyEvent {
+                    version: version.clone(),
+                }
+                .emit(self.manager.app_handle());
+            } else {
+                let _ = UpdateAvailableEvent {
+                    version: version.clone(),
+                }
+                .emit(self.manager.app_handle());
+            }
+        }
+
+        Ok(version)
     }
 
     pub fn has_cached_update(&self, version: &str) -> bool {

--- a/plugins/updater2/src/lib.rs
+++ b/plugins/updater2/src/lib.rs
@@ -25,6 +25,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::maybe_emit_updated::<tauri::Wry>,
         ])
         .events(tauri_specta::collect_events![
+            events::UpdateAvailableEvent,
             events::UpdateDownloadingEvent,
             events::UpdateDownloadProgressEvent,
             events::UpdateDownloadFailedEvent,


### PR DESCRIPTION
Emit available update state to the desktop chrome so expanded sidebars show the download action while collapsed sidebars keep the badge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly OTA UI/event wiring and tests; plugin init order is a small desktop startup change with no auth or data-path impact.
> 
> **Overview**
> Adds **`UpdateAvailableEvent`** in `updater2`: `check()` now emits **available** when an update exists but isn’t cached, and **ready** when it is—so background checks can drive UI without polling alone.
> 
> **Desktop chrome** subscribes to that event in `useDesktopUpdateControl`, with rules so **downloading / ready / failed** aren’t overwritten by a late “available”, stale “available” clears when a check finds nothing, and **restart** wins when the periodic check sees a cached build. The sidebar update control and collapsed-sidebar dot switch from **primary/red** to **blue**.
> 
> **Tray** listens for `UpdateAvailableEvent` and marks the tray as having an update. **Tauri** registers `updater2` before `tray` so those events are available at setup.
> 
> Includes new **Vitest** coverage for event-driven download, stale-state clearing, retry vs available, and ready vs available. A **transcribe-proxy** contract test also accepts **"Connection reset"** in abnormal-close error text (orthogonal to OTA).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2d1e49ef7dca9861f81e2fee10c77985c04959b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5610 
- <kbd>&nbsp;1&nbsp;</kbd> #5600 👈 
<!-- GitButler Footer Boundary Bottom -->

