### PR TITLE
Show summary tab for short transcripts

### DIFF
--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -315,6 +315,45 @@ describe("EnhancerService", () => {
       expect(result).toEqual({ type: "queued" });
       expect(aiTaskStore.getState().generate).toHaveBeenCalled();
     });
+
+    it("creates a visible summary tab when transcript is too short for auto-enhance", () => {
+      vi.useFakeTimers();
+      const tables = createTables({
+        transcripts: {
+          "t-1": {
+            session_id: "session-1",
+            words: JSON.stringify([{ text: "hi" }, { text: "there" }]),
+          },
+        },
+      });
+      const store = createMockStore(tables);
+      const aiTaskStore = createMockAITaskStore();
+      const deps = createDeps({
+        mainStore: store,
+        indexes: createMockIndexes(tables),
+        aiTaskStore,
+      });
+      const service = new EnhancerService(deps);
+
+      try {
+        const result = service.queueAutoEnhanceIfSummaryEmpty("session-1");
+
+        expect(result).toEqual({ type: "queued" });
+        expect(store.setRow).toHaveBeenCalledWith(
+          "enhanced_notes",
+          expect.any(String),
+          expect.objectContaining({
+            session_id: "session-1",
+            content: "",
+            title: "Summary",
+          }),
+        );
+        expect(aiTaskStore.getState().generate).not.toHaveBeenCalled();
+      } finally {
+        service.dispose();
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("checkEligibility()", () => {

--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -181,6 +181,13 @@ export class EnhancerService {
       return { type: "summary_exists", noteId: existingNoteId };
     }
 
+    if (!existingNoteId) {
+      const eligibility = this.checkEligibility(sessionId);
+      if (!eligibility.eligible && eligibility.wordCount > 0) {
+        this.ensureNote(sessionId, templateId);
+      }
+    }
+
     this.queueAutoEnhance(sessionId);
     return { type: "queued" };
   }


### PR DESCRIPTION
Create a placeholder summary note when auto-enhance is skipped because the transcript is too short.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX change in enhancer auto-queue flow; no auth or data-model changes beyond adding a placeholder note row.
> 
> **Overview**
> When **auto-enhance** runs via `queueAutoEnhanceIfSummaryEmpty` and there is no matching summary note yet, the enhancer now **creates an empty “Summary” enhanced note** if the session has a transcript with words but fails eligibility (e.g. below the minimum word count). Users still get a visible summary tab instead of nothing while generation is skipped.
> 
> Auto-enhance is still queued as before; **LLM generation is not started** in the short-transcript case—only the placeholder row is written via `ensureNote`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e03520846bc3716afac7f7186792841af5913e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->