### PR TITLE
Protect active sessions from empty cleanup

### DIFF
--- a/apps/desktop/src/shared/desktop-tab-lifecycle.test.ts
+++ b/apps/desktop/src/shared/desktop-tab-lifecycle.test.ts
@@ -100,27 +100,29 @@ describe("desktop tab lifecycle", () => {
       );
     });
 
-    it("skips cleanup for active batch sessions and non-session tabs", () => {
-      const invalidateSessionResource = vi.fn();
-      const deleteSessionFn = vi.fn();
-      const handler = createSessionTabCloseHandler({
-        store: {} as Parameters<
-          typeof createSessionTabCloseHandler
-        >[0]["store"],
-        indexes: {} as Parameters<
-          typeof createSessionTabCloseHandler
-        >[0]["indexes"],
-        invalidateSessionResource,
-        getSessionMode: vi.fn().mockReturnValue("running_batch"),
-        isSessionEmptyFn: vi.fn().mockReturnValue(true),
-        deleteSessionFn,
-      });
+    it("skips cleanup for non-inactive sessions and non-session tabs", () => {
+      for (const sessionMode of ["active", "finalizing", "running_batch"]) {
+        const invalidateSessionResource = vi.fn();
+        const deleteSessionFn = vi.fn();
+        const handler = createSessionTabCloseHandler({
+          store: {} as Parameters<
+            typeof createSessionTabCloseHandler
+          >[0]["store"],
+          indexes: {} as Parameters<
+            typeof createSessionTabCloseHandler
+          >[0]["indexes"],
+          invalidateSessionResource,
+          getSessionMode: vi.fn().mockReturnValue(sessionMode),
+          isSessionEmptyFn: vi.fn().mockReturnValue(true),
+          deleteSessionFn,
+        });
 
-      handler(createSessionTab({ id: "session-2" }));
-      handler(createContactsTab());
+        handler(createSessionTab({ id: `session-${sessionMode}` }));
+        handler(createContactsTab());
 
-      expect(invalidateSessionResource).not.toHaveBeenCalled();
-      expect(deleteSessionFn).not.toHaveBeenCalled();
+        expect(invalidateSessionResource).not.toHaveBeenCalled();
+        expect(deleteSessionFn).not.toHaveBeenCalled();
+      }
     });
   });
 });

--- a/apps/desktop/src/shared/desktop-tab-lifecycle.ts
+++ b/apps/desktop/src/shared/desktop-tab-lifecycle.ts
@@ -72,7 +72,12 @@ export function createSessionTabCloseHandler({
     }
 
     const sessionId = tab.id;
-    if (getSessionMode(sessionId) === "running_batch") {
+    const sessionMode = getSessionMode(sessionId);
+    if (
+      sessionMode === "active" ||
+      sessionMode === "finalizing" ||
+      sessionMode === "running_batch"
+    ) {
       return;
     }
 


### PR DESCRIPTION
Skip automatic empty-session cleanup for active and finalizing recordings, matching the existing running-batch protection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when empty sessions are deleted on tab close, which affects recording lifecycle; the change only adds skip conditions and aligns with existing batch protection.
> 
> **Overview**
> Closing a session tab no longer triggers automatic empty-session cleanup when that session is in **`active`** or **`finalizing`** mode, in addition to the existing **`running_batch`** guard in `createSessionTabCloseHandler`.
> 
> The close handler still only deletes empty sessions after invalidating resources when the session is inactive and empty; live or in-progress recordings are left alone when their tab is closed.
> 
> Tests now assert that cleanup is skipped for all three non-inactive modes in a loop, not only `running_batch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cfe205e25f7989264c1ecbc7d201c68487e5c9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->