### PR TITLE
Show devtools panel in dev builds

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -43,19 +43,7 @@ pub async fn get_env<R: tauri::Runtime>(_app: tauri::AppHandle<R>, key: String) 
 #[tauri::command]
 #[specta::specta]
 pub fn show_devtool() -> bool {
-    if cfg!(debug_assertions) {
-        return true;
-    }
-
-    #[cfg(feature = "devtools")]
-    {
-        return true;
-    }
-
-    #[cfg(not(feature = "devtools"))]
-    {
-        false
-    }
+    cfg!(any(debug_assertions, feature = "dev", feature = "devtools"))
 }
 
 #[tauri::command]

--- a/apps/desktop/src/devtools-panel/host.tsx
+++ b/apps/desktop/src/devtools-panel/host.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
 
 import { commands as notificationCommands } from "@hypr/plugin-notification";
@@ -29,8 +30,7 @@ import { useTabs } from "~/store/zustand/tabs";
 import { createAutoStopEndedNotificationKey } from "~/stt/auto-stop-notification";
 import { commands } from "~/types/tauri.gen";
 
-const forceDevtoolsPanel =
-  import.meta.env.DEV && import.meta.env.MODE !== "test";
+const canResolveDevtoolsPanel = import.meta.env.MODE !== "test";
 
 type DevtoolsPanelAction =
   | "navigation:onboarding"
@@ -65,7 +65,7 @@ type DevtoolsPanelAction =
 
 export function DevtoolsFloatingPanelHost() {
   const isMainWindow = getCurrentWebviewWindowLabel() === "main";
-  const shouldShow = isMainWindow && forceDevtoolsPanel;
+  const shouldShow = useShouldShowDevtoolsPanel(isMainWindow);
 
   if (!isMainWindow) {
     return null;
@@ -76,6 +76,17 @@ export function DevtoolsFloatingPanelHost() {
   }
 
   return <DevtoolsFloatingPanelSync />;
+}
+
+function useShouldShowDevtoolsPanel(isMainWindow: boolean) {
+  const enabledQuery = useQuery({
+    queryKey: ["devtools-panel", "enabled"],
+    queryFn: commands.showDevtool,
+    enabled: isMainWindow && canResolveDevtoolsPanel,
+    staleTime: Infinity,
+  });
+
+  return enabledQuery.data ?? false;
 }
 
 function DevtoolsFloatingPanelDisabled() {


### PR DESCRIPTION
Use the desktop runtime devtools gate for the floating panel and include the dev feature in the native show_devtool command.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only devtools gating in non-production-style builds; production behavior stays off unless native features/debug assert.
> 
> **Overview**
> The floating devtools panel no longer relies on **`import.meta.env.DEV`** to decide visibility. On the main window (outside test mode), it now asks the desktop runtime via **`commands.showDevtool`**, cached with React Query, so web and native agree on when devtools are allowed.
> 
> On the Rust side, **`show_devtool`** is collapsed to a single **`cfg!`** check that also treats the **`dev`** Cargo feature like **`devtools`** and debug builds, so dev-feature desktop builds can expose the panel even when the old frontend-only gate would not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3b14b2e77087a4c721bf0865eced1b4d566a28a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->