### PR TITLE
Make session header drag regions complete

### DIFF
--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -1012,10 +1012,16 @@ export function Header({
   }
 
   return (
-    <div className="flex flex-col">
-      <div className="flex items-center justify-between gap-2">
-        <div className="relative min-w-0 flex-1">
-          <div className="scroll-fade-x scrollbar-hide flex items-center gap-1 overflow-x-auto">
+    <div data-tauri-drag-region className="flex flex-col">
+      <div
+        data-tauri-drag-region
+        className="flex items-center justify-between gap-2"
+      >
+        <div data-tauri-drag-region className="relative min-w-0 flex-1">
+          <div
+            data-tauri-drag-region
+            className="scroll-fade-x scrollbar-hide flex items-center gap-1 overflow-x-auto"
+          >
             {editorTabs.map((view, index) => {
               if (view.type === "enhanced") {
                 return (

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -225,6 +225,27 @@ describe("OuterHeader", () => {
     expect(container.firstElementChild?.className).toContain("h-12");
   });
 
+  it("marks the structural title and action strip as draggable", () => {
+    const { container } = render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    const header = container.firstElementChild;
+    const title = screen.getByText("Session title");
+    const titleWrapper = title.parentElement;
+    const titleSlot = titleWrapper?.parentElement;
+    const actionStrip = header?.lastElementChild;
+
+    expect(header?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(titleSlot?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(titleWrapper?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(actionStrip?.hasAttribute("data-tauri-drag-region")).toBe(true);
+  });
+
   it("keeps the dedicated stop button hidden while the sidebar is expanded", () => {
     mocks.sessionModes = { "session-1": "active" };
 

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -35,6 +35,7 @@ export function OuterHeader({
 
   return (
     <div
+      data-tauri-drag-region
       className={cn([
         "relative flex w-full items-center",
         "h-12",
@@ -43,6 +44,7 @@ export function OuterHeader({
     >
       {title ? (
         <div
+          data-tauri-drag-region
           className={cn([
             "pointer-events-none absolute inset-y-0 flex items-center",
             reserveCollapsedLiveControls ? "right-[153px]" : "right-[70px]",
@@ -53,10 +55,18 @@ export function OuterHeader({
                 : "left-[114px]",
           ])}
         >
-          <div className="pointer-events-auto max-w-full min-w-0">{title}</div>
+          <div
+            data-tauri-drag-region
+            className="pointer-events-auto max-w-full min-w-0"
+          >
+            {title}
+          </div>
         </div>
       ) : null}
-      <div className="relative z-10 ml-auto flex shrink-0 items-center gap-0 pr-1">
+      <div
+        data-tauri-drag-region
+        className="relative z-10 ml-auto flex shrink-0 items-center gap-0 pr-1"
+      >
         <SidebarModeStopButton sessionMode={sessionMode} />
         <HeaderMeetingControl sessionId={sessionId} sessionMode={sessionMode} />
         <OverflowButton sessionId={sessionId} currentView={currentView} />


### PR DESCRIPTION
Mark non-interactive session header, title, action, and tab surfaces as Tauri drag regions. Keep interactive controls opted out and add an outer-header regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Tauri attribute changes with no auth, data, or business-logic impact; regression test covers the outer header drag markup.
> 
> **Overview**
> Fills gaps in **frameless window dragging** by marking non-interactive session chrome as Tauri drag regions on **`OuterHeader`** (root bar, title slot, title wrapper, right action strip) and on the **note tab row** in **`header.tsx`** (outer layout and tab scroll container).
> 
> Interactive controls stay opted out via existing **`data-tauri-drag-region="false"`** on tabs, buttons, and similar controls. Adds an **`OuterHeader`** test that asserts the structural title and action areas expose **`data-tauri-drag-region`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2584e0becc7effdeff1b34d9e7469abc9f479de8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->