### PR TITLE
Shrink Azure provider icons

### DIFF
--- a/apps/desktop/src/settings/ai/llm/shared.tsx
+++ b/apps/desktop/src/settings/ai/llm/shared.tsx
@@ -136,7 +136,7 @@ const _PROVIDERS = [
     id: "azure_openai",
     displayName: "Azure OpenAI",
     badge: "Beta",
-    icon: <Azure size={16} />,
+    icon: <Azure size={14} style={{ height: 14, width: 14 }} />,
     baseUrl: undefined,
     requirements: [
       { kind: "requires_config", fields: ["base_url", "api_key"] },
@@ -146,7 +146,7 @@ const _PROVIDERS = [
     id: "azure_ai",
     displayName: "Azure AI Foundry",
     badge: "Beta",
-    icon: <AzureAI size={16} />,
+    icon: <AzureAI size={14} style={{ height: 14, width: 14 }} />,
     baseUrl: undefined,
     requirements: [
       { kind: "requires_config", fields: ["base_url", "api_key"] },


### PR DESCRIPTION
Render the Azure OpenAI and Azure AI Foundry marks at 14px inside the shared provider icon slot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic-only change to two provider icon definitions in settings UI; no logic, auth, or API behavior affected.
> 
> **Overview**
> **Azure OpenAI** and **Azure AI Foundry** entries in the shared LLM provider list now render their `@lobehub/icons` marks at **14px** instead of 16px, with explicit `height`/`width` inline styles so they fit the same icon slot as other providers without appearing oversized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d070ce0e16d9e523ef044680c46055946446b3b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->