### PR TITLE
Ignore empty chat assistant placeholders

### DIFF
--- a/apps/desktop/src/chat/components/session-provider.test.tsx
+++ b/apps/desktop/src/chat/components/session-provider.test.tsx
@@ -1,0 +1,235 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  chatRegenerate: vi.fn(),
+  chatSendMessage: vi.fn(),
+  chatSetMessages: vi.fn(),
+  chatStop: vi.fn(),
+  messages: [] as unknown[],
+  store: null as unknown,
+}));
+
+vi.mock("@ai-sdk/react", () => ({
+  useChat: () => ({
+    messages: mocks.messages,
+    sendMessage: mocks.chatSendMessage,
+    regenerate: mocks.chatRegenerate,
+    stop: mocks.chatStop,
+    status: "ready",
+    error: undefined,
+    setMessages: mocks.chatSetMessages,
+  }),
+}));
+
+vi.mock("~/chat/context/use-chat-context-pipeline", () => ({
+  useChatContextPipeline: () => ({
+    contextEntities: [],
+    pendingRefs: [],
+  }),
+}));
+
+vi.mock("~/chat/transport/use-transport", () => ({
+  useTransport: () => ({
+    transport: {},
+    isSystemPromptReady: true,
+  }),
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useStore: () => mocks.store,
+    useValues: () => ({ user_id: "user-1" }),
+  },
+}));
+
+import { ChatSession } from "./session-provider";
+
+import { buildPersistedChatMessageRow } from "~/chat/store/persisted-messages";
+import type { HyprUIMessage } from "~/chat/types";
+
+type FakeStore = ReturnType<typeof createStore>;
+
+function createStore(rows: Record<string, Record<string, unknown>>) {
+  const table = new Map(Object.entries(rows));
+
+  return {
+    delRow: vi.fn((tableName: string, rowId: string) => {
+      if (tableName === "chat_messages") {
+        table.delete(rowId);
+      }
+    }),
+    forEachRow: vi.fn(
+      (
+        tableName: string,
+        callback: (rowId: string, forEachCell: () => void) => void,
+      ) => {
+        if (tableName !== "chat_messages") {
+          return;
+        }
+        table.forEach((_row, rowId) => callback(rowId, () => {}));
+      },
+    ),
+    getRow: vi.fn((tableName: string, rowId: string) => {
+      if (tableName !== "chat_messages") {
+        return undefined;
+      }
+      return table.get(rowId);
+    }),
+    setRow: vi.fn(
+      (tableName: string, rowId: string, row: Record<string, unknown>) => {
+        if (tableName === "chat_messages") {
+          table.set(rowId, row);
+        }
+      },
+    ),
+    transaction: vi.fn((callback: () => void) => callback()),
+  };
+}
+
+function persistedAssistantRow(message: HyprUIMessage) {
+  return buildPersistedChatMessageRow({
+    message,
+    chatGroupId: "group-1",
+    userId: "user-1",
+    status: "ready",
+  }) as unknown as Record<string, unknown>;
+}
+
+function renderSession() {
+  render(
+    <ChatSession chatGroupId="group-1" sessionId="session-1">
+      {({ regenerate }) => (
+        <button type="button" onClick={regenerate}>
+          Regenerate
+        </button>
+      )}
+    </ChatSession>,
+  );
+}
+
+describe("ChatSession", () => {
+  beforeEach(() => {
+    cleanup();
+    mocks.chatRegenerate.mockClear();
+    mocks.chatSendMessage.mockClear();
+    mocks.chatSetMessages.mockClear();
+    mocks.chatStop.mockClear();
+    mocks.messages = [];
+    mocks.store = createStore({});
+  });
+
+  it("does not delete the previous persisted assistant when retrying an unpersisted empty assistant", () => {
+    const previousAssistant: HyprUIMessage = {
+      id: "assistant-previous",
+      role: "assistant",
+      parts: [{ type: "text", text: "Previous answer" }],
+      metadata: { createdAt: Date.parse("2024-01-01T00:00:01Z") },
+    };
+    const store = createStore({
+      "assistant-previous": persistedAssistantRow(previousAssistant),
+    });
+    mocks.store = store;
+    mocks.messages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "First question" }],
+      },
+      previousAssistant,
+      {
+        id: "user-2",
+        role: "user",
+        parts: [{ type: "text", text: "Retry question" }],
+      },
+      {
+        id: "assistant-empty",
+        role: "assistant",
+        parts: [],
+      },
+    ];
+
+    renderSession();
+
+    fireEvent.click(screen.getByRole("button", { name: "Regenerate" }));
+
+    expect(store.delRow).toHaveBeenCalledWith(
+      "chat_messages",
+      "assistant-empty",
+    );
+    expect(
+      (store as FakeStore).getRow("chat_messages", "assistant-previous"),
+    ).toBeDefined();
+    expect(mocks.chatRegenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes the persisted row for the in-memory assistant being regenerated", () => {
+    const assistant: HyprUIMessage = {
+      id: "assistant-current",
+      role: "assistant",
+      parts: [{ type: "text", text: "Current answer" }],
+      metadata: { createdAt: Date.parse("2024-01-01T00:00:01Z") },
+    };
+    const store = createStore({
+      "assistant-current": persistedAssistantRow(assistant),
+    });
+    mocks.store = store;
+    mocks.messages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Question" }],
+      },
+      assistant,
+    ];
+
+    renderSession();
+
+    fireEvent.click(screen.getByRole("button", { name: "Regenerate" }));
+
+    expect(store.delRow).toHaveBeenCalledWith(
+      "chat_messages",
+      "assistant-current",
+    );
+    expect(store.getRow("chat_messages", "assistant-current")).toBeUndefined();
+    expect(mocks.chatRegenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes the last assistant row when a trailing user message is present", () => {
+    const assistant: HyprUIMessage = {
+      id: "assistant-current",
+      role: "assistant",
+      parts: [{ type: "text", text: "Current answer" }],
+      metadata: { createdAt: Date.parse("2024-01-01T00:00:01Z") },
+    };
+    const store = createStore({
+      "assistant-current": persistedAssistantRow(assistant),
+    });
+    mocks.store = store;
+    mocks.messages = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Question" }],
+      },
+      assistant,
+      {
+        id: "user-2",
+        role: "user",
+        parts: [{ type: "text", text: "Follow-up" }],
+      },
+    ];
+
+    renderSession();
+
+    fireEvent.click(screen.getByRole("button", { name: "Regenerate" }));
+
+    expect(store.delRow).toHaveBeenCalledWith(
+      "chat_messages",
+      "assistant-current",
+    );
+    expect(store.getRow("chat_messages", "assistant-current")).toBeUndefined();
+    expect(mocks.chatRegenerate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/chat/components/session-provider.tsx
+++ b/apps/desktop/src/chat/components/session-provider.tsx
@@ -18,6 +18,7 @@ import {
   buildPersistedChatMessageRow,
   getPersistedChatMessages,
   getVisibleChatMessages,
+  shouldPersistFinishedMessage,
 } from "~/chat/store/persisted-messages";
 import { stripEphemeralToolContext } from "~/chat/tools/strip-ephemeral-tool-context";
 import { useTransport } from "~/chat/transport/use-transport";
@@ -117,6 +118,10 @@ export function ChatSession({
         sanitizedParts === message.parts
           ? message
           : { ...message, parts: sanitizedParts };
+      if (!shouldPersistFinishedMessage(sanitizedMessage)) {
+        store.delRow("chat_messages", sanitizedMessage.id);
+        return;
+      }
       store.setRow(
         "chat_messages",
         sanitizedMessage.id,
@@ -142,12 +147,16 @@ export function ChatSession({
 
   const regenerate = useCallback(() => {
     if (!store || !chatGroupId) return;
-    const last = [...getPersistedChatMessages(store, chatGroupId)]
-      .reverse()
-      .find((m) => m.message.role === "assistant");
-    if (last) store.delRow("chat_messages", last.id);
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role !== "assistant") {
+        continue;
+      }
+
+      store.delRow("chat_messages", messages[i].id);
+      break;
+    }
     void chatRegenerate();
-  }, [store, chatGroupId, chatRegenerate]);
+  }, [store, chatGroupId, messages, chatRegenerate]);
 
   const setMessages = useCallback(
     (next: HyprUIMessage[] | ((prev: HyprUIMessage[]) => HyprUIMessage[])) => {

--- a/apps/desktop/src/chat/components/shared.test.ts
+++ b/apps/desktop/src/chat/components/shared.test.ts
@@ -22,4 +22,14 @@ describe("hasRenderableContent", () => {
       }),
     ).toBe(true);
   });
+
+  test("returns false for blank text-only messages", () => {
+    expect(
+      hasRenderableContent({
+        id: "message-3",
+        role: "assistant",
+        parts: [{ type: "text", text: " " }],
+      }),
+    ).toBe(false);
+  });
 });

