### PR TITLE
Round notification close button

### DIFF
--- a/crates/notification-macos/swift-lib/src/NotificationButtons.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationButtons.swift
@@ -69,6 +69,11 @@ class CloseButton: NSButton, TrackableButton {
     NSSize(width: CloseButtonConfig.size, height: CloseButtonConfig.size)
   }
 
+  override func layout() {
+    super.layout()
+    layer?.cornerRadius = min(bounds.width, bounds.height) / 2
+  }
+
   override func updateTrackingAreas() {
     super.updateTrackingAreas()
     setupTrackingArea()

--- a/crates/notification-macos/swift-lib/src/NotificationManager+Creation.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationManager+Creation.swift
@@ -270,12 +270,14 @@ extension NotificationManager {
     closeButton.translatesAutoresizingMaskIntoConstraints = false
     clickableView.addSubview(closeButton, positioned: .above, relativeTo: nil)
 
-    let buttonOffset =
+    let horizontalButtonOffset =
       isMacOS26() ? (CloseButtonConfig.size / 2) + 4 : (CloseButtonConfig.size / 2) - 2
+    let verticalButtonOffset = buttonOverhang() - (CloseButtonConfig.size / 2)
     NSLayoutConstraint.activate([
-      closeButton.centerYAnchor.constraint(equalTo: container.topAnchor, constant: buttonOffset),
+      closeButton.centerYAnchor.constraint(
+        equalTo: container.topAnchor, constant: verticalButtonOffset),
       closeButton.centerXAnchor.constraint(
-        equalTo: container.leadingAnchor, constant: buttonOffset),
+        equalTo: container.leadingAnchor, constant: horizontalButtonOffset),
       closeButton.widthAnchor.constraint(equalToConstant: CloseButtonConfig.size),
       closeButton.heightAnchor.constraint(equalToConstant: CloseButtonConfig.size),
     ])


### PR DESCRIPTION
Keep the hover close button fully inside the notification panel and derive its corner radius from the final bounds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Swift UI/layout tweaks in the macOS notification close button with no auth, data, or backend impact.
> 
> **Overview**
> Adjusts the macOS notification **hover close button** so it stays fully inside the panel and stays visually circular after layout.
> 
> **`CloseButton`** now updates `layer.cornerRadius` in `layout()` from `min(bounds.width, bounds.height) / 2`, so rounding tracks the laid-out size instead of relying only on the fixed size set in `setup()`.
> 
> **`createCloseButton`** splits placement into separate horizontal and vertical offsets. Vertical position uses `buttonOverhang() - (CloseButtonConfig.size / 2)` relative to the container top, pulling the control inward on layouts that use button overhang (0 on macOS 26 liquid-glass, `Layout.buttonOverhang` otherwise).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc5c5110635f6da65d1520c0d4402a7197ed7f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->