### PR TITLE
Fix live speaker caps and config refresh

### DIFF
--- a/apps/desktop/src/services/event-listeners.test.tsx
+++ b/apps/desktop/src/services/event-listeners.test.tsx
@@ -18,6 +18,7 @@ const {
   getOrCreateSessionForEventIdMock,
   setTriggerAppIdsMock,
   stopMock,
+  updateCaptureConfigMock,
   getListenerStateMock,
 } = vi.hoisted(() => ({
   notificationListenMock: vi.fn(),
@@ -31,6 +32,7 @@ const {
   getOrCreateSessionForEventIdMock: vi.fn(() => "session-event"),
   setTriggerAppIdsMock: vi.fn(),
   stopMock: vi.fn(),
+  updateCaptureConfigMock: vi.fn(),
   getListenerStateMock: vi.fn(),
 }));
 
@@ -66,6 +68,12 @@ vi.mock("~/store/tinybase/store/main", () => ({
 
 vi.mock("~/store/tinybase/store/settings", () => ({
   STORE_ID: "settings-store",
+  SETTINGS_MAPPING: {
+    values: {
+      ai_language: { default: "en" },
+      spoken_languages: { default: "[]" },
+    },
+  },
   UI: {
     useStore: useSettingsStoreMock,
   },
@@ -100,6 +108,7 @@ describe("EventListeners notification events", () => {
     getOrCreateSessionForEventIdMock.mockReset();
     setTriggerAppIdsMock.mockReset();
     stopMock.mockReset();
+    updateCaptureConfigMock.mockReset();
     getListenerStateMock.mockReset();
 
     getCurrentWebviewWindowLabelMock.mockReturnValue("main");
@@ -112,11 +121,13 @@ describe("EventListeners notification events", () => {
     getListenerStateMock.mockReturnValue({
       setTriggerAppIds: setTriggerAppIdsMock,
       stop: stopMock,
+      updateCaptureConfig: updateCaptureConfigMock,
       live: { status: "active", sessionId: "session-1" },
     });
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -179,6 +190,58 @@ describe("EventListeners notification events", () => {
     expect(stopMock).toHaveBeenCalledTimes(1);
     expect(createSessionMock).not.toHaveBeenCalled();
     expect(openNewMock).not.toHaveBeenCalled();
+  });
+
+  test("live capture config sync mounts without auth providers", async () => {
+    vi.useFakeTimers();
+
+    const mainStore = {
+      addTableListener: vi.fn(() => "main-listener"),
+      delListener: vi.fn(),
+      forEachRow: vi.fn(),
+      getValue: vi.fn((key: string) =>
+        key === "user_id" ? "human-self" : undefined,
+      ),
+    };
+    const settingsStore = {
+      addValueListener: vi.fn(() => "settings-listener"),
+      delListener: vi.fn(),
+      getValue: vi.fn((key: string) => {
+        if (key === "ai_language") {
+          return "ko";
+        }
+        if (key === "spoken_languages") {
+          return JSON.stringify(["ko"]);
+        }
+        if (key === "current_stt_provider") {
+          return "soniox";
+        }
+        if (key === "current_stt_model") {
+          return "stt-v4";
+        }
+        return undefined;
+      }),
+    };
+
+    useMainStoreMock.mockReturnValue(mainStore as never);
+    useSettingsStoreMock.mockReturnValue(settingsStore as never);
+
+    render(<EventListeners />);
+
+    expect(mainStore.addTableListener).toHaveBeenCalledWith(
+      "mapping_session_participant",
+      expect.any(Function),
+    );
+    expect(settingsStore.addValueListener).toHaveBeenCalledTimes(4);
+
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(updateCaptureConfigMock).toHaveBeenCalledWith({
+      session_id: "session-1",
+      languages: ["ko"],
+      participant_human_ids: [],
+      self_human_id: "human-self",
+    });
   });
 
   test("notification_confirm with auto-stop prompt ignores collapsed body click", async () => {

--- a/apps/desktop/src/services/event-listeners.tsx
+++ b/apps/desktop/src/services/event-listeners.tsx
@@ -8,6 +8,7 @@ import {
 } from "@hypr/plugin-updater2";
 import { getCurrentWebviewWindowLabel } from "@hypr/plugin-windows";
 
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import * as main from "~/store/tinybase/store/main";
 import {
   createSession,
@@ -18,8 +19,15 @@ import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
 import { parseAutoStopEndedNotificationKey } from "~/stt/auto-stop-notification";
 import { parseBatchCompletedNotificationKey } from "~/stt/batch-completed-notification";
+import {
+  getLiveTranscriptionConfig,
+  getTranscriptionLanguages,
+} from "~/stt/capabilities";
 
 type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
+type SettingsStore = NonNullable<ReturnType<typeof settings.UI.useStore>>;
+
+const LIVE_CAPTURE_CONFIG_DEBOUNCE_MS = 750;
 
 function parseIgnoredPlatforms(value: unknown) {
   if (typeof value !== "string") {
@@ -82,6 +90,193 @@ function handleAutoStopEndedNotification(
   }
 
   return true;
+}
+
+function getSessionParticipantHumanIds(store: MainStore, sessionId: string) {
+  const seen = new Set<string>();
+  const participantHumanIds: string[] = [];
+
+  store.forEachRow("mapping_session_participant", (mappingId, _forEachCell) => {
+    const sid = store.getCell(
+      "mapping_session_participant",
+      mappingId,
+      "session_id",
+    );
+    if (sid !== sessionId) return;
+
+    const humanId = store.getCell(
+      "mapping_session_participant",
+      mappingId,
+      "human_id",
+    );
+    if (typeof humanId !== "string" || !humanId || seen.has(humanId)) {
+      return;
+    }
+
+    seen.add(humanId);
+    participantHumanIds.push(humanId);
+  });
+
+  return participantHumanIds;
+}
+
+function createCaptureConfigSignature(config: {
+  session_id: string;
+  languages: string[];
+  participant_human_ids: string[];
+  self_human_id: string | null;
+}) {
+  return JSON.stringify(config);
+}
+
+function parseStringArray(value: unknown, fallback: string[]) {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === "string");
+  }
+
+  if (typeof value !== "string") {
+    return fallback;
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string")
+      : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function getSettingsDefault(key: "ai_language" | "spoken_languages") {
+  const mapping = settings.SETTINGS_MAPPING?.values[key];
+  return mapping && "default" in mapping ? mapping.default : undefined;
+}
+
+function getLiveConfigLanguages(settingsStore: SettingsStore) {
+  const aiLanguageValue = settingsStore.getValue("ai_language");
+  const aiLanguage =
+    typeof aiLanguageValue === "string"
+      ? aiLanguageValue
+      : typeof getSettingsDefault("ai_language") === "string"
+        ? getSettingsDefault("ai_language")
+        : undefined;
+
+  return getTranscriptionLanguages(
+    aiLanguage,
+    parseStringArray(
+      settingsStore.getValue("spoken_languages"),
+      parseStringArray(getSettingsDefault("spoken_languages"), []),
+    ),
+  );
+}
+
+function LiveCaptureConfigSync() {
+  const store = main.UI.useStore(main.STORE_ID);
+  const settingsStore = settings.UI.useStore(settings.STORE_ID);
+
+  if (!store || !settingsStore) {
+    return null;
+  }
+
+  return (
+    <LiveCaptureConfigSyncReady
+      settingsStore={settingsStore as SettingsStore}
+      store={store as MainStore}
+    />
+  );
+}
+
+function LiveCaptureConfigSyncReady({
+  store,
+  settingsStore,
+}: {
+  store: MainStore;
+  settingsStore: SettingsStore;
+}) {
+  useMountEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let lastSignature: string | null = null;
+
+    const pushConfig = async () => {
+      const live = listenerStore.getState().live;
+      if (live.status !== "active" || !live.sessionId) {
+        return;
+      }
+
+      const languages = getLiveConfigLanguages(settingsStore);
+      const provider = settingsStore.getValue("current_stt_provider");
+      const model = settingsStore.getValue("current_stt_model");
+      const liveConfig = await getLiveTranscriptionConfig({
+        provider: typeof provider === "string" ? provider : undefined,
+        model: typeof model === "string" ? model : undefined,
+        languages,
+      });
+
+      if (liveConfig.transcriptionMode === "batch") {
+        return;
+      }
+
+      const selfHumanId = store.getValue("user_id");
+      const nextConfig = {
+        session_id: live.sessionId,
+        languages: liveConfig.languages,
+        participant_human_ids: getSessionParticipantHumanIds(
+          store,
+          live.sessionId,
+        ),
+        self_human_id: typeof selfHumanId === "string" ? selfHumanId : null,
+      };
+      const signature = createCaptureConfigSignature(nextConfig);
+      if (signature === lastSignature) {
+        return;
+      }
+
+      lastSignature = signature;
+      await listenerStore.getState().updateCaptureConfig(nextConfig);
+    };
+
+    const schedulePush = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+
+      timeoutId = setTimeout(() => {
+        void pushConfig().catch((error) => {
+          console.error(
+            "[listener] failed to update live capture config",
+            error,
+          );
+        });
+      }, LIVE_CAPTURE_CONFIG_DEBOUNCE_MS);
+    };
+
+    const mainListenerIds = [
+      store.addTableListener("mapping_session_participant", schedulePush),
+    ];
+    const settingsListenerIds = [
+      settingsStore.addValueListener("ai_language", schedulePush),
+      settingsStore.addValueListener("spoken_languages", schedulePush),
+      settingsStore.addValueListener("current_stt_provider", schedulePush),
+      settingsStore.addValueListener("current_stt_model", schedulePush),
+    ];
+
+    schedulePush();
+
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      for (const listenerId of mainListenerIds) {
+        store.delListener(listenerId);
+      }
+      for (const listenerId of settingsListenerIds) {
+        settingsStore.delListener(listenerId);
+      }
+    };
+  });
+
+  return null;
 }
 
 function useUpdaterEvents() {
@@ -297,6 +492,15 @@ function useNotificationEvents() {
 }
 
 export function EventListeners() {
+  return (
+    <>
+      <EventListenersInner />
+      <LiveCaptureConfigSync />
+    </>
+  );
+}
+
+function EventListenersInner() {
   useUpdaterEvents();
   useNotificationEvents();
 

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -11,6 +11,7 @@ import * as main from "~/store/tinybase/store/main";
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
 import { useListener } from "~/stt/contexts";
 import {
+  getMaxSpeakerNumberForParticipants,
   mergeRenderedAndLiveSegments,
   SegmentKeyUtils,
   type Segment,
@@ -85,7 +86,8 @@ function LiveTranscriptFooterContent({
   isExpanded?: boolean;
 }) {
   const store = main.UI.useStore(main.STORE_ID);
-  const { segments, transcriptIdByWordId } = useLiveTranscriptData(sessionId);
+  const { maxSpeakerNumber, segments, transcriptIdByWordId } =
+    useLiveTranscriptData(sessionId);
   const labelContext = useMemo(
     () => (store ? defaultRenderLabelContext(store) : undefined),
     [store],
@@ -96,8 +98,12 @@ function LiveTranscriptFooterContent({
       return new SpeakerLabelManager();
     }
 
-    return SpeakerLabelManager.fromSegments(segments, labelContext);
-  }, [labelContext, segments, store]);
+    return SpeakerLabelManager.fromSegments(
+      segments,
+      labelContext,
+      maxSpeakerNumber,
+    );
+  }, [labelContext, maxSpeakerNumber, segments, store]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const previewText = useMemo(() => getTranscriptPreview(segments), [segments]);
@@ -264,6 +270,7 @@ function CollapsedFooterMessage({ message }: { message: string }) {
 }
 
 function useLiveTranscriptData(sessionId: string): {
+  maxSpeakerNumber?: number;
   segments: Segment[];
   transcriptIdByWordId: Map<string, string>;
 } {
@@ -292,6 +299,12 @@ function useLiveTranscriptData(sessionId: string): {
       renderedSegments,
       liveSegments,
     );
+    const maxSpeakerNumber = request
+      ? getMaxSpeakerNumberForParticipants(
+          request.participant_human_ids,
+          request.self_human_id,
+        )
+      : undefined;
     const transcriptIdByWordId = new Map<string, string>();
 
     for (const { transcriptId, row } of transcriptRows) {
@@ -302,8 +315,8 @@ function useLiveTranscriptData(sessionId: string): {
       }
     }
 
-    return { segments, transcriptIdByWordId };
-  }, [liveSegments, renderedSegments, transcriptRows]);
+    return { maxSpeakerNumber, segments, transcriptIdByWordId };
+  }, [liveSegments, renderedSegments, request, transcriptRows]);
 }
 
 function getLiveTranscriptScrollKey(segments: Segment[]): string {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
@@ -7,7 +7,10 @@ import {
 } from "../render-request-hooks";
 
 import * as main from "~/store/tinybase/store/main";
-import type { Segment } from "~/stt/live-segment";
+import {
+  getMaxSpeakerNumberForParticipants,
+  type Segment,
+} from "~/stt/live-segment";
 import {
   getRenderTranscriptRequestKey,
   renderTranscriptSegments,
@@ -16,6 +19,13 @@ import {
 const emptyIds: string[] = [];
 
 export function useRenderedTranscriptSegments(transcriptId: string): Segment[] {
+  return useRenderedTranscriptData(transcriptId).segments;
+}
+
+export function useRenderedTranscriptData(transcriptId: string): {
+  maxSpeakerNumber?: number;
+  segments: Segment[];
+} {
   const { request } = useTranscriptRenderData(transcriptId);
   const requestKey = useMemo(
     () => getRenderTranscriptRequestKey(request),
@@ -35,7 +45,18 @@ export function useRenderedTranscriptSegments(transcriptId: string): Segment[] {
     gcTime: 0,
   });
 
-  return data;
+  const maxSpeakerNumber = useMemo(
+    () =>
+      request
+        ? getMaxSpeakerNumberForParticipants(
+            request.participant_human_ids,
+            request.self_human_id,
+          )
+        : undefined,
+    [request],
+  );
+
+  return { maxSpeakerNumber, segments: data };
 }
 
 export function useTranscriptOffset(transcriptId: string): number {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
@@ -2,10 +2,7 @@ import { memo, useCallback, useEffect, useMemo } from "react";
 
 import { cn } from "@hypr/utils";
 
-import {
-  useRenderedTranscriptSegments,
-  useTranscriptOffset,
-} from "./data-hooks";
+import { useRenderedTranscriptData, useTranscriptOffset } from "./data-hooks";
 import { SegmentRenderer } from "./segment";
 import {
   createSegmentKey,
@@ -46,7 +43,8 @@ export function RenderTranscript({
   startPlayback: () => void;
   audioExists: boolean;
 }) {
-  const storedSegments = useRenderedTranscriptSegments(transcriptId);
+  const { maxSpeakerNumber, segments: storedSegments } =
+    useRenderedTranscriptData(transcriptId);
   const mergedSegments = useMemo(
     () => mergeRenderedAndLiveSegments(storedSegments, liveSegments),
     [liveSegments, storedSegments],
@@ -69,6 +67,7 @@ export function RenderTranscript({
       seek={seek}
       startPlayback={startPlayback}
       audioExists={audioExists}
+      maxSpeakerNumber={maxSpeakerNumber}
     />
   );
 }
@@ -84,6 +83,7 @@ const SegmentsList = memo(
     seek,
     startPlayback,
     audioExists,
+    maxSpeakerNumber,
   }: {
     segments: Segment[];
     scrollElement: HTMLDivElement | null;
@@ -94,6 +94,7 @@ const SegmentsList = memo(
     seek: (sec: number) => void;
     startPlayback: () => void;
     audioExists: boolean;
+    maxSpeakerNumber?: number;
   }) => {
     const store = main.UI.useStore(main.STORE_ID);
     const speakerLabelManager = useMemo(() => {
@@ -101,8 +102,8 @@ const SegmentsList = memo(
         return new SpeakerLabelManager();
       }
       const ctx = defaultRenderLabelContext(store);
-      return SpeakerLabelManager.fromSegments(segments, ctx);
-    }, [segments, store]);
+      return SpeakerLabelManager.fromSegments(segments, ctx, maxSpeakerNumber);
+    }, [maxSpeakerNumber, segments, store]);
 
     const seekAndPlay = useCallback(
       (word: SegmentWord) => {
@@ -156,6 +157,7 @@ const SegmentsList = memo(
       prevProps.shouldScrollToEnd === nextProps.shouldScrollToEnd &&
       prevProps.currentMs === nextProps.currentMs &&
       prevProps.audioExists === nextProps.audioExists &&
+      prevProps.maxSpeakerNumber === nextProps.maxSpeakerNumber &&
       prevProps.seek === nextProps.seek &&
       prevProps.startPlayback === nextProps.startPlayback &&
       segmentsShallowEqual(prevProps.segments, nextProps.segments)

--- a/apps/desktop/src/store/zustand/listener/general-live.ts
+++ b/apps/desktop/src/store/zustand/listener/general-live.ts
@@ -10,6 +10,7 @@ import {
   commands as listenerCommands,
   events as listenerEvents,
   type CaptureDataEvent,
+  type CaptureConfigUpdate,
   type CaptureLifecycleEvent,
   type CaptureParams,
   type CaptureStatusEvent,
@@ -66,6 +67,9 @@ const startSessionEffect = (params: CaptureParams) =>
   fromResult(listenerCommands.startCapture(params));
 
 const stopSessionEffect = () => fromResult(listenerCommands.stopCapture());
+
+export const updateLiveSessionConfig = (update: CaptureConfigUpdate) =>
+  fromResult(listenerCommands.updateCaptureConfig(update));
 
 function getAutoStopTriggerAppIds(
   appIds: string[] | null,

--- a/apps/desktop/src/store/zustand/listener/general.ts
+++ b/apps/desktop/src/store/zustand/listener/general.ts
@@ -9,7 +9,11 @@ import type { TranscriptionParams } from "@hypr/plugin-transcription";
 
 import type { BatchActions, BatchState } from "./batch";
 import { runBatchSession } from "./general-batch";
-import { startLiveSession, stopLiveSession } from "./general-live";
+import {
+  startLiveSession,
+  stopLiveSession,
+  updateLiveSessionConfig,
+} from "./general-live";
 import {
   type GeneralState,
   type SessionMode,
@@ -39,6 +43,12 @@ export type GeneralActions = {
   stop: () => void;
   setMuted: (value: boolean) => void;
   setTriggerAppIds: (appIds: string[] | null) => void;
+  updateCaptureConfig: (
+    update: Pick<
+      CaptureParams,
+      "session_id" | "languages" | "participant_human_ids" | "self_human_id"
+    >,
+  ) => Promise<void>;
   startTranscription: (
     params: TranscriptionParams,
     options?: { handlePersist?: BatchPersistCallback },
@@ -119,6 +129,19 @@ export const createGeneralSlice = <
   setTriggerAppIds: (appIds) => {
     setLiveState(set, (live) => {
       live.triggerAppIds = appIds;
+    });
+  },
+  updateCaptureConfig: async (update) => {
+    const live = get().live;
+    if (live.status !== "active" || live.sessionId !== update.session_id) {
+      return;
+    }
+
+    await updateLiveSessionConfig({
+      session_id: update.session_id,
+      languages: update.languages,
+      participant_human_ids: update.participant_human_ids ?? [],
+      self_human_id: update.self_human_id ?? null,
     });
   },
   startTranscription: async (params, options) => {

--- a/apps/desktop/src/stt/live-segment.test.ts
+++ b/apps/desktop/src/stt/live-segment.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { SegmentKeyUtils, type RenderLabelContext } from "./live-segment";
+import {
+  getMaxSpeakerNumberForParticipants,
+  SegmentKeyUtils,
+  SpeakerLabelManager,
+  type RenderLabelContext,
+  type Segment,
+} from "./live-segment";
 
 const ctx: RenderLabelContext = {
   getSelfHumanId: () => "self",
@@ -17,5 +23,42 @@ describe("SegmentKeyUtils", () => {
 
     expect(SegmentKeyUtils.isKnownSpeaker(key, ctx)).toBe(false);
     expect(SegmentKeyUtils.renderLabel(key, ctx)).toBe("Speaker 3");
+  });
+
+  it("caps unknown speaker labels when a participant max is provided", () => {
+    const segments: Segment[] = [0, 1, 2].map(
+      (speakerIndex) =>
+        ({
+          id: `segment-${speakerIndex}`,
+          key: {
+            channel: "RemoteParty",
+            speaker_index: speakerIndex,
+            speaker_human_id: null,
+          },
+          words: [],
+          start_ms: 0,
+          end_ms: 0,
+          text: "",
+        }) as Segment,
+    );
+    const manager = SpeakerLabelManager.fromSegments(segments, undefined, 2);
+
+    expect(
+      SegmentKeyUtils.renderLabel(segments[0]!.key, undefined, manager),
+    ).toBe("Speaker 1");
+    expect(
+      SegmentKeyUtils.renderLabel(segments[1]!.key, undefined, manager),
+    ).toBe("Speaker 2");
+    expect(
+      SegmentKeyUtils.renderLabel(segments[2]!.key, undefined, manager),
+    ).toBe("Speaker 2");
+  });
+
+  it("derives max speaker number from distinct participants plus self", () => {
+    expect(getMaxSpeakerNumberForParticipants(["remote"], "self")).toBe(2);
+    expect(getMaxSpeakerNumberForParticipants(["self", "remote"], "self")).toBe(
+      2,
+    );
+    expect(getMaxSpeakerNumberForParticipants([], "self")).toBeUndefined();
   });
 });

--- a/apps/desktop/src/stt/live-segment.ts
+++ b/apps/desktop/src/stt/live-segment.ts
@@ -62,6 +62,8 @@ export class SpeakerLabelManager {
   private unknownSpeakerMap: Map<string, number> = new Map();
   private nextIndex = 1;
 
+  constructor(private readonly maxUnknownSpeakerNumber?: number) {}
+
   getUnknownSpeakerNumber(key: SegmentKey): number {
     const serialized = SegmentKeyUtils.serialize(key);
     const existing = this.unknownSpeakerMap.get(serialized);
@@ -69,7 +71,10 @@ export class SpeakerLabelManager {
       return existing;
     }
 
-    const newIndex = this.nextIndex;
+    const newIndex =
+      this.maxUnknownSpeakerNumber && this.maxUnknownSpeakerNumber > 0
+        ? Math.min(this.nextIndex, this.maxUnknownSpeakerNumber)
+        : this.nextIndex;
     this.unknownSpeakerMap.set(serialized, newIndex);
     this.nextIndex += 1;
     return newIndex;
@@ -78,8 +83,9 @@ export class SpeakerLabelManager {
   static fromSegments(
     segments: Segment[],
     ctx?: RenderLabelContext,
+    maxUnknownSpeakerNumber?: number,
   ): SpeakerLabelManager {
-    const manager = new SpeakerLabelManager();
+    const manager = new SpeakerLabelManager(maxUnknownSpeakerNumber);
     for (const segment of segments) {
       if (!SegmentKeyUtils.isKnownSpeaker(segment.key, ctx)) {
         manager.getUnknownSpeakerNumber(segment.key);
@@ -147,6 +153,18 @@ export const SegmentKeyUtils = {
       : `Speaker ${channelLabel}`;
   },
 };
+
+export function getMaxSpeakerNumberForParticipants(
+  participantHumanIds: readonly string[],
+  selfHumanId?: string | null,
+): number | undefined {
+  const ids = new Set(participantHumanIds.filter(Boolean));
+  if (selfHumanId) {
+    ids.add(selfHumanId);
+  }
+
+  return ids.size > 1 ? ids.size : undefined;
+}
 
 export function mergeRenderedAndLiveSegments(
   renderedSegments: Segment[],

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -456,7 +456,9 @@ fn format_languages(languages: &[hypr_language::Language]) -> String {
 }
 
 fn build_extra(args: &ListenerArgs) -> (f64, Extra) {
-    let session_offset_secs = args.session_started_at.elapsed().as_secs_f64();
+    let session_offset_secs = args
+        .stream_offset_secs
+        .unwrap_or_else(|| args.session_started_at.elapsed().as_secs_f64());
     let started_unix_millis = args
         .session_started_at_unix
         .duration_since(UNIX_EPOCH)
@@ -641,6 +643,7 @@ mod tests {
             mode: crate::actors::ChannelMode::MicOnly,
             session_started_at: Instant::now(),
             session_started_at_unix: SystemTime::now(),
+            stream_offset_secs: None,
             session_id: "session".to_string(),
             participant_human_ids: vec![],
             self_human_id: None,
@@ -654,6 +657,16 @@ mod tests {
         args.self_human_id = Some("self".to_string());
 
         assert_eq!(expected_speakers(&args), Some(2));
+    }
+
+    #[test]
+    fn build_extra_prefers_explicit_stream_offset() {
+        let mut args = listener_args("https://api.deepgram.com", "nova-3");
+        args.stream_offset_secs = Some(12.5);
+
+        let (offset_secs, _) = build_extra(&args);
+
+        assert_eq!(offset_secs, 12.5);
     }
 
     #[test]

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -422,6 +422,7 @@ fn build_listen_params(args: &ListenerArgs) -> owhisper_interface::ListenParams 
         sample_rate: super::super::SAMPLE_RATE,
         keywords: args.keywords.clone(),
         num_speakers,
+        max_speakers: num_speakers,
         custom_query: Some(custom_query),
         ..Default::default()
     }
@@ -665,6 +666,7 @@ mod tests {
         let custom_query = params.custom_query.expect("custom query");
 
         assert_eq!(params.num_speakers, Some(2));
+        assert_eq!(params.max_speakers, Some(2));
         assert!(!custom_query.contains_key("speaker_labels"));
         assert!(!custom_query.contains_key("max_speakers"));
     }
@@ -679,6 +681,7 @@ mod tests {
         let custom_query = params.custom_query.expect("custom query");
 
         assert_eq!(params.num_speakers, Some(2));
+        assert_eq!(params.max_speakers, Some(2));
         assert!(!custom_query.contains_key("speaker_labels"));
         assert!(!custom_query.contains_key("max_speakers"));
     }

--- a/crates/listener-core/src/actors/listener/mod.rs
+++ b/crates/listener-core/src/actors/listener/mod.rs
@@ -21,16 +21,24 @@ use crate::{
 use adapters::spawn_rx_task;
 
 pub(super) const LISTEN_STREAM_TIMEOUT: Duration = Duration::from_secs(15 * 60);
-pub(super) const FINALIZE_STREAM_TIMEOUT: Duration = Duration::from_secs(2);
+pub(super) const FINALIZE_STREAM_TIMEOUT: Duration = Duration::from_secs(5);
 pub(super) const DEVICE_FINGERPRINT_HEADER: &str = "x-device-fingerprint";
 
 pub enum ListenerMsg {
     AudioSingle(Bytes),
     AudioDual(Bytes, Bytes),
+    UpdateConfig(ListenerConfigUpdate),
     StreamResponse(StreamResponse),
     StreamError(String),
     StreamEnded,
     StreamTimeout(Elapsed),
+}
+
+#[derive(Clone)]
+pub struct ListenerConfigUpdate {
+    pub languages: Vec<hypr_language::Language>,
+    pub participant_human_ids: Vec<String>,
+    pub self_human_id: Option<String>,
 }
 
 #[derive(Clone)]
@@ -46,6 +54,7 @@ pub struct ListenerArgs {
     pub mode: crate::actors::ChannelMode,
     pub session_started_at: Instant,
     pub session_started_at_unix: SystemTime,
+    pub stream_offset_secs: Option<f64>,
     pub session_id: String,
     pub participant_human_ids: Vec<String>,
     pub self_human_id: Option<String>,
@@ -210,6 +219,16 @@ impl Actor for ListenerActor {
                 }
                 ChannelSender::Single(_) => {}
             },
+
+            ListenerMsg::UpdateConfig(update) => {
+                state.args.languages = update.languages;
+                state.args.participant_human_ids = update.participant_human_ids;
+                state.args.self_human_id = update.self_human_id;
+                state.transcript.update_participants(
+                    &state.args.participant_human_ids,
+                    state.args.self_human_id.as_deref(),
+                );
+            }
 
             ListenerMsg::StreamResponse(mut response) => {
                 if let StreamResponse::ErrorResponse {

--- a/crates/listener-core/src/actors/root.rs
+++ b/crates/listener-core/src/actors/root.rs
@@ -11,13 +11,15 @@ use crate::actors::session::lifecycle::{
     clear_sentry_session_context, configure_sentry_session_context, emit_session_ended,
 };
 use crate::actors::{
-    SessionContext, SessionMsg, SessionParams, session_span, spawn_session_supervisor,
+    SessionConfigUpdate, SessionContext, SessionMsg, SessionParams, session_span,
+    spawn_session_supervisor,
 };
 use crate::{ListenerRuntime, SessionLifecycleEvent, StartSessionError, State};
 use hypr_audio::AudioProvider;
 
 pub enum RootMsg {
     StartSession(SessionParams, RpcReplyPort<Result<(), StartSessionError>>),
+    UpdateSessionConfig(SessionConfigUpdate, RpcReplyPort<()>),
     StopSession(RpcReplyPort<()>),
     GetState(RpcReplyPort<State>),
 }
@@ -73,6 +75,10 @@ impl Actor for RootActor {
             RootMsg::StartSession(params, reply) => {
                 let result = start_session_impl(myself.get_cell(), params, state).await;
                 let _ = reply.send(result);
+            }
+            RootMsg::UpdateSessionConfig(update, reply) => {
+                update_session_config_impl(update, state).await;
+                let _ = reply.send(());
             }
             RootMsg::StopSession(reply) => {
                 stop_session_impl(state).await;
@@ -188,6 +194,25 @@ async fn start_session_impl(
     }
     .instrument(span)
     .await
+}
+
+async fn update_session_config_impl(update: SessionConfigUpdate, state: &mut RootState) {
+    let Some(active_session_id) = &state.active_session_id else {
+        return;
+    };
+
+    if active_session_id != &update.session_id {
+        return;
+    }
+
+    let Some(supervisor) = &state.active_supervisor else {
+        return;
+    };
+
+    let session_ref: ActorRef<SessionMsg> = supervisor.clone().into();
+    if let Err(error) = session_ref.cast(SessionMsg::UpdateConfig(update)) {
+        tracing::warn!(?error, "failed_to_cast_session_config_update");
+    }
 }
 
 fn clear_stopped_supervisors(state: &mut RootState) {

--- a/crates/listener-core/src/actors/session/supervisor.rs
+++ b/crates/listener-core/src/actors/session/supervisor.rs
@@ -5,7 +5,10 @@ use ractor::{Actor, ActorCell, ActorProcessingErr, ActorRef, SupervisionEvent};
 use tracing::Instrument;
 
 use crate::DegradedError;
-use crate::actors::session::types::{SessionContext, session_span, session_supervisor_name};
+use crate::actors::session::types::{
+    SessionConfigUpdate, SessionContext, SessionParams, session_span, session_supervisor_name,
+};
+use crate::actors::{ListenerConfigUpdate, ListenerMsg};
 use owhisper_client::AdapterKind;
 
 use self::children::{ChildKind, RESTART_BUDGET};
@@ -27,6 +30,7 @@ pub struct SessionActor;
 #[derive(Debug)]
 pub enum SessionMsg {
     Shutdown,
+    UpdateConfig(SessionConfigUpdate),
 }
 
 #[ractor::async_trait]
@@ -91,7 +95,7 @@ impl Actor for SessionActor {
                 return Ok(());
             }
 
-            match children::spawn_listener(myself.get_cell(), &state.ctx).await {
+            match children::spawn_listener(myself.get_cell(), &state.ctx, None).await {
                 Ok(listener_cell) => {
                     state.listener_cell = Some(listener_cell);
                     state.mode.on_listener_attached();
@@ -130,6 +134,9 @@ impl Actor for SessionActor {
                 state.shutting_down = true;
                 children::shutdown_children(state, "session_stop").await;
                 myself.stop(None);
+            }
+            SessionMsg::UpdateConfig(update) => {
+                update_config(myself, state, update).await;
             }
         }
         Ok(())
@@ -257,6 +264,100 @@ async fn enter_batch_fallback(state: &mut SessionState, degraded: DegradedError)
     state.mode.enter_batch_fallback();
     children::attach_listener_to_source(state).await;
     emit_active_lifecycle_event(state, Some(degraded)).await;
+}
+
+async fn update_config(
+    myself: ActorRef<SessionMsg>,
+    state: &mut SessionState,
+    update: SessionConfigUpdate,
+) {
+    if update.session_id != state.ctx.params.session_id {
+        return;
+    }
+
+    let should_refresh_listener = state.mode.should_spawn_listener()
+        && update_requires_listener_refresh(&state.ctx.params, &update);
+
+    state.ctx.params.languages = update.languages;
+    state.ctx.params.participant_human_ids = update.participant_human_ids;
+    state.ctx.params.self_human_id = update.self_human_id;
+
+    if should_refresh_listener {
+        refresh_listener(myself, state).await;
+        return;
+    }
+
+    if let Some(listener_cell) = &state.listener_cell {
+        let listener_ref: ractor::ActorRef<ListenerMsg> = listener_cell.clone().into();
+        if let Err(error) = listener_ref.cast(ListenerMsg::UpdateConfig(ListenerConfigUpdate {
+            languages: state.ctx.params.languages.clone(),
+            participant_human_ids: state.ctx.params.participant_human_ids.clone(),
+            self_human_id: state.ctx.params.self_human_id.clone(),
+        })) {
+            tracing::warn!(?error, "failed_to_cast_listener_config_update");
+        }
+    }
+}
+
+async fn refresh_listener(myself: ActorRef<SessionMsg>, state: &mut SessionState) {
+    let replay_duration_secs = children::stop_listener(state, "config_update").await;
+
+    if !state.mode.should_spawn_listener() {
+        return;
+    }
+
+    let replay_offset_secs =
+        (state.ctx.started_at_instant.elapsed().as_secs_f64() - replay_duration_secs).max(0.0);
+
+    match children::spawn_listener(myself.get_cell(), &state.ctx, Some(replay_offset_secs)).await {
+        Ok(listener_cell) => {
+            state.listener_cell = Some(listener_cell);
+            state.mode.on_listener_attached();
+            children::attach_listener_to_source(state).await;
+        }
+        Err(error) => {
+            tracing::warn!(?error, "listener_refresh_failed");
+            let degraded = if should_stop_on_listener_failure(state) {
+                DegradedError::StreamError {
+                    message: error.to_string(),
+                }
+            } else {
+                DegradedError::UpstreamUnavailable {
+                    message: mode::classify_connection_failure(&state.ctx.params.base_url),
+                }
+            };
+            handle_listener_failure(&myself, state, degraded).await;
+        }
+    }
+}
+
+fn update_requires_listener_refresh(current: &SessionParams, update: &SessionConfigUpdate) -> bool {
+    current.languages != update.languages
+        || expected_speaker_count(
+            &current.participant_human_ids,
+            current.self_human_id.as_deref(),
+        ) != expected_speaker_count(
+            &update.participant_human_ids,
+            update.self_human_id.as_deref(),
+        )
+}
+
+fn expected_speaker_count(
+    participant_human_ids: &[String],
+    self_human_id: Option<&str>,
+) -> Option<u32> {
+    let mut participants = participant_human_ids.to_vec();
+
+    if let Some(self_human_id) = self_human_id
+        && !participants.iter().any(|id| id == self_human_id)
+    {
+        participants.push(self_human_id.to_string());
+    }
+
+    participants.sort();
+    participants.dedup();
+
+    (participants.len() > 1).then_some(participants.len() as u32)
 }
 
 async fn handle_listener_failure(
@@ -487,6 +588,64 @@ mod tests {
             mode: SessionModeState::new(TranscriptionMode::Live, TranscriptionMode::Live),
             shutting_down: false,
         }
+    }
+
+    fn test_update(
+        languages: Vec<hypr_language::Language>,
+        participant_human_ids: Vec<&str>,
+        self_human_id: Option<&str>,
+    ) -> SessionConfigUpdate {
+        SessionConfigUpdate {
+            session_id: "session".to_string(),
+            languages,
+            participant_human_ids: participant_human_ids
+                .into_iter()
+                .map(ToString::to_string)
+                .collect(),
+            self_human_id: self_human_id.map(ToString::to_string),
+        }
+    }
+
+    #[test]
+    fn config_update_refreshes_when_languages_change() {
+        let mut ctx = test_ctx();
+        ctx.params.languages = vec![hypr_language::ISO639::En.into()];
+        let state = test_state(ctx);
+        let update = test_update(
+            vec![
+                hypr_language::ISO639::En.into(),
+                hypr_language::ISO639::Ko.into(),
+            ],
+            vec![],
+            None,
+        );
+
+        assert!(update_requires_listener_refresh(&state.ctx.params, &update));
+    }
+
+    #[test]
+    fn config_update_refreshes_when_expected_speaker_count_changes() {
+        let mut ctx = test_ctx();
+        ctx.params.participant_human_ids = vec!["self".to_string()];
+        ctx.params.self_human_id = Some("self".to_string());
+        let state = test_state(ctx);
+        let update = test_update(vec![], vec!["self", "remote"], Some("self"));
+
+        assert!(update_requires_listener_refresh(&state.ctx.params, &update));
+    }
+
+    #[test]
+    fn config_update_does_not_refresh_for_same_speaker_count() {
+        let mut ctx = test_ctx();
+        ctx.params.participant_human_ids = vec!["self".to_string(), "remote-a".to_string()];
+        ctx.params.self_human_id = Some("self".to_string());
+        let state = test_state(ctx);
+        let update = test_update(vec![], vec!["self", "remote-b"], Some("self"));
+
+        assert!(!update_requires_listener_refresh(
+            &state.ctx.params,
+            &update
+        ));
     }
 
     #[test]

--- a/crates/listener-core/src/actors/session/supervisor/children.rs
+++ b/crates/listener-core/src/actors/session/supervisor/children.rs
@@ -100,6 +100,7 @@ pub(super) async fn spawn_recorder(
 pub(super) async fn spawn_listener(
     supervisor_cell: ActorCell,
     ctx: &SessionContext,
+    stream_offset_secs: Option<f64>,
 ) -> Result<ActorCell, ractor::SpawnErr> {
     let mode = ChannelMode::determine(ctx.params.onboarding);
     let (listener_ref, _): (ActorRef<crate::actors::ListenerMsg>, _) = Actor::spawn_linked(
@@ -117,6 +118,7 @@ pub(super) async fn spawn_listener(
             mode,
             session_started_at: ctx.started_at_instant,
             session_started_at_unix: ctx.started_at_system,
+            stream_offset_secs,
             session_id: ctx.params.session_id.clone(),
             participant_human_ids: ctx.params.participant_human_ids.clone(),
             self_human_id: ctx.params.self_human_id.clone(),
@@ -197,6 +199,37 @@ pub(super) async fn attach_listener_to_source(state: &SessionState) {
             state.mode.listener_routing(state.listener_cell.as_ref()),
         )) {
             tracing::warn!(?error, "failed_to_attach_listener_to_source");
+        }
+    }
+}
+
+pub(super) async fn stop_listener(state: &mut SessionState, reason: &str) -> f64 {
+    if let Some(cell) = state.listener_cell.take() {
+        let replay_duration_secs = prepare_listener_refresh(state).await;
+        stop_child(&cell, reason, "listener").await;
+        return replay_duration_secs;
+    }
+
+    0.0
+}
+
+pub(super) async fn prepare_listener_refresh(state: &SessionState) -> f64 {
+    let Some(source_cell) = &state.source_cell else {
+        return 0.0;
+    };
+
+    let source_ref: ActorRef<SourceMsg> = source_cell.clone().into();
+    match ractor::call_t!(source_ref, SourceMsg::PrepareListenerRefresh, 500) {
+        Ok(replay) => replay.duration_secs,
+        Err(error) => {
+            tracing::warn!(?error, "failed_to_prepare_listener_refresh");
+            if let Some(source_cell) = &state.source_cell {
+                let source_ref: ActorRef<SourceMsg> = source_cell.clone().into();
+                let _ = source_ref.cast(SourceMsg::SetListenerRouting(
+                    state.mode.listener_routing(state.listener_cell.as_ref()),
+                ));
+            }
+            0.0
         }
     }
 }

--- a/crates/listener-core/src/actors/session/types.rs
+++ b/crates/listener-core/src/actors/session/types.rs
@@ -30,6 +30,17 @@ pub struct SessionParams {
     pub self_human_id: Option<String>,
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct SessionConfigUpdate {
+    pub session_id: String,
+    pub languages: Vec<hypr_language::Language>,
+    #[serde(default)]
+    pub participant_human_ids: Vec<String>,
+    #[serde(default)]
+    pub self_human_id: Option<String>,
+}
+
 impl SessionParams {
     pub fn effective_transcription_mode(&self) -> TranscriptionMode {
         if self.transcription_mode == TranscriptionMode::Batch {

--- a/crates/listener-core/src/actors/source/mod.rs
+++ b/crates/listener-core/src/actors/source/mod.rs
@@ -27,6 +27,7 @@ pub enum SourceMsg {
     SetMicMute(bool),
     GetMicMute(RpcReplyPort<bool>),
     GetMicDevice(RpcReplyPort<Option<String>>),
+    PrepareListenerRefresh(RpcReplyPort<ListenerRefreshReplay>),
     SetListenerRouting(ListenerRouting),
     SetRecorder(Option<ActorRef<RecMsg>>),
     Frame(SourceFrame),
@@ -36,6 +37,11 @@ pub enum SourceMsg {
 pub struct SourceFrame {
     pub capture: CaptureFrame,
     pub mic_muted: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ListenerRefreshReplay {
+    pub duration_secs: f64,
 }
 
 #[derive(Clone)]
@@ -186,6 +192,13 @@ impl Actor for SourceActor {
             SourceMsg::GetMicDevice(reply) => {
                 if !reply.is_closed() {
                     let _ = reply.send(st.mic_device.clone());
+                }
+            }
+            SourceMsg::PrepareListenerRefresh(reply) => {
+                st.listener_routing = ListenerRouting::Buffering;
+                let replay = st.pipeline.prepare_listener_refresh();
+                if !reply.is_closed() {
+                    let _ = reply.send(replay);
                 }
             }
             SourceMsg::SetListenerRouting(routing) => {

--- a/crates/listener-core/src/actors/source/pipeline.rs
+++ b/crates/listener-core/src/actors/source/pipeline.rs
@@ -8,22 +8,39 @@ use ractor::ActorRef;
 
 use crate::{
     ListenerRuntime, SessionDataEvent,
-    actors::{ChannelMode, ListenerMsg, RecMsg},
+    actors::{ChannelMode, ListenerMsg, RecMsg, SAMPLE_RATE},
 };
 use hypr_audio_utils::f32_to_i16_bytes;
 use hypr_vad_masking::VadMask;
 
-use super::{ListenerRouting, SourceFrame};
+use super::{ListenerRefreshReplay, ListenerRouting, SourceFrame};
 
 const AUDIO_AMPLITUDE_THROTTLE: Duration = Duration::from_millis(100);
 const MAX_BUFFER_CHUNKS: usize = 150;
+const REPLAY_HISTORY_SECS: usize = 5;
 
-type BufferedAudio = (Arc<[f32]>, Arc<[f32]>, ChannelMode);
+#[derive(Clone)]
+struct BufferedAudio {
+    mic: Arc<[f32]>,
+    spk: Arc<[f32]>,
+    mode: ChannelMode,
+}
+
+impl BufferedAudio {
+    fn new(mic: Arc<[f32]>, spk: Arc<[f32]>, mode: ChannelMode) -> Self {
+        Self { mic, spk, mode }
+    }
+
+    fn sample_count(&self) -> usize {
+        self.mic.len().max(self.spk.len())
+    }
+}
 
 pub(in crate::actors) struct Pipeline {
     vad_mask: VadMask,
     amplitude: AmplitudeEmitter,
     audio_buffer: AudioBuffer,
+    replay_history: ReplayHistory,
     backlog_quota: f32,
 }
 
@@ -35,6 +52,7 @@ impl Pipeline {
         Self {
             amplitude: AmplitudeEmitter::new(runtime, session_id),
             audio_buffer: AudioBuffer::new(MAX_BUFFER_CHUNKS),
+            replay_history: ReplayHistory::new(SAMPLE_RATE as usize * REPLAY_HISTORY_SECS),
             backlog_quota: 0.0,
             vad_mask: VadMask::default(),
         }
@@ -43,6 +61,7 @@ impl Pipeline {
     pub(super) fn reset(&mut self) {
         self.amplitude.reset();
         self.audio_buffer.clear();
+        self.replay_history.clear();
         self.backlog_quota = 0.0;
         self.vad_mask = VadMask::default();
     }
@@ -73,6 +92,19 @@ impl Pipeline {
         }
     }
 
+    pub(super) fn prepare_listener_refresh(&mut self) -> ListenerRefreshReplay {
+        self.audio_buffer.clear();
+        self.backlog_quota = 0.0;
+
+        for item in self.replay_history.items() {
+            self.audio_buffer.push_item(item);
+        }
+
+        ListenerRefreshReplay {
+            duration_secs: self.replay_history.duration_secs(),
+        }
+    }
+
     fn dispatch(
         &mut self,
         frame: SourceFrame,
@@ -83,19 +115,20 @@ impl Pipeline {
         let (mut processed_mic, processed_spk) = Self::select_tracks(frame, mode);
         self.vad_mask.process(&mut processed_mic);
         let processed_mic = Arc::<[f32]>::from(processed_mic);
+        let item = BufferedAudio::new(processed_mic, processed_spk, mode);
 
-        self.amplitude.observe_mic(&processed_mic);
-        self.amplitude.observe_spk(&processed_spk);
+        self.replay_history.push(item.clone());
+
+        self.amplitude.observe_mic(&item.mic);
+        self.amplitude.observe_spk(&item.spk);
 
         if let Some(actor) = recorder {
             let result = match mode {
-                ChannelMode::MicOnly => actor.cast(RecMsg::AudioSingle(Arc::clone(&processed_mic))),
-                ChannelMode::SpeakerOnly => {
-                    actor.cast(RecMsg::AudioSingle(Arc::clone(&processed_spk)))
-                }
+                ChannelMode::MicOnly => actor.cast(RecMsg::AudioSingle(Arc::clone(&item.mic))),
+                ChannelMode::SpeakerOnly => actor.cast(RecMsg::AudioSingle(Arc::clone(&item.spk))),
                 ChannelMode::MicAndSpeaker => actor.cast(RecMsg::AudioDual(
-                    Arc::clone(&processed_mic),
-                    Arc::clone(&processed_spk),
+                    Arc::clone(&item.mic),
+                    Arc::clone(&item.spk),
                 )),
             };
             if let Err(e) = result {
@@ -105,7 +138,7 @@ impl Pipeline {
 
         match listener_routing {
             ListenerRouting::Buffering => {
-                self.audio_buffer.push(processed_mic, processed_spk, mode);
+                self.audio_buffer.push_item(item);
                 tracing::debug!(
                     buffered = self.audio_buffer.len(),
                     "listener_unavailable_buffering"
@@ -113,7 +146,7 @@ impl Pipeline {
             }
             ListenerRouting::Attached(actor) => {
                 self.flush_buffer_to_listener(actor);
-                self.send_to_listener(actor, &processed_mic, &processed_spk, mode);
+                self.send_to_listener(actor, &item.mic, &item.spk, item.mode);
             }
             ListenerRouting::Dropped => {}
         }
@@ -125,11 +158,11 @@ impl Pipeline {
                 (self.backlog_quota + Self::BACKLOG_QUOTA_INCREMENT).min(Self::MAX_BACKLOG_QUOTA);
 
             while self.backlog_quota >= 1.0 {
-                let Some((mic, spk, buffered_mode)) = self.audio_buffer.pop() else {
+                let Some(item) = self.audio_buffer.pop() else {
                     break;
                 };
 
-                self.send_to_listener(actor, &mic, &spk, buffered_mode);
+                self.send_to_listener(actor, &item.mic, &item.spk, item.mode);
                 self.backlog_quota -= 1.0;
             }
         }
@@ -196,7 +229,7 @@ impl AudioBuffer {
         }
     }
 
-    fn push(&mut self, mic: Arc<[f32]>, spk: Arc<[f32]>, mode: ChannelMode) {
+    fn push_item(&mut self, item: BufferedAudio) {
         if self.buffer.len() >= self.max_size {
             self.buffer.pop_front();
             if !self.overflowing {
@@ -204,7 +237,7 @@ impl AudioBuffer {
                 tracing::warn!("audio_buffer_overflow_listener_unavailable");
             }
         }
-        self.buffer.push_back((mic, spk, mode));
+        self.buffer.push_back(item);
     }
 
     fn pop(&mut self) -> Option<BufferedAudio> {
@@ -226,6 +259,48 @@ impl AudioBuffer {
     fn clear(&mut self) {
         self.buffer.clear();
         self.overflowing = false;
+    }
+}
+
+struct ReplayHistory {
+    buffer: VecDeque<BufferedAudio>,
+    max_samples: usize,
+    samples: usize,
+}
+
+impl ReplayHistory {
+    fn new(max_samples: usize) -> Self {
+        Self {
+            buffer: VecDeque::new(),
+            max_samples,
+            samples: 0,
+        }
+    }
+
+    fn push(&mut self, item: BufferedAudio) {
+        self.samples += item.sample_count();
+        self.buffer.push_back(item);
+
+        while self.samples > self.max_samples {
+            let Some(item) = self.buffer.pop_front() else {
+                self.samples = 0;
+                return;
+            };
+            self.samples = self.samples.saturating_sub(item.sample_count());
+        }
+    }
+
+    fn items(&self) -> impl Iterator<Item = BufferedAudio> + '_ {
+        self.buffer.iter().cloned()
+    }
+
+    fn duration_secs(&self) -> f64 {
+        self.samples as f64 / SAMPLE_RATE as f64
+    }
+
+    fn clear(&mut self) {
+        self.buffer.clear();
+        self.samples = 0;
     }
 }
 
@@ -475,6 +550,53 @@ mod tests {
         assert!(pipeline.audio_buffer.is_empty());
 
         handle.abort();
+    }
+
+    #[tokio::test]
+    async fn listener_refresh_replays_recent_audio_history() {
+        let mut pipeline = test_pipeline();
+
+        let (old_probe_tx, mut old_probe_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (old_listener_ref, old_handle) = Actor::spawn(None, ListenerProbe(old_probe_tx), ())
+            .await
+            .unwrap();
+
+        for _ in 0..3 {
+            pipeline.dispatch_frame(
+                source_frame(false),
+                ChannelMode::MicAndSpeaker,
+                &ListenerRouting::Attached(old_listener_ref.clone()),
+                None,
+            );
+        }
+
+        for _ in 0..3 {
+            tokio::time::timeout(std::time::Duration::from_secs(1), old_probe_rx.recv())
+                .await
+                .unwrap()
+                .unwrap();
+        }
+
+        let replay = pipeline.prepare_listener_refresh();
+
+        assert_eq!(pipeline.audio_buffer.len(), 3);
+        assert!(replay.duration_secs > 0.0);
+
+        let (new_probe_tx, mut new_probe_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (new_listener_ref, new_handle) = Actor::spawn(None, ListenerProbe(new_probe_tx), ())
+            .await
+            .unwrap();
+
+        pipeline.on_listener_routing_changed(&ListenerRouting::Attached(new_listener_ref));
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), new_probe_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(event, ProbeEvent::ListenerDual));
+
+        old_handle.abort();
+        new_handle.abort();
     }
 
     #[tokio::test]

--- a/crates/listener-core/src/live_transcript.rs
+++ b/crates/listener-core/src/live_transcript.rs
@@ -67,6 +67,7 @@ pub struct LiveTranscriptEngine {
     processor: TranscriptProcessor,
     normalizer: TranscriptNormalizer,
     rendered_segments: RenderedSegmentState,
+    max_speaker_index: Option<i32>,
 }
 
 impl LiveTranscriptEngine {
@@ -79,6 +80,8 @@ impl LiveTranscriptEngine {
             channel_assignments_for_participants(participant_human_ids, self_human_id);
         let segment_options =
             segment_options_for_participants(participant_human_ids, self_human_id);
+        let max_speaker_index =
+            max_speaker_index_for_participants(participant_human_ids, self_human_id);
 
         let normalizer = TranscriptNormalizer::for_provider(provider_name);
 
@@ -92,12 +95,14 @@ impl LiveTranscriptEngine {
                 segment_options: Some(segment_options),
                 ..Default::default()
             },
+            max_speaker_index,
         }
     }
 
     pub fn process(&mut self, response: &StreamResponse) -> Option<LiveTranscriptUpdate> {
         let mut normalized = response.clone();
         self.normalizer.normalize(&mut normalized);
+        clamp_response_speaker_indices(&mut normalized, self.max_speaker_index);
         let transcript_delta: LiveTranscriptDelta = self.processor.process(&normalized)?.into();
         let segment_delta = self.rendered_segments.apply_delta(&transcript_delta);
         Some(LiveTranscriptUpdate {
@@ -117,6 +122,46 @@ impl LiveTranscriptEngine {
             transcript_delta,
             segment_delta,
         })
+    }
+}
+
+fn max_speaker_index_for_participants(
+    participant_human_ids: &[String],
+    self_human_id: Option<&str>,
+) -> Option<i32> {
+    let mut participants = participant_human_ids.to_vec();
+
+    if let Some(self_human_id) = self_human_id
+        && !participants.iter().any(|id| id == self_human_id)
+    {
+        participants.push(self_human_id.to_string());
+    }
+
+    participants.sort();
+    participants.dedup();
+
+    if participants.len() <= 1 {
+        return None;
+    }
+
+    i32::try_from(participants.len() - 1).ok()
+}
+
+fn clamp_response_speaker_indices(response: &mut StreamResponse, max_speaker_index: Option<i32>) {
+    let Some(max_speaker_index) = max_speaker_index else {
+        return;
+    };
+
+    let StreamResponse::TranscriptResponse { channel, .. } = response else {
+        return;
+    };
+
+    for alternative in &mut channel.alternatives {
+        for word in &mut alternative.words {
+            if let Some(speaker) = word.speaker {
+                word.speaker = Some(speaker.clamp(0, max_speaker_index));
+            }
+        }
     }
 }
 
@@ -1208,6 +1253,34 @@ mod tests {
 
         assert_eq!(final_text.trim(), "hello world");
         assert!(flush_update.transcript_delta.partials.is_empty());
+    }
+
+    #[test]
+    fn clamps_provider_speakers_to_participant_count() {
+        let max_speaker_index =
+            max_speaker_index_for_participants(&["remote".to_string()], Some("self"));
+        let mut high_word = word("too-high", 0.0, 0.5);
+        high_word.speaker = Some(2);
+        let mut negative_word = word("negative", 0.5, 1.0);
+        negative_word.speaker = Some(-1);
+        let mut response = transcript_response_at(
+            "too-high negative",
+            vec![high_word, negative_word],
+            true,
+            0,
+            0.0,
+            1.0,
+        );
+
+        clamp_response_speaker_indices(&mut response, max_speaker_index);
+
+        let StreamResponse::TranscriptResponse { channel, .. } = response else {
+            panic!("expected transcript response");
+        };
+        let words = &channel.alternatives[0].words;
+
+        assert_eq!(words[0].speaker, Some(1));
+        assert_eq!(words[1].speaker, Some(0));
     }
 
     #[test]

--- a/crates/listener-core/src/live_transcript.rs
+++ b/crates/listener-core/src/live_transcript.rs
@@ -111,6 +111,21 @@ impl LiveTranscriptEngine {
         })
     }
 
+    pub fn update_participants(
+        &mut self,
+        participant_human_ids: &[String],
+        self_human_id: Option<&str>,
+    ) {
+        self.rendered_segments.channel_assignments =
+            channel_assignments_for_participants(participant_human_ids, self_human_id);
+        self.rendered_segments.segment_options = Some(segment_options_for_participants(
+            participant_human_ids,
+            self_human_id,
+        ));
+        self.max_speaker_index =
+            max_speaker_index_for_participants(participant_human_ids, self_human_id);
+    }
+
     pub fn flush(&mut self) -> Option<LiveTranscriptUpdate> {
         let transcript_delta: LiveTranscriptDelta = self.processor.flush().into();
         let segment_delta = self.rendered_segments.apply_delta(&transcript_delta);

--- a/crates/owhisper-client/src/adapter/soniox/live.rs
+++ b/crates/owhisper-client/src/adapter/soniox/live.rs
@@ -534,6 +534,31 @@ mod tests {
     }
 
     #[test]
+    fn parse_response_normalizes_numeric_string_speaker_ids_to_zero_based_indices() {
+        let responses = SonioxAdapter.parse_response(
+            r#"{
+                "tokens": [
+                    { "text": "hello", "start_ms": 0, "end_ms": 400, "is_final": true, "speaker": "1" },
+                    { "text": " there", "start_ms": 400, "end_ms": 900, "is_final": true, "speaker": "2" }
+                ]
+            }"#,
+        );
+
+        assert_eq!(responses.len(), 1);
+
+        let words = match &responses[0] {
+            StreamResponse::TranscriptResponse { channel, .. } => &channel.alternatives[0].words,
+            _ => panic!("expected transcript response"),
+        };
+
+        assert_eq!(words.len(), 2);
+        assert_eq!(words[0].word, "hello");
+        assert_eq!(words[0].speaker, Some(0));
+        assert_eq!(words[1].word, "there");
+        assert_eq!(words[1].speaker, Some(1));
+    }
+
+    #[test]
     fn parse_response_keeps_korean_eojeol_partial_when_finality_splits_mid_word() {
         let responses = SonioxAdapter.parse_response(
             r#"{

--- a/crates/owhisper-client/src/adapter/soniox/words.rs
+++ b/crates/owhisper-client/src/adapter/soniox/words.rs
@@ -28,7 +28,7 @@ impl PendingWord {
         self.text.push_str(text);
 
         if self.speaker.is_none() {
-            self.speaker = token.speaker.as_ref().and_then(|speaker| speaker.as_i32());
+            self.speaker = token.speaker.as_ref().and_then(soniox_speaker_index);
         }
         if self.language.is_none() {
             self.language = token.language.clone();
@@ -57,6 +57,23 @@ impl PendingWord {
             speaker: self.speaker,
             language: self.language,
         })
+    }
+}
+
+fn soniox_speaker_index(speaker: &soniox::SpeakerId) -> Option<i32> {
+    match speaker {
+        soniox::SpeakerId::Num(n) => Some(*n),
+        soniox::SpeakerId::Str(value) => {
+            let trimmed = value.trim();
+            if trimmed.chars().all(|c| c.is_ascii_digit()) {
+                return trimmed
+                    .parse::<i32>()
+                    .ok()
+                    .map(|speaker| speaker.saturating_sub(1));
+            }
+
+            speaker.as_i32()
+        }
     }
 }
 

--- a/crates/transcript/src/label.rs
+++ b/crates/transcript/src/label.rs
@@ -12,6 +12,7 @@ pub struct SpeakerLabelContext {
 pub struct SpeakerLabeler {
     unknown_speaker_map: HashMap<SegmentKey, usize>,
     next_index: usize,
+    max_unknown_speaker_number: Option<usize>,
 }
 
 impl SpeakerLabeler {
@@ -19,11 +20,21 @@ impl SpeakerLabeler {
         Self {
             unknown_speaker_map: HashMap::new(),
             next_index: 1,
+            max_unknown_speaker_number: None,
         }
     }
 
-    pub fn from_segments(segments: &[Segment], ctx: Option<&SpeakerLabelContext>) -> Self {
-        let mut labeler = Self::new();
+    pub fn with_max_unknown_speaker_number(mut self, max: Option<usize>) -> Self {
+        self.max_unknown_speaker_number = max;
+        self
+    }
+
+    pub fn from_segments(
+        segments: &[Segment],
+        ctx: Option<&SpeakerLabelContext>,
+        max_unknown_speaker_number: Option<usize>,
+    ) -> Self {
+        let mut labeler = Self::new().with_max_unknown_speaker_number(max_unknown_speaker_number);
         for segment in segments {
             if !segment.key.is_known_speaker(ctx) {
                 labeler.unknown_speaker_number(&segment.key);
@@ -41,7 +52,10 @@ impl SpeakerLabeler {
             return *existing;
         }
 
-        let next = self.next_index;
+        let next = self
+            .max_unknown_speaker_number
+            .map(|max| self.next_index.min(max))
+            .unwrap_or(self.next_index);
         self.unknown_speaker_map.insert(key.clone(), next);
         self.next_index += 1;
         next
@@ -149,6 +163,30 @@ mod tests {
         assert_eq!(labeler.label_for(&a, None), "Speaker 1");
         assert_eq!(labeler.label_for(&b, None), "Speaker 2");
         assert_eq!(labeler.label_for(&a, None), "Speaker 1");
+    }
+
+    #[test]
+    fn caps_unknown_speaker_numbers() {
+        let mut labeler = SpeakerLabeler::new().with_max_unknown_speaker_number(Some(2));
+        let a = SegmentKey {
+            channel: ChannelProfile::DirectMic,
+            speaker_index: Some(0),
+            speaker_human_id: None,
+        };
+        let b = SegmentKey {
+            channel: ChannelProfile::RemoteParty,
+            speaker_index: Some(1),
+            speaker_human_id: None,
+        };
+        let c = SegmentKey {
+            channel: ChannelProfile::RemoteParty,
+            speaker_index: Some(2),
+            speaker_human_id: None,
+        };
+
+        assert_eq!(labeler.label_for(&a, None), "Speaker 1");
+        assert_eq!(labeler.label_for(&b, None), "Speaker 2");
+        assert_eq!(labeler.label_for(&c, None), "Speaker 2");
     }
 
     #[test]

--- a/crates/transcript/src/render.rs
+++ b/crates/transcript/src/render.rs
@@ -84,13 +84,15 @@ pub fn render_transcript_segments(
     all_segments.sort_by_key(|seg| seg.words.first().map(|w| w.start_ms).unwrap_or(i64::MAX));
 
     let ctx = SpeakerLabelContext {
-        self_human_id,
+        self_human_id: self_human_id.clone(),
         human_name_by_id: humans
             .into_iter()
             .map(|human| (human.human_id, human.name))
             .collect::<HashMap<_, _>>(),
     };
-    let mut labeler = SpeakerLabeler::from_segments(&all_segments, Some(&ctx));
+    let max_speaker_number =
+        max_speaker_number_for_participants(&participant_human_ids, self_human_id.as_deref());
+    let mut labeler = SpeakerLabeler::from_segments(&all_segments, Some(&ctx), max_speaker_number);
 
     all_segments
         .into_iter()
@@ -119,6 +121,24 @@ pub fn render_transcript_segments(
             })
         })
         .collect()
+}
+
+fn max_speaker_number_for_participants(
+    participant_human_ids: &[String],
+    self_human_id: Option<&str>,
+) -> Option<usize> {
+    let mut participants = participant_human_ids.to_vec();
+
+    if let Some(self_human_id) = self_human_id
+        && !participants.iter().any(|id| id == self_human_id)
+    {
+        participants.push(self_human_id.to_string());
+    }
+
+    participants.sort();
+    participants.dedup();
+
+    (participants.len() > 1).then_some(participants.len())
 }
 
 fn offset_transcript_data(
@@ -303,6 +323,29 @@ mod tests {
         assert_eq!(segments[0].text, "hello");
         assert_eq!(segments[1].speaker_label, "Bob");
         assert_eq!(segments[1].text, "world");
+    }
+
+    #[test]
+    fn caps_unknown_speaker_labels_to_participant_count() {
+        let segments = render_transcript_segments(RenderTranscriptRequest {
+            transcripts: vec![RenderTranscriptInput {
+                started_at: Some(0),
+                words: vec![
+                    word_si("w1", " one", 0, 100, 2, 0),
+                    word_si("w2", " two", 200, 300, 2, 1),
+                    word_si("w3", " three", 400, 500, 2, 2),
+                ],
+                assignments: vec![],
+            }],
+            participant_human_ids: vec!["self".to_string(), "remote".to_string()],
+            self_human_id: Some("self".to_string()),
+            humans: vec![],
+        });
+
+        assert_eq!(segments.len(), 3);
+        assert_eq!(segments[0].speaker_label, "Speaker 1");
+        assert_eq!(segments[1].speaker_label, "Speaker 2");
+        assert_eq!(segments[2].speaker_label, "Speaker 2");
     }
 
     #[test]

--- a/plugins/transcription/js/bindings.gen.ts
+++ b/plugins/transcription/js/bindings.gen.ts
@@ -54,6 +54,14 @@ async stopCapture() : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async updateCaptureConfig(update: CaptureConfigUpdate) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:transcription|update_capture_config", { update }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async getCaptureState() : Promise<Result<CaptureState, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("plugin:transcription|get_capture_state") };
@@ -192,6 +200,7 @@ export type BatchResults = { channels: BatchChannel[] }
 export type BatchRunMode = "direct" | "streamed"
 export type BatchStreamEvent = { type: "progress"; percentage: number; partial_text?: string | null } | { type: "segment"; response: StreamResponse; percentage: number } | { type: "terminal"; request_id: string; created: string; duration: number; channels: number } | { type: "result"; response: BatchResponse } | { type: "error"; error_code: number | null; error_message: string; provider: string }
 export type BatchWord = { word: string; start: number; end: number; confidence: number; channel?: number; speaker: number | null; punctuated_word: string | null }
+export type CaptureConfigUpdate = { session_id: string; languages: string[]; participant_human_ids?: string[]; self_human_id?: string | null }
 export type CaptureDataEvent = { type: "audio_amplitude"; session_id: string; mic: number; speaker: number } | { type: "mic_muted"; session_id: string; value: boolean } | { type: "transcript_delta"; session_id: string; delta: LiveTranscriptDelta } | { type: "transcript_segment_delta"; session_id: string; delta: LiveTranscriptSegmentDelta }
 export type CaptureLifecycleEvent = { type: "started"; session_id: string; requested_live_transcription: boolean; live_transcription_active: boolean; degraded: DegradedError | null } | { type: "finalizing"; session_id: string } | { type: "stopped"; session_id: string; audio_path: string | null; requested_live_transcription: boolean; live_transcription_active: boolean; error: string | null }
 export type CaptureParams = { session_id: string; languages: string[]; onboarding: boolean; model: string; base_url: string; api_key: string; keywords: string[]; transcription_mode?: TranscriptionMode | null; participant_human_ids?: string[]; self_human_id?: string | null }

--- a/plugins/transcription/src/api.rs
+++ b/plugins/transcription/src/api.rs
@@ -26,6 +26,16 @@ pub struct CaptureParams {
     pub self_human_id: Option<String>,
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+pub struct CaptureConfigUpdate {
+    pub session_id: String,
+    pub languages: Vec<hypr_language::Language>,
+    #[serde(default)]
+    pub participant_human_ids: Vec<String>,
+    #[serde(default)]
+    pub self_human_id: Option<String>,
+}
+
 impl CaptureParams {
     fn default_transcription_mode(&self) -> listener::TranscriptionMode {
         if self.transcription_mode == Some(listener::TranscriptionMode::Batch) {
@@ -205,6 +215,17 @@ impl From<CaptureParams> for listener::actors::SessionParams {
             base_url: value.base_url,
             api_key: value.api_key,
             keywords: value.keywords,
+            participant_human_ids: value.participant_human_ids,
+            self_human_id: value.self_human_id,
+        }
+    }
+}
+
+impl From<CaptureConfigUpdate> for listener::actors::SessionConfigUpdate {
+    fn from(value: CaptureConfigUpdate) -> Self {
+        Self {
+            session_id: value.session_id,
+            languages: value.languages,
             participant_human_ids: value.participant_human_ids,
             self_human_id: value.self_human_id,
         }

--- a/plugins/transcription/src/lib.rs
+++ b/plugins/transcription/src/lib.rs
@@ -73,6 +73,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             listener::commands::set_mic_muted::<tauri::Wry>,
             listener::commands::start_capture::<tauri::Wry>,
             listener::commands::stop_capture::<tauri::Wry>,
+            listener::commands::update_capture_config::<tauri::Wry>,
             listener::commands::get_capture_state::<tauri::Wry>,
             listener::commands::is_supported_languages_live::<tauri::Wry>,
             listener::commands::suggest_providers_for_languages_live::<tauri::Wry>,

--- a/plugins/transcription/src/listener/commands.rs
+++ b/plugins/transcription/src/listener/commands.rs
@@ -2,7 +2,7 @@ use owhisper_client::AdapterKind;
 use std::str::FromStr;
 
 use crate::listener::ListenerPluginExt;
-use crate::{CaptureParams, CaptureState};
+use crate::{CaptureConfigUpdate, CaptureParams, CaptureState};
 use hypr_transcript::{RenderTranscriptRequest, RenderedTranscriptSegment};
 use hypr_transcription_core::listener2 as listener2_core;
 
@@ -60,6 +60,16 @@ pub async fn start_capture<R: tauri::Runtime>(
 #[specta::specta]
 pub async fn stop_capture<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Result<(), String> {
     app.listener().stop_capture().await;
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn update_capture_config<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    update: CaptureConfigUpdate,
+) -> Result<(), String> {
+    app.listener().update_capture_config(update).await;
     Ok(())
 }
 

--- a/plugins/transcription/src/listener/ext.rs
+++ b/plugins/transcription/src/listener/ext.rs
@@ -1,6 +1,6 @@
 use ractor::{ActorRef, call_t, registry};
 
-use crate::{CaptureParams, CaptureState};
+use crate::{CaptureConfigUpdate, CaptureParams, CaptureState};
 use hypr_transcription_core::listener::{
     StartSessionError,
     actors::{RootActor, RootMsg, SessionParams, SourceActor, SourceMsg},
@@ -88,6 +88,15 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Listener<'a, R, M> {
         if let Some(cell) = registry::where_is(RootActor::name()) {
             let actor: ActorRef<RootMsg> = cell.into();
             let _ = ractor::call!(actor, RootMsg::StopSession);
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn update_capture_config(&self, update: CaptureConfigUpdate) {
+        if let Some(cell) = registry::where_is(RootActor::name()) {
+            let actor: ActorRef<RootMsg> = cell.into();
+            let update = update.into();
+            let _ = ractor::call!(actor, RootMsg::UpdateSessionConfig, update);
         }
     }
 }


### PR DESCRIPTION
## Summary
- cap cloud live speaker labels to the known participant count, including Soniox numeric speaker IDs
- debounce participant and language changes, then refresh the active listener without requiring pause/resume
- replay recent source audio around provider reconnects so refresh transitions do not drop boundary audio

## Testing
- pnpm exec dprint fmt
- pnpm -F desktop typecheck
- cargo test -p listener-core
- cargo test -p tauri-plugin-transcription
- cargo check -p listener-core -p tauri-plugin-transcription
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the live transcription reconnect path and provider session parameters; incorrect refresh or replay could drop or mis-time audio, but behavior is covered by listener-core and desktop tests.
> 
> **Overview**
> Live capture can now **push language and participant changes into an active session** without stopping recording. The desktop adds **`LiveCaptureConfigSync`**, which watches session participants and STT settings, debounces (~750ms), and calls **`updateCaptureConfig`** when the active live session’s effective config changes.
> 
> On the backend, **`update_capture_config`** flows through the listener root into the session supervisor. **Language or expected speaker-count changes restart the live listener**; other participant tweaks update the in-process listener and transcript engine. Reconnect uses a **~5s replay buffer** and **`stream_offset_secs`** so timestamps stay continuous and boundary audio is not lost. Listen params now set **`max_speakers`** alongside **`num_speakers`**.
> 
> **Unknown diarized speaker labels** are capped to the distinct participant count (self + attendees) in the UI (`SpeakerLabelManager` / `getMaxSpeakerNumberForParticipants`) and in **`LiveTranscriptEngine`** (clamp provider speaker indices). **Soniox** string numeric speaker IDs are normalized to **0-based** indices. Rendered and live transcript views pass the participant-derived cap into labeling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a89bceff6bea10642961ebaab1fa90fc8b0956. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->