--- a/apps/desktop/src/chat/components/shared.ts
+++ b/apps/desktop/src/chat/components/shared.ts
@@ -1,15 +1,1 @@
-import type { HyprUIMessage } from "~/chat/types";
-
-export function hasRenderableContent(message: HyprUIMessage): boolean {
-  return message.parts.some((part) => {
-    if (part.type === "step-start") {
-      return false;
-    }
-
-    if (part.type === "reasoning") {
-      return part.text.trim().length > 0;
-    }
-
-    return true;
-  });
-}
+export { hasRenderableContent } from "~/chat/message-content";

--- a/apps/desktop/src/chat/message-content.ts
+++ b/apps/desktop/src/chat/message-content.ts
@@ -1,0 +1,31 @@
+import type { HyprUIMessage } from "~/chat/types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function hasRenderableParts(parts: unknown): boolean {
+  if (!Array.isArray(parts)) {
+    return false;
+  }
+
+  return parts.some((part) => {
+    if (!isRecord(part) || typeof part.type !== "string") {
+      return false;
+    }
+
+    if (part.type === "step-start") {
+      return false;
+    }
+
+    if (part.type === "reasoning" || part.type === "text") {
+      return typeof part.text === "string" && part.text.trim().length > 0;
+    }
+
+    return true;
+  });
+}
+
+export function hasRenderableContent(message: HyprUIMessage) {
+  return hasRenderableParts(message.parts);
+}

