### PR TITLE
Add Cloudflare transcription provider

### DIFF
--- a/apps/desktop/src/settings/ai/stt/configure.tsx
+++ b/apps/desktop/src/settings/ai/stt/configure.tsx
@@ -51,13 +51,15 @@ function ProviderContext({ providerId }: { providerId: ProviderId }) {
               ? `Use [Gladia](https://www.gladia.io) for transcriptions.`
               : providerId === "openai"
                 ? `Use [OpenAI](https://openai.com) for transcriptions.`
-                : providerId === "fireworks"
-                  ? `Use [Fireworks AI](https://fireworks.ai) for transcriptions.`
-                  : providerId === "mistral"
-                    ? `Use [Mistral](https://mistral.ai) for transcriptions.`
-                    : providerId === "custom"
-                      ? `We only support **Deepgram compatible** endpoints for now.`
-                      : "";
+                : providerId === "cloudflare_workers_ai"
+                  ? `Use a [Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/) endpoint that exposes Deepgram-compatible Nova-3 transcription.`
+                  : providerId === "fireworks"
+                    ? `Use [Fireworks AI](https://fireworks.ai) for transcriptions.`
+                    : providerId === "mistral"
+                      ? `Use [Mistral](https://mistral.ai) for transcriptions.`
+                      : providerId === "custom"
+                        ? `We only support **Deepgram compatible** endpoints for now.`
+                        : "";
 
   if (!content.trim()) {
     return null;

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -14,7 +14,6 @@ import {
   type LocalModel,
 } from "@hypr/plugin-local-stt";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
-import { commands as listenerCommands } from "@hypr/plugin-transcription";
 import type { AIProviderStorage } from "@hypr/store";
 import { Input } from "@hypr/ui/components/ui/input";
 import {
@@ -53,6 +52,8 @@ import {
   isHyprnoteLocalSttModel,
   isLiveTranscriptionSupported,
   isRealtimeLocalModel,
+  isSupportedLanguagesBatch,
+  isSupportedLanguagesLive,
   isSupportedLocalSttModel,
 } from "~/stt/capabilities";
 
@@ -325,18 +326,17 @@ function useHasLanguageWarning() {
       const useLiveMode = isOnDeviceModel
         ? useLiveOnDeviceModel && liveSupport.data
         : liveSupport.data;
-      const result = useLiveMode
-        ? await listenerCommands.isSupportedLanguagesLive(
+      return useLiveMode
+        ? await isSupportedLanguagesLive(
             current_stt_provider!,
             selectedSttModel ?? null,
             spoken_languages ?? [],
           )
-        : await listenerCommands.isSupportedLanguagesBatch(
+        : await isSupportedLanguagesBatch(
             current_stt_provider!,
             selectedSttModel ?? null,
             spoken_languages ?? [],
           );
-      return result.status === "ok" ? result.data : true;
     },
     enabled:
       isConfigured &&

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -27,11 +27,23 @@ type Provider = {
   models: LocalModel[] | string[];
   badge?: string | null;
   requirements: ProviderRequirement[];
+  links?: {
+    models?: { label: string; url: string };
+    setup?: { label: string; url: string };
+  };
 };
 
 export const displayModelId = (model: string) => {
   if (model === "cloud") {
     return "Pro (Cloud)";
+  }
+
+  if (model === "nova-3" || model === "nova-3-general") {
+    return "Nova 3";
+  }
+
+  if (model === "nova-3-medical") {
+    return "Nova 3 Medical";
   }
 
   if (model === "u3-rt-pro") {
@@ -175,6 +187,28 @@ const _PROVIDERS = [
     baseUrl: "https://api.openai.com/v1",
     models: ["gpt-4o-transcribe", "gpt-4o-mini-transcribe", "whisper-1"],
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+  },
+  {
+    disabled: false,
+    id: "cloudflare_workers_ai",
+    displayName: "Cloudflare Workers AI",
+    badge: null,
+    icon: <Icon icon="simple-icons:cloudflare" className="size-4" />,
+    baseUrl: undefined,
+    models: ["nova-3"],
+    requirements: [
+      { kind: "requires_config", fields: ["base_url", "api_key"] },
+    ],
+    links: {
+      models: {
+        label: "Nova-3 docs",
+        url: "https://developers.cloudflare.com/workers-ai/models/nova-3/",
+      },
+      setup: {
+        label: "Workers AI docs",
+        url: "https://developers.cloudflare.com/workers-ai/",
+      },
+    },
   },
   {
     disabled: false,

--- a/apps/desktop/src/stt/capabilities.test.ts
+++ b/apps/desktop/src/stt/capabilities.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const { isSupportedLanguagesLiveMock } = vi.hoisted(() => ({
-  isSupportedLanguagesLiveMock: vi.fn(),
-}));
+const { isSupportedLanguagesBatchMock, isSupportedLanguagesLiveMock } =
+  vi.hoisted(() => ({
+    isSupportedLanguagesBatchMock: vi.fn(),
+    isSupportedLanguagesLiveMock: vi.fn(),
+  }));
 
 vi.mock("@hypr/plugin-transcription", () => ({
   commands: {
+    isSupportedLanguagesBatch: isSupportedLanguagesBatchMock,
     isSupportedLanguagesLive: isSupportedLanguagesLiveMock,
   },
 }));
@@ -16,12 +19,18 @@ import {
   getOnDeviceTranscriptionMode,
   getTranscriptionLanguages,
   isConfiguredSttModel,
+  isSupportedLanguagesBatch,
+  isSupportedLanguagesLive,
   isSupportedLocalSttModel,
 } from "./capabilities";
 
 beforeEach(() => {
   vi.clearAllMocks();
   isSupportedLanguagesLiveMock.mockResolvedValue({
+    status: "ok",
+    data: true,
+  });
+  isSupportedLanguagesBatchMock.mockResolvedValue({
     status: "ok",
     data: true,
   });
@@ -158,6 +167,36 @@ describe("getLiveTranscriptionConfig", () => {
     });
 
     expect(isSupportedLanguagesLiveMock.mock.calls[0]?.[0]).toBe("deepgram");
+  });
+
+  test("checks Cloudflare Workers AI as Deepgram-compatible for language fallback", async () => {
+    await getLiveTranscriptionConfig({
+      provider: "cloudflare_workers_ai",
+      model: "nova-3",
+      languages: ["en", "ko"],
+    });
+
+    expect(isSupportedLanguagesLiveMock.mock.calls[0]?.[0]).toBe("deepgram");
+  });
+
+  test("checks Cloudflare Workers AI as Deepgram-compatible for live language support", async () => {
+    await isSupportedLanguagesLive("cloudflare_workers_ai", "nova-3", ["en"]);
+
+    expect(isSupportedLanguagesLiveMock.mock.calls[0]).toEqual([
+      "deepgram",
+      "nova-3",
+      ["en"],
+    ]);
+  });
+
+  test("checks Cloudflare Workers AI as Deepgram-compatible for batch language support", async () => {
+    await isSupportedLanguagesBatch("cloudflare_workers_ai", "nova-3", ["en"]);
+
+    expect(isSupportedLanguagesBatchMock.mock.calls[0]).toEqual([
+      "deepgram",
+      "nova-3",
+      ["en"],
+    ]);
   });
 });
 

--- a/apps/desktop/src/stt/capabilities.ts
+++ b/apps/desktop/src/stt/capabilities.ts
@@ -87,15 +87,31 @@ function baseLanguageCode(language: string) {
 }
 
 function languageSupportProvider(provider: string) {
-  return provider === "custom" ? "deepgram" : provider;
+  return provider === "custom" || provider === "cloudflare_workers_ai"
+    ? "deepgram"
+    : provider;
 }
 
-async function isSupportedLanguagesLive(
+export async function isSupportedLanguagesLive(
   provider: string,
   model: string | null | undefined,
   languages: readonly string[],
 ) {
   const result = await listenerCommands.isSupportedLanguagesLive(
+    languageSupportProvider(provider),
+    model ?? null,
+    [...languages],
+  );
+
+  return result.status === "ok" ? result.data : true;
+}
+
+export async function isSupportedLanguagesBatch(
+  provider: string,
+  model: string | null | undefined,
+  languages: readonly string[],
+) {
+  const result = await listenerCommands.isSupportedLanguagesBatch(
     languageSupportProvider(provider),
     model ?? null,
     [...languages],

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -132,6 +132,12 @@ describe("getBatchProvider", () => {
     expect(getBatchProvider("openai", "gpt-4o-transcribe")).toBe("openai");
   });
 
+  test("maps Cloudflare Workers AI to the Deepgram-compatible batch provider", () => {
+    expect(getBatchProvider("cloudflare_workers_ai", "nova-3")).toBe(
+      "deepgram",
+    );
+  });
+
   test("maps local soniqo models to soniqo batch provider", () => {
     expect(getBatchProvider("hyprnote", "soniqo-parakeet-batch")).toBe(
       "soniqo",

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -53,6 +53,10 @@ export function getBatchProvider(
   provider: string,
   model: string,
 ): TranscriptionParams["provider"] | null {
+  if (provider === "cloudflare_workers_ai") {
+    return "deepgram";
+  }
+
   if (provider === "hyprnote") {
     if (model.startsWith("soniqo-")) return "soniqo";
     if (model.startsWith("am-")) return "am";

--- a/plugins/transcription/src/api.rs
+++ b/plugins/transcription/src/api.rs
@@ -366,6 +366,13 @@ mod tests {
     }
 
     #[test]
+    fn defaults_cloudflare_workers_ai_capture_to_live_mode() {
+        let params = capture_params("https://example.workers.dev", "nova-3");
+
+        assert_eq!(params.default_transcription_mode(), TranscriptionMode::Live);
+    }
+
+    #[test]
     fn defaults_soniox_capture_to_live_mode_without_languages() {
         let params = capture_params("https://api.soniox.com", "stt-rt-v5");
 


### PR DESCRIPTION
Add Cloudflare Workers AI to STT settings and route its live/batch transcription through the Deepgram-compatible provider path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the STT provider selection and transcription routing for a new external endpoint type; risk is moderated because execution reuses the existing Deepgram adapter rather than new backend logic.
> 
> **Overview**
> Adds **Cloudflare Workers AI** as a configurable STT provider (Nova 3, user-supplied `base_url` and API key) in desktop settings, with setup/docs links and display labels for Nova 3 models.
> 
> **Live and batch transcription** for `cloudflare_workers_ai` are routed through the existing **Deepgram-compatible** path: batch jobs map to the `deepgram` provider in `getBatchProvider`, and language live/batch checks alias the provider to `deepgram` (same pattern as custom endpoints). The spoken-language warning UI now calls exported `isSupportedLanguagesLive` / `isSupportedLanguagesBatch` from `capabilities` instead of the transcription plugin directly.
> 
> A Rust test asserts capture on a Workers-style URL with `nova-3` defaults to **live** transcription mode. Unit tests cover the new mappings and language-support aliasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78bee6c3f0917aec1f13238187f7884767945b37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->