### PR TITLE
fix: add image copy context menu

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -26,6 +26,7 @@
     "@hypr/store": "workspace:*",
     "@hypr/tiptap": "workspace:^",
     "@hypr/utils": "workspace:^",
+    "@tauri-apps/api": "^2.10.1",
     "facehash": "^0.0.7",
     "lucide-react": "^0.544.0",
     "markdown-it": "^14.1.1",

--- a/packages/editor/src/node-views/image-view.tsx
+++ b/packages/editor/src/node-views/image-view.tsx
@@ -4,7 +4,13 @@ import {
   useEditorState,
 } from "@handlewithcare/react-prosemirror";
 import type { NodeSpec } from "prosemirror-model";
-import { forwardRef, useCallback, useRef, useState } from "react";
+import {
+  forwardRef,
+  type MouseEvent,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
 
 import { cn } from "@hypr/utils";
 
@@ -13,6 +19,52 @@ import { getSafeNodePos } from "./error-boundary";
 const MIN_IMAGE_WIDTH = 15;
 const MAX_IMAGE_WIDTH = 100;
 const DEFAULT_IMAGE_WIDTH = 80;
+
+type MenuModule = typeof import("@tauri-apps/api/menu");
+
+type WindowWithTauri = Window & {
+  __TAURI_INTERNALS__?: unknown;
+};
+
+async function copyImageToClipboard(src: string, alt?: string | null) {
+  const response = await fetch(src);
+  const blob = await response.blob();
+
+  if (blob.type.startsWith("image/") && "ClipboardItem" in window) {
+    await navigator.clipboard.write([
+      new ClipboardItem({
+        [blob.type]: blob,
+      }),
+    ]);
+    return;
+  }
+
+  await navigator.clipboard.writeText(alt || src);
+}
+
+async function showImageContextMenu(
+  event: MouseEvent,
+  action: () => void,
+) {
+  event.preventDefault();
+  event.stopPropagation();
+
+  if (!(window as WindowWithTauri).__TAURI_INTERNALS__) {
+    action();
+    return;
+  }
+
+  const { Menu, MenuItem } = (await import(
+    "@tauri-apps/api/menu"
+  )) as MenuModule;
+  const copyItem = await MenuItem.new({
+    id: "copy-image",
+    text: "Copy Image",
+    action,
+  });
+  const menu = await Menu.new({ items: [copyItem] });
+  await menu.popup();
+}
 
 function clampImageWidth(value: number) {
   if (Number.isNaN(value)) return DEFAULT_IMAGE_WIDTH;
@@ -166,6 +218,19 @@ export const ResizableImageView = forwardRef<
     [updateAttributes],
   );
 
+  const handleCopyImage = useCallback(() => {
+    if (typeof node.attrs.src !== "string") return;
+
+    void copyImageToClipboard(node.attrs.src, node.attrs.alt);
+  }, [node.attrs.alt, node.attrs.src]);
+
+  const handleContextMenu = useCallback(
+    (event: MouseEvent) => {
+      void showImageContextMenu(event, handleCopyImage);
+    },
+    [handleCopyImage],
+  );
+
   const showControls = isHovered || isSelected || isResizing;
   const editorWidth = clampImageWidth(node.attrs.editorWidth);
   const imageWidth =
@@ -183,6 +248,7 @@ export const ResizableImageView = forwardRef<
         style={imageWidth ? { width: imageWidth } : undefined}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
+        onContextMenu={handleContextMenu}
       >
         <img
           ref={imageRef}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1122,6 +1122,9 @@ importers:
       '@hypr/utils':
         specifier: workspace:^
         version: link:../utils
+      '@tauri-apps/api':
+        specifier: ^2.10.1
+        version: 2.10.1
       facehash:
         specifier: ^0.0.7
         version: 0.0.7(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
### Motivation
- Provide a native “Copy Image” action when right-clicking images in the editor so users can copy image content to the system clipboard from the desktop app.
- Fall back to safe behavior in non-Tauri or browser environments and for cases where image clipboard items are unsupported.

### Description
- Add a `copyImageToClipboard` helper that fetches the image `src`, converts to a `Blob`, and writes an image `ClipboardItem` when supported, falling back to `navigator.clipboard.writeText` with `alt` or the `src`.
- Add `showImageContextMenu` which uses `@tauri-apps/api/menu` to show a native menu item labeled `Copy Image`, and guard it to call the fallback action in non-Tauri environments.
- Wire up an `onContextMenu` handler on the image container in `ResizableImageView` to show the menu and invoke the copy action.
- Add `@tauri-apps/api` to `packages/editor/package.json` and update the lockfile importer in `pnpm-lock.yaml`.

### Testing
- Ran `git diff --check` which succeeded with no whitespace errors.
- Attempted `pnpm exec dprint fmt` but it was blocked because Corepack could not download `pnpm` in this environment (network/proxy 403).
- Attempted TypeScript checks (`pnpm -F @hypr/editor typecheck` / `./node_modules/.bin/tsc -p packages/editor/tsconfig.json --noEmit`) but these were not run / failed due to `node_modules` not being installed in this environment and the same `pnpm` availability issue.
- No additional automated tests were executed in this environment due to package manager/network limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32447989cc832ebb1dfdf42374939b)