### PR TITLE
Preserve recordings during cleanup

### DIFF
--- a/apps/desktop/src/services/audio-retention.test.ts
+++ b/apps/desktop/src/services/audio-retention.test.ts
@@ -114,7 +114,7 @@ describe("audio retention", () => {
     expect(sessionAudioExpired("not-a-date", "oneDay")).toBe(false);
   });
 
-  test("deletes expired inactive audio and orphaned expired audio", async () => {
+  test("deletes expired inactive audio without deleting orphaned audio", async () => {
     const now = Date.parse("2026-05-13T00:00:00.000Z");
     const store = createMainStore();
     const settingsStore = createSettingsStore();
@@ -142,21 +142,12 @@ describe("audio retention", () => {
     getSessionModeMock.mockImplementation((sessionId) =>
       sessionId === "active" ? "active" : "inactive",
     );
-    audioDeleteOrphanedExpiredMock.mockResolvedValue({
-      status: "ok",
-      data: ["orphan"],
-    });
-
     const deleted = await cleanupExpiredAudio(store, settingsStore, now);
 
     expect(audioDeleteMock).toHaveBeenCalledTimes(1);
     expect(audioDeleteMock).toHaveBeenCalledWith("expired");
-    expect(audioDeleteOrphanedExpiredMock).toHaveBeenCalledWith(
-      ["expired", "fresh", "active"],
-      24 * 60 * 60 * 1000,
-      now,
-    );
-    expect(deleted).toEqual(["expired", "orphan"]);
+    expect(audioDeleteOrphanedExpiredMock).not.toHaveBeenCalled();
+    expect(deleted).toEqual(["expired"]);
   });
 
   test("keeps unsaved audio when retention is none until transcript words exist", async () => {
@@ -191,6 +182,7 @@ describe("audio retention", () => {
 
     expect(audioDeleteMock).toHaveBeenCalledTimes(1);
     expect(audioDeleteMock).toHaveBeenCalledWith("processed");
+    expect(audioDeleteOrphanedExpiredMock).not.toHaveBeenCalled();
     expect(deleted).toEqual(["processed"]);
   });
 
@@ -356,11 +348,7 @@ describe("audio retention", () => {
     const deleted = await cleanupExpiredAudio(store, settingsStore, now);
 
     expect(audioDeleteMock).not.toHaveBeenCalled();
-    expect(audioDeleteOrphanedExpiredMock).toHaveBeenCalledWith(
-      ["fresh"],
-      30 * 24 * 60 * 60 * 1000,
-      now,
-    );
+    expect(audioDeleteOrphanedExpiredMock).not.toHaveBeenCalled();
     expect(deleted).toEqual([]);
   });
 });

--- a/apps/desktop/src/services/audio-retention.ts
+++ b/apps/desktop/src/services/audio-retention.ts
@@ -4,7 +4,6 @@ import {
   AUDIO_RETENTION_DURATION_MS,
   normalizeAudioRetention as normalizeAudioRetentionPolicy,
   type AudioRetentionPolicy,
-  type ExpiringAudioRetentionPolicy,
 } from "./audio-retention-policy";
 
 import type * as main from "~/store/tinybase/store/main";
@@ -88,10 +87,6 @@ function sessionHasTranscriptWords(store: main.Store, sessionId: string) {
   return hasWords;
 }
 
-function audioRetentionDurationMs(policy: ExpiringAudioRetentionPolicy) {
-  return AUDIO_RETENTION_DURATION_MS[policy];
-}
-
 export async function deleteProcessedAudioForRetention(
   store: main.Store,
   settingsStore: settings.Store,
@@ -141,12 +136,9 @@ export async function cleanupExpiredAudio(
   }
 
   const deletes: Promise<void>[] = [];
-  const knownSessionIds: string[] = [];
   const deletedSessionIds: string[] = [];
 
   store.forEachRow("sessions", (sessionId, _forEachCell) => {
-    knownSessionIds.push(sessionId);
-
     if (listenerStore.getState().getSessionMode(sessionId) !== "inactive") {
       return;
     }
@@ -184,26 +176,6 @@ export async function cleanupExpiredAudio(
   });
 
   await Promise.all(deletes);
-
-  try {
-    const orphanedResult = await fsSyncCommands.audioDeleteOrphanedExpired(
-      knownSessionIds,
-      audioRetentionDurationMs(policy),
-      nowMs,
-    );
-
-    if (orphanedResult.status === "error") {
-      console.error("[audio-retention] failed to delete orphaned audio", {
-        error: orphanedResult.error,
-      });
-    } else {
-      deletedSessionIds.push(...orphanedResult.data);
-    }
-  } catch (error) {
-    console.error("[audio-retention] failed to delete orphaned audio", {
-      error,
-    });
-  }
 
   return deletedSessionIds;
 }

--- a/apps/desktop/src/shared/desktop-tab-lifecycle.test.ts
+++ b/apps/desktop/src/shared/desktop-tab-lifecycle.test.ts
@@ -96,6 +96,7 @@ describe("desktop tab lifecycle", () => {
         expect.anything(),
         expect.anything(),
         "session-1",
+        { deferFilesystemDelete: true },
       );
     });
 

--- a/apps/desktop/src/shared/desktop-tab-lifecycle.ts
+++ b/apps/desktop/src/shared/desktop-tab-lifecycle.ts
@@ -81,7 +81,9 @@ export function createSessionTabCloseHandler({
     }
 
     invalidateSessionResource(sessionId);
-    void deleteSessionFn(store, indexes, sessionId);
+    void deleteSessionFn(store, indexes, sessionId, {
+      deferFilesystemDelete: true,
+    });
   };
 }
 


### PR DESCRIPTION
Avoid deleting orphaned audio during retention cleanup and keep automatic empty-tab cleanup from removing session folders.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when audio and session folders are deleted on disk; recordings may persist longer and orphaned folders may accumulate until handled elsewhere.
> 
> **Overview**
> Stops **orphaned audio folder cleanup** during scheduled retention: `cleanupExpiredAudio` no longer calls `audioDeleteOrphanedExpired` and only deletes audio for known, expired inactive sessions via `audioDelete`.
> 
> When an **empty session tab is closed**, automatic cleanup now passes `{ deferFilesystemDelete: true }` to `deleteSessionCascade`, so the store row is removed without immediately deleting the on-disk session/recording folder (aligned with explicit user deletes that defer filesystem removal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3728822b493d2a0972030f58c510223ef5da2a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->