### PR TITLE
Replace related meetings with insights tab

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -34,7 +34,7 @@ const hoisted = vi.hoisted(() => ({
   }>,
   batch: {} as Record<string, { error: string | null }>,
   generateMissingPastNotes: vi.fn(),
-  regeneratePastNote: vi.fn(),
+  regenerateInsights: vi.fn(),
 }));
 
 vi.mock("react-hotkeys-hook", () => ({
@@ -64,7 +64,8 @@ vi.mock("./past-notes", () => ({
     isGenerating: false,
     canGenerate: true,
     generateMissing: hoisted.generateMissingPastNotes,
-    regenerate: hoisted.regeneratePastNote,
+    regenerate: vi.fn(),
+    regenerateAll: hoisted.regenerateInsights,
   }),
 }));
 
@@ -107,7 +108,7 @@ describe("useSessionBottomAccessory", () => {
     hoisted.pastNotes = [];
     hoisted.batch = {};
     hoisted.generateMissingPastNotes.mockClear();
-    hoisted.regeneratePastNote.mockClear();
+    hoisted.regenerateInsights.mockClear();
     useShellMock.mockReturnValue({
       chat: {
         mode: "Closed",
@@ -246,7 +247,7 @@ describe("useSessionBottomAccessory", () => {
     expect(result.current.bottomAccessory).toBeNull();
   });
 
-  it("generates missing past note facts when the past notes tab opens", () => {
+  it("generates missing insights when the insights tab opens", () => {
     hoisted.pastNotes = [
       {
         sessionId: "past-session",
@@ -268,14 +269,14 @@ describe("useSessionBottomAccessory", () => {
 
     const handle = result.current.bottomBorderHandle;
     expect(
-      isValidElement<{ onSelect: (tab: "past_notes") => void }>(handle),
+      isValidElement<{ onSelect: (tab: "insights") => void }>(handle),
     ).toBe(true);
-    if (!isValidElement<{ onSelect: (tab: "past_notes") => void }>(handle)) {
+    if (!isValidElement<{ onSelect: (tab: "insights") => void }>(handle)) {
       return;
     }
 
     act(() => {
-      handle.props.onSelect("past_notes");
+      handle.props.onSelect("insights");
     });
 
     expect(hoisted.generateMissingPastNotes).toHaveBeenCalledTimes(1);
@@ -285,7 +286,7 @@ describe("useSessionBottomAccessory", () => {
     });
   });
 
-  it("uses related meetings as the only tab when there is no transcript content", () => {
+  it("uses insights as the only tab when there is no transcript content", () => {
     hoisted.pastNotes = [
       {
         sessionId: "past-session",
@@ -314,9 +315,7 @@ describe("useSessionBottomAccessory", () => {
 
     expect(screen.queryByRole("button", { name: /Transcript/ })).toBeNull();
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Expand Related meetings" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Expand Insights" }));
 
     expect(hoisted.generateMissingPastNotes).toHaveBeenCalledTimes(1);
     expect(result.current.bottomAccessoryState).toEqual({
@@ -379,7 +378,7 @@ describe("useSessionBottomAccessory", () => {
       screen.getByRole("button", { name: "Expand Transcript" }),
     ).not.toBeNull();
     expect(
-      screen.getByRole("button", { name: "Expand Related meetings" }),
+      screen.getByRole("button", { name: "Expand Insights" }),
     ).not.toBeNull();
   });
 

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -85,12 +85,9 @@ export function useSessionBottomAccessory({
   });
   const hasPastNotes = pastNotes.hasPastNotes;
   const generateMissingPastNotes = pastNotes.generateMissing;
-  const regeneratePastNote = pastNotes.canGenerate
-    ? pastNotes.regenerate
-    : undefined;
   const activePostSessionTab: PostSessionTab =
     hasPastNotes && !canShowTranscriptTab
-      ? "past_notes"
+      ? "insights"
       : hasPastNotes
         ? (postSessionTab ?? "transcript")
         : "transcript";
@@ -122,7 +119,7 @@ export function useSessionBottomAccessory({
   const selectPostSessionTab = useCallback(
     (tab: PostSessionTab) => {
       const shouldExpand = activePostSessionTab !== tab || !isExpanded;
-      if (tab === "past_notes" && shouldExpand) {
+      if (tab === "insights" && shouldExpand) {
         generateMissingPastNotes();
       }
 
@@ -195,7 +192,9 @@ export function useSessionBottomAccessory({
           isTranscriptExpanded={isExpanded}
           activeTab={activePostSessionTab}
           pastNotes={pastNotes.notes}
-          onRegeneratePastNote={regeneratePastNote}
+          onRegenerateInsights={
+            pastNotes.canGenerate ? pastNotes.regenerateAll : undefined
+          }
           fillHeight={isExpanded}
         />
       ) : null,
@@ -250,8 +249,8 @@ function PostSessionTabHandle({
         />
       ) : null}
       <PostSessionTabButton
-        label="Related meetings"
-        tab="past_notes"
+        label="Insights"
+        tab="insights"
         activeTab={activeTab}
         isExpanded={isExpanded}
         onSelect={onSelect}

--- a/apps/desktop/src/session/components/bottom-accessory/past-note-key-facts.system.md.jinja
+++ b/apps/desktop/src/session/components/bottom-accessory/past-note-key-facts.system.md.jinja
@@ -1,10 +1,11 @@
-You extract reusable key facts from prior meeting notes.
+You extract reusable insights from prior meeting notes.
 
 Return facts that will help someone prepare for the next meeting with the same people.
 
 Rules:
 
 - Capture concrete decisions, commitments, blockers, preferences, constraints, open questions, names, dates, numbers, and follow-ups.
+- Prefer facts that clarify what has been discussed with the participants before.
 - Omit generic meeting-summary language.
 - Do not mention that these are notes or that you are summarizing.
 - Keep each fact short and standalone.

--- a/apps/desktop/src/session/components/bottom-accessory/past-note-key-facts.user.md.jinja
+++ b/apps/desktop/src/session/components/bottom-accessory/past-note-key-facts.user.md.jinja
@@ -2,6 +2,7 @@
 
 Title: {{ session.title }}
 Date: {{ session.date_label }}
+Participants: {{ session.participant_names | join(", ") }}
 
 # Notes
 

--- a/apps/desktop/src/session/components/bottom-accessory/past-note-regenerate.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/past-note-regenerate.test.tsx
@@ -129,8 +129,8 @@ afterEach(() => {
   cleanup();
 });
 
-describe("past note regeneration", () => {
-  it("regenerates a selected past note from its timeline row", () => {
+describe("insights regeneration", () => {
+  it("regenerates compiled insights from the insights panel", () => {
     const regenerate = vi.fn();
 
     render(
@@ -139,7 +139,7 @@ describe("past note regeneration", () => {
         hasAudio={false}
         hasTranscript
         isTranscriptExpanded
-        activeTab="past_notes"
+        activeTab="insights"
         pastNotes={[
           {
             sessionId: "session-0",
@@ -149,25 +149,25 @@ describe("past note regeneration", () => {
             isGenerating: false,
           },
         ]}
-        onRegeneratePastNote={regenerate}
+        onRegenerateInsights={regenerate}
       />,
     );
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Regenerate past note summary" }),
+      screen.getByRole("button", { name: "Regenerate insights" }),
     );
 
-    expect(regenerate).toHaveBeenCalledWith("session-0");
+    expect(regenerate).toHaveBeenCalledTimes(1);
   });
 
-  it("disables the row regenerate action while that note is generating", () => {
+  it("disables the regenerate action while insights are generating", () => {
     render(
       <PostSessionAccessory
         sessionId="session-1"
         hasAudio={false}
         hasTranscript
         isTranscriptExpanded
-        activeTab="past_notes"
+        activeTab="insights"
         pastNotes={[
           {
             sessionId: "session-0",
@@ -177,16 +177,16 @@ describe("past note regeneration", () => {
             isGenerating: true,
           },
         ]}
-        onRegeneratePastNote={vi.fn()}
+        onRegenerateInsights={vi.fn()}
       />,
     );
 
     expect(
-      screen.getByRole("button", { name: "Regenerate past note summary" }),
+      screen.getByRole("button", { name: "Regenerate insights" }),
     ).toHaveProperty("disabled", true);
   });
 
-  it("disables row regenerate actions while another note is generating", () => {
+  it("disables regeneration while another insight source is generating", () => {
     const regenerate = vi.fn();
 
     render(
@@ -195,7 +195,7 @@ describe("past note regeneration", () => {
         hasAudio={false}
         hasTranscript
         isTranscriptExpanded
-        activeTab="past_notes"
+        activeTab="insights"
         pastNotes={[
           {
             sessionId: "session-0",
@@ -214,18 +214,16 @@ describe("past note regeneration", () => {
             isRegenerateDisabled: true,
           },
         ]}
-        onRegeneratePastNote={regenerate}
+        onRegenerateInsights={regenerate}
       />,
     );
 
-    const buttons = screen.getAllByRole("button", {
-      name: "Regenerate past note summary",
+    const button = screen.getByRole("button", {
+      name: "Regenerate insights",
     });
 
-    expect(buttons).toHaveLength(2);
-    expect(buttons[0]).toHaveProperty("disabled", true);
-    expect(buttons[1]).toHaveProperty("disabled", true);
-    fireEvent.click(buttons[0]!);
+    expect(button).toHaveProperty("disabled", true);
+    fireEvent.click(button);
     expect(regenerate).not.toHaveBeenCalled();
   });
 
@@ -353,12 +351,12 @@ describe("past note regeneration", () => {
     await waitFor(() => {
       expect(hoisted.showTransientToast).toHaveBeenCalledWith({
         id: "past-note-key-facts-error",
-        description: "Could not generate related meeting facts. Try again.",
+        description: "Could not generate meeting insights. Try again.",
         variant: "error",
       });
     });
     expect(consoleError).toHaveBeenCalledWith(
-      "Failed to generate related meeting facts",
+      "Failed to generate meeting insights",
       expect.any(Error),
     );
     await waitFor(() => {

--- a/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
+++ b/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
@@ -22,6 +22,7 @@ export type PastSessionNote = {
   sessionId: string;
   title: string;
   dateLabel: string;
+  participantNames?: string[];
   summary: string | null;
   isGenerating: boolean;
   isRegenerateDisabled?: boolean;
@@ -34,6 +35,7 @@ export type PastSessionNoteRequest = {
   dateLabel: string;
   sourceText: string;
   sourceHash: string;
+  participantNames: string[];
 };
 
 export type PastSessionNotesResult = {
@@ -43,6 +45,7 @@ export type PastSessionNotesResult = {
   canGenerate: boolean;
   generateMissing: () => void;
   regenerate: (sessionId: string) => void;
+  regenerateAll: () => void;
 };
 
 type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
@@ -71,6 +74,10 @@ export function usePastSessionNotes(
     enabled
       ? "mapping_session_participant"
       : ("__disabled_past_notes_participants" as "mapping_session_participant"),
+    main.STORE_ID,
+  );
+  const humansTable = main.UI.useTable(
+    enabled ? "humans" : ("__disabled_past_notes_humans" as "humans"),
     main.STORE_ID,
   );
   const enhancedNotesTable = main.UI.useTable(
@@ -105,6 +112,7 @@ export function usePastSessionNotes(
     userId,
     sessionsTable,
     participantsTable,
+    humansTable,
     enhancedNotesTable,
     keyFactsTable,
   ]);
@@ -122,10 +130,10 @@ export function usePastSessionNotes(
       });
     },
     onError: (error) => {
-      console.error("Failed to generate related meeting facts", error);
+      console.error("Failed to generate meeting insights", error);
       showTransientToast({
         id: "past-note-key-facts-error",
-        description: "Could not generate related meeting facts. Try again.",
+        description: "Could not generate meeting insights. Try again.",
         variant: "error",
       });
     },
@@ -180,6 +188,19 @@ export function usePastSessionNotes(
     [built.requests, enabled, model, mutation],
   );
 
+  const regenerateAll = useCallback(() => {
+    if (
+      !enabled ||
+      !model ||
+      built.requests.length === 0 ||
+      mutation.isPending
+    ) {
+      return;
+    }
+
+    mutation.mutate(built.requests);
+  }, [built.requests, enabled, model, mutation]);
+
   return {
     notes,
     hasPastNotes: notes.length > 0,
@@ -187,6 +208,7 @@ export function usePastSessionNotes(
     canGenerate: enabled && Boolean(model),
     generateMissing,
     regenerate,
+    regenerateAll,
   };
 }
 
@@ -271,6 +293,10 @@ export function buildPastSessionNotes(
     const sourceHash = createSourceHash([title, dateLabel, source].join("\n"));
     const saved = getSavedKeyFacts(store, candidateSessionId, sourceHash);
     const ownerUserId = getSessionUserId(candidateSession, userId);
+    const participantNames = getSessionParticipantNames(
+      store,
+      new Set([...currentParticipantIds, ...candidateParticipantIds]),
+    );
     const request = {
       sessionId: candidateSessionId,
       userId: ownerUserId,
@@ -278,6 +304,7 @@ export function buildPastSessionNotes(
       dateLabel,
       sourceText: source,
       sourceHash,
+      participantNames,
     };
 
     items.push({
@@ -285,6 +312,7 @@ export function buildPastSessionNotes(
         sessionId: candidateSessionId,
         title,
         dateLabel,
+        participantNames,
         summary: saved,
         isGenerating: false,
         dateMs: candidateTimestamp,
@@ -366,6 +394,7 @@ async function generatePastSessionKeyFacts({
     session: {
       title: request.title,
       date_label: request.dateLabel,
+      participant_names: request.participantNames,
     },
     notes: request.sourceText,
   });
@@ -515,6 +544,31 @@ function getSessionParticipantIds(
   });
 
   return participantIds;
+}
+
+function getSessionParticipantNames(
+  store: MainStore,
+  participantIds: Set<string>,
+): string[] {
+  const seen = new Set<string>();
+  const names: string[] = [];
+
+  for (const participantId of participantIds) {
+    const human = store.getRow("humans", participantId);
+    const name =
+      typeof human.name === "string" && human.name.trim()
+        ? human.name.trim()
+        : participantId;
+    const key = name.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    names.push(name);
+  }
+
+  return names.sort((a, b) => a.localeCompare(b));
 }
 
 function isRelatedPastSession({

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -447,19 +447,20 @@ describe("PostSessionAccessory", () => {
     expect(screen.queryByTestId("transcript")).toBeNull();
   });
 
-  it("renders the past notes timeline when the past notes tab is active", () => {
+  it("renders compiled insights when the insights tab is active", () => {
     render(
       <PostSessionAccessory
         sessionId="session-1"
         hasAudio={false}
         hasTranscript
         isTranscriptExpanded
-        activeTab="past_notes"
+        activeTab="insights"
         pastNotes={[
           {
             sessionId: "session-0",
             title: "Weekly Product Sync",
             dateLabel: "May 28, 2026",
+            participantNames: ["Alex", "Jamie"],
             summary:
               "- Ship the transcript panel.\nRevisit visual polish next week.\n3. Confirm keyboard behavior.\nDo not show this fourth fact.",
             isGenerating: false,
@@ -468,14 +469,11 @@ describe("PostSessionAccessory", () => {
       />,
     );
 
-    expect(screen.getByText("Related meetings")).toBeTruthy();
-    const title = screen.getByText("Weekly Product Sync");
-    const date = screen.getByText("May 28, 2026");
-    expect(title).toBeTruthy();
-    expect(date).toBeTruthy();
-    expect(date.compareDocumentPosition(title)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
+    expect(screen.getByText("Insights")).toBeTruthy();
+    expect(screen.getByText("Alex")).toBeTruthy();
+    expect(screen.getByText("Jamie")).toBeTruthy();
+    expect(screen.queryByText("Weekly Product Sync")).toBeNull();
+    expect(screen.queryByText("May 28, 2026")).toBeNull();
     const factsList = screen.getByRole("list");
     expect(factsList.className).toContain("list-disc");
     expect(factsList.className).not.toContain("list-inside");
@@ -629,6 +627,7 @@ describe("PostSessionAccessory", () => {
         sessionId: "previous",
         title: "Weekly Product Sync",
         dateLabel: "May 28, 2026",
+        participantNames: ["alex", "jamie"],
         summary: null,
         isGenerating: false,
       },
@@ -636,6 +635,7 @@ describe("PostSessionAccessory", () => {
         sessionId: "same_title",
         title: "Weekly Product Sync",
         dateLabel: "May 27, 2026",
+        participantNames: ["alex", "jamie"],
         summary: null,
         isGenerating: false,
       },
@@ -748,6 +748,7 @@ describe("PostSessionAccessory", () => {
         sessionId: "previous",
         title: "Weekly Product Sync",
         dateLabel: "May 28, 2026",
+        participantNames: ["alex"],
         summary: "Alex committed to send pricing by Friday.",
         isGenerating: false,
       },

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -31,7 +31,9 @@ import { showTransientToast } from "~/sidebar/toast/transient";
 import { useListener } from "~/stt/contexts";
 import { isStoppedTranscriptionError, useRunBatch } from "~/stt/useRunBatch";
 
-export type PostSessionTab = "transcript" | "past_notes";
+export type PostSessionTab = "transcript" | "insights";
+
+const MAX_COMPILED_INSIGHTS = 12;
 
 export function PostSessionAccessory({
   sessionId,
@@ -40,7 +42,7 @@ export function PostSessionAccessory({
   isTranscriptExpanded,
   activeTab = "transcript",
   pastNotes = [],
-  onRegeneratePastNote,
+  onRegenerateInsights,
   fillHeight = false,
 }: {
   sessionId: string;
@@ -49,18 +51,18 @@ export function PostSessionAccessory({
   isTranscriptExpanded: boolean;
   activeTab?: PostSessionTab;
   pastNotes?: PastSessionNote[];
-  onRegeneratePastNote?: (sessionId: string) => void;
+  onRegenerateInsights?: () => void;
   fillHeight?: boolean;
 }) {
   const screen = useTranscriptScreen({ sessionId });
   const isBatching = screen.kind === "running_batch";
   const effectiveActiveTab =
-    activeTab === "past_notes" && pastNotes.length > 0
-      ? "past_notes"
+    activeTab === "insights" && pastNotes.length > 0
+      ? "insights"
       : "transcript";
   const shouldFillExpandedPanel =
     fillHeight &&
-    (effectiveActiveTab === "past_notes" || hasTranscript || isBatching);
+    (effectiveActiveTab === "insights" || hasTranscript || isBatching);
   const timeline = isBatching ? (
     <BatchProgressTimeline sessionId={sessionId} screen={screen} />
   ) : hasAudio && isTranscriptExpanded ? (
@@ -86,10 +88,10 @@ export function PostSessionAccessory({
               : "shrink-0",
           ])}
         >
-          {effectiveActiveTab === "past_notes" ? (
-            <PastNotesPanel
+          {effectiveActiveTab === "insights" ? (
+            <InsightsPanel
               notes={pastNotes}
-              onRegenerateNote={onRegeneratePastNote}
+              onRegenerateInsights={onRegenerateInsights}
               fillHeight={shouldFillExpandedPanel}
             />
           ) : (
@@ -130,21 +132,35 @@ function TimelineSlot({
   );
 }
 
-function PastNotesPanel({
+function InsightsPanel({
   notes,
-  onRegenerateNote,
+  onRegenerateInsights,
   fillHeight,
 }: {
   notes: PastSessionNote[];
-  onRegenerateNote?: (sessionId: string) => void;
+  onRegenerateInsights?: () => void;
   fillHeight: boolean;
 }) {
+  const participantNames = getCompiledParticipantNames(notes);
+  const insightFacts = getCompiledInsightFacts(notes);
+  const isGenerating = notes.some((note) => note.isGenerating);
+  const isRegenerateDisabled =
+    notes.length === 0 ||
+    notes.some((note) => note.isGenerating || note.isRegenerateDisabled);
+
   return (
     <TranscriptCard fillHeight={fillHeight}>
       <div className="flex shrink-0 items-center justify-between px-3 py-1.5">
         <span className="text-muted-foreground text-xs font-medium">
-          Related meetings
+          Insights
         </span>
+        {onRegenerateInsights ? (
+          <RegenerateInsightsButton
+            isDisabled={isRegenerateDisabled}
+            isGenerating={isGenerating}
+            onClick={onRegenerateInsights}
+          />
+        ) : null}
       </div>
 
       <div
@@ -153,52 +169,44 @@ function PastNotesPanel({
           fillHeight ? "flex-1" : "max-h-[300px]",
         ])}
       >
-        <div className="relative flex flex-col gap-4 pt-2">
-          <div className="bg-accent absolute top-2 bottom-0 left-[3px] w-px" />
-          {notes.map((note) => (
-            <div
-              key={note.sessionId}
-              className="relative grid min-w-0 grid-cols-1 pl-5"
-            >
-              <div className="border-border bg-card absolute top-1.5 left-0 h-2 w-2 rounded-full border" />
-              <div className="flex min-w-0 flex-col gap-1">
-                <div className="flex min-w-0 items-center justify-between gap-2">
-                  <div className="flex min-w-0 items-baseline gap-2">
-                    <span className="text-muted-foreground shrink-0 text-[11px]">
-                      {note.dateLabel}
-                    </span>
-                    <span className="text-muted-foreground min-w-0 truncate text-xs font-medium">
-                      {note.title}
-                    </span>
-                  </div>
-                  {onRegenerateNote ? (
-                    <RegeneratePastNoteButton
-                      isDisabled={
-                        note.isGenerating || note.isRegenerateDisabled === true
-                      }
-                      isGenerating={note.isGenerating}
-                      onClick={() => onRegenerateNote(note.sessionId)}
-                    />
-                  ) : null}
-                </div>
-                {note.summary ? (
-                  <ul className="text-muted-foreground min-w-0 list-disc space-y-1 pr-1 pl-5 text-xs leading-5">
-                    {splitKeyFacts(note.summary).map((fact) => (
-                      <li key={fact} className="min-w-0 break-words">
-                        {fact}
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="text-muted-foreground text-xs leading-5">
-                    {note.isGenerating
-                      ? "Generating key facts..."
-                      : "Key facts will be generated when this tab opens."}
-                  </p>
-                )}
-              </div>
+        <div className="flex min-w-0 flex-col gap-3 pt-2">
+          {participantNames.length > 0 ? (
+            <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+              <span className="text-muted-foreground mr-0.5 text-[11px] font-medium">
+                With
+              </span>
+              {participantNames.map((participantName) => (
+                <span
+                  key={participantName}
+                  className="border-border bg-accent/35 text-muted-foreground max-w-full truncate rounded-full border px-2 py-0.5 text-[11px] leading-4"
+                >
+                  {participantName}
+                </span>
+              ))}
             </div>
-          ))}
+          ) : null}
+
+          {insightFacts.length > 0 ? (
+            <ul className="text-muted-foreground min-w-0 list-disc space-y-1.5 pr-1 pl-5 text-xs leading-5">
+              {insightFacts.map((fact) => (
+                <li key={fact.key} className="min-w-0 break-words">
+                  {fact.text}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-muted-foreground text-xs leading-5">
+              {isGenerating
+                ? "Generating insights..."
+                : "Insights will be generated when this tab opens."}
+            </p>
+          )}
+
+          {insightFacts.length > 0 && isGenerating ? (
+            <p className="text-muted-foreground text-xs leading-5">
+              Updating insights...
+            </p>
+          ) : null}
         </div>
       </div>
     </TranscriptCard>
@@ -218,7 +226,55 @@ function splitKeyFacts(content: string): string[] {
     .slice(0, 3);
 }
 
-function RegeneratePastNoteButton({
+function getCompiledParticipantNames(notes: PastSessionNote[]): string[] {
+  const seen = new Set<string>();
+  const names: string[] = [];
+
+  for (const note of notes) {
+    for (const participantName of note.participantNames ?? []) {
+      const text = participantName.trim();
+      const key = text.toLowerCase();
+      if (!text || seen.has(key)) {
+        continue;
+      }
+
+      seen.add(key);
+      names.push(text);
+    }
+  }
+
+  return names.sort((a, b) => a.localeCompare(b));
+}
+
+function getCompiledInsightFacts(
+  notes: PastSessionNote[],
+): Array<{ key: string; text: string }> {
+  const seen = new Set<string>();
+  const facts: Array<{ key: string; text: string }> = [];
+
+  for (const note of notes) {
+    if (!note.summary) {
+      continue;
+    }
+
+    for (const fact of splitKeyFacts(note.summary)) {
+      const key = fact.toLowerCase();
+      if (seen.has(key)) {
+        continue;
+      }
+
+      seen.add(key);
+      facts.push({ key: `${note.sessionId}-${key}`, text: fact });
+      if (facts.length >= MAX_COMPILED_INSIGHTS) {
+        return facts;
+      }
+    }
+  }
+
+  return facts;
+}
+
+function RegenerateInsightsButton({
   isDisabled,
   isGenerating,
   onClick,
@@ -234,7 +290,7 @@ function RegeneratePastNoteButton({
           type="button"
           variant="ghost"
           size="icon"
-          aria-label="Regenerate past note summary"
+          aria-label="Regenerate insights"
           disabled={isDisabled}
           onClick={onClick}
           className={cn([
@@ -251,11 +307,7 @@ function RegeneratePastNoteButton({
         </Button>
       </TooltipTrigger>
       <TooltipContent side="bottom">
-        <p>
-          {isGenerating
-            ? "Regenerating past note summary"
-            : "Regenerate past note summary"}
-        </p>
+        <p>{isGenerating ? "Regenerating insights" : "Regenerate insights"}</p>
       </TooltipContent>
     </Tooltip>
   );


### PR DESCRIPTION
Summarize related meeting context as compiled insights with participant chips and a panel-level refresh action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-session UX and LLM prompts for stored key facts, but stays within the desktop session accessory and existing generation/storage paths.
> 
> **Overview**
> Renames the post-session **Related meetings** tab to **Insights** (`insights`) and replaces the per-meeting timeline with a single compiled view: **With** participant chips plus a deduplicated bullet list (up to 12 facts) aggregated from related past sessions.
> 
> Regeneration is now **panel-level** (`regenerateAll` / **Regenerate insights**) instead of per-meeting row actions. Opening the tab still triggers generation for missing key facts.
> 
> **`past-notes`** resolves participant display names from the `humans` table, attaches them to notes and generation requests, and passes `participant_names` into the key-facts Jinja prompts (system copy now targets reusable insights; user prompt includes participants). User-facing errors refer to “meeting insights.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4298b2ec1240afb4bf17b6e15634bd164e50076e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->