### PR TITLE
Hide open upcoming note sidebar badge

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -67,6 +67,10 @@ export function ClassicMainBody() {
   const mainAreaTopDrag = useMainAreaTopWindowDrag(enableMainAreaTopDrag);
   const update = useDesktopUpdateControl();
   const upcomingMeetingStatus = useSidebarUpcomingMeetingStatus();
+  const hasUpcomingMeetingBadge = upcomingMeetingStatus
+    ? currentTab?.type !== "sessions" ||
+      upcomingMeetingStatus.itemKey !== `session-${currentTab.id}`
+    : false;
   const createNewNote = useNewNote();
   const openNoteDialog = useOpenNoteDialog();
   const handleOpenNoteDialog = useCallback(() => {
@@ -93,7 +97,7 @@ export function ClassicMainBody() {
               onNewNote={createNewNote}
               onSearch={handleOpenNoteDialog}
               onToggleSidebar={leftsidebar.toggleExpanded}
-              hasUpcomingMeeting={Boolean(upcomingMeetingStatus)}
+              hasUpcomingMeeting={hasUpcomingMeetingBadge}
               update={update}
             />
           </div>

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -19,7 +19,11 @@ const mocks = vi.hoisted(() => ({
   startDragging: vi.fn().mockResolvedValue(undefined),
   canGoBack: false,
   canGoNext: false,
-  upcomingMeetingStatus: null as null | { label: string; title: string },
+  upcomingMeetingStatus: null as null | {
+    itemKey: string;
+    label: string;
+    title: string;
+  },
   leftSidebarExpanded: true,
   sidebarUpdateControl: {
     status: null as null | "available" | "downloading" | "ready" | "failed",
@@ -36,6 +40,12 @@ const mocks = vi.hoisted(() => ({
     pinned: false,
     slotId: "slot-1",
     type: "empty",
+  } as null | {
+    active: boolean;
+    id?: string;
+    pinned: boolean;
+    slotId: string;
+    type: string;
   },
 }));
 
@@ -333,6 +343,7 @@ describe("ClassicMainBody", () => {
     mocks.sidebarUpdateControl.status = "available";
     mocks.sidebarUpdateControl.version = "1.0.34";
     mocks.upcomingMeetingStatus = {
+      itemKey: "session-upcoming",
       label: "Starts in 3m",
       title: "Devtool design sync",
     };
@@ -347,6 +358,35 @@ describe("ClassicMainBody", () => {
     expect(badge).toBeTruthy();
     expect(badge.className.split(" ")).toContain("bg-red-500");
     expect(badge.className.split(" ")).not.toContain("bg-blue-500");
+    expect(
+      within(sidebarToggle).queryByTestId("collapsed-sidebar-update-badge"),
+    ).toBeNull();
+  });
+
+  it("hides the red upcoming meeting badge when that note is already open", () => {
+    mocks.leftSidebarExpanded = false;
+    mocks.currentTab = {
+      active: true,
+      id: "upcoming",
+      pinned: false,
+      slotId: "slot-1",
+      type: "sessions",
+    };
+    mocks.upcomingMeetingStatus = {
+      itemKey: "session-upcoming",
+      label: "Starts in 3m",
+      title: "Devtool design sync",
+    };
+
+    render(<ClassicMainBody />);
+
+    const sidebarToggle = screen.getByRole("button", { name: "Show sidebar" });
+
+    expect(
+      within(sidebarToggle).queryByTestId(
+        "collapsed-sidebar-upcoming-meeting-badge",
+      ),
+    ).toBeNull();
     expect(
       within(sidebarToggle).queryByTestId("collapsed-sidebar-update-badge"),
     ).toBeNull();


### PR DESCRIPTION
Suppress the collapsed sidebar red badge when the upcoming meeting session is already open. Add coverage for the collapsed sidebar chrome state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to sidebar chrome badge visibility with unit test coverage; no auth or data paths.
> 
> **Overview**
> The collapsed sidebar **red upcoming-meeting dot** no longer shows when the user is already viewing that meeting’s **sessions** tab.
> 
> `ClassicMainBody` derives `hasUpcomingMeetingBadge` from `useSidebarUpcomingMeetingStatus()` and the active tab: the badge stays on unless the current tab is `sessions` and its id matches `upcomingMeetingStatus.itemKey` (e.g. `session-upcoming`). That flag replaces the previous “any upcoming status” check passed into `SidebarTimelineChrome`.
> 
> Tests mock `itemKey` on upcoming status and add a case asserting the badge is absent when the matching session tab is open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8381658fa1828da8fa92fd7e919ae850094aa18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->