### PR TITLE
Widen blog layout

### DIFF
--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -1,10 +1,17 @@
 import { MDXContent } from "@content-collections/mdx/react";
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { type Article, allArticles } from "content-collections";
+import { Download } from "lucide-react";
+import type { ComponentProps } from "react";
 
 import { mdxComponents } from "@/components/mdx-components";
 import { SiteFooter } from "@/components/site-footer";
 import { ANARLOG_SITE_URL } from "@/lib/seo";
+
+const blogMdxComponents = {
+  ...mdxComponents,
+  table: BlogTable,
+};
 
 export const Route = createFileRoute("/blog/$slug")({
   component: Component,
@@ -45,7 +52,7 @@ function Component() {
 
   return (
     <main className="min-h-screen bg-white text-[#181613]">
-      <div className="mx-auto w-full max-w-[700px] px-5 py-8 md:px-8 md:py-12">
+      <div className="mx-auto w-full max-w-[860px] px-5 py-8 md:px-8 md:py-12">
         <header className="flex items-center justify-between gap-6">
           <Link to="/" aria-label="Anarlog home">
             <img src="/logo.svg" alt="Anarlog" className="h-9 w-auto" />
@@ -60,7 +67,7 @@ function Component() {
         </Link>
 
         <header className="pt-10 pb-12">
-          <h1 className="font-hand text-5xl leading-[1.02] font-semibold tracking-normal text-balance text-black md:text-7xl">
+          <h1 className="font-hand text-5xl leading-[1.02] font-semibold tracking-normal text-balance text-black md:text-6xl">
             {article.title}
           </h1>
           <div className="mt-6 flex items-center gap-2 text-sm text-[#756b5d]">
@@ -81,21 +88,58 @@ function Component() {
             aria-label="TLDR"
             className="mb-12 border-y border-[#eee8df] py-5"
           >
-            <p className="font-hand text-xl font-semibold tracking-normal text-[#756b5d]">
+            <p className="font-hand text-lg font-semibold tracking-normal text-[#756b5d]">
               TL;DR
             </p>
-            <p className="font-hand mt-3 text-2xl leading-8 font-semibold text-[#363029]">
+            <p className="font-hand mt-3 text-xl leading-7 font-semibold text-[#363029] md:text-2xl md:leading-8">
               {tldr}
             </p>
           </aside>
         )}
 
         <article className="blog-prose prose prose-stone prose-headings:font-hand prose-headings:font-semibold prose-headings:text-[#756b5d] prose-p:text-[#363029] prose-a:text-[#181613] prose-a:underline hover:prose-a:text-[#4f4940] prose-strong:text-[#181613] prose-li:text-[#363029] prose-img:rounded-md prose-img:border prose-img:border-[#eee8df] max-w-none">
-          <MDXContent code={article.mdx} components={mdxComponents} />
+          <MDXContent code={article.mdx} components={blogMdxComponents} />
         </article>
+
+        <BlogDownloadCta />
       </div>
 
       <SiteFooter />
     </main>
+  );
+}
+
+function BlogTable({ children, ...props }: ComponentProps<"table">) {
+  return (
+    <div className="my-8 overflow-x-auto">
+      <table {...props}>{children}</table>
+    </div>
+  );
+}
+
+function BlogDownloadCta() {
+  return (
+    <aside
+      aria-label="Download Anarlog"
+      className="mt-20 border-y border-[#eee8df] bg-[#faf7f1] px-5 py-8 md:px-7"
+    >
+      <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="font-hand text-3xl leading-none font-semibold tracking-normal text-[#756b5d] md:text-4xl">
+            Take notes without inviting a bot
+          </p>
+          <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
+            Download Anarlog for private, local-first meeting notes on your Mac.
+          </p>
+        </div>
+        <Link
+          to="/download/"
+          className="inline-flex h-12 shrink-0 items-center justify-center gap-2 rounded-full bg-[#181613] px-5 text-sm font-semibold text-white transition-colors hover:bg-[#363029]"
+        >
+          <Download size={17} strokeWidth={2.2} aria-hidden="true" />
+          Download app
+        </Link>
+      </div>
+    </aside>
   );
 }

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -28,7 +28,7 @@ function Component() {
 
   return (
     <main className="min-h-screen bg-white text-[#181613]">
-      <div className="mx-auto w-full max-w-[700px] px-5 py-8 md:px-8 md:py-12">
+      <div className="mx-auto w-full max-w-[860px] px-5 py-8 md:px-8 md:py-12">
         <header className="flex items-center justify-between gap-6">
           <Link to="/" aria-label="Anarlog home">
             <img src="/logo.svg" alt="Anarlog" className="h-9 w-auto" />

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -443,8 +443,49 @@
 
 .blog-prose
   :where(p, li):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-  font-size: 1.3rem;
-  line-height: 1.5;
+  font-size: 1.125rem;
+  line-height: 1.6;
+}
+
+.blog-prose
+  :where(table):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  min-width: 100%;
+  width: max-content;
+  border-collapse: separate;
+  border-spacing: 0 0.375rem;
+  font-family: var(--font-sans);
+  white-space: nowrap;
+}
+
+.blog-prose
+  :where(th):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  padding: 0.75rem;
+  background: #eee7db;
+  color: #4f4940;
+  font-family: var(--font-sans);
+  font-size: 1.0625rem;
+  font-weight: 650;
+  line-height: 1.25;
+  text-align: left;
+}
+
+.blog-prose
+  :where(td):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  padding: 0.875rem 0.75rem;
+  background: #faf7f1;
+  color: #363029;
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  line-height: 1.35;
+  vertical-align: top;
+}
+
+.blog-prose
+  :where(tbody
+    tr
+    td:first-child):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  background: #f3eee6;
+  font-weight: 600;
 }
 
 .blog-prose