--- a/apps/desktop/src/chat/store/persisted-messages.test.ts
+++ b/apps/desktop/src/chat/store/persisted-messages.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeChatMessageStatus,
   rowToPersistedChatMessage,
   shouldHidePersistedMessage,
+  shouldPersistFinishedMessage,
 } from "./persisted-messages";
 
 import type { HyprUIMessage } from "~/chat/types";
@@ -63,7 +64,7 @@ describe("persisted chat messages", () => {
     });
   });
 
-  test("hides only empty streaming assistant messages", () => {
+  test("hides empty assistant messages regardless of status", () => {
     expect(
       shouldHidePersistedMessage(
         rowToPersistedChatMessage("assistant-1", {
@@ -75,6 +76,21 @@ describe("persisted chat messages", () => {
           metadata: "{}",
           parts: "[]",
           status: "streaming",
+        }),
+      ),
+    ).toBe(true);
+
+    expect(
+      shouldHidePersistedMessage(
+        rowToPersistedChatMessage("assistant-ready", {
+          user_id: "user-1",
+          created_at: "2024-01-01T00:00:01.000Z",
+          chat_group_id: "group-1",
+          role: "assistant",
+          content: "",
+          metadata: "{}",
+          parts: "[]",
+          status: "ready",
         }),
       ),
     ).toBe(true);
@@ -93,5 +109,23 @@ describe("persisted chat messages", () => {
         }),
       ),
     ).toBe(false);
+  });
+
+  test("does not persist empty finished assistant messages", () => {
+    expect(
+      shouldPersistFinishedMessage({
+        id: "assistant-empty",
+        role: "assistant",
+        parts: [],
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldPersistFinishedMessage({
+        id: "assistant-text",
+        role: "assistant",
+        parts: [{ type: "text", text: "Done" }],
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/desktop/src/chat/store/persisted-messages.ts
+++ b/apps/desktop/src/chat/store/persisted-messages.ts
@@ -1,5 +1,6 @@
 import type { ChatMessageStatus, ChatMessageStorage } from "@hypr/store";
 
+import { hasRenderableContent } from "~/chat/message-content";
 import type { HyprUIMessage } from "~/chat/types";
 import * as main from "~/store/tinybase/store/main";
 
@@ -141,9 +142,13 @@ export function getPersistedChatMessages(
 export function shouldHidePersistedMessage(message: PersistedChatMessage) {
   return (
     message.message.role === "assistant" &&
-    message.status === "streaming" &&
-    message.message.parts.length === 0
+    !hasRenderableContent(message.message) &&
+    !(message.row.content ?? "").trim()
   );
+}
+
+export function shouldPersistFinishedMessage(message: HyprUIMessage): boolean {
+  return message.role !== "assistant" || hasRenderableContent(message);
 }
 
 export function getVisibleChatMessages(

--- a/apps/desktop/src/store/tinybase/persister/chat/load.ts
+++ b/apps/desktop/src/store/tinybase/persister/chat/load.ts
@@ -6,6 +6,7 @@ import type { ChatMessageStatus } from "@hypr/store";
 
 import type { ChatJson, LoadedChatData } from "./types";
 
+import { hasRenderableParts } from "~/chat/message-content";
 import {
   CHAT_MESSAGES_FILE,
   err,
@@ -43,6 +44,30 @@ function normalizeLoadedChatMessage(
   };
 }
 
+function parseMessageParts(parts: unknown): unknown {
+  if (typeof parts !== "string") {
+    return parts;
+  }
+
+  try {
+    return JSON.parse(parts);
+  } catch {
+    return [];
+  }
+}
+
+function shouldLoadChatMessage(message: Record<string, unknown>): boolean {
+  if (message.role !== "assistant") {
+    return true;
+  }
+
+  const content = typeof message.content === "string" ? message.content : "";
+  return (
+    content.trim().length > 0 ||
+    hasRenderableParts(parseMessageParts(message.parts))
+  );
+}
+
 export function chatJsonToData(json: ChatJson): LoadedChatData {
   const result: LoadedChatData = {
     chat_groups: {},
@@ -54,6 +79,9 @@ export function chatJsonToData(json: ChatJson): LoadedChatData {
 
   for (const message of json.messages) {
     const { id: messageId, ...messageData } = message;
+    if (!shouldLoadChatMessage(messageData)) {
+      continue;
+    }
     result.chat_messages[messageId] = normalizeLoadedChatMessage(
       messageData,
     ) as LoadedChatData["chat_messages"][string];

--- a/apps/desktop/src/store/tinybase/persister/chat/transform.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/chat/transform.test.ts
@@ -117,6 +117,44 @@ describe("chatJsonToData", () => {
     expect(data.chat_messages["msg-2"]?.status).toBe("aborted");
   });
 
+  test("skips empty assistant placeholders", () => {
+    const data = chatJsonToData({
+      chat_group: {
+        id: "group-1",
+        user_id: "user-1",
+        created_at: "2024-01-01T00:00:00Z",
+        title: "Test Chat",
+      },
+      messages: [
+        {
+          id: "msg-user",
+          user_id: "user-1",
+          created_at: "2024-01-01T00:00:01Z",
+          chat_group_id: "group-1",
+          role: "user",
+          content: "Hello",
+          metadata: "{}",
+          parts: '[{"type":"text","text":"Hello"}]',
+          ...readyMessage,
+        },
+        {
+          id: "msg-empty-assistant",
+          user_id: "user-1",
+          created_at: "2024-01-01T00:00:02Z",
+          chat_group_id: "group-1",
+          role: "assistant",
+          content: "",
+          metadata: "{}",
+          parts: "[]",
+          ...readyMessage,
+        },
+      ],
+    });
+
+    expect(data.chat_messages["msg-user"]).toBeDefined();
+    expect(data.chat_messages["msg-empty-assistant"]).toBeUndefined();
+  });
+
   test("handles empty messages array", () => {
     const json: ChatJson = {
       chat_group: {


### PR DESCRIPTION
Skip empty finished assistant messages during chat persistence and loading so stale placeholder rows cannot make existing chats appear stuck.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes chat persistence, reload filtering, and regenerate deletion logic—user-visible history and retry behavior, though scoped to empty-placeholder edge cases with solid test coverage.
> 
> **Overview**
> Stops **empty assistant placeholders** from sticking around in local chat storage and from making threads look stuck when reopened.
> 
> Shared **`hasRenderableContent` / `hasRenderableParts`** in `message-content.ts` (blank text/reasoning no longer count as content). **Finish persistence** skips or removes rows for assistants with nothing renderable via `shouldPersistFinishedMessage`; **visibility** hides empty assistants for any status, not only streaming. **Disk load** drops empty assistant rows when importing chat JSON.
> 
> **Regenerate** now deletes the **last in-memory assistant** message’s store row (walking `messages` backward) instead of the last persisted assistant—so retrying after an unpersisted empty placeholder does not wipe the previous real answer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 015f42d589f4b00ba1029b9c0d691d6f7321b3ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->