### PR TITLE
Cap summary image context size

### DIFF
--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-images.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-images.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   collectEnhanceImageContext,
@@ -39,6 +39,11 @@ describe("enhance image context", () => {
       status: "ok",
       data: [104, 101, 108, 108, 111],
     });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("reads only image attachments referenced by note JSON", async () => {
@@ -92,6 +97,75 @@ describe("enhance image context", () => {
 
     expect(images).toEqual([{ base64: "abc123", mimeType: "image/png" }]);
     expect(fsSyncMocks.attachmentList).not.toHaveBeenCalled();
+  });
+
+  it("skips oversized base64 data URL images when compression is unavailable", async () => {
+    const oversized = "a".repeat(350 * 1024);
+
+    const images = await collectEnhanceImageContext(
+      "session-1",
+      `![pasted](data:image/png;base64,${oversized})`,
+    );
+
+    expect(images).toEqual([]);
+    expect(fsSyncMocks.attachmentList).not.toHaveBeenCalled();
+  });
+
+  it("compresses oversized base64 data URL images into budget", async () => {
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation(
+      (tagName: string, options?: ElementCreationOptions) => {
+        if (tagName !== "canvas") {
+          return originalCreateElement(tagName, options);
+        }
+
+        return {
+          width: 0,
+          height: 0,
+          getContext: () => ({
+            clearRect: vi.fn(),
+            drawImage: vi.fn(),
+          }),
+          toDataURL: () => "data:image/jpeg;base64,aGVsbG8=",
+        } as unknown as HTMLCanvasElement;
+      },
+    );
+    vi.stubGlobal(
+      "createImageBitmap",
+      vi.fn(async () => ({
+        width: 2400,
+        height: 1600,
+        close: vi.fn(),
+      })),
+    );
+
+    const images = await collectEnhanceImageContext(
+      "session-1",
+      `![pasted](data:image/png;base64,${"a".repeat(350 * 1024)})`,
+    );
+
+    expect(images).toEqual([
+      { base64: "aGVsbG8=", mimeType: "image/jpeg", filename: undefined },
+    ]);
+  });
+
+  it("keeps image context within the aggregate byte budget", async () => {
+    const image = "a".repeat(170 * 1024);
+
+    const images = await collectEnhanceImageContext(
+      "session-1",
+      [
+        `![one](data:image/png;base64,${image})`,
+        `![two](data:image/png;base64,${image})`,
+        `![three](data:image/png;base64,${image})`,
+        `![four](data:image/png;base64,${image})`,
+        `![five](data:image/png;base64,${image})`,
+        `![six](data:image/png;base64,${image})`,
+        `![seven](data:image/png;base64,${image})`,
+      ].join("\n"),
+    );
+
+    expect(images).toHaveLength(6);
   });
 
   it("does not load an attachment again for a node that already has a data URL", async () => {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-images.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-images.ts
@@ -16,7 +16,13 @@ type ImageReference = {
 };
 
 const MAX_IMAGE_COUNT = 10;
-const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+const MAX_IMAGE_BYTES = 128 * 1024;
+const MAX_TOTAL_IMAGE_BYTES = 768 * 1024;
+const MAX_SOURCE_IMAGE_BYTES = 8 * 1024 * 1024;
+const COMPRESSED_IMAGE_MIME_TYPE = "image/jpeg";
+const MAX_COMPRESSED_IMAGE_EDGE = 1280;
+const MIN_COMPRESSED_IMAGE_EDGE = 512;
+const COMPRESSED_IMAGE_QUALITY_STEPS = [0.82, 0.72, 0.62, 0.52];
 
 const EXTENSION_TO_MIME: Record<string, string> = {
   gif: "image/gif",
@@ -36,13 +42,21 @@ export async function collectEnhanceImageContext(
     ? rawContent.flatMap(collectImageReferences)
     : collectImageReferences(rawContent);
   const images: EnhanceImageContext[] = [];
+  let totalImageBytes = 0;
 
   for (const ref of references) {
     if (!ref.dataUrl) {
       continue;
     }
 
-    images.push(ref.dataUrl);
+    const image = await prepareImageForBudget(ref.dataUrl, totalImageBytes);
+    if (!image) {
+      continue;
+    }
+
+    const imageBytes = getBase64ByteLength(image.base64);
+    images.push(image);
+    totalImageBytes += imageBytes;
     if (images.length >= MAX_IMAGE_COUNT) {
       return images;
     }
@@ -91,13 +105,122 @@ export async function collectEnhanceImageContext(
       continue;
     }
 
-    images.push(image);
+    const budgetedImage = await prepareImageForBudget(image, totalImageBytes);
+    if (!budgetedImage) {
+      continue;
+    }
+
+    const imageBytes = getBase64ByteLength(budgetedImage.base64);
+    images.push(budgetedImage);
+    totalImageBytes += imageBytes;
     if (images.length >= MAX_IMAGE_COUNT) {
       return images;
     }
   }
 
   return images;
+}
+
+async function prepareImageForBudget(
+  image: EnhanceImageContext,
+  currentTotalBytes: number,
+): Promise<EnhanceImageContext | null> {
+  const targetBytes = Math.min(
+    MAX_IMAGE_BYTES,
+    MAX_TOTAL_IMAGE_BYTES - currentTotalBytes,
+  );
+  if (targetBytes <= 0) {
+    return null;
+  }
+
+  const imageBytes = getBase64ByteLength(image.base64);
+  if (imageBytes <= targetBytes) {
+    return image;
+  }
+
+  return compressImageContext(image, targetBytes);
+}
+
+async function compressImageContext(
+  image: EnhanceImageContext,
+  targetBytes: number,
+): Promise<EnhanceImageContext | null> {
+  if (
+    typeof createImageBitmap !== "function" ||
+    typeof fetch !== "function" ||
+    typeof document === "undefined"
+  ) {
+    return null;
+  }
+
+  let bitmap: ImageBitmap;
+  try {
+    const response = await fetch(toDataUrl(image));
+    bitmap = await createImageBitmap(await response.blob());
+  } catch {
+    return null;
+  }
+
+  try {
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return null;
+    }
+
+    let maxEdge = MAX_COMPRESSED_IMAGE_EDGE;
+    while (maxEdge >= MIN_COMPRESSED_IMAGE_EDGE) {
+      const scale = Math.min(
+        1,
+        maxEdge / Math.max(bitmap.width, bitmap.height),
+      );
+      canvas.width = Math.max(1, Math.round(bitmap.width * scale));
+      canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+
+      for (const quality of COMPRESSED_IMAGE_QUALITY_STEPS) {
+        const compressed = parseGeneratedImageDataUrl(
+          canvas.toDataURL(COMPRESSED_IMAGE_MIME_TYPE, quality),
+          image.filename,
+        );
+        if (
+          compressed &&
+          getBase64ByteLength(compressed.base64) <= targetBytes
+        ) {
+          return compressed;
+        }
+      }
+
+      maxEdge = Math.floor(maxEdge * 0.75);
+    }
+  } finally {
+    bitmap.close?.();
+  }
+
+  return null;
+}
+
+function toDataUrl(image: EnhanceImageContext): string {
+  return `data:${image.mimeType};base64,${image.base64}`;
+}
+
+function parseGeneratedImageDataUrl(
+  src: string,
+  filename: string | undefined,
+): EnhanceImageContext | null {
+  const match = src.match(
+    /^data:(image\/(?:gif|jpe?g|png|webp));base64,(.+)$/i,
+  );
+  if (!match) {
+    return null;
+  }
+
+  return {
+    base64: match[2],
+    mimeType: match[1].toLowerCase() === "image/jpg" ? "image/jpeg" : match[1],
+    filename,
+  };
 }
 
 export function collectImageReferences(rawContent: string): ImageReference[] {
@@ -135,7 +258,7 @@ async function readImageAttachment(
     return null;
   }
 
-  if (readResult.data.length > MAX_IMAGE_BYTES) {
+  if (readResult.data.length > MAX_SOURCE_IMAGE_BYTES) {
     return null;
   }
 
@@ -227,7 +350,7 @@ function parseImageDataUrl(src: string): EnhanceImageContext | null {
   const mimeType =
     match[1].toLowerCase() === "image/jpg" ? "image/jpeg" : match[1];
   const base64 = match[2];
-  if (getBase64ByteLength(base64) > MAX_IMAGE_BYTES) {
+  if (getBase64ByteLength(base64) > MAX_SOURCE_IMAGE_BYTES) {
     return null;
   }
 


### PR DESCRIPTION
Limit image context collected for note enhancement so large pasted or attached images do not exceed the hosted LLM request body limit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what visual context reaches the enhance model (skipped or downscaled images) and relies on browser canvas APIs in the desktop renderer; behavior is well-tested but could affect enhancement quality for image-heavy notes.
> 
> **Overview**
> **Tightens image payload limits** for note-enhancement LLM calls so large pasted or attached images stay under hosted request body limits.
> 
> `collectEnhanceImageContext` now enforces a **128KB per-image** cap and a **768KB total** budget across up to 10 images (down from an 8MB per-image limit). Raw data URLs and attachments may still be up to **8MB** at read time; anything larger is dropped before budgeting.
> 
> Oversized images are run through a new **browser-side JPEG compression** path (`createImageBitmap`, canvas resize, stepped quality) via `prepareImageForBudget`. Images that still exceed the remaining budget—or that cannot be compressed when DOM APIs are missing—are **skipped** rather than sent whole.
> 
> Tests cover compression mocks, skip-on-failure behavior, aggregate byte limits, and `afterEach` cleanup for global stubs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3234c0473febfe4e42b0f412487a975955c80b4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5621 
- <kbd>&nbsp;1&nbsp;</kbd> #5618 👈 
<!-- GitButler Footer Boundary Bottom -->

