### PR TITLE
Add desktop 1.0.47 changelog

### DIFF
--- a/packages/changelog/content/1.0.47.md
+++ b/packages/changelog/content/1.0.47.md
@@ -1,0 +1,20 @@
+---
+date: "2026-06-18"
+summary: "Anarlog now handles image-heavy summaries more reliably, turns related meeting context into insights, and prevents stale chat placeholders."
+---
+
+## Summaries
+
+- Image-heavy notes now stay within hosted summary request limits by compressing, sampling, or skipping oversized images before generation
+- Large image sets are sampled across the whole note instead of only using the first images
+- Auto-template generation now stays text-only, while summary generation still uses visual context when available
+
+## Meetings
+
+- Related meeting context is now shown as an Insights tab with participant chips and deduplicated facts
+- Meeting insights now regenerate at the panel level instead of one related meeting at a time
+- Key fact generation now includes participant names so related context reads more clearly
+
+## Chat
+
+- Empty assistant placeholders are now ignored when chats are saved or loaded, preventing existing chats from appearing stuck


### PR DESCRIPTION
## Summary
- Add the desktop 1.0.47 changelog entry for the next stable release.
- Cover image-heavy summary handling, meeting insights, and chat placeholder fixes.

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/changelog typecheck
- git diff --check
- doxxer --config doxxer.desktop.toml current
- doxxer --config doxxer.desktop.toml next patch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog content with no application or build logic changes.
> 
> **Overview**
> Adds a new **`packages/changelog/content/1.0.47.md`** entry (dated 2026-06-18) for the next stable desktop release.
> 
> The notes document shipped behavior for **Summaries** (image compression/sampling and text-only auto-templates), **Meetings** (Insights tab, panel-level regeneration, participant names in key facts), and **Chat** (dropping empty assistant placeholders on save/load).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b516418a67ed1ce1adbf6f55e61d33be2177e05e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->