### PR TITLE
Remove delete recording overflow action

### DIFF
--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -57,7 +57,6 @@ vi.mock("@hypr/ui/components/ui/dropdown-menu", () => ({
 
 vi.mock("./delete", () => ({
   DeleteNote: () => <button type="button">Delete note</button>,
-  DeleteRecording: () => <button type="button">Delete recording</button>,
 }));
 
 vi.mock("./export-modal", () => ({
@@ -70,12 +69,6 @@ vi.mock("./listening", () => ({
 
 vi.mock("./misc", () => ({
   ShowInFinder: () => <button type="button">Show in Finder</button>,
-}));
-
-vi.mock("~/audio-player", () => ({
-  useAudioPlayer: () => ({
-    audioExists: true,
-  }),
 }));
 
 vi.mock("~/meeting-float/host", () => ({
@@ -208,5 +201,19 @@ describe("OverflowButton", () => {
     expect(
       screen.queryByRole("button", { name: "Open floating panel" }),
     ).toBeNull();
+  });
+
+  it("does not show the delete recording action", () => {
+    render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Delete recording" }),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: "Delete note" })).not.toBeNull();
   });
 });

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -17,12 +17,11 @@ import {
   DropdownMenuTrigger,
 } from "@hypr/ui/components/ui/dropdown-menu";
 
-import { DeleteNote, DeleteRecording } from "./delete";
+import { DeleteNote } from "./delete";
 import { ExportModal } from "./export-modal";
 import { Listening } from "./listening";
 import { ShowInFinder } from "./misc";
 
-import { useAudioPlayer } from "~/audio-player";
 import { openFloatingMeetingPanel } from "~/meeting-float/host";
 import {
   useCurrentNoteHasContent,
@@ -48,7 +47,6 @@ export function OverflowButton({
     currentView,
   );
   const { uploadAudio, uploadTranscript } = useUploadFile(sessionId);
-  const { audioExists } = useAudioPlayer();
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const floatingBarEnabled = useConfigValue("floating_bar_enabled");
   const canOpenFloatingPanel = floatingBarEnabled && sessionMode === "active";
@@ -125,8 +123,6 @@ export function OverflowButton({
             )}
             <DropdownMenuSeparator />
             <ShowInFinder sessionId={sessionId} />
-            {audioExists && <DropdownMenuSeparator />}
-            {audioExists && <DeleteRecording sessionId={sessionId} />}
             <DeleteNote sessionId={sessionId} />
           </AppFloatingPanel>
         </DropdownMenuContent>


### PR DESCRIPTION
Summary: Removes the Delete recording item from the session overflow menu and updates overflow menu test coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only menu change; delete recording may still be reachable elsewhere (e.g. audio timeline context menu).
> 
> **Overview**
> Removes the **Delete recording** entry from the session header overflow menu (`OverflowButton`), including the `audioExists` gating and `useAudioPlayer` dependency that only existed to show it.
> 
> **Delete note** and the rest of the overflow actions are unchanged. Tests drop the unused mocks and add coverage that **Delete recording** is absent while **Delete note** still renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e9dc64f0c272c822c22e5544a5d3706b8e443df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->