### PR TITLE
Add Cartesia BYOK STT support

### DIFF
--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -86,6 +86,14 @@ export const displayModelId = (model: string) => {
     return "Whisper 1";
   }
 
+  if (model === "ink-whisper") {
+    return "Ink Whisper";
+  }
+
+  if (model === "ink-2") {
+    return "Ink 2";
+  }
+
   if (model === "gpt-4o-transcribe") {
     return "GPT-4o Transcribe";
   }
@@ -187,6 +195,26 @@ const _PROVIDERS = [
     baseUrl: "https://api.openai.com/v1",
     models: ["gpt-4o-transcribe", "gpt-4o-mini-transcribe", "whisper-1"],
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+  },
+  {
+    disabled: false,
+    id: "cartesia",
+    displayName: "Cartesia",
+    badge: null,
+    icon: <Icon icon="mingcute:voiceprint-fill" className="size-4" />,
+    baseUrl: "https://api.cartesia.ai",
+    models: ["ink-2"],
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Cartesia STT docs",
+        url: "https://docs.cartesia.ai/api-reference/stt/transcribe",
+      },
+      setup: {
+        label: "API keys",
+        url: "https://play.cartesia.ai/keys",
+      },
+    },
   },
   {
     disabled: false,

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -132,6 +132,10 @@ describe("getBatchProvider", () => {
     expect(getBatchProvider("openai", "gpt-4o-transcribe")).toBe("openai");
   });
 
+  test("keeps cartesia mapped to the batch transcription provider", () => {
+    expect(getBatchProvider("cartesia", "ink-2")).toBe("cartesia");
+  });
+
   test("maps Cloudflare Workers AI to the Deepgram-compatible batch provider", () => {
     expect(getBatchProvider("cloudflare_workers_ai", "nova-3")).toBe(
       "deepgram",

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -36,6 +36,7 @@ type Store = NonNullable<ReturnType<typeof main.UI.useStore>>;
 
 const DIRECT_BATCH_PROVIDERS: Set<TranscriptionParams["provider"]> = new Set([
   "deepgram",
+  "cartesia",
   "soniox",
   "assemblyai",
   "openai",

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -5,9 +5,9 @@ use bytes::Bytes;
 use ractor::{ActorProcessingErr, ActorRef};
 
 use owhisper_client::{
-    AdapterKind, ArgmaxAdapter, AssemblyAIAdapter, DashScopeAdapter, DeepgramAdapter,
-    ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, HyprnoteAdapter, MistralAdapter,
-    RealtimeSttAdapter, SonioxAdapter, hypr_ws_client,
+    AdapterKind, ArgmaxAdapter, AssemblyAIAdapter, CartesiaAdapter, DashScopeAdapter,
+    DeepgramAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, HyprnoteAdapter,
+    MistralAdapter, RealtimeSttAdapter, SonioxAdapter, hypr_ws_client,
 };
 use owhisper_interface::stream::Extra;
 use owhisper_interface::{ControlMessage, MixedMessage};
@@ -94,6 +94,7 @@ pub(super) async fn spawn_rx_task(
 
     let result = dispatch_realtime!(adapter_kind, is_dual, args, myself, {
         Argmax => ArgmaxAdapter,
+        Cartesia => CartesiaAdapter,
         Soniox => SonioxAdapter,
         Fireworks => FireworksAdapter,
         Deepgram => DeepgramAdapter,

--- a/crates/listener2-core/src/batch/mod.rs
+++ b/crates/listener2-core/src/batch/mod.rs
@@ -34,6 +34,7 @@ pub enum BatchProvider {
     Am,
     Soniqo,
     AquaVoice,
+    Cartesia,
 }
 
 impl BatchProvider {
@@ -51,6 +52,7 @@ impl BatchProvider {
             Self::Mistral => Some(AdapterKind::Mistral),
             Self::Hyprnote => Some(AdapterKind::Hyprnote),
             Self::AquaVoice => Some(AdapterKind::AquaVoice),
+            Self::Cartesia => Some(AdapterKind::Cartesia),
             Self::Am | Self::WhisperLocal | Self::Soniqo | Self::DashScope => None,
         }
     }

--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -3,8 +3,8 @@ use std::time::Instant;
 
 use owhisper_client::{
     AdapterKind, AquaVoiceAdapter, ArgmaxAdapter, AssemblyAIAdapter, BatchSttAdapter,
-    DeepgramAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, HyprnoteAdapter,
-    MistralAdapter, OpenAIAdapter, PyannoteAdapter, SonioxAdapter,
+    CartesiaAdapter, DeepgramAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter,
+    HyprnoteAdapter, MistralAdapter, OpenAIAdapter, PyannoteAdapter, SonioxAdapter,
 };
 use tracing::Instrument;
 
@@ -43,6 +43,7 @@ pub(super) async fn run_direct_batch_for_adapter_kind(
 ) -> crate::Result<BatchRunOutput> {
     dispatch_batch!(adapter_kind, params, listen_params, {
         Argmax => ArgmaxAdapter,
+        Cartesia => CartesiaAdapter,
         Deepgram => DeepgramAdapter,
         Soniox => SonioxAdapter,
         AssemblyAI => AssemblyAIAdapter,

--- a/crates/owhisper-client/src/adapter/cartesia/batch.rs
+++ b/crates/owhisper-client/src/adapter/cartesia/batch.rs
@@ -1,0 +1,242 @@
+use std::path::Path;
+
+use owhisper_interface::ListenParams;
+use owhisper_interface::batch::{
+    Alternatives, Channel, Response as BatchResponse, Results, Word as BatchWord,
+};
+use reqwest::multipart::Form;
+
+use crate::adapter::http::{ensure_success, streaming_file_part};
+use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware, MIXED_CAPTURE_CHANNEL};
+use crate::error::Error;
+
+use super::{API_VERSION, CartesiaAdapter, DEFAULT_MODEL};
+
+impl BatchSttAdapter for CartesiaAdapter {
+    fn provider_name(&self) -> &'static str {
+        "cartesia"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[hypr_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        CartesiaAdapter::is_supported_languages_batch(languages)
+    }
+
+    fn transcribe_file<'a, P: AsRef<Path> + Send + 'a>(
+        &'a self,
+        client: &'a ClientWithMiddleware,
+        api_base: &'a str,
+        api_key: &'a str,
+        params: &'a ListenParams,
+        file_path: P,
+    ) -> BatchFuture<'a> {
+        let path = file_path.as_ref().to_path_buf();
+        Box::pin(async move { transcribe_file(client, api_base, api_key, params, &path).await })
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CartesiaTranscriptionResponse {
+    #[serde(rename = "type")]
+    response_type: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    request_id: Option<String>,
+    #[serde(default)]
+    is_final: Option<bool>,
+    #[serde(default)]
+    language: Option<String>,
+    #[serde(default)]
+    duration: Option<f64>,
+    #[serde(default)]
+    words: Vec<CartesiaWord>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CartesiaWord {
+    #[serde(default)]
+    word: String,
+    #[serde(default)]
+    start: f64,
+    #[serde(default)]
+    end: f64,
+}
+
+async fn transcribe_file(
+    client: &ClientWithMiddleware,
+    api_base: &str,
+    api_key: &str,
+    params: &ListenParams,
+    file_path: &Path,
+) -> Result<BatchResponse, Error> {
+    let file_part = streaming_file_part(file_path).await?;
+    let model = resolve_model(params.model.as_deref());
+
+    let mut form = Form::new()
+        .part("file", file_part)
+        .text("model", model.to_string())
+        .text("timestamp_granularities[]", "word");
+
+    if let Some(language) = params.languages.first() {
+        form = form.text("language", language.iso639().code().to_string());
+    }
+
+    let mut request = client.post(transcription_url(api_base)?.to_string());
+    for (name, value) in request_headers(api_key) {
+        request = request.header(name, value);
+    }
+
+    let response = request.multipart(form).send().await?;
+
+    let response = ensure_success(response).await?;
+    let transcript = response.json::<CartesiaTranscriptionResponse>().await?;
+
+    Ok(convert_response(transcript))
+}
+
+fn resolve_model(model: Option<&str>) -> &str {
+    match model {
+        Some(model) if crate::providers::is_meta_model(model) => DEFAULT_MODEL,
+        Some("ink-2") => DEFAULT_MODEL,
+        Some(model) => model,
+        None => DEFAULT_MODEL,
+    }
+}
+
+fn transcription_url(api_base: &str) -> Result<url::Url, Error> {
+    let mut url: url::Url = if api_base.is_empty() {
+        crate::providers::Provider::Cartesia
+            .default_api_base()
+            .parse()
+            .expect("invalid_default_cartesia_api_base")
+    } else {
+        api_base
+            .parse()
+            .map_err(|e: url::ParseError| Error::AudioProcessing(e.to_string()))?
+    };
+
+    crate::adapter::append_path_if_missing(&mut url, "stt");
+    Ok(url)
+}
+
+fn request_headers(api_key: &str) -> [(&'static str, String); 2] {
+    [
+        ("X-API-Key", api_key.to_string()),
+        ("Cartesia-Version", API_VERSION.to_string()),
+    ]
+}
+
+fn convert_response(response: CartesiaTranscriptionResponse) -> BatchResponse {
+    let words = response
+        .words
+        .into_iter()
+        .map(|word| BatchWord {
+            word: word.word.clone(),
+            start: word.start,
+            end: word.end,
+            confidence: 1.0,
+            channel: MIXED_CAPTURE_CHANNEL,
+            speaker: None,
+            punctuated_word: Some(word.word),
+        })
+        .collect();
+
+    BatchResponse {
+        metadata: serde_json::json!({
+            "provider": "cartesia",
+            "type": response.response_type,
+            "request_id": response.request_id,
+            "is_final": response.is_final,
+            "language": response.language,
+            "duration": response.duration,
+        }),
+        results: Results {
+            channels: vec![Channel {
+                alternatives: vec![Alternatives {
+                    transcript: response.text,
+                    confidence: 1.0,
+                    words,
+                }],
+            }],
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_model_uses_default_for_meta_models() {
+        assert_eq!(resolve_model(None), DEFAULT_MODEL);
+        assert_eq!(resolve_model(Some("cloud")), DEFAULT_MODEL);
+        assert_eq!(resolve_model(Some("auto")), DEFAULT_MODEL);
+        assert_eq!(resolve_model(Some("ink-2")), DEFAULT_MODEL);
+        assert_eq!(resolve_model(Some("ink-whisper")), "ink-whisper");
+    }
+
+    #[test]
+    fn transcription_url_appends_stt() {
+        assert_eq!(
+            transcription_url("").unwrap().as_str(),
+            "https://api.cartesia.ai/stt"
+        );
+        assert_eq!(
+            transcription_url("https://api.cartesia.ai")
+                .unwrap()
+                .as_str(),
+            "https://api.cartesia.ai/stt"
+        );
+        assert_eq!(
+            transcription_url("https://api.cartesia.ai/stt")
+                .unwrap()
+                .as_str(),
+            "https://api.cartesia.ai/stt"
+        );
+    }
+
+    #[test]
+    fn request_headers_use_cartesia_api_key_header() {
+        let headers = request_headers("cartesia-key");
+
+        assert_eq!(headers[0], ("X-API-Key", "cartesia-key".to_string()));
+        assert_eq!(headers[1], ("Cartesia-Version", API_VERSION.to_string()));
+        assert!(!headers.iter().any(|(name, _)| *name == "Authorization"));
+    }
+
+    #[test]
+    fn convert_response_preserves_word_timestamps() {
+        let batch = convert_response(CartesiaTranscriptionResponse {
+            response_type: "transcript".to_string(),
+            text: "hello world".to_string(),
+            request_id: Some("req_123".to_string()),
+            is_final: Some(true),
+            language: Some("en".to_string()),
+            duration: Some(1.2),
+            words: vec![
+                CartesiaWord {
+                    word: "hello".to_string(),
+                    start: 0.0,
+                    end: 0.4,
+                },
+                CartesiaWord {
+                    word: "world".to_string(),
+                    start: 0.5,
+                    end: 0.9,
+                },
+            ],
+        });
+
+        let alternative = &batch.results.channels[0].alternatives[0];
+        assert_eq!(alternative.transcript, "hello world");
+        assert_eq!(alternative.words.len(), 2);
+        assert_eq!(alternative.words[0].word, "hello");
+        assert_eq!(alternative.words[0].channel, MIXED_CAPTURE_CHANNEL);
+        assert_eq!(alternative.words[0].speaker, None);
+        assert_eq!(batch.metadata["provider"], "cartesia");
+    }
+}

--- a/crates/owhisper-client/src/adapter/cartesia/live.rs
+++ b/crates/owhisper-client/src/adapter/cartesia/live.rs
@@ -1,0 +1,276 @@
+use hypr_ws_client::client::Message;
+use owhisper_interface::ListenParams;
+use owhisper_interface::stream::{Alternatives, Channel, Metadata, StreamResponse};
+use serde::Deserialize;
+
+use crate::adapter::RealtimeSttAdapter;
+
+use super::{API_VERSION, CartesiaAdapter};
+
+const LIVE_MODEL: &str = "ink-2";
+
+impl RealtimeSttAdapter for CartesiaAdapter {
+    fn provider_name(&self) -> &'static str {
+        "cartesia"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[hypr_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        CartesiaAdapter::is_supported_languages_live(languages)
+    }
+
+    fn supports_native_multichannel(&self) -> bool {
+        false
+    }
+
+    fn build_ws_url(&self, api_base: &str, params: &ListenParams, _channels: u8) -> url::Url {
+        let (mut url, existing_params) = CartesiaAdapter::build_ws_url_from_base(api_base);
+        let model = resolve_live_model(params.model.as_deref());
+
+        {
+            let mut query = url.query_pairs_mut();
+            for (key, value) in &existing_params {
+                query.append_pair(key, value);
+            }
+            query.append_pair("model", model);
+            query.append_pair("encoding", "pcm_s16le");
+            query.append_pair("sample_rate", &params.sample_rate.to_string());
+            query.append_pair("cartesia_version", API_VERSION);
+        }
+
+        url
+    }
+
+    fn build_auth_header(&self, api_key: Option<&str>) -> Option<(&'static str, String)> {
+        api_key.map(|key| ("X-API-Key", key.to_string()))
+    }
+
+    fn keep_alive_message(&self) -> Option<Message> {
+        None
+    }
+
+    fn finalize_message(&self) -> Message {
+        Message::Text(r#"{"type":"close"}"#.into())
+    }
+
+    fn parse_response(&self, raw: &str) -> Vec<StreamResponse> {
+        let event: CartesiaEvent = match serde_json::from_str(raw) {
+            Ok(event) => event,
+            Err(error) => {
+                tracing::warn!(
+                    error = ?error,
+                    hyprnote.payload.size_bytes = raw.len() as u64,
+                    "cartesia_json_parse_failed"
+                );
+                return vec![];
+            }
+        };
+
+        match event {
+            CartesiaEvent::Connected { request_id } => {
+                tracing::debug!(request.id = %request_id, "cartesia_connected");
+                vec![]
+            }
+            CartesiaEvent::TurnStart { .. } => vec![StreamResponse::SpeechStartedResponse {
+                channel: vec![0],
+                timestamp: 0.0,
+            }],
+            CartesiaEvent::TurnUpdate {
+                transcript,
+                request_id,
+            }
+            | CartesiaEvent::TurnEagerEnd {
+                transcript,
+                request_id,
+            } => build_transcript_response(transcript, request_id, false),
+            CartesiaEvent::TurnEnd {
+                transcript,
+                request_id,
+            } => build_transcript_response(transcript, request_id, true),
+            CartesiaEvent::TurnResume { .. } => vec![],
+            CartesiaEvent::Done { request_id } => vec![StreamResponse::TerminalResponse {
+                request_id,
+                created: chrono_like_now(),
+                duration: 0.0,
+                channels: 1,
+            }],
+            CartesiaEvent::Error {
+                message,
+                title,
+                status_code,
+                ..
+            } => vec![StreamResponse::ErrorResponse {
+                error_code: status_code,
+                error_message: message.unwrap_or(title),
+                provider: "cartesia".to_string(),
+            }],
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum CartesiaEvent {
+    #[serde(rename = "connected")]
+    Connected { request_id: String },
+    #[serde(rename = "turn.start")]
+    TurnStart {
+        #[serde(rename = "request_id")]
+        _request_id: String,
+    },
+    #[serde(rename = "turn.update")]
+    TurnUpdate {
+        transcript: String,
+        request_id: String,
+    },
+    #[serde(rename = "turn.eager_end")]
+    TurnEagerEnd {
+        transcript: String,
+        request_id: String,
+    },
+    #[serde(rename = "turn.resume")]
+    TurnResume {
+        #[serde(rename = "request_id")]
+        _request_id: String,
+    },
+    #[serde(rename = "turn.end")]
+    TurnEnd {
+        transcript: String,
+        request_id: String,
+    },
+    #[serde(rename = "done")]
+    Done { request_id: String },
+    #[serde(rename = "error")]
+    Error {
+        title: String,
+        #[serde(default)]
+        message: Option<String>,
+        #[serde(default)]
+        status_code: Option<i32>,
+    },
+}
+
+fn resolve_live_model(model: Option<&str>) -> &str {
+    match model {
+        Some(model) if crate::providers::is_meta_model(model) => LIVE_MODEL,
+        Some("ink-whisper") => LIVE_MODEL,
+        Some(model) => model,
+        None => LIVE_MODEL,
+    }
+}
+
+fn build_transcript_response(
+    transcript: String,
+    request_id: String,
+    is_final: bool,
+) -> Vec<StreamResponse> {
+    vec![StreamResponse::TranscriptResponse {
+        start: 0.0,
+        duration: 0.0,
+        is_final,
+        speech_final: is_final,
+        from_finalize: false,
+        channel: Channel {
+            alternatives: vec![Alternatives {
+                transcript,
+                words: Vec::new(),
+                confidence: 1.0,
+                languages: vec!["en".to_string()],
+            }],
+        },
+        metadata: Metadata {
+            request_id,
+            model_info: owhisper_interface::stream::ModelInfo {
+                name: LIVE_MODEL.to_string(),
+                version: String::new(),
+                arch: String::new(),
+            },
+            model_uuid: String::new(),
+            extra: None,
+        },
+        channel_index: vec![0, 1],
+    }]
+}
+
+fn chrono_like_now() -> String {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs().to_string())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_ws_url_uses_ink_2_turn_endpoint() {
+        let params = ListenParams {
+            model: Some("ink-2".to_string()),
+            sample_rate: 16_000,
+            ..Default::default()
+        };
+        let adapter = CartesiaAdapter;
+
+        let url = adapter.build_ws_url("https://api.cartesia.ai", &params, 1);
+
+        assert_eq!(url.scheme(), "wss");
+        assert_eq!(url.host_str(), Some("api.cartesia.ai"));
+        assert_eq!(url.path(), "/stt/turns/websocket");
+        let query: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
+        assert_eq!(query.get("model").map(String::as_str), Some("ink-2"));
+        assert_eq!(query.get("encoding").map(String::as_str), Some("pcm_s16le"));
+        assert_eq!(query.get("sample_rate").map(String::as_str), Some("16000"));
+        assert_eq!(
+            query.get("cartesia_version").map(String::as_str),
+            Some(API_VERSION)
+        );
+    }
+
+    #[test]
+    fn turn_end_becomes_final_transcript() {
+        let adapter = CartesiaAdapter;
+        let responses = adapter
+            .parse_response(r#"{"type":"turn.end","transcript":"hello","request_id":"req_123"}"#);
+
+        assert_eq!(responses.len(), 1);
+        let StreamResponse::TranscriptResponse {
+            is_final,
+            speech_final,
+            channel,
+            metadata,
+            ..
+        } = &responses[0]
+        else {
+            panic!("expected transcript response");
+        };
+
+        assert!(*is_final);
+        assert!(*speech_final);
+        assert_eq!(metadata.request_id, "req_123");
+        assert_eq!(channel.alternatives[0].transcript, "hello");
+    }
+
+    #[test]
+    fn turn_update_becomes_partial_transcript() {
+        let adapter = CartesiaAdapter;
+        let responses = adapter.parse_response(
+            r#"{"type":"turn.update","transcript":"hello","request_id":"req_123"}"#,
+        );
+
+        let StreamResponse::TranscriptResponse {
+            is_final,
+            speech_final,
+            ..
+        } = &responses[0]
+        else {
+            panic!("expected transcript response");
+        };
+
+        assert!(!*is_final);
+        assert!(!*speech_final);
+    }
+}

--- a/crates/owhisper-client/src/adapter/cartesia/mod.rs
+++ b/crates/owhisper-client/src/adapter/cartesia/mod.rs
@@ -1,0 +1,97 @@
+mod batch;
+mod live;
+
+use super::{LanguageQuality, LanguageSupport};
+
+pub const DEFAULT_MODEL: &str = "ink-whisper";
+pub(crate) const API_VERSION: &str = "2026-03-01";
+
+#[derive(Clone, Default)]
+pub struct CartesiaAdapter;
+
+impl CartesiaAdapter {
+    pub fn language_support_live(languages: &[hypr_language::Language]) -> LanguageSupport {
+        LanguageSupport::min(languages.iter().map(|language| {
+            if language.iso639() == hypr_language::ISO639::En {
+                LanguageSupport::Supported {
+                    quality: LanguageQuality::NoData,
+                }
+            } else {
+                LanguageSupport::NotSupported
+            }
+        }))
+    }
+
+    pub fn language_support_batch(languages: &[hypr_language::Language]) -> LanguageSupport {
+        LanguageSupport::min(languages.iter().map(|language| {
+            if BATCH_LANGUAGE_CODES.contains(&language.iso639().code()) {
+                LanguageSupport::Supported {
+                    quality: LanguageQuality::NoData,
+                }
+            } else {
+                LanguageSupport::NotSupported
+            }
+        }))
+    }
+
+    pub fn is_supported_languages_batch(languages: &[hypr_language::Language]) -> bool {
+        Self::language_support_batch(languages).is_supported()
+    }
+
+    pub fn is_supported_languages_live(languages: &[hypr_language::Language]) -> bool {
+        Self::language_support_live(languages).is_supported()
+    }
+
+    pub(crate) fn build_ws_url_from_base(api_base: &str) -> (url::Url, Vec<(String, String)>) {
+        super::build_ws_url_from_base_with(
+            crate::providers::Provider::Cartesia,
+            api_base,
+            |parsed| {
+                super::build_url_with_scheme(
+                    parsed,
+                    crate::providers::Provider::Cartesia.default_api_host(),
+                    crate::providers::Provider::Cartesia.ws_path(),
+                    true,
+                )
+            },
+        )
+    }
+}
+
+const BATCH_LANGUAGE_CODES: &[&str] = &[
+    "af", "am", "ar", "as", "az", "ba", "be", "bg", "bn", "bo", "br", "bs", "ca", "cs", "cy", "da",
+    "de", "el", "en", "es", "et", "eu", "fa", "fi", "fo", "fr", "gl", "gu", "ha", "haw", "he",
+    "hi", "hr", "ht", "hu", "hy", "id", "is", "it", "ja", "jw", "ka", "kk", "km", "kn", "ko", "la",
+    "lb", "ln", "lo", "lt", "lv", "mg", "mi", "mk", "ml", "mn", "mr", "ms", "mt", "my", "ne", "nl",
+    "nn", "no", "oc", "pa", "pl", "ps", "pt", "ro", "ru", "sa", "sd", "si", "sk", "sl", "sn", "so",
+    "sq", "sr", "su", "sv", "sw", "ta", "te", "tg", "th", "tk", "tl", "tr", "tt", "uk", "ur", "uz",
+    "vi", "yi", "yo", "zh",
+];
+
+pub(super) fn documented_language_codes_live() -> impl Iterator<Item = &'static str> {
+    ["en"].into_iter()
+}
+
+pub(super) fn documented_language_codes_batch() -> impl Iterator<Item = &'static str> {
+    BATCH_LANGUAGE_CODES.iter().copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn documented_language_codes_live_matches_ink_2_support() {
+        let codes: Vec<_> = documented_language_codes_live().collect();
+
+        assert_eq!(codes, vec!["en"]);
+    }
+
+    #[test]
+    fn documented_language_codes_batch_includes_batch_catalog() {
+        let codes: Vec<_> = documented_language_codes_batch().collect();
+
+        assert!(codes.contains(&"ko"));
+        assert!(codes.contains(&"zh"));
+    }
+}

--- a/crates/owhisper-client/src/adapter/mod.rs
+++ b/crates/owhisper-client/src/adapter/mod.rs
@@ -4,6 +4,7 @@ mod url_builder;
 mod aquavoice;
 mod argmax;
 pub(crate) mod assemblyai;
+pub(crate) mod cartesia;
 mod dashscope;
 pub mod deepgram;
 mod deepgram_compat;
@@ -24,6 +25,7 @@ mod whispercpp;
 pub use aquavoice::*;
 pub use argmax::*;
 pub use assemblyai::*;
+pub use cartesia::*;
 pub use dashscope::*;
 pub use deepgram::*;
 pub use elevenlabs::*;
@@ -92,6 +94,7 @@ pub fn documented_language_codes_live() -> Vec<String> {
     let mut codes = Vec::new();
 
     codes.extend(deepgram::documented_language_codes());
+    codes.extend(cartesia::documented_language_codes_live());
     codes.extend(soniox::documented_language_codes().iter().copied());
     codes.extend(gladia::documented_language_codes().iter().copied());
     codes.extend(assemblyai::documented_language_codes_live().iter().copied());
@@ -104,6 +107,7 @@ pub fn documented_language_codes_live() -> Vec<String> {
 pub fn documented_language_codes_batch() -> Vec<String> {
     let mut codes = Vec::new();
 
+    codes.extend(cartesia::documented_language_codes_batch());
     codes.extend(deepgram::documented_language_codes());
     codes.extend(soniox::documented_language_codes().iter().copied());
     codes.extend(gladia::documented_language_codes().iter().copied());
@@ -396,6 +400,8 @@ pub fn append_provider_param(base_url: &str, provider: &str) -> String {
 pub enum AdapterKind {
     #[strum(serialize = "aquavoice")]
     AquaVoice,
+    #[strum(serialize = "cartesia")]
+    Cartesia,
     #[strum(serialize = "argmax")]
     Argmax,
     #[strum(serialize = "soniox")]
@@ -447,6 +453,7 @@ impl AdapterKind {
         match self {
             Self::AquaVoice | Self::Argmax | Self::OpenAI | Self::Pyannote => false,
             Self::Soniox
+            | Self::Cartesia
             | Self::Fireworks
             | Self::Deepgram
             | Self::AssemblyAI
@@ -465,6 +472,7 @@ impl AdapterKind {
     ) -> LanguageSupport {
         match self {
             Self::AquaVoice => LanguageSupport::NotSupported,
+            Self::Cartesia => CartesiaAdapter::language_support_live(languages),
             Self::Deepgram => {
                 let model = model.and_then(|m| m.parse::<deepgram::DeepgramModel>().ok());
                 DeepgramAdapter::language_support_live(languages, model)
@@ -490,6 +498,7 @@ impl AdapterKind {
     ) -> LanguageSupport {
         match self {
             Self::AquaVoice => AquaVoiceAdapter::language_support_batch(languages),
+            Self::Cartesia => CartesiaAdapter::language_support_batch(languages),
             Self::Deepgram => {
                 let model = model.and_then(|m| m.parse::<deepgram::DeepgramModel>().ok());
                 DeepgramAdapter::language_support_batch(languages, model)
@@ -550,6 +559,7 @@ impl From<crate::providers::Provider> for AdapterKind {
         use crate::providers::Provider;
         match p {
             Provider::AquaVoice => Self::AquaVoice,
+            Provider::Cartesia => Self::Cartesia,
             Provider::Deepgram => Self::Deepgram,
             Provider::AssemblyAI => Self::AssemblyAI,
             Provider::Soniox => Self::Soniox,

--- a/crates/owhisper-client/src/lib.rs
+++ b/crates/owhisper-client/src/lib.rs
@@ -19,11 +19,12 @@ pub use adapter::StreamingBatchConfig;
 pub use adapter::deepgram::DeepgramModel;
 pub use adapter::{
     AdapterKind, AquaVoiceAdapter, ArgmaxAdapter, AssemblyAIAdapter, BatchSttAdapter,
-    CallbackResult, CallbackSttAdapter, DashScopeAdapter, DeepgramAdapter, ElevenLabsAdapter,
-    FireworksAdapter, GladiaAdapter, HyprnoteAdapter, LanguageQuality, LanguageSupport,
-    MistralAdapter, OpenAIAdapter, PyannoteAdapter, RealtimeSttAdapter, SmallestAIAdapter,
-    SonioxAdapter, WhisperCppAdapter, append_provider_param, documented_language_codes_batch,
-    documented_language_codes_live, is_hyprnote_proxy, is_local_host, normalize_languages,
+    CallbackResult, CallbackSttAdapter, CartesiaAdapter, DashScopeAdapter, DeepgramAdapter,
+    ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, HyprnoteAdapter, LanguageQuality,
+    LanguageSupport, MistralAdapter, OpenAIAdapter, PyannoteAdapter, RealtimeSttAdapter,
+    SmallestAIAdapter, SonioxAdapter, WhisperCppAdapter, append_provider_param,
+    documented_language_codes_batch, documented_language_codes_live, is_hyprnote_proxy,
+    is_local_host, normalize_languages,
 };
 pub use adapter::{StreamingBatchEvent, StreamingBatchStream};
 

--- a/crates/owhisper-client/src/providers.rs
+++ b/crates/owhisper-client/src/providers.rs
@@ -1,4 +1,5 @@
 use crate::adapter::assemblyai;
+use crate::adapter::cartesia;
 use crate::adapter::deepgram;
 use crate::adapter::elevenlabs;
 use crate::adapter::soniox;
@@ -68,6 +69,8 @@ impl Auth {
 pub enum Provider {
     #[strum(serialize = "aquavoice")]
     AquaVoice,
+    #[strum(serialize = "cartesia")]
+    Cartesia,
     #[strum(serialize = "deepgram")]
     Deepgram,
     #[strum(serialize = "assemblyai")]
@@ -91,8 +94,9 @@ pub enum Provider {
 }
 
 impl Provider {
-    const ALL: [Provider; 11] = [
+    const ALL: [Provider; 12] = [
         Self::AquaVoice,
+        Self::Cartesia,
         Self::Deepgram,
         Self::AssemblyAI,
         Self::Soniox,
@@ -114,6 +118,10 @@ impl Provider {
             Self::AquaVoice => Auth::Header {
                 name: "Authorization",
                 prefix: Some("Bearer "),
+            },
+            Self::Cartesia => Auth::Header {
+                name: "X-API-Key",
+                prefix: None,
             },
             Self::Deepgram => Auth::Header {
                 name: "Authorization",
@@ -167,6 +175,7 @@ impl Provider {
     pub fn default_api_host(&self) -> &'static str {
         match self {
             Self::AquaVoice => "api.aquavoice.com",
+            Self::Cartesia => "api.cartesia.ai",
             Self::Deepgram => "api.deepgram.com",
             Self::AssemblyAI => "api.assemblyai.com",
             Self::Soniox => "api.soniox.com",
@@ -183,6 +192,7 @@ impl Provider {
     pub fn default_ws_host(&self) -> &'static str {
         match self {
             Self::AquaVoice => "api.aquavoice.com",
+            Self::Cartesia => "api.cartesia.ai",
             Self::Deepgram => "api.deepgram.com",
             Self::AssemblyAI => "streaming.assemblyai.com",
             Self::Soniox => "stt-rt.soniox.com",
@@ -199,6 +209,7 @@ impl Provider {
     pub fn ws_path(&self) -> &'static str {
         match self {
             Self::AquaVoice => "",
+            Self::Cartesia => "/stt/turns/websocket",
             Self::Deepgram => "/v1/listen",
             Self::AssemblyAI => "/v3/ws",
             Self::Soniox => "/transcribe-websocket",
@@ -215,6 +226,7 @@ impl Provider {
     pub fn default_api_url(&self) -> Option<&'static str> {
         match self {
             Self::AquaVoice => None,
+            Self::Cartesia => None,
             Self::Deepgram => None,
             Self::AssemblyAI => Some("https://api.assemblyai.com/v2"),
             Self::Soniox => None,
@@ -231,6 +243,7 @@ impl Provider {
     pub fn default_api_base(&self) -> &'static str {
         match self {
             Self::AquaVoice => "https://api.aquavoice.com/api/v1",
+            Self::Cartesia => "https://api.cartesia.ai",
             Self::Deepgram => "https://api.deepgram.com/v1",
             Self::AssemblyAI => "https://api.assemblyai.com/v2",
             Self::Soniox => "https://api.soniox.com",
@@ -247,6 +260,7 @@ impl Provider {
     pub fn domain(&self) -> &'static str {
         match self {
             Self::AquaVoice => "aquavoice.com",
+            Self::Cartesia => "cartesia.ai",
             Self::Deepgram => "deepgram.com",
             Self::AssemblyAI => "assemblyai.com",
             Self::Soniox => "soniox.com",
@@ -281,6 +295,7 @@ impl Provider {
     pub fn env_key_name(&self) -> &'static str {
         match self {
             Self::AquaVoice => "AQUAVOICE_API_KEY",
+            Self::Cartesia => "CARTESIA_API_KEY",
             Self::Deepgram => "DEEPGRAM_API_KEY",
             Self::AssemblyAI => "ASSEMBLYAI_API_KEY",
             Self::Soniox => "SONIOX_API_KEY",
@@ -297,6 +312,7 @@ impl Provider {
     pub fn default_live_model(&self) -> &'static str {
         match self {
             Self::AquaVoice => "avalon-v1-en",
+            Self::Cartesia => "ink-2",
             Self::Deepgram => "nova-3",
             Self::Soniox => "stt-rt-v5",
             Self::AssemblyAI => "u3-rt-pro",
@@ -322,6 +338,7 @@ impl Provider {
     pub fn default_batch_model(&self) -> &'static str {
         match self {
             Self::AquaVoice => "avalon-v1-en",
+            Self::Cartesia => cartesia::DEFAULT_MODEL,
             Self::Deepgram => "nova-3",
             Self::Soniox => "stt-async-v5",
             Self::AssemblyAI => "universal-3-pro",
@@ -348,6 +365,7 @@ impl Provider {
         match self {
             Self::Deepgram | Self::Gladia => true,
             Self::AquaVoice
+            | Self::Cartesia
             | Self::Soniox
             | Self::AssemblyAI
             | Self::Fireworks
@@ -362,6 +380,7 @@ impl Provider {
     pub fn control_message_types(&self) -> &'static [&'static str] {
         match self {
             Self::AquaVoice => &[],
+            Self::Cartesia => &[],
             Self::Deepgram => &["KeepAlive", "CloseStream", "Finalize"],
             Self::AssemblyAI => &["Terminate"],
             Self::Soniox => &["keepalive", "finalize"],
@@ -388,7 +407,7 @@ impl Provider {
                     "words_accurate_timestamps": true
                 }
             })),
-            Self::AquaVoice | Self::Mistral | Self::Pyannote => None,
+            Self::AquaVoice | Self::Cartesia | Self::Mistral | Self::Pyannote => None,
             _ => None,
         }
     }
@@ -426,6 +445,7 @@ impl Provider {
             Self::DashScope => from_adapter(&crate::adapter::DashScopeAdapter, msg),
             Self::Mistral => from_adapter(&crate::adapter::MistralAdapter::default(), msg),
             Self::AquaVoice => None,
+            Self::Cartesia => from_adapter(&crate::adapter::CartesiaAdapter, msg),
             Self::OpenAI => None,
             Self::Pyannote => None,
         }
@@ -438,6 +458,7 @@ impl Provider {
             Self::ElevenLabs => elevenlabs::error::detect_error(data),
             Self::AssemblyAI => assemblyai::error::detect_error(data),
             Self::AquaVoice
+            | Self::Cartesia
             | Self::Fireworks
             | Self::OpenAI
             | Self::Gladia

--- a/crates/transcribe-proxy/src/env.rs
+++ b/crates/transcribe-proxy/src/env.rs
@@ -8,6 +8,8 @@ pub struct SttApiKeysEnv {
     #[serde(default)]
     pub deepgram_api_key: Option<String>,
     #[serde(default)]
+    pub cartesia_api_key: Option<String>,
+    #[serde(default)]
     pub assemblyai_api_key: Option<String>,
     #[serde(default)]
     pub soniox_api_key: Option<String>,
@@ -65,6 +67,9 @@ impl From<&SttApiKeysEnv> for ApiKeys {
         let mut map = HashMap::new();
         if let Some(key) = env.deepgram_api_key.as_ref().filter(|s| !s.is_empty()) {
             map.insert(Provider::Deepgram, key.clone());
+        }
+        if let Some(key) = env.cartesia_api_key.as_ref().filter(|s| !s.is_empty()) {
+            map.insert(Provider::Cartesia, key.clone());
         }
         if let Some(key) = env.assemblyai_api_key.as_ref().filter(|s| !s.is_empty()) {
             map.insert(Provider::AssemblyAI, key.clone());

--- a/crates/transcribe-proxy/src/routes/batch/sync.rs
+++ b/crates/transcribe-proxy/src/routes/batch/sync.rs
@@ -8,9 +8,9 @@ use axum::{
 };
 use backon::{ExponentialBuilder, Retryable};
 use owhisper_client::{
-    AquaVoiceAdapter, AssemblyAIAdapter, BatchClient, DeepgramAdapter, ElevenLabsAdapter,
-    FireworksAdapter, GladiaAdapter, MistralAdapter, OpenAIAdapter, Provider, PyannoteAdapter,
-    SonioxAdapter,
+    AquaVoiceAdapter, AssemblyAIAdapter, BatchClient, CartesiaAdapter, DeepgramAdapter,
+    ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, MistralAdapter, OpenAIAdapter, Provider,
+    PyannoteAdapter, SonioxAdapter,
 };
 use owhisper_interface::ListenParams;
 use owhisper_interface::batch::Response as BatchResponse;
@@ -287,6 +287,7 @@ pub(super) async fn transcribe_with_provider(
     let result = match provider {
         Provider::Deepgram => batch_transcribe!(DeepgramAdapter),
         Provider::AssemblyAI => batch_transcribe!(AssemblyAIAdapter),
+        Provider::Cartesia => batch_transcribe!(CartesiaAdapter),
         Provider::Soniox => batch_transcribe!(SonioxAdapter),
         Provider::OpenAI => batch_transcribe!(OpenAIAdapter),
         Provider::Gladia => batch_transcribe!(GladiaAdapter),

--- a/crates/transcribe-proxy/src/routes/streaming/hyprnote.rs
+++ b/crates/transcribe-proxy/src/routes/streaming/hyprnote.rs
@@ -2,7 +2,7 @@ use base64::Engine;
 use std::sync::Arc;
 
 use owhisper_client::{
-    AssemblyAIAdapter, Auth, DashScopeAdapter, DeepgramAdapter, ElevenLabsAdapter,
+    AssemblyAIAdapter, Auth, CartesiaAdapter, DashScopeAdapter, DeepgramAdapter, ElevenLabsAdapter,
     FireworksAdapter, GladiaAdapter, MistralAdapter, Provider, RealtimeSttAdapter, SonioxAdapter,
     normalize_listen_params,
 };
@@ -44,6 +44,7 @@ fn build_upstream_url_with_adapter(
     match provider {
         Provider::Deepgram => DeepgramAdapter.build_ws_url(api_base, params, channels),
         Provider::AssemblyAI => AssemblyAIAdapter.build_ws_url(api_base, params, channels),
+        Provider::Cartesia => CartesiaAdapter.build_ws_url(api_base, params, channels),
         Provider::Soniox => SonioxAdapter.build_ws_url(api_base, params, channels),
         Provider::Fireworks => FireworksAdapter.build_ws_url(api_base, params, channels),
         Provider::OpenAI => unreachable!("openai only supports batch transcription"),
@@ -65,6 +66,7 @@ fn build_initial_message_with_adapter(
     let msg = match provider {
         Provider::Deepgram => DeepgramAdapter.initial_message(api_key, params, channels),
         Provider::AssemblyAI => AssemblyAIAdapter.initial_message(api_key, params, channels),
+        Provider::Cartesia => CartesiaAdapter.initial_message(api_key, params, channels),
         Provider::Soniox => SonioxAdapter.initial_message(api_key, params, channels),
         Provider::Fireworks => FireworksAdapter.initial_message(api_key, params, channels),
         Provider::OpenAI => unreachable!("openai only supports batch transcription"),
@@ -90,6 +92,7 @@ fn build_response_transformer(
         let responses: Vec<owhisper_interface::stream::StreamResponse> = match provider {
             Provider::Deepgram => DeepgramAdapter.parse_response(raw),
             Provider::AssemblyAI => AssemblyAIAdapter.parse_response(raw),
+            Provider::Cartesia => CartesiaAdapter.parse_response(raw),
             Provider::Soniox => SonioxAdapter.parse_response(raw),
             Provider::Fireworks => FireworksAdapter.parse_response(raw),
             Provider::OpenAI => unreachable!("openai only supports batch transcription"),

--- a/crates/transcribe-proxy/tests/common/mod.rs
+++ b/crates/transcribe-proxy/tests/common/mod.rs
@@ -105,6 +105,7 @@ pub fn env_with_provider(provider: Provider, api_key: String) -> transcribe_prox
     let mut env = transcribe_proxy::Env::default();
     match provider {
         Provider::Deepgram => env.stt.deepgram_api_key = Some(api_key),
+        Provider::Cartesia => env.stt.cartesia_api_key = Some(api_key),
         Provider::AssemblyAI => env.stt.assemblyai_api_key = Some(api_key),
         Provider::Soniox => env.stt.soniox_api_key = Some(api_key),
         Provider::Fireworks => env.stt.fireworks_api_key = Some(api_key),

--- a/plugins/transcription/js/bindings.gen.ts
+++ b/plugins/transcription/js/bindings.gen.ts
@@ -194,7 +194,7 @@ transcriptionEvent: "plugin:transcription:transcription-event"
 export type BatchAlternatives = { transcript: string; confidence: number; words?: BatchWord[] }
 export type BatchChannel = { alternatives: BatchAlternatives[] }
 export type BatchErrorCode = "unknown" | "timed_out" | "audio_metadata_join_failed" | "audio_metadata_read_failed" | "batch_capability_unsupported" | "direct_batch_unsupported" | "progressive_batch_unsupported" | "direct_request_failed" | "progressive_actor_spawn_failed" | "progressive_start_cancelled" | "progressive_stopped_without_completion_signal" | "progressive_finished_without_status" | "progressive_start_failed" | "progressive_stream_error" | "progressive_stream_timeout"
-export type BatchProvider = "argmax" | "whispercpp" | "deepgram" | "soniox" | "assemblyai" | "fireworks" | "openai" | "gladia" | "elevenlabs" | "pyannote" | "dashscope" | "mistral" | "hyprnote" | "am" | "soniqo" | "aquavoice"
+export type BatchProvider = "argmax" | "whispercpp" | "deepgram" | "soniox" | "assemblyai" | "fireworks" | "openai" | "gladia" | "elevenlabs" | "pyannote" | "dashscope" | "mistral" | "hyprnote" | "am" | "soniqo" | "aquavoice" | "cartesia"
 export type BatchResponse = { metadata: JsonValue; results: BatchResults }
 export type BatchResults = { channels: BatchChannel[] }
 export type BatchRunMode = "direct" | "streamed"


### PR DESCRIPTION
Adds Cartesia Ink 2 live STT and batch fallback wiring across desktop settings, transcription adapters, proxy dispatch, and generated bindings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live streaming, batch transcription, and API-key auth across desktop, listener, and proxy—same pattern as other providers but a broad integration surface for a new vendor API.
> 
> **Overview**
> **Cartesia BYOK** is wired end-to-end so users can bring their own API key and use **Ink 2** for live transcription and batch fallback on recordings.
> 
> The desktop STT settings add a **Cartesia** provider (`ink-2`, docs/key links) and display labels for **Ink Whisper** / **Ink 2**. Batch routing treats `cartesia` like other direct batch providers.
> 
> A new **`CartesiaAdapter`** implements **realtime** WebSocket turns (`/stt/turns/websocket`, `X-API-Key`, turn events → partial/final transcripts) and **batch** multipart upload to `/stt` (default batch model `ink-whisper`, word timestamps). Live is English-only; batch supports a large language catalog.
> 
> **`Provider` / `AdapterKind`**, listener live dispatch, `BatchProvider`, transcribe-proxy streaming and sync batch routes, and **`CARTESIA_API_KEY`** env loading are updated; plugin **`BatchProvider`** bindings include `cartesia`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dbbabbf03b07b87c222681024df14b183684e72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->