### PR TITLE
Make session title hitbox content sized

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -166,7 +166,8 @@ describe("OuterHeader", () => {
     expect(header?.className).toContain("pl-[156px]");
     expect(header?.className).toContain("h-11");
     expect(header?.className).not.toContain("pb-1");
-    expect(titleWrapper?.className).toContain("w-full");
+    expect(titleWrapper?.classList.contains("w-full")).toBe(false);
+    expect(titleWrapper?.className).toContain("max-w-full");
     expect(titleWrapper?.className).not.toContain("max-w-[680px]");
     expect(titleSlot?.className).toContain("left-[104px]");
     expect(titleSlot?.className).not.toContain("-translate-y-1");

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -53,7 +53,7 @@ export function OuterHeader({
                 : "left-[114px]",
           ])}
         >
-          <div className="pointer-events-auto w-full min-w-0">{title}</div>
+          <div className="pointer-events-auto max-w-full min-w-0">{title}</div>
         </div>
       ) : null}
       <div className="relative z-10 ml-auto flex shrink-0 items-center gap-0 pr-1">

--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -91,6 +91,10 @@ describe("TitleInput", () => {
 
     const input = screen.getByPlaceholderText("Untitled");
     expect(input.parentElement?.className).toContain("relative");
+    expect(input.parentElement?.className).toContain("max-w-full");
+    expect(input.parentElement?.className).toContain("text-xl");
+    expect(input.parentElement?.className).toContain("font-semibold");
+    expect(input.parentElement?.classList.contains("w-full")).toBe(false);
     expect(input.className).toContain("text-left");
     expect(
       screen.queryByRole("button", { name: "Regenerate title" }),
@@ -115,6 +119,7 @@ describe("TitleInput", () => {
 
     const input = screen.getByPlaceholderText("Untitled");
     expect(input.className).toContain("w-full");
+    expect(input.parentElement?.style.width).toBe("calc(10ch + 2px)");
     expect(
       screen.queryByRole("button", { name: "Regenerate title" }),
     ).toBeNull();

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -218,6 +218,14 @@ const TitleInputInner = memo(
             ).toFixed(2)}s`,
           } as CSSProperties)
         : undefined;
+      const visibleTitleLength = Math.max(
+        localTitle.length || "Untitled".length,
+        "Untitled".length,
+      );
+      const titleShellStyle = {
+        ...titleFadeStyle,
+        width: `calc(${visibleTitleLength}ch + 2px)`,
+      };
 
       useImperativeHandle(
         ref,
@@ -348,11 +356,12 @@ const TitleInputInner = memo(
       return (
         <div
           data-tauri-drag-region="false"
-          style={titleFadeStyle}
-          className="group/title-input relative flex h-8 w-full items-center overflow-hidden"
+          style={titleShellStyle}
+          className="group/title-input relative flex h-8 max-w-full items-center overflow-hidden text-xl font-semibold"
         >
           <input
             data-tauri-drag-region="false"
+            aria-label="Session title"
             ref={setInputRef}
             id={`title-input-${sessionId}-${editorId}`}
             placeholder="Untitled"
@@ -381,6 +390,7 @@ const TitleInputInner = memo(
             onScroll={(e) => updateOverflowState(e.currentTarget)}
             onSelect={(e) => updateOverflowState(e.currentTarget)}
             value={localTitle}
+            size={visibleTitleLength}
             className={cn([
               "w-full min-w-0 transition-opacity duration-200",
               "border-none bg-transparent focus:outline-hidden",


### PR DESCRIPTION
Keep the session title input interactive only over its visible width so surrounding header space remains draggable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header layout and drag-region hit testing only; no auth, data, or backend changes.
> 
> **Overview**
> Shrinks the session title’s interactive area so empty header space stays draggable in the Tauri window chrome.
> 
> **`TitleInput`** no longer stretches the title shell across the full header slot: the wrapper uses **`max-w-full`** and an inline **`width: calc(Nch + 2px)`** derived from visible title length (including placeholder), with matching **`size`** on the input. Typography moves to the shell; **`aria-label="Session title"`** is added.
> 
> **`OuterHeader`** stops forcing **`w-full`** on the title wrapper in favor of **`max-w-full min-w-0`**, so pointer events only apply over the title’s actual width inside the absolute title slot.
> 
> Tests assert the new layout classes, content-sized width for whitespace-only titles, and collapsed-sidebar header behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96c0bd1494e9d35dd67970e2a5dc95f76e7603f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->