### PR TITLE
Increase toast CTA contrast

### DIFF
--- a/apps/desktop/src/sidebar/toast/component.test.tsx
+++ b/apps/desktop/src/sidebar/toast/component.test.tsx
@@ -29,6 +29,12 @@ describe("Toast", () => {
     expect(pill?.className).toContain("bg-card");
     expect(screen.getByText("Language model needed")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Add" }).className).toContain(
+      "bg-foreground",
+    );
+    expect(screen.getByRole("button", { name: "Add" }).className).toContain(
+      "text-background",
+    );
+    expect(screen.getByRole("button", { name: "Hide" }).className).toContain(
       "bg-muted",
     );
 

--- a/apps/desktop/src/sidebar/toast/component.tsx
+++ b/apps/desktop/src/sidebar/toast/component.tsx
@@ -93,7 +93,7 @@ function getActionClassName(toast: ToastType, index: number) {
   }
 
   if (index === 0) {
-    return "bg-muted text-foreground hover:bg-accent";
+    return "bg-foreground text-background hover:bg-foreground/90";
   }
 
   return "border-border bg-muted text-foreground hover:bg-accent border";


### PR DESCRIPTION
Render the primary toast action with inverted foreground/background colors so it stands apart from secondary actions in light and dark modes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only class changes in the toast component with no auth, data, or behavior changes beyond styling.
> 
> **Overview**
> **Primary toast actions** now use inverted theme colors (`bg-foreground` / `text-background` with a matching hover) instead of muted styling, so the first action reads clearly as the CTA next to secondary buttons in light and dark mode.
> 
> **Error toasts** are unchanged: the first action still uses destructive colors. Tests were updated to assert the new primary and secondary class names on the Add and Hide buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e437c35e0f4534c5185488808ef9409b801973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->