### PR TITLE
Add desktop changelog for 1.0.48

### DIFF
--- a/packages/changelog/content/1.0.48.md
+++ b/packages/changelog/content/1.0.48.md
@@ -1,0 +1,26 @@
+---
+date: "2026-06-19"
+summary: "Anarlog now supports Cartesia speech-to-text, improves transcript speaker corrections, and keeps sessions, recordings, meetings, and notifications steadier."
+---
+
+## Transcription
+
+- Cartesia is now available as a speech-to-text provider with Ink 2 live transcription and batch fallback support
+- Transcript speaker labels can now be reassigned from the transcript, either across matching speaker turns or for a single segment
+- Speaker corrections now carry through transcript rendering and exports more reliably
+
+## Notes and Summaries
+
+- Short transcripts now still show the Summary tab with an empty summary note when auto-enhance is skipped
+- Active sessions and recordings are preserved more safely when empty tabs close or retention cleanup runs
+- Collapsed session headers now keep a stable height as notes load or close
+- Long session titles now keep the surrounding header area draggable instead of stretching the title hitbox across the window
+
+## Meetings and Notifications
+
+- Collapsed sidebars no longer show the upcoming meeting badge when that meeting note is already open
+- Notification close buttons now stay inside the notification panel and keep a round shape while hovering
+
+## Settings
+
+- The Intelligence provider picker no longer shows a Pro chip next to gated providers while preserving upgrade prompts for locked choices


### PR DESCRIPTION
Summary: Adds the desktop 1.0.48 changelog entry with release notes for the latest desktop updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only changelog addition with no runtime or build impact.
> 
> **Overview**
> Adds **`packages/changelog/content/1.0.48.md`**, a new desktop changelog entry dated **2026-06-19** with frontmatter summary and release notes grouped under Transcription, Notes and Summaries, Meetings and Notifications, and Settings.
> 
> The bullets document user-facing fixes and features for that release (e.g. Cartesia STT, transcript speaker reassignment, summary tab behavior for short transcripts, session/recording retention, meeting badge and notification UI, Intelligence provider picker Pro chip removal)—**documentation only**, no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd6d7d4b998a39093732010c780a2d4e73514eb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->