### PR TITLE
Separate accessibility permission row

### DIFF
--- a/apps/desktop/src/settings/general/permissions.tsx
+++ b/apps/desktop/src/settings/general/permissions.tsx
@@ -173,17 +173,15 @@ export function Permissions() {
         />
       </PermissionGroup>
 
-      <PermissionGroup title="Dailynote">
-        <PermissionRow
-          title="Accessibility"
-          description="Required to detect meeting apps and sync mute status"
-          status={accessibility.status}
-          isPending={accessibility.isPending}
-          onRequest={accessibility.request}
-          onReset={accessibility.reset}
-          onOpen={accessibility.open}
-        />
-      </PermissionGroup>
+      <PermissionRow
+        title="Accessibility"
+        description="Required to detect meeting apps and sync mute status"
+        status={accessibility.status}
+        isPending={accessibility.isPending}
+        onRequest={accessibility.request}
+        onReset={accessibility.reset}
+        onOpen={accessibility.open}
+      />
 
       <PermissionGroup title="Others">
         <PermissionRow


### PR DESCRIPTION
Remove the extra Dailynote grouping so Accessibility renders as its own permission item.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only restructuring of the permissions list with no changes to permission APIs or behavior.
> 
> **Overview**
> **Accessibility** on the desktop General permissions screen is no longer under a **Dailynote** section heading. It is rendered as a standalone `PermissionRow` between the **Audio** group and the **Others** group, with the same copy and request/reset/open behavior as before.
> 
> This is a layout-only change: no permission hooks, handlers, or status logic were modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30be4cd7a1881e84ec39e0bd3a27580878237c39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->