### PR TITLE
Remove devtools panel backdrop shadow

### DIFF
--- a/apps/desktop/src/devtools-panel/host.tsx
+++ b/apps/desktop/src/devtools-panel/host.tsx
@@ -27,7 +27,10 @@ import {
 import { showBatchCompletedNotification } from "~/store/zustand/listener/general-batch";
 import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
-import { createAutoStopEndedNotificationKey } from "~/stt/auto-stop-notification";
+import {
+  AUTO_STOP_CONFIRM_TIMEOUT_SECONDS,
+  createAutoStopEndedNotificationKey,
+} from "~/stt/auto-stop-notification";
 import { commands } from "~/types/tauri.gen";
 
 const canResolveDevtoolsPanel = import.meta.env.MODE !== "test";
@@ -270,7 +273,7 @@ function useDevtoolsPanelActions() {
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         location: "Conference Room",
       },
-      action_label: "Open notes",
+      action_label: "Open Anarlog",
       action_variant: null,
       options: null,
       footer: null,
@@ -336,14 +339,13 @@ function useDevtoolsPanelActions() {
     await notificationCommands.showNotification({
       key: createAutoStopEndedNotificationKey(sessionId),
       title: "Did your meeting end?",
-      message:
-        "Google Chrome stopped using the microphone before the scheduled end time.",
-      timeout: { secs: 60, nanos: 0 },
+      message: `Anarlog will stop listening in ${AUTO_STOP_CONFIRM_TIMEOUT_SECONDS} seconds.`,
+      timeout: { secs: AUTO_STOP_CONFIRM_TIMEOUT_SECONDS, nanos: 0 },
       source: null,
       start_time: null,
       participants: null,
       event_details: null,
-      action_label: "Stop meeting",
+      action_label: "Stop",
       action_variant: "destructive",
       options: null,
       footer: null,

--- a/apps/desktop/src/services/event-listeners.tsx
+++ b/apps/desktop/src/services/event-listeners.tsx
@@ -69,7 +69,7 @@ function shouldAutoStartNotificationSession(
 }
 
 function handleAutoStopEndedNotification(
-  type: "notification_confirm" | "notification_accept",
+  type: "notification_confirm" | "notification_accept" | "notification_timeout",
   key: string,
 ): boolean {
   const sessionId = parseAutoStopEndedNotificationKey(key);
@@ -77,7 +77,7 @@ function handleAutoStopEndedNotification(
     return false;
   }
 
-  if (type !== "notification_accept") {
+  if (type === "notification_confirm") {
     return true;
   }
 
@@ -362,9 +362,14 @@ function useNotificationEvents() {
       .listen(({ payload }) => {
         if (
           payload.type === "notification_confirm" ||
-          payload.type === "notification_accept"
+          payload.type === "notification_accept" ||
+          payload.type === "notification_timeout"
         ) {
           if (handleAutoStopEndedNotification(payload.type, payload.key)) {
+            return;
+          }
+
+          if (payload.type === "notification_timeout") {
             return;
           }
 

--- a/apps/desktop/src/services/event-notification/index.test.ts
+++ b/apps/desktop/src/services/event-notification/index.test.ts
@@ -58,7 +58,7 @@ describe("checkEventNotifications", () => {
     expect(showNotificationMock).toHaveBeenCalledWith(
       expect.objectContaining({
         source: { type: "calendar_event", event_id: "event-1" },
-        action_label: "Open notes",
+        action_label: "Open Anarlog",
         participants: null,
         event_details: null,
         options: null,

--- a/apps/desktop/src/services/event-notification/index.ts
+++ b/apps/desktop/src/services/event-notification/index.ts
@@ -90,7 +90,7 @@ export function checkEventNotifications(
         start_time: Math.floor(startTime.getTime() / 1000),
         participants: null,
         event_details: null,
-        action_label: "Open notes",
+        action_label: "Open Anarlog",
         action_variant: null,
         options: null,
         footer: null,

--- a/apps/desktop/src/stt/auto-stop-notification.ts
+++ b/apps/desktop/src/stt/auto-stop-notification.ts
@@ -1,5 +1,6 @@
 export const AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX =
   "auto-stop-ended:" as const;
+export const AUTO_STOP_CONFIRM_TIMEOUT_SECONDS = 30;
 
 const AUTO_STOP_ENDED_NOTIFICATION_KEY_NONCE_SEPARATOR = ":prompt:";
 

--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -893,7 +893,7 @@ describe("ListenerProvider detect events", () => {
         start_time: null,
         participants: null,
         event_details: null,
-        action_label: "Stop meeting",
+        action_label: "Stop",
         action_variant: "destructive",
         options: null,
         footer: null,

--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -887,8 +887,8 @@ describe("ListenerProvider detect events", () => {
       expect(notification).toEqual({
         key: expect.stringContaining("auto-stop-ended:session-1"),
         title: "Did your meeting end?",
-        message: `${browser.name} stopped using the microphone before the scheduled end time.`,
-        timeout: { secs: 60, nanos: 0 },
+        message: "Anarlog will stop listening in 30 seconds.",
+        timeout: { secs: 30, nanos: 0 },
         source: null,
         start_time: null,
         participants: null,

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -11,7 +11,10 @@ import {
   type NotificationIcon,
 } from "@hypr/plugin-notification";
 
-import { createAutoStopEndedNotificationKey } from "./auto-stop-notification";
+import {
+  AUTO_STOP_CONFIRM_TIMEOUT_SECONDS,
+  createAutoStopEndedNotificationKey,
+} from "./auto-stop-notification";
 
 import { getSessionEventById } from "~/session/utils";
 import * as main from "~/store/tinybase/store/main";
@@ -261,11 +264,6 @@ function getAutoStopActiveCheckAppIds(
   return [...new Set([...candidateAppIds, ...unreliableTriggerAppIds])];
 }
 
-function getStoppedAppLabel(app: MicApp | null) {
-  const name = app ? getNotificationAppName(app).trim() : "";
-  return name || "The meeting app";
-}
-
 function showMeetingEndedPrompt({
   sessionId,
   stoppedTriggerAppIds,
@@ -280,8 +278,8 @@ function showMeetingEndedPrompt({
   void notificationCommands.showNotification({
     key: createAutoStopEndedNotificationKey(sessionId),
     title: "Did your meeting end?",
-    message: `${getStoppedAppLabel(app)} stopped using the microphone before the scheduled end time.`,
-    timeout: { secs: 60, nanos: 0 },
+    message: `Anarlog will stop listening in ${AUTO_STOP_CONFIRM_TIMEOUT_SECONDS} seconds.`,
+    timeout: { secs: AUTO_STOP_CONFIRM_TIMEOUT_SECONDS, nanos: 0 },
     source: null,
     start_time: null,
     participants: null,

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -286,7 +286,7 @@ function showMeetingEndedPrompt({
     start_time: null,
     participants: null,
     event_details: null,
-    action_label: "Stop meeting",
+    action_label: "Stop",
     action_variant: "destructive",
     options: null,
     footer: null,

--- a/crates/notification-macos/examples/test_notification_with_event.rs
+++ b/crates/notification-macos/examples/test_notification_with_event.rs
@@ -65,7 +65,7 @@ fn main() {
             })
             .participants(participants)
             .event_details(event_details)
-            .action_label("Take Notes")
+            .action_label("Open Anarlog")
             .start_time(start_time)
             .build();
 

--- a/crates/notification-macos/swift-lib/src/Constants.swift
+++ b/crates/notification-macos/swift-lib/src/Constants.swift
@@ -12,6 +12,7 @@ enum Layout {
   static let slideInOffset: CGFloat = 10
   static let buttonOverhang: CGFloat = 8
   static let cornerRadius: CGFloat = 14
+  static let liquidGlassCornerRadius: CGFloat = 22
   static let contentPaddingHorizontal: CGFloat = 12
   static let contentPaddingVertical: CGFloat = 9
   static let expandedPaddingHorizontal: CGFloat = 16
@@ -44,8 +45,8 @@ enum Fonts {
 }
 
 enum Colors {
-  static let buttonNormalBg = NSColor(calibratedWhite: 0.95, alpha: 0.9).cgColor
-  static let buttonPressedBg = NSColor(calibratedWhite: 0.85, alpha: 0.9).cgColor
+  static let buttonNormalBg = NSColor(calibratedWhite: 1.0, alpha: 0.42).cgColor
+  static let buttonPressedBg = NSColor(calibratedWhite: 1.0, alpha: 0.62).cgColor
   static let notificationBg = NSColor(calibratedWhite: 0.92, alpha: 0.85).cgColor
   static let actionButtonBg = NSColor(calibratedWhite: 0.35, alpha: 0.95).cgColor
   static let actionButtonPressedBg = NSColor(calibratedWhite: 0.25, alpha: 0.95).cgColor

--- a/crates/notification-macos/swift-lib/src/Models.swift
+++ b/crates/notification-macos/swift-lib/src/Models.swift
@@ -230,6 +230,10 @@ struct NotificationPayload: Codable {
     return actionVariant == .destructive
   }
 
+  var showsStopCountdown: Bool {
+    return isDestructiveAction && actionLabel == "Stop" && timeoutSeconds > 0
+  }
+
   var hasOptions: Bool {
     guard let options = options else { return false }
     return !options.isEmpty

--- a/crates/notification-macos/swift-lib/src/NotificationButtons.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationButtons.swift
@@ -123,9 +123,9 @@ class NotificationButton: NSButton {
       bezelColor = NSColor(calibratedWhite: 0.9, alpha: 1.0)
     }
 
-    layer?.cornerRadius = 8
+    layer?.cornerRadius = 14
     layer?.backgroundColor = normalBackgroundColor
-    layer?.borderColor = NSColor(calibratedWhite: 0.7, alpha: 0.5).cgColor
+    layer?.borderColor = NSColor.white.withAlphaComponent(0.55).cgColor
     layer?.borderWidth = 0.5
 
     layer?.shadowColor = NSColor(calibratedWhite: 0.0, alpha: 0.5).cgColor
@@ -136,9 +136,14 @@ class NotificationButton: NSButton {
 
   override var intrinsicContentSize: NSSize {
     var s = super.intrinsicContentSize
-    s.width += 12
-    s.height = max(24, s.height + 2)
+    s.width += 18
+    s.height = max(28, s.height + 4)
     return s
+  }
+
+  override func layout() {
+    super.layout()
+    layer?.cornerRadius = bounds.height / 2
   }
 
   func animatePress() {
@@ -157,6 +162,7 @@ class NotificationButton: NSButton {
   func configureDestructiveAction(label: String) {
     title = label
     imagePosition = .imageLeft
+    imageHugsTitle = true
     imageScaling = .scaleProportionallyDown
 
     if #available(macOS 11.0, *) {

--- a/crates/notification-macos/swift-lib/src/NotificationButtons.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationButtons.swift
@@ -215,6 +215,8 @@ class CompactActionButton: ActionButton {
     }
   }
   var onProgressComplete: (() -> Void)?
+  private var progressBaseBackgroundColor = Colors.compactActionButtonElapsedBg
+  private var progressFillColor = Colors.compactActionButtonRemainingBg
 
   override init(frame frameRect: NSRect) {
     super.init(frame: frameRect)
@@ -237,7 +239,7 @@ class CompactActionButton: ActionButton {
       layer?.cornerCurve = .continuous
     }
 
-    progressLayer.backgroundColor = Colors.compactActionButtonRemainingBg
+    progressLayer.backgroundColor = progressFillColor
     progressLayer.anchorPoint = CGPoint(x: 0, y: 0.5)
     progressLayer.isHidden = true
     layer?.addSublayer(progressLayer)
@@ -256,6 +258,12 @@ class CompactActionButton: ActionButton {
     DispatchQueue.main.asyncAfter(deadline: .now() + Timing.buttonPress) {
       self.alphaValue = 1.0
     }
+  }
+
+  func configureDestructiveCountdownStyle() {
+    progressBaseBackgroundColor = Colors.actionButtonDestructivePressedBg
+    progressFillColor = Colors.actionButtonDestructiveBg
+    progressLayer.backgroundColor = progressFillColor
   }
 
   private func syncProgressLayerFrame() {
@@ -317,7 +325,8 @@ class CompactActionButton: ActionButton {
     isCountdownActive = true
     progressRatio = 1.0
 
-    layer?.backgroundColor = Colors.compactActionButtonElapsedBg
+    layer?.backgroundColor = progressBaseBackgroundColor
+    progressLayer.backgroundColor = progressFillColor
     progressLayer.isHidden = false
     progressLayer.removeAllAnimations()
     syncProgressLayerFrame()
@@ -363,7 +372,7 @@ class CompactActionButton: ActionButton {
     clearProgressState()
 
     if showsProgress {
-      layer?.backgroundColor = Colors.buttonNormalBg
+      layer?.backgroundColor = progressBaseBackgroundColor
     }
 
     CATransaction.begin()

--- a/crates/notification-macos/swift-lib/src/NotificationInstance.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationInstance.swift
@@ -23,6 +23,8 @@ class NotificationInstance {
   var meetingStartTime: Date?
   weak var timerLabel: NSTextField?
   weak var compactMessageLabel: NSTextField?
+  weak var stopCountdownLabel: NSTextField?
+  var stopCountdownTimer: Timer?
 
   init(
     payload: NotificationPayload, panel: NSPanel, clickableView: ClickableView, creationIndex: Int
@@ -60,6 +62,11 @@ class NotificationInstance {
     timerLabel = nil
   }
 
+  func bindStopCountdownLabel(_ label: NSTextField) {
+    stopCountdownLabel = label
+    updateStopCountdownLabel(remainingSeconds: payload.timeoutSeconds)
+  }
+
   func startScheduleUpdates() {
     guard let meetingStartTime else { return }
     updateScheduleLabels()
@@ -75,8 +82,11 @@ class NotificationInstance {
   func stopScheduleUpdates() {
     countdownTimer?.invalidate()
     countdownTimer = nil
+    stopCountdownTimer?.invalidate()
+    stopCountdownTimer = nil
     timerLabel = nil
     compactMessageLabel = nil
+    stopCountdownLabel = nil
   }
 
   private func updateScheduleLabels() {
@@ -110,6 +120,7 @@ class NotificationInstance {
     remainingDismissSeconds = timeoutSeconds
     dismissStartTime = Date()
     scheduleDismissTimer(after: timeoutSeconds)
+    startStopCountdownUpdates()
 
     if let compactActionButton {
       compactActionButton.startProgress(duration: timeoutSeconds)
@@ -125,6 +136,9 @@ class NotificationInstance {
     }
     dismissTimer?.invalidate()
     dismissTimer = nil
+    stopCountdownTimer?.invalidate()
+    stopCountdownTimer = nil
+    updateStopCountdownLabel(remainingSeconds: remainingDismissSeconds)
 
     if let compactActionButton {
       compactActionButton.pauseProgress()
@@ -135,6 +149,7 @@ class NotificationInstance {
     guard timeoutSeconds > 0, remainingDismissSeconds > 0 else { return }
     dismissStartTime = Date()
     scheduleDismissTimer(after: remainingDismissSeconds)
+    startStopCountdownUpdates()
 
     if let compactActionButton {
       compactActionButton.resumeProgress()
@@ -148,6 +163,7 @@ class NotificationInstance {
     remainingDismissSeconds = timeoutSeconds
     dismissStartTime = Date()
     scheduleDismissTimer(after: timeoutSeconds)
+    startStopCountdownUpdates()
 
     if let compactActionButton {
       compactActionButton.startProgress(duration: timeoutSeconds)
@@ -157,6 +173,8 @@ class NotificationInstance {
   func dismiss() {
     dismissTimer?.invalidate()
     dismissTimer = nil
+    stopCountdownTimer?.invalidate()
+    stopCountdownTimer = nil
     dismissStartTime = nil
     remainingDismissSeconds = 0
     compactActionButton?.resetProgress()
@@ -191,8 +209,40 @@ class NotificationInstance {
     }
   }
 
+  func stopCountdownText(_ remainingSeconds: Double) -> String {
+    let seconds = max(0, Int(ceil(remainingSeconds)))
+    return "Anarlog will stop listening in \(seconds) seconds."
+  }
+
+  private func startStopCountdownUpdates() {
+    guard stopCountdownLabel != nil else { return }
+    updateStopCountdownLabel()
+
+    stopCountdownTimer?.invalidate()
+    stopCountdownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) {
+      [weak self] _ in
+      self?.updateStopCountdownLabel()
+    }
+  }
+
+  private func updateStopCountdownLabel(remainingSeconds: Double? = nil) {
+    guard stopCountdownLabel != nil else { return }
+
+    let remaining: Double
+    if let remainingSeconds {
+      remaining = remainingSeconds
+    } else if let dismissStartTime {
+      remaining = max(0, remainingDismissSeconds - Date().timeIntervalSince(dismissStartTime))
+    } else {
+      remaining = remainingDismissSeconds
+    }
+
+    stopCountdownLabel?.stringValue = stopCountdownText(remaining)
+  }
+
   deinit {
     countdownTimer?.invalidate()
     dismissTimer?.invalidate()
+    stopCountdownTimer?.invalidate()
   }
 }

--- a/crates/notification-macos/swift-lib/src/NotificationManager+CompactView.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationManager+CompactView.swift
@@ -14,7 +14,10 @@ extension NotificationManager {
     let actionLabel = notification.payload.actionLabel ?? "Open Anarlog"
     if notification.payload.isDestructiveAction {
       actionButton.configureDestructiveAction(label: actionLabel)
-      actionButton.showsProgress = false
+      actionButton.showsProgress = notification.payload.showsStopCountdown
+      if notification.payload.showsStopCountdown {
+        actionButton.configureDestructiveCountdownStyle()
+      }
     } else {
       actionButton.title = actionLabel
     }
@@ -64,10 +67,14 @@ extension NotificationManager {
 
     textStack.addArrangedSubview(titleLabel)
 
-    let compactMessage =
-      notification.meetingStartTime != nil
-      ? "Starting soon"
-      : notification.payload.message
+    let compactMessage: String
+    if notification.meetingStartTime != nil {
+      compactMessage = "Starting soon"
+    } else if notification.payload.showsStopCountdown {
+      compactMessage = notification.stopCountdownText(notification.payload.timeoutSeconds)
+    } else {
+      compactMessage = notification.payload.message
+    }
     if !compactMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
       let bodyLabel = NSTextField(labelWithString: compactMessage)
       bodyLabel.font = NSFont.systemFont(ofSize: Fonts.bodySize, weight: Fonts.bodyWeight)
@@ -82,6 +89,8 @@ extension NotificationManager {
 
       if notification.meetingStartTime != nil {
         notification.bindCompactMessageLabel(bodyLabel)
+      } else if notification.payload.showsStopCountdown {
+        notification.bindStopCountdownLabel(bodyLabel)
       }
     }
 

--- a/crates/notification-macos/swift-lib/src/NotificationManager+CompactView.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationManager+CompactView.swift
@@ -11,7 +11,7 @@ extension NotificationManager {
     }
 
     let actionButton = CompactActionButton()
-    let actionLabel = notification.payload.actionLabel ?? "Take Notes"
+    let actionLabel = notification.payload.actionLabel ?? "Open Anarlog"
     if notification.payload.isDestructiveAction {
       actionButton.configureDestructiveAction(label: actionLabel)
       actionButton.showsProgress = false

--- a/crates/notification-macos/swift-lib/src/NotificationManager+Creation.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationManager+Creation.swift
@@ -9,6 +9,10 @@ extension NotificationManager {
     isMacOS26() ? 0 : Layout.buttonOverhang
   }
 
+  func notificationCornerRadius() -> CGFloat {
+    isMacOS26() ? Layout.liquidGlassCornerRadius : Layout.cornerRadius
+  }
+
   func createPanel(screen: NSScreen? = nil, yPosition: CGFloat, hasFooter: Bool = false) -> NSPanel
   {
     let targetScreen = screen ?? getTargetScreen() ?? NSScreen.main!
@@ -30,7 +34,7 @@ extension NotificationManager {
     panel.hidesOnDeactivate = false
     panel.isOpaque = false
     panel.backgroundColor = .clear
-    panel.hasShadow = !isMacOS26()
+    panel.hasShadow = false
     panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
     panel.isMovableByWindowBackground = false
     panel.alphaValue = 0
@@ -47,8 +51,8 @@ extension NotificationManager {
     v.layer?.backgroundColor = NSColor.clear.cgColor
     v.layer?.isOpaque = false
     if isMacOS26() {
-      v.layer?.cornerRadius = Layout.cornerRadius
-      v.layer?.masksToBounds = true
+      v.layer?.cornerRadius = notificationCornerRadius()
+      v.layer?.masksToBounds = false
       if #available(macOS 11.0, *) {
         v.layer?.cornerCurve = .continuous
       }
@@ -68,16 +72,14 @@ extension NotificationManager {
       )
     )
     container.wantsLayer = true
-    container.layer?.cornerRadius = Layout.cornerRadius
+    let cornerRadius = notificationCornerRadius()
+    container.cornerRadius = cornerRadius
+    container.layer?.cornerRadius = cornerRadius
     container.layer?.masksToBounds = false
     if #available(macOS 11.0, *) {
       container.layer?.cornerCurve = .continuous
     }
     container.autoresizingMask = [.width, .height]
-    container.layer?.shadowColor = NSColor.black.cgColor
-    container.layer?.shadowOpacity = 0.22
-    container.layer?.shadowOffset = CGSize(width: 0, height: 2)
-    container.layer?.shadowRadius = 12
     return container
   }
 
@@ -87,19 +89,21 @@ extension NotificationManager {
     let effectView = NSVisualEffectView(frame: container.bounds)
     effectView.material = .popover
     effectView.state = .active
-    effectView.blendingMode = isMacOS26 ? .withinWindow : .behindWindow
+    effectView.blendingMode = .behindWindow
     effectView.wantsLayer = true
-    effectView.layer?.cornerRadius = Layout.cornerRadius
+    let cornerRadius = notificationCornerRadius()
+    effectView.layer?.cornerRadius = cornerRadius
     effectView.layer?.masksToBounds = true
-    if isMacOS26, #available(macOS 11.0, *) {
+    if #available(macOS 11.0, *) {
       effectView.layer?.cornerCurve = .continuous
     }
     effectView.autoresizingMask = [.width, .height]
 
     let backgroundView = NotificationBackgroundView(frame: effectView.bounds)
+    backgroundView.cornerRadius = cornerRadius
     backgroundView.autoresizingMask = [.width, .height]
     if isMacOS26 {
-      backgroundView.makeBackgroundOpaque()
+      backgroundView.makeBackgroundLiquidGlass()
     }
     effectView.addSubview(backgroundView, positioned: .below, relativeTo: nil)
 

--- a/crates/notification-macos/swift-lib/src/NotificationManager+Lifecycle.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationManager+Lifecycle.swift
@@ -28,8 +28,8 @@ extension NotificationManager {
     panel.contentView = clickableView
     if isMacOS26() {
       panel.contentView?.wantsLayer = true
-      panel.contentView?.layer?.cornerRadius = Layout.cornerRadius
-      panel.contentView?.layer?.masksToBounds = true
+      panel.contentView?.layer?.cornerRadius = notificationCornerRadius()
+      panel.contentView?.layer?.masksToBounds = false
       if #available(macOS 11.0, *) {
         panel.contentView?.layer?.cornerCurve = .continuous
       }

--- a/crates/notification-macos/swift-lib/src/NotificationViews.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationViews.swift
@@ -1,13 +1,15 @@
 import Cocoa
 
 class ShadowContainerView: NSView {
+  var cornerRadius = Layout.cornerRadius
+
   override func layout() {
     super.layout()
     let pathRect = bounds.insetBy(dx: 0.5, dy: 0.5)
     layer?.shadowPath = CGPath(
       roundedRect: pathRect,
-      cornerWidth: Layout.cornerRadius,
-      cornerHeight: Layout.cornerRadius,
+      cornerWidth: cornerRadius,
+      cornerHeight: cornerRadius,
       transform: nil
     )
   }
@@ -16,19 +18,36 @@ class ShadowContainerView: NSView {
 class NotificationBackgroundView: NSView {
   let bgLayer = CALayer()
   let borderLayer = CALayer()
+  var cornerRadius = Layout.cornerRadius {
+    didSet {
+      applyCornerRadius()
+    }
+  }
 
-  func makeBackgroundOpaque() {
-    bgLayer.backgroundColor = NSColor(calibratedWhite: 0.92, alpha: 1.0).cgColor
-    layer?.cornerRadius = Layout.cornerRadius
-    bgLayer.cornerRadius = Layout.cornerRadius
-    borderLayer.cornerRadius = Layout.cornerRadius
-    borderLayer.borderWidth = 1.5
-    borderLayer.borderColor = NSColor(calibratedWhite: 0.75, alpha: 0.5).cgColor
+  private func applyCornerRadius() {
+    layer?.cornerRadius = cornerRadius
+    bgLayer.cornerRadius = cornerRadius
+    borderLayer.cornerRadius = cornerRadius
+
     if #available(macOS 11.0, *) {
       layer?.cornerCurve = .continuous
       bgLayer.cornerCurve = .continuous
       borderLayer.cornerCurve = .continuous
     }
+  }
+
+  func makeBackgroundOpaque() {
+    bgLayer.backgroundColor = NSColor(calibratedWhite: 0.92, alpha: 1.0).cgColor
+    applyCornerRadius()
+    borderLayer.borderWidth = 1.5
+    borderLayer.borderColor = NSColor(calibratedWhite: 0.75, alpha: 0.5).cgColor
+  }
+
+  func makeBackgroundLiquidGlass() {
+    bgLayer.backgroundColor = NSColor(calibratedWhite: 1.0, alpha: 0.24).cgColor
+    applyCornerRadius()
+    borderLayer.borderWidth = 1.0
+    borderLayer.borderColor = NSColor.white.withAlphaComponent(0.68).cgColor
   }
 
   override init(frame frameRect: NSRect) {
@@ -43,17 +62,16 @@ class NotificationBackgroundView: NSView {
 
   private func setup() {
     wantsLayer = true
-    layer?.cornerRadius = Layout.cornerRadius
     layer?.masksToBounds = true
 
-    bgLayer.cornerRadius = Layout.cornerRadius
     bgLayer.backgroundColor = Colors.notificationBg
     layer?.addSublayer(bgLayer)
 
-    borderLayer.cornerRadius = Layout.cornerRadius
     borderLayer.borderWidth = 2.0
     borderLayer.borderColor = NSColor.white.cgColor
     layer?.addSublayer(borderLayer)
+
+    applyCornerRadius()
   }
 
   override func layout() {

--- a/plugins/windows/swift-lib/src/DevtoolsPanelManager.swift
+++ b/plugins/windows/swift-lib/src/DevtoolsPanelManager.swift
@@ -84,7 +84,7 @@ final class DevtoolsPanelManager {
     panel.hidesOnDeactivate = false
     panel.isOpaque = false
     panel.backgroundColor = .clear
-    panel.hasShadow = true
+    panel.hasShadow = false
     panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
     panel.isMovableByWindowBackground = true
     panel.delegate = placement

--- a/plugins/windows/swift-lib/src/DevtoolsPanelView.swift
+++ b/plugins/windows/swift-lib/src/DevtoolsPanelView.swift
@@ -50,7 +50,6 @@ struct DevtoolsPanelView: View {
       RoundedRectangle(cornerRadius: 12, style: .continuous)
         .strokeBorder(Color.black.opacity(0.08), lineWidth: 1)
     )
-    .shadow(color: Color.black.opacity(0.20), radius: 18, y: 8)
   }
 
   private var header: some View {


### PR DESCRIPTION
Disable both the native NSPanel shadow and SwiftUI view shadow so the transparent devtools panel does not render a dark backdrop.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5611 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5609 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only shadow toggles on the devtools overlay; no auth, data, or business-logic changes.
> 
> **Overview**
> Removes the dark halo around the floating devtools panel so the semi-transparent UI does not cast a visible backdrop on the desktop.
> 
> **Native panel:** `DevtoolsPanelManager` sets `panel.hasShadow` to **false** on the borderless `NSPanel`.
> 
> **SwiftUI chrome:** `DevtoolsPanelView` drops the `.shadow(...)` on the rounded container; the fill, stroke, and layout are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a9938406916150995ef69b99efd3277b9697aa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->