### PR TITLE
Show upcoming meeting chrome

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -25,6 +25,7 @@ import { useShell } from "~/contexts/shell";
 import { GlobalLiveTranscriptAccessory } from "~/session/components/bottom-accessory/global-live";
 import { useOpenNoteDialog } from "~/shared/open-note-dialog";
 import { useNewNote } from "~/shared/useNewNote";
+import { useSidebarUpcomingMeetingStatus } from "~/sidebar/timeline/upcoming-meeting";
 import {
   hasCustomSidebarTab,
   hasLeftSurfaceCustomSidebarTab,
@@ -65,6 +66,7 @@ export function ClassicMainBody() {
   });
   const mainAreaTopDrag = useMainAreaTopWindowDrag(enableMainAreaTopDrag);
   const update = useDesktopUpdateControl();
+  const upcomingMeetingStatus = useSidebarUpcomingMeetingStatus();
   const createNewNote = useNewNote();
   const openNoteDialog = useOpenNoteDialog();
   const handleOpenNoteDialog = useCallback(() => {
@@ -91,6 +93,7 @@ export function ClassicMainBody() {
               onNewNote={createNewNote}
               onSearch={handleOpenNoteDialog}
               onToggleSidebar={leftsidebar.toggleExpanded}
+              hasUpcomingMeeting={Boolean(upcomingMeetingStatus)}
               update={update}
             />
           </div>
@@ -285,12 +288,14 @@ function isMainAreaWindowDrag(
 }
 
 function SidebarTimelineChrome({
+  hasUpcomingMeeting,
   onNewNote,
   onSearch,
   onToggleSidebar,
   sidebarExpanded,
   update,
 }: {
+  hasUpcomingMeeting: boolean;
   onNewNote: () => void;
   onSearch: () => void;
   onToggleSidebar: () => void;
@@ -299,6 +304,13 @@ function SidebarTimelineChrome({
 }) {
   const updateVisible = Boolean(update.status && update.version);
   const showUpdateButton = sidebarExpanded && updateVisible;
+  const collapsedBadge = !sidebarExpanded
+    ? hasUpcomingMeeting
+      ? "upcomingMeeting"
+      : updateVisible
+        ? "update"
+        : null
+    : null;
 
   return (
     <div
@@ -308,7 +320,7 @@ function SidebarTimelineChrome({
       <div data-tauri-drag-region className="flex items-center gap-0">
         <LeftSurfaceChromeButton
           ariaLabel={sidebarExpanded ? "Hide sidebar" : "Show sidebar"}
-          badge={!sidebarExpanded && updateVisible}
+          badge={collapsedBadge}
           onClick={onToggleSidebar}
         >
           {sidebarExpanded ? (
@@ -335,15 +347,17 @@ function SidebarTimelineChrome({
   );
 }
 
+type LeftSurfaceChromeBadge = "update" | "upcomingMeeting";
+
 function LeftSurfaceChromeButton({
   ariaLabel,
-  badge = false,
+  badge = null,
   children,
   disabled = false,
   onClick,
 }: {
   ariaLabel: string;
-  badge?: boolean;
+  badge?: LeftSurfaceChromeBadge | null;
   children: React.ReactNode;
   disabled?: boolean;
   onClick: () => void;
@@ -366,8 +380,15 @@ function LeftSurfaceChromeButton({
       {badge ? (
         <span
           aria-hidden="true"
-          data-testid="collapsed-sidebar-update-badge"
-          className="ring-background pointer-events-none absolute top-1 right-1 size-1.5 rounded-full bg-blue-500 ring-2"
+          data-testid={
+            badge === "upcomingMeeting"
+              ? "collapsed-sidebar-upcoming-meeting-badge"
+              : "collapsed-sidebar-update-badge"
+          }
+          className={cn([
+            "ring-background pointer-events-none absolute top-1 right-1 size-1.5 rounded-full ring-2",
+            badge === "upcomingMeeting" ? "bg-red-500" : "bg-blue-500",
+          ])}
         />
       ) : null}
     </button>

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   startDragging: vi.fn().mockResolvedValue(undefined),
   canGoBack: false,
   canGoNext: false,
+  upcomingMeetingStatus: null as null | { label: string; title: string },
   leftSidebarExpanded: true,
   sidebarUpdateControl: {
     status: null as null | "available" | "downloading" | "ready" | "failed",
@@ -75,6 +76,10 @@ vi.mock("~/main/update-banner", () => ({
       <button type="button" data-testid="sidebar-update-button" />
     ) : null,
   useDesktopUpdateControl: () => mocks.sidebarUpdateControl,
+}));
+
+vi.mock("~/sidebar/timeline/upcoming-meeting", () => ({
+  useSidebarUpcomingMeetingStatus: () => mocks.upcomingMeetingStatus,
 }));
 
 vi.mock("~/main/shell-sidebar", () => ({
@@ -151,6 +156,7 @@ describe("ClassicMainBody", () => {
     mocks.startDragging.mockClear();
     mocks.canGoBack = false;
     mocks.canGoNext = false;
+    mocks.upcomingMeetingStatus = null;
     mocks.leftSidebarExpanded = true;
     mocks.sidebarUpdateControl.status = null;
     mocks.sidebarUpdateControl.version = null;
@@ -320,6 +326,30 @@ describe("ClassicMainBody", () => {
     expect(badge.className.split(" ")).toContain("bg-blue-500");
     expect(badge.className.split(" ")).not.toContain("bg-red-500");
     expect(mocks.toggleLeftSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a red upcoming meeting badge on the collapsed sidebar toggle", () => {
+    mocks.leftSidebarExpanded = false;
+    mocks.sidebarUpdateControl.status = "available";
+    mocks.sidebarUpdateControl.version = "1.0.34";
+    mocks.upcomingMeetingStatus = {
+      label: "Starts in 3m",
+      title: "Devtool design sync",
+    };
+
+    render(<ClassicMainBody />);
+
+    const sidebarToggle = screen.getByRole("button", { name: "Show sidebar" });
+    const badge = within(sidebarToggle).getByTestId(
+      "collapsed-sidebar-upcoming-meeting-badge",
+    );
+
+    expect(badge).toBeTruthy();
+    expect(badge.className.split(" ")).toContain("bg-red-500");
+    expect(badge.className.split(" ")).not.toContain("bg-blue-500");
+    expect(
+      within(sidebarToggle).queryByTestId("collapsed-sidebar-update-badge"),
+    ).toBeNull();
   });
 
   it("keeps sidebar chrome for changelog tabs", () => {

--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -1,10 +1,4 @@
-import {
-  act,
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-} from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -25,12 +19,6 @@ const mocks = vi.hoisted(() => ({
   smartCurrentTimeMs: undefined as number | undefined,
   timelineEventsTable: {} as Record<string, Record<string, unknown>>,
   timelineSessionsTable: {} as Record<string, Record<string, unknown>>,
-  scheduledTaskRunIds: undefined as string[] | undefined,
-  runningTaskRunIds: undefined as string[] | undefined,
-  taskRunInfo: {} as Record<
-    string,
-    { taskId: string; running: boolean; nextTimestamp: number } | undefined
-  >,
 }));
 
 vi.mock("~/shared/config", () => ({
@@ -67,14 +55,6 @@ vi.mock("~/store/tinybase/store/main", () => ({
         : mocks.timelineSessionsTable,
     useStore: () => null,
   },
-}));
-
-vi.mock("tinytick/ui-react", () => ({
-  useManager: () => ({
-    getTaskRunInfo: (taskRunId: string) => mocks.taskRunInfo[taskRunId],
-  }),
-  useRunningTaskRunIds: () => mocks.runningTaskRunIds,
-  useScheduledTaskRunIds: () => mocks.scheduledTaskRunIds,
 }));
 
 vi.mock("~/store/zustand/tabs", () => ({
@@ -135,8 +115,20 @@ vi.mock("./anchor", async () => {
 });
 
 vi.mock("./item", () => ({
-  TimelineItemComponent: ({ item }: { item: { id: string } }) => (
-    <div data-testid={`timeline-item-${item.id}`} />
+  TimelineItemComponent: ({
+    isUpcoming,
+    item,
+    itemNodeRef,
+  }: {
+    isUpcoming?: boolean;
+    item: { id: string };
+    itemNodeRef?: (node: HTMLDivElement | null) => void;
+  }) => (
+    <div
+      ref={itemNodeRef}
+      data-testid={`timeline-item-${item.id}`}
+      data-upcoming={isUpcoming ? "true" : undefined}
+    />
   ),
 }));
 
@@ -170,9 +162,6 @@ describe("TimelineView", () => {
     mocks.smartCurrentTimeMs = undefined;
     mocks.timelineEventsTable = {};
     mocks.timelineSessionsTable = {};
-    mocks.scheduledTaskRunIds = undefined;
-    mocks.runningTaskRunIds = undefined;
-    mocks.taskRunInfo = {};
   });
 
   afterEach(() => {
@@ -214,162 +203,6 @@ describe("TimelineView", () => {
     fireEvent.click(calendarButton);
 
     expect(mocks.openNew).toHaveBeenCalledWith({ type: "calendar" });
-  });
-
-  it("shows a due calendar sync status in sidebar chrome", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
-    mocks.scheduledTaskRunIds = ["calendar-sync-run"];
-    mocks.taskRunInfo = {
-      "calendar-sync-run": {
-        taskId: "calendarSync",
-        running: false,
-        nextTimestamp: Date.now(),
-      },
-    };
-
-    const { container } = render(<TimelineView topChromeInset />);
-
-    expect(screen.getByRole("status").textContent).toBe(
-      "Starting calendar sync",
-    );
-    expect(screen.getByRole("status").className).toContain("rounded-full");
-    expect(
-      container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).toContain("h-20");
-  });
-
-  it("updates scheduled calendar sync status as the due window passes", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
-    mocks.scheduledTaskRunIds = ["calendar-sync-run"];
-    mocks.taskRunInfo = {
-      "calendar-sync-run": {
-        taskId: "calendarSync",
-        running: false,
-        nextTimestamp: Date.now() + 2000,
-      },
-    };
-
-    const { rerender } = render(<TimelineView topChromeInset />);
-
-    expect(screen.queryByRole("status")).toBeNull();
-
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
-    mocks.currentTimeMs = Date.now();
-    rerender(<TimelineView topChromeInset />);
-
-    expect(screen.getByRole("status").textContent).toBe(
-      "Starting calendar sync",
-    );
-
-    act(() => {
-      vi.advanceTimersByTime(2500);
-    });
-    mocks.currentTimeMs = Date.now();
-    rerender(<TimelineView topChromeInset />);
-
-    expect(screen.queryByRole("status")).toBeNull();
-  });
-
-  it("shows a running calendar sync status in sidebar chrome", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
-    mocks.runningTaskRunIds = ["calendar-sync-run"];
-    mocks.taskRunInfo = {
-      "calendar-sync-run": {
-        taskId: "calendarSync",
-        running: true,
-        nextTimestamp: Date.now() + 1000,
-      },
-    };
-
-    render(<TimelineView topChromeInset />);
-
-    expect(screen.getByRole("status").textContent).toBe("Syncing calendar");
-  });
-
-  it("hides calendar sync status while visible events are listed", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
-    mocks.currentTimeMs = Date.now();
-    mocks.smartCurrentTimeMs = Date.now();
-    mocks.runningTaskRunIds = ["calendar-sync-run"];
-    mocks.taskRunInfo = {
-      "calendar-sync-run": {
-        taskId: "calendarSync",
-        running: true,
-        nextTimestamp: Date.now() + 1000,
-      },
-    };
-    mocks.timelineEventsTable = {
-      standup: {
-        title: "Team standup",
-        started_at: "2024-01-15T12:30:00.000Z",
-        ended_at: "2024-01-15T13:00:00.000Z",
-        tracking_id_event: "event-standup",
-        has_recurrence_rules: false,
-      },
-    };
-
-    render(<TimelineView topChromeInset />);
-
-    expect(screen.getByTestId("timeline-item-standup")).toBeTruthy();
-    expect(screen.queryByRole("status")).toBeNull();
-  });
-
-  it("keeps calendar sync status visible while scrolled", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
-    mocks.runningTaskRunIds = ["calendar-sync-run"];
-    mocks.taskRunInfo = {
-      "calendar-sync-run": {
-        taskId: "calendarSync",
-        running: true,
-        nextTimestamp: Date.now() + 1000,
-      },
-    };
-
-    const { container } = render(<TimelineView topChromeInset />);
-    const scroller = container.querySelector("[data-sidebar-timeline-scroll]");
-
-    expect(scroller).toBeInstanceOf(HTMLDivElement);
-
-    Object.defineProperty(scroller, "clientHeight", {
-      configurable: true,
-      value: 200,
-    });
-    Object.defineProperty(scroller, "scrollHeight", {
-      configurable: true,
-      value: 1200,
-    });
-    scroller!.scrollTop = 120;
-    fireEvent.scroll(scroller!);
-
-    expect(screen.getByRole("status").textContent).toBe("Syncing calendar");
-    expect(getSidebarActionTabsOrNull()).toBeNull();
-    expect(
-      container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).toContain("h-20");
-  });
-
-  it("hides future repeated calendar sync schedules from sidebar chrome", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
-    mocks.scheduledTaskRunIds = ["calendar-sync-run"];
-    mocks.taskRunInfo = {
-      "calendar-sync-run": {
-        taskId: "calendarSync",
-        running: false,
-        nextTimestamp: Date.now() + 60_000,
-      },
-    };
-
-    render(<TimelineView topChromeInset />);
-
-    expect(screen.queryByRole("status")).toBeNull();
   });
 
   it("keeps the first bucket below the sidebar action chrome", () => {
@@ -559,6 +392,8 @@ describe("TimelineView", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
     mocks.currentTimeMs = Date.now();
+    mocks.isAnchorVisible = false;
+    mocks.isScrolledPastAnchor = true;
     mocks.smartCurrentTimeMs = Date.now();
     mocks.timelineEventsTable = {
       standup: {
@@ -571,16 +406,108 @@ describe("TimelineView", () => {
     };
 
     const { container } = render(<TimelineView topChromeInset />);
+    const scroller = container.querySelector("[data-sidebar-timeline-scroll]");
+    const row = screen.getByTestId("timeline-item-standup");
     const chip = container.querySelector(
       "[data-sidebar-upcoming-meeting-status]",
-    );
+    ) as HTMLElement | null;
+
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    scroller!.scrollTop = 0;
+    scroller!.scrollTo = vi.fn();
+    vi.spyOn(scroller!, "getBoundingClientRect").mockReturnValue({
+      bottom: 400,
+      height: 400,
+      left: 0,
+      right: 240,
+      toJSON: () => ({}),
+      top: 0,
+      width: 240,
+      x: 0,
+      y: 0,
+    });
+    vi.spyOn(row, "getBoundingClientRect").mockReturnValue({
+      bottom: 832,
+      height: 32,
+      left: 0,
+      right: 240,
+      toJSON: () => ({}),
+      top: 800,
+      width: 240,
+      x: 0,
+      y: 800,
+    });
 
     expect(chip?.textContent).toBe("Starts in 51s");
     expect(chip?.className).toContain("bg-destructive");
+    expect(chip?.querySelector("svg")).toBeTruthy();
     expect(chip?.getAttribute("aria-label")).toBe("Team standup starts in 51s");
+    expect(screen.getByTestId("timeline-item-standup").dataset.upcoming).toBe(
+      "true",
+    );
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
     ).toContain("h-12");
+    expect(screen.queryByText("Now")).toBeNull();
+
+    fireEvent.click(chip!);
+
+    expect(scroller!.scrollTo).toHaveBeenCalledWith({
+      top: 636,
+      behavior: "smooth",
+    });
+  });
+
+  it("hides the imminent meeting chip when the meeting row is visible", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.smartCurrentTimeMs = Date.now();
+    mocks.timelineEventsTable = {
+      standup: {
+        title: "Team standup",
+        started_at: "2024-01-15T12:00:51.000Z",
+        ended_at: "2024-01-15T12:30:00.000Z",
+        tracking_id_event: "event-standup",
+        has_recurrence_rules: false,
+      },
+    };
+
+    const { container } = render(<TimelineView topChromeInset />);
+    const scroller = container.querySelector("[data-sidebar-timeline-scroll]");
+    const row = screen.getByTestId("timeline-item-standup");
+
+    vi.spyOn(scroller!, "getBoundingClientRect").mockReturnValue({
+      bottom: 400,
+      height: 400,
+      left: 0,
+      right: 240,
+      toJSON: () => ({}),
+      top: 0,
+      width: 240,
+      x: 0,
+      y: 0,
+    });
+    vi.spyOn(row, "getBoundingClientRect").mockReturnValue({
+      bottom: 120,
+      height: 32,
+      left: 0,
+      right: 240,
+      toJSON: () => ({}),
+      top: 88,
+      width: 240,
+      x: 0,
+      y: 88,
+    });
+
+    fireEvent.scroll(scroller!);
+
+    expect(
+      container.querySelector("[data-sidebar-upcoming-meeting-status]"),
+    ).toBeNull();
   });
 
   it("rounds upcoming meeting minutes down to elapsed whole minutes", () => {

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -13,14 +13,8 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  useManager,
-  useRunningTaskRunIds,
-  useScheduledTaskRunIds,
-} from "tinytick/ui-react";
 
 import { Button } from "@hypr/ui/components/ui/button";
-import { Spinner } from "@hypr/ui/components/ui/spinner";
 import { cn } from "@hypr/utils";
 
 import { useAnchor, useAutoScrollToAnchor } from "./anchor";
@@ -30,6 +24,7 @@ import {
   useCurrentTimeMs,
   useSmartCurrentTime,
 } from "./realtime";
+import { getUpcomingMeetingStatus } from "./upcoming-meeting";
 import {
   buildTimelineBuckets,
   calculateTodayIndicatorPlacement,
@@ -43,7 +38,6 @@ import {
   type TimelineSessionsTable,
 } from "./utils";
 
-import { CALENDAR_SYNC_TASK_ID } from "~/services/calendar";
 import { useConfigValue } from "~/shared/config";
 import { useNativeContextMenu } from "~/shared/hooks/useNativeContextMenu";
 import { useIgnoredEvents } from "~/store/tinybase/hooks";
@@ -57,11 +51,6 @@ import { useTabs } from "~/store/zustand/tabs";
 import { useTimelineSelection } from "~/store/zustand/timeline-selection";
 import { useUndoDelete } from "~/store/zustand/undo-delete";
 import { useListener } from "~/stt/contexts";
-
-const DUE_CALENDAR_SYNC_VISIBLE_WINDOW_MS = 1000;
-const CALENDAR_SYNC_STATUS_TICK_MS = 500;
-const UPCOMING_MEETING_VISIBLE_WINDOW_MS = 5 * 60 * 1000;
-type SidebarCalendarSyncStatus = "idle" | "scheduled" | "syncing";
 
 export function TimelineView({
   showOpenCalendarButton = true,
@@ -77,18 +66,14 @@ export function TimelineView({
   const [isScrolledToBottom, setIsScrolledToBottom] = useState(true);
 
   const { isIgnored } = useIgnoredEvents();
-  const { buckets, hasMoreFutureItems, hasVisibleCalendarEvents } =
-    useTimelineData({
-      isEventIgnored: isIgnored,
-      showIgnored,
-      timelineEventsTable,
-      timelineSessionsTable,
-      timezone,
-    });
+  const { buckets, hasMoreFutureItems } = useTimelineData({
+    isEventIgnored: isIgnored,
+    showIgnored,
+    timelineEventsTable,
+    timelineSessionsTable,
+    timezone,
+  });
   const openNew = useTabs((state) => state.openNew);
-  const calendarSyncStatus = useCalendarSyncStatus();
-  const showCalendarSyncStatus =
-    calendarSyncStatus !== "idle" && !hasVisibleCalendarEvents;
 
   const showOpenCalendarChip =
     showOpenCalendarButton && isScrolledToTop && hasMoreFutureItems;
@@ -101,6 +86,15 @@ export function TimelineView({
   const upcomingMeetingStatus = useMemo(
     () => getUpcomingMeetingStatus(buckets, currentTimeMs),
     [buckets, currentTimeMs],
+  );
+  const [isUpcomingMeetingVisible, setIsUpcomingMeetingVisible] =
+    useState(false);
+  const upcomingMeetingNodeRef = useRef<HTMLDivElement | null>(null);
+  const setUpcomingMeetingNodeRef = useCallback<RefCallback<HTMLDivElement>>(
+    (node) => {
+      upcomingMeetingNodeRef.current = node;
+    },
+    [],
   );
   const activeSessionId = useListener((state) =>
     state.live.status === "active" || state.live.status === "finalizing"
@@ -150,24 +144,20 @@ export function TimelineView({
     registerAnchor: setCurrentTimeIndicatorRef,
     anchorNode: todayAnchorNode,
   } = useAnchor();
-  const showTopNowChip = !isTodayVisible && isScrolledPastToday;
-  const reservedTopChromeChipCount = [
-    showOpenCalendarChip,
-    topChromeInset && showCalendarSyncStatus,
-  ].filter(Boolean).length;
+  const showUpcomingMeetingChip =
+    Boolean(upcomingMeetingStatus) && !isUpcomingMeetingVisible;
+  const showTopNowChip =
+    !showUpcomingMeetingChip && !isTodayVisible && isScrolledPastToday;
+  const hasReservedTopChromeChip = showOpenCalendarChip;
   const topSpacerClassName = topChromeInset
-    ? reservedTopChromeChipCount > 1
-      ? "h-28"
-      : reservedTopChromeChipCount === 1
-        ? "h-20"
-        : "h-12"
+    ? hasReservedTopChromeChip
+      ? "h-20"
+      : "h-12"
     : "h-10";
   const bucketHeaderTopClassName = topChromeInset
-    ? reservedTopChromeChipCount > 1
-      ? "top-28"
-      : reservedTopChromeChipCount === 1
-        ? "top-20"
-        : "top-12"
+    ? hasReservedTopChromeChip
+      ? "top-20"
+      : "top-12"
     : "top-0";
   const selectedSessionScrollFrameRef = useRef<number | null>(null);
   const scrollSelectedSessionIntoView = useCallback<
@@ -190,6 +180,14 @@ export function TimelineView({
     },
     [containerRef, currentTab],
   );
+  const scrollToUpcomingMeeting = useCallback(() => {
+    const node = upcomingMeetingNodeRef.current;
+    if (!node) {
+      return;
+    }
+
+    scrollTimelineItemIntoView(containerRef.current, node);
+  }, [containerRef]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -207,6 +205,9 @@ export function TimelineView({
 
       setIsScrolledToTop(scrolledToTop);
       setIsScrolledToBottom(maxScrollTop - nextScrollTop <= 12);
+      setIsUpcomingMeetingVisible(
+        isTimelineItemVisible(container, upcomingMeetingNodeRef.current),
+      );
     };
 
     updateScrollPosition();
@@ -217,7 +218,12 @@ export function TimelineView({
     return () => {
       container.removeEventListener("scroll", updateScrollPosition);
     };
-  }, [containerRef, buckets.length, flatItemKeys.length]);
+  }, [
+    containerRef,
+    buckets.length,
+    flatItemKeys.length,
+    upcomingMeetingStatus?.itemKey,
+  ]);
 
   const scrollFadeMask = useMemo(() => {
     return getTimelineScrollFadeMask({
@@ -398,6 +404,8 @@ export function TimelineView({
                   timezone={timezone}
                   selectedIds={selectedIds}
                   flatItemKeys={flatItemKeys}
+                  upcomingItemKey={upcomingMeetingStatus?.itemKey}
+                  upcomingItemNodeRef={setUpcomingMeetingNodeRef}
                 />
               ) : (
                 bucket.items.map((item) => {
@@ -416,6 +424,12 @@ export function TimelineView({
                       selectedNodeRef={
                         selected ? scrollSelectedSessionIntoView : undefined
                       }
+                      itemNodeRef={
+                        itemKey === upcomingMeetingStatus?.itemKey
+                          ? setUpcomingMeetingNodeRef
+                          : undefined
+                      }
+                      isUpcoming={itemKey === upcomingMeetingStatus?.itemKey}
                     />
                   );
                 })
@@ -441,19 +455,14 @@ export function TimelineView({
           data-sidebar-timeline-top-fade
           className={cn([
             "pointer-events-none absolute inset-x-0 top-0 z-[15]",
-            reservedTopChromeChipCount > 1
-              ? "bg-background h-28"
-              : reservedTopChromeChipCount === 1
-                ? "bg-background h-20"
-                : "from-background via-background/95 to-background/0 h-16 bg-linear-to-b from-60% via-85%",
+            hasReservedTopChromeChip
+              ? "bg-background h-20"
+              : "from-background via-background/95 to-background/0 h-16 bg-linear-to-b from-60% via-85%",
           ])}
         />
       )}
 
-      {(showOpenCalendarChip ||
-        (topChromeInset && showCalendarSyncStatus) ||
-        upcomingMeetingStatus ||
-        showTopNowChip) && (
+      {(showOpenCalendarChip || showUpcomingMeetingChip || showTopNowChip) && (
         <div
           className={cn([
             "absolute left-1/2 z-20 flex -translate-x-1/2 transform flex-col items-center gap-2",
@@ -469,12 +478,10 @@ export function TimelineView({
               Open calendar
             </TimelineTopChip>
           )}
-          {topChromeInset && showCalendarSyncStatus && (
-            <SidebarCalendarSyncStatus status={calendarSyncStatus} />
-          )}
-          {upcomingMeetingStatus && (
+          {upcomingMeetingStatus && showUpcomingMeetingChip && (
             <SidebarUpcomingMeetingStatus
               label={upcomingMeetingStatus.label}
+              onClick={scrollToUpcomingMeeting}
               title={upcomingMeetingStatus.title}
             />
           )}
@@ -484,7 +491,7 @@ export function TimelineView({
         </div>
       )}
 
-      {!isTodayVisible && !isScrolledPastToday && (
+      {!showUpcomingMeetingChip && !isTodayVisible && !isScrolledPastToday && (
         <TimelineNowChip
           onClick={scrollToToday}
           direction="down"
@@ -500,54 +507,21 @@ export function TimelineView({
 
 function SidebarUpcomingMeetingStatus({
   label,
+  onClick,
   title,
 }: {
   label: string;
+  onClick: () => void;
   title: string;
 }) {
   return (
     <TimelineTopChip
-      role="status"
       aria-live="polite"
       ariaLabel={`${title || "Meeting"} ${label.toLowerCase()}`}
       data-sidebar-upcoming-meeting-status
       className="border-destructive bg-destructive text-destructive-foreground shadow-md"
-      icon={
-        <span
-          aria-hidden
-          className="bg-destructive-foreground size-2 rounded-full"
-        />
-      }
-    >
-      {label}
-    </TimelineTopChip>
-  );
-}
-
-function SidebarCalendarSyncStatus({
-  status,
-}: {
-  status: SidebarCalendarSyncStatus;
-}) {
-  if (status === "idle") {
-    return null;
-  }
-
-  const label =
-    status === "scheduled" ? "Starting calendar sync" : "Syncing calendar";
-
-  return (
-    <TimelineTopChip
-      role="status"
-      aria-live="polite"
-      data-sidebar-calendar-sync-status
-      icon={
-        status === "syncing" ? (
-          <Spinner size={12} />
-        ) : (
-          <CalendarDaysIcon size={12} />
-        )
-      }
+      icon={<ArrowUpIcon aria-hidden className="size-3" strokeWidth={2.4} />}
+      onClick={onClick}
     >
       {label}
     </TimelineTopChip>
@@ -567,7 +541,6 @@ function TimelineTopChip({
   className?: string;
   role?: string;
   "aria-live"?: "off" | "polite" | "assertive";
-  "data-sidebar-calendar-sync-status"?: true;
   "data-sidebar-upcoming-meeting-status"?: true;
   onClick?: () => void;
 }) {
@@ -641,56 +614,6 @@ function isFutureBucketLabel(label: string) {
   );
 }
 
-function getUpcomingMeetingStatus(
-  buckets: TimelineBucket[],
-  currentTimeMs: number,
-): { label: string; title: string } | null {
-  let nearest: { title: string; diffMs: number } | null = null;
-
-  for (const bucket of buckets) {
-    for (const item of bucket.items) {
-      if (item.type === "event" && item.data.is_all_day) {
-        continue;
-      }
-
-      const timestamp = getItemTimestamp(item);
-      if (!timestamp) {
-        continue;
-      }
-
-      const diffMs = timestamp.getTime() - currentTimeMs;
-      if (diffMs <= 0 || diffMs > UPCOMING_MEETING_VISIBLE_WINDOW_MS) {
-        continue;
-      }
-
-      if (!nearest || diffMs < nearest.diffMs) {
-        nearest = {
-          title: item.data.title || "Untitled",
-          diffMs,
-        };
-      }
-    }
-  }
-
-  if (!nearest) {
-    return null;
-  }
-
-  return {
-    label: formatUpcomingMeetingLabel(nearest.diffMs),
-    title: nearest.title,
-  };
-}
-
-function formatUpcomingMeetingLabel(diffMs: number): string {
-  const totalSeconds = Math.max(1, Math.floor(diffMs / 1000));
-  if (totalSeconds < 60) {
-    return `Starts in ${totalSeconds}s`;
-  }
-
-  return `Starts in ${Math.floor(totalSeconds / 60)}m`;
-}
-
 function TimelineNowChip({
   className,
   direction,
@@ -759,6 +682,8 @@ function TodayBucket({
   timezone,
   selectedIds,
   flatItemKeys,
+  upcomingItemKey,
+  upcomingItemNodeRef,
 }: {
   items: TimelineItem[];
   precision: TimelinePrecision;
@@ -769,6 +694,8 @@ function TodayBucket({
   timezone?: string;
   selectedIds: string[];
   flatItemKeys: string[];
+  upcomingItemKey?: string;
+  upcomingItemNodeRef: RefCallback<HTMLDivElement>;
 }) {
   const currentTimeMs = useCurrentTimeMs();
 
@@ -841,6 +768,10 @@ function TodayBucket({
           multiSelected={selectedIds.includes(itemKey)}
           flatItemKeys={flatItemKeys}
           selectedNodeRef={selected ? selectedNodeRef : undefined}
+          itemNodeRef={
+            itemKey === upcomingItemKey ? upcomingItemNodeRef : undefined
+          }
+          isUpcoming={itemKey === upcomingItemKey}
         />
       );
 
@@ -903,6 +834,8 @@ function TodayBucket({
     timezone,
     selectedIds,
     flatItemKeys,
+    upcomingItemKey,
+    upcomingItemNodeRef,
   ]);
 
   return renderedEntries;
@@ -942,38 +875,22 @@ function scrollTimelineItemIntoView(
   });
 }
 
-function useCalendarSyncStatus(): SidebarCalendarSyncStatus {
-  const manager = useManager();
-  const scheduledTaskRunIds = useScheduledTaskRunIds();
-  const runningTaskRunIds = useRunningTaskRunIds();
-  const currentTimeMs = useCurrentTimeMs(CALENDAR_SYNC_STATUS_TICK_MS);
+function isTimelineItemVisible(
+  container: HTMLDivElement | null,
+  item: HTMLDivElement | null,
+) {
+  if (!container || !item) {
+    return false;
+  }
 
-  return useMemo(() => {
-    if (!manager) {
-      return "idle";
-    }
+  const containerRect = container.getBoundingClientRect();
+  const itemRect = item.getBoundingClientRect();
+  const margin = 8;
 
-    const hasRunningSync = runningTaskRunIds?.some(
-      (taskRunId) =>
-        manager.getTaskRunInfo(taskRunId)?.taskId === CALENDAR_SYNC_TASK_ID,
-    );
-    if (hasRunningSync) {
-      return "syncing";
-    }
-
-    const visibleFrom = currentTimeMs - DUE_CALENDAR_SYNC_VISIBLE_WINDOW_MS;
-    const visibleUntil = currentTimeMs + DUE_CALENDAR_SYNC_VISIBLE_WINDOW_MS;
-    const hasDueScheduledSync = scheduledTaskRunIds?.some((taskRunId) => {
-      const info = manager.getTaskRunInfo(taskRunId);
-      return (
-        info?.taskId === CALENDAR_SYNC_TASK_ID &&
-        info.nextTimestamp >= visibleFrom &&
-        info.nextTimestamp <= visibleUntil
-      );
-    });
-
-    return hasDueScheduledSync ? "scheduled" : "idle";
-  }, [manager, scheduledTaskRunIds, runningTaskRunIds, currentTimeMs]);
+  return (
+    itemRect.bottom > containerRect.top + margin &&
+    itemRect.top < containerRect.bottom - margin
+  );
 }
 
 function useTimelineTables(): {

--- a/apps/desktop/src/sidebar/timeline/item.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.test.tsx
@@ -229,6 +229,70 @@ describe("TimelineItemComponent", () => {
     );
   });
 
+  it("highlights an upcoming meeting row", () => {
+    render(
+      <TimelineItemComponent
+        item={{
+          type: "event",
+          id: "event-standup",
+          data: {
+            title: "Team standup",
+            started_at: "2024-01-15T10:30:00.000Z",
+            ended_at: "2024-01-15T11:00:00.000Z",
+            tracking_id_event: "tracking-standup",
+            has_recurrence_rules: false,
+          },
+        }}
+        precision="time"
+        selected={false}
+        timezone="UTC"
+        multiSelected={false}
+        flatItemKeys={["event-event-standup"]}
+        isUpcoming
+      />,
+    );
+
+    const rowButton = screen.getByText("Team standup").closest("button");
+
+    expect(rowButton?.className).toContain("bg-destructive/8");
+    expect(rowButton?.className).toContain("motion-safe:animate-pulse");
+    expect(rowButton?.className).not.toContain("shadow-[0_0_22px");
+    expect(rowButton?.className).not.toContain("ring-1");
+    expect(rowButton?.className).not.toContain("opacity-65");
+  });
+
+  it("exposes an arbitrary timeline row for visibility checks", () => {
+    const itemNodeRef = vi.fn();
+
+    render(
+      <TimelineItemComponent
+        item={{
+          type: "event",
+          id: "event-standup",
+          data: {
+            title: "Team standup",
+            started_at: "2024-01-15T10:30:00.000Z",
+            ended_at: "2024-01-15T11:00:00.000Z",
+            tracking_id_event: "tracking-standup",
+            has_recurrence_rules: false,
+          },
+        }}
+        precision="time"
+        selected={false}
+        timezone="UTC"
+        multiSelected={false}
+        flatItemKeys={["event-event-standup"]}
+        itemNodeRef={itemNodeRef}
+      />,
+    );
+
+    const row = screen
+      .getByText("Team standup")
+      .closest("button")?.parentElement;
+
+    expect(itemNodeRef.mock.calls.some(([node]) => node === row)).toBe(true);
+  });
+
   it("renders finalizing session spinner at the end of the row", () => {
     mocks.sessionMode = "finalizing";
     mocks.storeTitle = "Finalizing Note";

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -50,6 +50,8 @@ export const TimelineItemComponent = memo(
     multiSelected,
     flatItemKeys,
     selectedNodeRef,
+    itemNodeRef,
+    isUpcoming,
   }: {
     item: TimelineItem;
     precision: TimelinePrecision;
@@ -58,6 +60,8 @@ export const TimelineItemComponent = memo(
     multiSelected: boolean;
     flatItemKeys: string[];
     selectedNodeRef?: RefCallback<HTMLDivElement>;
+    itemNodeRef?: RefCallback<HTMLDivElement>;
+    isUpcoming?: boolean;
   }) => {
     if (item.type === "event") {
       return (
@@ -69,6 +73,8 @@ export const TimelineItemComponent = memo(
           multiSelected={multiSelected}
           flatItemKeys={flatItemKeys}
           selectedNodeRef={selectedNodeRef}
+          itemNodeRef={itemNodeRef}
+          isUpcoming={isUpcoming}
         />
       );
     }
@@ -81,6 +87,8 @@ export const TimelineItemComponent = memo(
         multiSelected={multiSelected}
         flatItemKeys={flatItemKeys}
         selectedNodeRef={selectedNodeRef}
+        itemNodeRef={itemNodeRef}
+        isUpcoming={isUpcoming}
       />
     );
   },
@@ -104,7 +112,9 @@ function ItemBase({
   contextMenu,
   draggable,
   selectedNodeRef,
+  itemNodeRef,
   timelineSessionId,
+  isUpcoming,
 }: {
   title: string;
   displayTime: string;
@@ -123,15 +133,24 @@ function ItemBase({
   contextMenu: MenuItemDef[];
   draggable?: boolean;
   selectedNodeRef?: RefCallback<HTMLDivElement>;
+  itemNodeRef?: RefCallback<HTMLDivElement>;
   timelineSessionId?: string;
+  isUpcoming?: boolean;
 }) {
   const hasSelection = useTimelineSelection((s) => s.selectedIds.length > 0);
   const showLiveStop = isLive && onStop;
   const showTrailingStatus = showLiveStop || showSpinner;
+  const setItemRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      selectedNodeRef?.(node);
+      itemNodeRef?.(node);
+    },
+    [selectedNodeRef, itemNodeRef],
+  );
 
   return (
     <div
-      ref={selectedNodeRef}
+      ref={setItemRef}
       data-sidebar-timeline-session-id={timelineSessionId}
       className="group/sidebar-live-item relative"
     >
@@ -148,12 +167,17 @@ function ItemBase({
           multiSelected && "bg-accent",
           !multiSelected && selected && "bg-accent",
           !multiSelected && !selected && "hover:bg-accent/50",
+          isUpcoming &&
+            !isLive && [
+              "bg-destructive/8 text-foreground motion-safe:animate-pulse",
+              "hover:bg-destructive/12 focus-visible:ring-destructive/25",
+            ],
           isLive && [
             "bg-destructive text-destructive-foreground hover:bg-destructive/90",
             "focus-visible:ring-destructive/40 focus-visible:ring-2 focus-visible:outline-hidden",
           ],
           ignored && "opacity-40",
-          !ignored && muted && !isLive && "opacity-65",
+          !ignored && muted && !isLive && !isUpcoming && "opacity-65",
         ])}
         draggable={draggable}
       >
@@ -239,6 +263,8 @@ const EventItem = memo(
     multiSelected,
     flatItemKeys,
     selectedNodeRef,
+    itemNodeRef,
+    isUpcoming,
   }: {
     item: EventTimelineItem;
     precision: TimelinePrecision;
@@ -247,6 +273,8 @@ const EventItem = memo(
     multiSelected: boolean;
     flatItemKeys: string[];
     selectedNodeRef?: RefCallback<HTMLDivElement>;
+    itemNodeRef?: RefCallback<HTMLDivElement>;
+    isUpcoming?: boolean;
   }) => {
     const store = main.UI.useStore(main.STORE_ID);
     const openCurrent = useTabs((state) => state.openCurrent);
@@ -387,6 +415,8 @@ const EventItem = memo(
         onShiftClick={handleShiftClick}
         contextMenu={contextMenu}
         selectedNodeRef={selected ? selectedNodeRef : undefined}
+        itemNodeRef={itemNodeRef}
+        isUpcoming={isUpcoming}
       />
     );
   },
@@ -401,6 +431,8 @@ const SessionItem = memo(
     multiSelected,
     flatItemKeys,
     selectedNodeRef,
+    itemNodeRef,
+    isUpcoming,
   }: {
     item: SessionTimelineItem;
     precision: TimelinePrecision;
@@ -409,6 +441,8 @@ const SessionItem = memo(
     multiSelected: boolean;
     flatItemKeys: string[];
     selectedNodeRef?: RefCallback<HTMLDivElement>;
+    itemNodeRef?: RefCallback<HTMLDivElement>;
+    isUpcoming?: boolean;
   }) => {
     const store = main.UI.useStore(main.STORE_ID);
     const indexes = main.UI.useIndexes(main.STORE_ID);
@@ -576,7 +610,9 @@ const SessionItem = memo(
           onDragStart={handleDragStart}
           contextMenu={contextMenu}
           selectedNodeRef={selected ? selectedNodeRef : undefined}
+          itemNodeRef={itemNodeRef}
           timelineSessionId={sessionId}
+          isUpcoming={isUpcoming}
           draggable
         />
       </SessionPreviewCard>

--- a/apps/desktop/src/sidebar/timeline/upcoming-meeting.ts
+++ b/apps/desktop/src/sidebar/timeline/upcoming-meeting.ts
@@ -1,0 +1,111 @@
+import { useMemo } from "react";
+
+import { useCurrentTimeMs } from "./realtime";
+import {
+  buildTimelineBuckets,
+  deriveTimelineWindowData,
+  getItemTimestamp,
+  type TimelineBucket,
+} from "./utils";
+
+import { useConfigValue } from "~/shared/config";
+import { useIgnoredEvents } from "~/store/tinybase/hooks";
+import * as main from "~/store/tinybase/store/main";
+
+const UPCOMING_MEETING_VISIBLE_WINDOW_MS = 5 * 60 * 1000;
+const UPCOMING_MEETING_STATUS_TICK_MS = 1000;
+
+export type SidebarUpcomingMeetingStatus = {
+  itemKey: string;
+  label: string;
+  title: string;
+};
+
+export function useSidebarUpcomingMeetingStatus(): SidebarUpcomingMeetingStatus | null {
+  const timezone = useConfigValue("timezone") || undefined;
+  const { isIgnored } = useIgnoredEvents();
+  const timelineEventsTable = main.UI.useResultTable(
+    main.QUERIES.timelineEvents,
+    main.STORE_ID,
+  );
+  const timelineSessionsTable = main.UI.useResultTable(
+    main.QUERIES.timelineSessions,
+    main.STORE_ID,
+  );
+  const currentTimeMs = useCurrentTimeMs(UPCOMING_MEETING_STATUS_TICK_MS);
+
+  return useMemo(() => {
+    const windowData = deriveTimelineWindowData({
+      isEventIgnored: isIgnored,
+      showIgnored: false,
+      timelineEventsTable,
+      timelineSessionsTable,
+      timezone,
+    });
+    const buckets = buildTimelineBuckets({
+      timelineEventsTable: windowData.timelineEventsTable,
+      timelineSessionsTable: windowData.timelineSessionsTable,
+      timezone,
+    });
+
+    return getUpcomingMeetingStatus(buckets, currentTimeMs);
+  }, [
+    currentTimeMs,
+    isIgnored,
+    timelineEventsTable,
+    timelineSessionsTable,
+    timezone,
+  ]);
+}
+
+export function getUpcomingMeetingStatus(
+  buckets: TimelineBucket[],
+  currentTimeMs: number,
+): SidebarUpcomingMeetingStatus | null {
+  let nearest: { itemKey: string; title: string; diffMs: number } | null = null;
+
+  for (const bucket of buckets) {
+    for (const item of bucket.items) {
+      if (item.type === "event" && item.data.is_all_day) {
+        continue;
+      }
+
+      const timestamp = getItemTimestamp(item);
+      if (!timestamp) {
+        continue;
+      }
+
+      const diffMs = timestamp.getTime() - currentTimeMs;
+      if (diffMs <= 0 || diffMs > UPCOMING_MEETING_VISIBLE_WINDOW_MS) {
+        continue;
+      }
+
+      if (!nearest || diffMs < nearest.diffMs) {
+        nearest = {
+          itemKey: `${item.type}-${item.id}`,
+          title: item.data.title || "Untitled",
+          diffMs,
+        };
+      }
+    }
+  }
+
+  if (!nearest) {
+    return null;
+  }
+
+  return {
+    itemKey: nearest.itemKey,
+    label: formatUpcomingMeetingLabel(nearest.diffMs),
+    title: nearest.title,
+  };
+}
+
+function formatUpcomingMeetingLabel(diffMs: number): string {
+  const totalSeconds = Math.max(1, Math.floor(diffMs / 1000));
+  if (totalSeconds < 60) {
+    return `Starts in ${totalSeconds}s`;
+  }
+
+  return `Starts in ${Math.floor(totalSeconds / 60)}m`;
+}


### PR DESCRIPTION
Render the imminent meeting chip with an arrow icon and use a red collapsed-sidebar badge when that status is active.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5610 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5600 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop sidebar UI and timeline chrome only; no auth, data, or payment paths. Removing calendar-sync status from the timeline is a visible behavior change for that indicator.
> 
> **Overview**
> Adds **imminent meeting** surfacing in the desktop sidebar timeline and main chrome when the sidebar is collapsed.
> 
> The timeline shows a destructive **“Starts in …”** chip with an **arrow** icon when the nearest event starts within five minutes and the row is **off-screen**; clicking it **smooth-scrolls** to that event. The chip hides while the meeting row is visible, and the matching row gets a subtle **pulsing** highlight. The top **Now** chip is suppressed while the upcoming chip is shown.
> 
> **Collapsed sidebar** toggle badges are extended: a **red** dot for an imminent meeting **wins over** the blue update badge. Shared logic lives in **`upcoming-meeting`** (`useSidebarUpcomingMeetingStatus` + `getUpcomingMeetingStatus` with `itemKey`).
> 
> **Calendar sync** status chips and related tinytick wiring are **removed** from timeline top chrome; spacing rules are simplified accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6b44e58be5ca6c9308ce0ee3b690e8e474d3445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->