### PR TITLE
Remove LLM provider Pro chip

### DIFF
--- a/apps/desktop/src/settings/ai/llm/select.tsx
+++ b/apps/desktop/src/settings/ai/llm/select.tsx
@@ -210,11 +210,6 @@ export function SelectProviderAndModel() {
                       <div className="flex items-center gap-2">
                         <ProviderIconSlot>{provider.icon}</ProviderIconSlot>
                         <span>{provider.displayName}</span>
-                        {requiresPro ? (
-                          <span className="border-border text-muted-foreground rounded-full border px-2 py-0.5 text-[10px] tracking-wide uppercase">
-                            Pro
-                          </span>
-                        ) : null}
                       </div>
                       {locked ? (
                         <span className="text-muted-foreground text-[11px]">


### PR DESCRIPTION
Hide the Pro badge in the Intelligence model provider picker while keeping upgrade gating intact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic UI change only; billing gating logic and disabled states are untouched.
> 
> **Overview**
> Removes the inline **Pro** pill next to pro-gated provider names in the Intelligence **Model being used** provider dropdown.
> 
> **Upgrade behavior is unchanged:** pro-required providers stay disabled for non‑paid users, and the *Upgrade to Pro to use this provider.* helper text still shows when a row is locked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ba7ab4f1ff1c45a213800585a8303a4367ffd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->