### PR TITLE
Update landing download count

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -341,7 +341,7 @@ function Component() {
             </h1>
             <p className="mt-6 max-w-2xl text-xl leading-9 text-[#363029]">
               The open-source Granola alternative for private meetings,
-              downloaded over 11.9M times. Record locally and choose where AI
+              downloaded over 18k times. Record locally and choose where AI
               runs.
             </p>
             <div className="mt-8 flex flex-wrap gap-x-5 gap-y-3 text-sm">


### PR DESCRIPTION
Change the landing page download count from 11.9M to 18k.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single static string on the marketing homepage with no logic, API, or data-handling impact.
> 
> **Overview**
> Updates the **homepage hero** subhead in `index.tsx` so the credibility line reads **“downloaded over 18k times”** instead of **“11.9M times.”**
> 
> This is a **static marketing copy** change only; download buttons, GitHub star count, and the rest of the landing page are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecdb8ef52b82198bc8fc731d97c5a405a3f4cd55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->