### PR TITLE
Keep collapsed session header height

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -164,7 +164,7 @@ describe("OuterHeader", () => {
     const header = titleSlot?.parentElement;
 
     expect(header?.className).toContain("pl-[156px]");
-    expect(header?.className).toContain("h-11");
+    expect(header?.className).toContain("h-12");
     expect(header?.className).not.toContain("pb-1");
     expect(titleWrapper?.classList.contains("w-full")).toBe(false);
     expect(titleWrapper?.className).toContain("max-w-full");

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -37,7 +37,7 @@ export function OuterHeader({
     <div
       className={cn([
         "relative flex w-full items-center",
-        showSidebarTimelineHeaderGutter ? "h-11" : "h-12",
+        "h-12",
         showSidebarTimelineHeaderGutter && "pl-[156px]",
       ])}
     >


### PR DESCRIPTION
Keep the session outer header at h-12 when the left sidebar is collapsed and update the regression expectation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Tailwind class change and a matching test update in session header UI only; no auth, data, or API impact.
> 
> **Overview**
> **Unifies session outer header height** so the bar is always **`h-12` (48px)**, whether the left sidebar is expanded or collapsed. Previously, the collapsed-sidebar gutter path used **`h-11`**, which made the header shorter in that layout.
> 
> The regression test for the collapsed-sidebar title layout now expects **`h-12`** on the header instead of **`h-11`**, aligned with the existing “keeps the session header at 48px tall” case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3633f629dc5988bd877874b79562709a8976e2da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->