### PR TITLE
Match live handle panel background

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/global-live.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/global-live.test.tsx
@@ -256,7 +256,7 @@ describe("GlobalLiveTranscriptAccessory", () => {
     expect(transcriptCard?.className).not.toContain("rounded-b-xl");
   });
 
-  it("uses dark-aware chrome for the global live handle", () => {
+  it("uses panel chrome for the global live handle", () => {
     render(
       <GlobalLiveTranscriptAccessory currentTab={{ type: "settings" } as any}>
         <div data-testid="tab-content" />
@@ -265,8 +265,8 @@ describe("GlobalLiveTranscriptAccessory", () => {
 
     const toggle = screen.getByRole("button", { name: "Expand Live" });
 
-    expect(toggle.className).toContain("bg-card");
-    expect(toggle.className).toContain("dark:bg-app-floating-chrome");
+    expect(toggle.className).toContain("bg-app-floating-panel");
+    expect(toggle.className).not.toContain("bg-card");
   });
 
   it("keeps the current surface divider in top chrome mode", () => {

--- a/apps/desktop/src/session/components/bottom-accessory/global-live.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/global-live.tsx
@@ -17,7 +17,7 @@ import { type Tab } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
 
 const GLOBAL_LIVE_AFTER_BORDER_EXPANDED_SIZE = 22;
-const LIVE_TRANSCRIPT_HANDLE_CLASS = "bg-card dark:bg-app-floating-chrome";
+const LIVE_TRANSCRIPT_HANDLE_CLASS = "bg-app-floating-panel";
 
 export function GlobalLiveTranscriptAccessory({
   children,

--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -574,7 +574,7 @@ describe("useSessionBottomAccessory", () => {
     expect(result.current.bottomAccessory).not.toBeNull();
   });
 
-  it("uses dark-aware chrome for the live handle", () => {
+  it("uses panel chrome for the live handle", () => {
     type LiveToggleProps = {
       collapsedClassName?: string;
       expandedClassName?: string;
@@ -599,12 +599,8 @@ describe("useSessionBottomAccessory", () => {
     }
 
     expect(toggle.props.label).toBe("Live");
-    expect(toggle.props.collapsedClassName).toBe(
-      "bg-card dark:bg-app-floating-chrome",
-    );
-    expect(toggle.props.expandedClassName).toBe(
-      "bg-card dark:bg-app-floating-chrome",
-    );
+    expect(toggle.props.collapsedClassName).toBe("bg-app-floating-panel");
+    expect(toggle.props.expandedClassName).toBe("bg-app-floating-panel");
 
     act(() => {
       toggle.props.onToggle();

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -22,6 +22,7 @@ import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
 import { useListener } from "~/stt/contexts";
 
 const BOTTOM_ACCESSORY_HANDLE_CLASS = "bg-card dark:bg-app-floating-chrome";
+const LIVE_ACCESSORY_HANDLE_CLASS = "bg-app-floating-panel";
 
 export type BottomAccessoryState = {
   mode: "live" | "playback" | "transcript_only";
@@ -175,8 +176,8 @@ export function useSessionBottomAccessory({
           isExpanded={effectiveExpanded}
           onToggle={() => setIsExpanded((v) => !v)}
           label="Live"
-          collapsedClassName={BOTTOM_ACCESSORY_HANDLE_CLASS}
-          expandedClassName={BOTTOM_ACCESSORY_HANDLE_CLASS}
+          collapsedClassName={LIVE_ACCESSORY_HANDLE_CLASS}
+          expandedClassName={LIVE_ACCESSORY_HANDLE_CLASS}
         />
       ) : null,
       bottomAccessoryState,


### PR DESCRIPTION
Render live transcript handles with the panel background token and update coverage for the handle class.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic class token swap on live handle UI only; no logic, auth, or data changes.
> 
> **Overview**
> **Live transcript expand handles** now use the `bg-app-floating-panel` token instead of `bg-card` with a dark-mode `app-floating-chrome` override, so the handle background matches the floating panel surface in both light and dark themes.
> 
> This applies to the **Live** `ExpandToggle` in the session bottom accessory (`useSessionBottomAccessory`) and the global live transcript accessory (`GlobalLiveTranscriptAccessory`). Post-session transcript/related-meetings handles are unchanged and still use `bg-card dark:bg-app-floating-chrome`.
> 
> Tests were renamed and updated to assert panel chrome and that `bg-card` is not applied on the live handle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5208e3dd060408727b2bd27d72bd52c4740e7e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->