@@ -452,7 +493,7 @@
   margin-top: 4rem;
   margin-bottom: 1.25rem;
   font-family: var(--font-hand);
-  font-size: 2.25rem;
+  font-size: 2.125rem;
   font-weight: 600;
   line-height: 1.05 !important;
   letter-spacing: 0;
@@ -464,7 +505,7 @@
   margin-top: 3.5rem;
   margin-bottom: 1rem;
   font-family: var(--font-hand);
-  font-size: 1.875rem;
+  font-size: 1.75rem;
   font-weight: 600;
   line-height: 1.05;
   letter-spacing: 0;
@@ -476,7 +517,7 @@
   margin-top: 2.5rem;
   margin-bottom: 0.75rem;
   font-family: var(--font-hand);
-  font-size: 1.5rem;
+  font-size: 1.375rem;
   font-weight: 600;
   line-height: 1.1;
   letter-spacing: 0;
@@ -502,12 +543,12 @@
 @media (min-width: 768px) {
   .blog-prose
     :where(h2):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-    font-size: 2.75rem;
+    font-size: 2.5rem;
   }
 
   .blog-prose
     :where(h3):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-    font-size: 2.25rem;
+    font-size: 2rem;
   }
 }
 


### PR DESCRIPTION
Increase the blog index and article content max width for a roomier desktop layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/blog UI and CSS only; no auth, data, or API behavior changes.
> 
> **Overview**
> Widens the blog index and article pages from **700px** to **860px** max width for a roomier desktop layout.
> 
> Article pages get **typography adjustments** (smaller title/TLDR and slightly reduced `.blog-prose` heading and body sizes) to match the wider column. MDX now uses **`blogMdxComponents`**, which wraps tables in a horizontally scrollable **`BlogTable`** and adds dedicated **`.blog-prose` table** styling (striped cells, nowrap). A **`BlogDownloadCta`** block was added below each post linking to `/download/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cc9eb987512bafffd1d99ca02f44e195a09d02b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->