### PR TITLE
Spread summary image context sampling

### DIFF
--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-images.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-images.test.ts
@@ -168,6 +168,25 @@ describe("enhance image context", () => {
     expect(images).toHaveLength(6);
   });
 
+  it("samples image context across the full note when over the image count cap", async () => {
+    const images = await collectEnhanceImageContext(
+      "session-1",
+      Array.from(
+        { length: 20 },
+        (_, index) =>
+          `![image-${index}](data:image/png;base64,image${String(index).padStart(2, "0")})`,
+      ).join("\n"),
+    );
+
+    expect(images).toEqual(
+      [0, 2, 4, 6, 8, 11, 13, 15, 17, 19].map((index) => ({
+        base64: `image${String(index).padStart(2, "0")}`,
+        mimeType: "image/png",
+      })),
+    );
+    expect(fsSyncMocks.attachmentList).not.toHaveBeenCalled();
+  });
+
   it("does not load an attachment again for a node that already has a data URL", async () => {
     const rawContent = JSON.stringify({
       type: "doc",

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-images.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-images.ts
@@ -15,6 +15,10 @@ type ImageReference = {
   dataUrl?: { base64: string; mimeType: string };
 };
 
+type IndexedImageReference = ImageReference & {
+  index: number;
+};
+
 const MAX_IMAGE_COUNT = 10;
 const MAX_IMAGE_BYTES = 128 * 1024;
 const MAX_TOTAL_IMAGE_BYTES = 768 * 1024;
@@ -41,84 +45,91 @@ export async function collectEnhanceImageContext(
   const references = Array.isArray(rawContent)
     ? rawContent.flatMap(collectImageReferences)
     : collectImageReferences(rawContent);
-  const images: EnhanceImageContext[] = [];
+  const candidateRefs = getCandidateImageReferences(references);
+  const images: Array<{ index: number; image: EnhanceImageContext }> = [];
   let totalImageBytes = 0;
-
-  for (const ref of references) {
-    if (!ref.dataUrl) {
-      continue;
-    }
-
-    const image = await prepareImageForBudget(ref.dataUrl, totalImageBytes);
-    if (!image) {
-      continue;
-    }
-
-    const imageBytes = getBase64ByteLength(image.base64);
-    images.push(image);
-    totalImageBytes += imageBytes;
-    if (images.length >= MAX_IMAGE_COUNT) {
-      return images;
-    }
-  }
-
-  const attachmentRefs = references.filter(
-    (ref) => !ref.dataUrl && (ref.attachmentId || ref.filename),
-  );
-  if (attachmentRefs.length === 0) {
-    return images;
-  }
-
-  const listResult = await fsSyncCommands.attachmentList(sessionId);
-  if (listResult.status === "error") {
-    console.warn(
-      "[enhance] failed to list image attachments",
-      listResult.error,
-    );
-    return images;
-  }
-
-  const attachmentsById = new Map(
-    listResult.data.map((attachment) => [attachment.attachmentId, attachment]),
-  );
-  const attachmentsByFilename = new Map(
-    listResult.data.map((attachment) => [
-      getPathFilename(attachment.path) || attachment.attachmentId,
-      attachment,
-    ]),
-  );
   const seen = new Set<string>();
+  let attachmentLookup:
+    | {
+        byId: Map<string, AttachmentInfo>;
+        byFilename: Map<string, AttachmentInfo>;
+      }
+    | null
+    | undefined;
 
-  for (const ref of attachmentRefs) {
-    const attachment =
-      (ref.attachmentId ? attachmentsById.get(ref.attachmentId) : undefined) ??
-      (ref.filename ? attachmentsById.get(ref.filename) : undefined) ??
-      (ref.filename ? attachmentsByFilename.get(ref.filename) : undefined);
+  async function getAttachmentLookup() {
+    if (attachmentLookup !== undefined) {
+      return attachmentLookup;
+    }
 
-    if (!attachment || seen.has(attachment.attachmentId)) {
+    const listResult = await fsSyncCommands.attachmentList(sessionId);
+    if (listResult.status === "error") {
+      console.warn(
+        "[enhance] failed to list image attachments",
+        listResult.error,
+      );
+      attachmentLookup = null;
+      return attachmentLookup;
+    }
+
+    attachmentLookup = {
+      byId: new Map(
+        listResult.data.map((attachment) => [
+          attachment.attachmentId,
+          attachment,
+        ]),
+      ),
+      byFilename: new Map(
+        listResult.data.map((attachment) => [
+          getPathFilename(attachment.path) || attachment.attachmentId,
+          attachment,
+        ]),
+      ),
+    };
+    return attachmentLookup;
+  }
+
+  for (const ref of prioritizeImageReferences(candidateRefs)) {
+    let sourceImage: EnhanceImageContext | null = null;
+
+    if (ref.dataUrl) {
+      sourceImage = ref.dataUrl;
+    } else {
+      const lookup = await getAttachmentLookup();
+      const attachment =
+        (ref.attachmentId ? lookup?.byId.get(ref.attachmentId) : undefined) ??
+        (ref.filename ? lookup?.byId.get(ref.filename) : undefined) ??
+        (ref.filename ? lookup?.byFilename.get(ref.filename) : undefined);
+
+      if (!attachment || seen.has(attachment.attachmentId)) {
+        continue;
+      }
+
+      seen.add(attachment.attachmentId);
+      sourceImage = await readImageAttachment(sessionId, attachment);
+    }
+
+    if (!sourceImage) {
       continue;
     }
 
-    seen.add(attachment.attachmentId);
-    const image = await readImageAttachment(sessionId, attachment);
-    if (!image) {
-      continue;
-    }
-
-    const budgetedImage = await prepareImageForBudget(image, totalImageBytes);
+    const budgetedImage = await prepareImageForBudget(
+      sourceImage,
+      totalImageBytes,
+    );
     if (!budgetedImage) {
       continue;
     }
 
     const imageBytes = getBase64ByteLength(budgetedImage.base64);
-    images.push(budgetedImage);
+    images.push({ index: ref.index, image: budgetedImage });
     totalImageBytes += imageBytes;
     if (images.length >= MAX_IMAGE_COUNT) {
-      return images;
+      return sortImageContexts(images);
     }
   }
 
-  return images;
+  return sortImageContexts(images);
 }
 
 async function prepareImageForBudget(
@@ -199,6 +210,41 @@ async function compressImageContext(
   }
 
   return null;
+}
+
+function getCandidateImageReferences(
+  references: ImageReference[],
+): IndexedImageReference[] {
+  return references.flatMap((ref, index) =>
+    ref.dataUrl || ref.attachmentId || ref.filename ? [{ ...ref, index }] : [],
+  );
+}
+
+function prioritizeImageReferences(
+  references: IndexedImageReference[],
+): IndexedImageReference[] {
+  if (references.length <= MAX_IMAGE_COUNT) {
+    return references;
+  }
+
+  const selectedIndexes = new Set<number>();
+  for (let i = 0; i < MAX_IMAGE_COUNT; i++) {
+    selectedIndexes.add(
+      Math.round((i * (references.length - 1)) / (MAX_IMAGE_COUNT - 1)),
+    );
+  }
+
+  const sampled = [...selectedIndexes].map((index) => references[index]);
+  const remaining = references.filter(
+    (_, index) => !selectedIndexes.has(index),
+  );
+  return [...sampled, ...remaining];
+}
+
+function sortImageContexts(
+  images: Array<{ index: number; image: EnhanceImageContext }>,
+): EnhanceImageContext[] {
+  return images.sort((a, b) => a.index - b.index).map(({ image }) => image);
 }
 
 function toDataUrl(image: EnhanceImageContext): string {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-workflow.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-workflow.ts
@@ -145,17 +145,14 @@ async function generateTemplateIfNeeded(params: {
     onProgress({ type: "analyzing" });
 
     const schema = z.object({ sections: z.array(templateSectionSchema) });
-    const userPrompt = withImageContextNote(
-      await getUserPrompt(args, store),
-      args.imageContext.length,
-    );
+    const userPrompt = await getUserPrompt(args, store);
 
     const result = await generateStructuredOutput({
       model,
       schema,
       signal,
       prompt: createTemplatePrompt(userPrompt, schema),
-      imageContext: args.imageContext,
+      imageContext: [],
     });
 
     if (!result) {


### PR DESCRIPTION
Sample large image sets across notes and keep auto-template generation text-only.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5621 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5618 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which images reach the enhance summary model and alters auto-template LLM inputs; behavior is covered by a new sampling test but affects AI output quality paths.
> 
> **Overview**
> When a note has more than **10** images, enhance image collection no longer keeps only the first images in document order. It **evenly samples** up to the cap across the full note, then returns the chosen images **sorted by their original position**.
> 
> `collectEnhanceImageContext` is refactored so data URLs and attachments share one prioritized loop, with **lazy** `attachmentList` only when attachment refs need resolving.
> 
> **Auto-template** generation (when no template is provided) is now **text-only**: it no longer passes `imageContext` or adds the image-context note to the prompt. Summary generation still uses images as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c4766b4b053f5ac6b147ccbe8f8d870c174a47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->