### PR TITLE
Add desktop 1.0.46 changelog

### DIFF
--- a/packages/changelog/content/1.0.46.md
+++ b/packages/changelog/content/1.0.46.md
@@ -1,0 +1,30 @@
+---
+date: "2026-06-18"
+summary: "Anarlog now surfaces upcoming meetings and available updates more clearly, adds Cloudflare transcription, and improves live speaker and Soniox settings."
+---
+
+## Meetings
+
+- The sidebar now highlights meetings that are about to start and can jump to the matching event
+- Collapsed sidebars now show a red meeting badge when an imminent meeting needs attention
+- Timeline scroll fades now appear only when there are hidden items in that direction
+- Meeting join and live capture surfaces have cleaner backgrounds and fewer distracting shadows
+- Auto-stop notifications now use shorter labels that fit better in system alerts
+
+## Transcription
+
+- Cloudflare Workers AI is now available as a transcription provider
+- Soniox realtime settings now show explicit v5 and v4 model choices, including migrated saved aliases
+- Live speaker labels now stay capped to the current participant count across the live transcript, rendered transcript, and exports
+- Participant and language changes now refresh the active listener while recording, including recent source audio around provider reconnects
+
+## Settings
+
+- Accessibility now appears as its own permission row in setup instead of being grouped under daily note permissions
+- AssemblyAI, ElevenLabs, Azure OpenAI, and Azure AI Foundry provider icons now sit more cleanly in the settings list
+- Dock and menu bar visibility settings now route through Anarlog's tray integration more reliably
+
+## Updates
+
+- Available updates now show a download action in the expanded sidebar, while collapsed sidebars keep the update badge
+- Primary toast actions now have stronger contrast, making update and setup prompts easier to spot


### PR DESCRIPTION
## Summary
- expand the desktop 1.0.46 changelog to cover meeting chrome, update actions, transcription, and settings polish

## Testing
- pnpm exec dprint fmt
- pnpm -F @hypr/changelog typecheck
- git diff --check -- packages/changelog/content/1.0.46.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog markdown with no application or runtime code changes.
> 
> **Overview**
> Adds the **desktop 1.0.46** changelog entry (`packages/changelog/content/1.0.46.md`) with front matter and user-facing release notes.
> 
> The entry documents **Meetings** (imminent-meeting sidebar highlights/badges, timeline scroll fades, join/capture UI polish, shorter auto-stop notification labels), **Transcription** (Cloudflare Workers AI provider, Soniox v5/v4 model choices with alias migration, speaker labels capped to participant count, listener refresh on participant/language changes during recording), **Settings** (standalone accessibility permission row, cleaner provider icons, tray routing for dock/menu bar visibility), and **Updates** (download action in expanded sidebar, stronger primary toast contrast).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22ef3e9183f671e6f16085bab0cf0627cae5dcb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->