### PR TITLE
Fix sidebar timeline scroll fades

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -485,6 +485,76 @@ describe("TimelineView", () => {
     expect(getTopFade(container).className).toContain("from-60%");
   });
 
+  it("does not show a top scroll fade when there are no hidden future notes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.timelineSessionsTable = {
+      today: {
+        title: "Design sync",
+        created_at: "2024-01-15T11:00:00.000Z",
+      },
+    };
+
+    const { container } = render(<TimelineView topChromeInset />);
+    const scroller = container.querySelector(
+      "[data-sidebar-timeline-scroll]",
+    ) as HTMLDivElement | null;
+
+    expect(scroller).toBeInstanceOf(HTMLDivElement);
+
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 1200,
+    });
+    scroller!.scrollTop = 120;
+    fireEvent.scroll(scroller!);
+
+    expect(scroller!.style.maskImage).toBe(
+      "linear-gradient(to bottom, #000 0, #000 calc(100% - 28px), transparent 100%)",
+    );
+  });
+
+  it("drops the bottom scroll fade at the bottom edge", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.timelineSessionsTable = {
+      today: {
+        title: "Design sync",
+        created_at: "2024-01-15T11:00:00.000Z",
+      },
+      later: {
+        title: "Quarterly planning",
+        created_at: "2024-01-17T12:00:00.000Z",
+      },
+    };
+
+    const { container } = render(<TimelineView topChromeInset />);
+    const scroller = container.querySelector(
+      "[data-sidebar-timeline-scroll]",
+    ) as HTMLDivElement | null;
+
+    expect(scroller).toBeInstanceOf(HTMLDivElement);
+
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 1200,
+    });
+    scroller!.scrollTop = 1000;
+    fireEvent.scroll(scroller!);
+
+    expect(scroller!.style.maskImage).toBe(
+      "linear-gradient(to bottom, transparent 0, #000 28px, #000 100%)",
+    );
+  });
+
   it("shows an imminent meeting chip over the sidebar timeline", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -220,11 +220,11 @@ export function TimelineView({
   }, [containerRef, buckets.length, flatItemKeys.length]);
 
   const scrollFadeMask = useMemo(() => {
-    const topFadeEnd = isScrolledToTop ? "0px" : "28px";
-    const bottomFadeStart = isScrolledToBottom ? "100%" : "calc(100% - 28px)";
-
-    return `linear-gradient(to bottom, transparent 0, #000 ${topFadeEnd}, #000 ${bottomFadeStart}, transparent 100%)`;
-  }, [isScrolledToTop, isScrolledToBottom]);
+    return getTimelineScrollFadeMask({
+      showBottomFade: !isScrolledToBottom,
+      showTopFade: hasMoreFutureItems && !isScrolledToTop,
+    });
+  }, [hasMoreFutureItems, isScrolledToBottom, isScrolledToTop]);
 
   const todayBucketLength = useMemo(() => {
     const b = buckets.find((bucket) => bucket.label === "Today");
@@ -1049,4 +1049,26 @@ function useTimelineData({
       ),
     };
   }, [windowData, currentTimeMs, timezone]);
+}
+
+function getTimelineScrollFadeMask({
+  showBottomFade,
+  showTopFade,
+}: {
+  showBottomFade: boolean;
+  showTopFade: boolean;
+}): string {
+  if (showTopFade && showBottomFade) {
+    return "linear-gradient(to bottom, transparent 0, #000 28px, #000 calc(100% - 28px), transparent 100%)";
+  }
+
+  if (showTopFade) {
+    return "linear-gradient(to bottom, transparent 0, #000 28px, #000 100%)";
+  }
+
+  if (showBottomFade) {
+    return "linear-gradient(to bottom, #000 0, #000 calc(100% - 28px), transparent 100%)";
+  }
+
+  return "none";
 }


### PR DESCRIPTION
Only show the top fade when hidden future timeline items exist and keep bottom fade state tied to the bottom edge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only scroll masking in the sidebar timeline with regression tests; no auth, data, or API changes.
> 
> **Overview**
> The sidebar timeline scroll **mask** no longer always applies a top fade when you scroll away from the top. The top fade only appears when **`hasMoreFutureItems`** is true and the list is not at the top, so scrolling with no hidden future notes keeps a bottom-only fade (or no top gradient).
> 
> Scroll fade strings are centralized in **`getTimelineScrollFadeMask`**, which picks full dual-edge, top-only, bottom-only, or **`none`** based on `showTopFade` / `showBottomFade`. Bottom fade still tracks **`!isScrolledToBottom`**.
> 
> Tests assert **`maskImage`** on the timeline scroller for the no-future-items and scrolled-to-bottom cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d42e367a4b4ba58f02d38ca4586d8eae75b0d5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->