### PR TITLE
Set main window minimum width to 500px

### DIFF
--- a/plugins/windows/src/window/v1.rs
+++ b/plugins/windows/src/window/v1.rs
@@ -115,7 +115,7 @@ impl WindowImpl for AppWindow {
                     .window_builder(app, "/app")
                     .maximizable(true)
                     .minimizable(true)
-                    .min_inner_size(620.0, 500.0);
+                    .min_inner_size(500.0, 500.0);
                 let window = builder.build()?;
                 window.set_size(LogicalSize::new(910.0, 600.0))?;
                 window


### PR DESCRIPTION
Summary: Lowers the main desktop window minimum width constraint to 500px.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI constraint tweak with no auth, data, or business-logic impact; possible minor layout issues at very narrow widths.
> 
> **Overview**
> Reduces the **main** Tauri window’s minimum inner width from **620px** to **500px** in `AppWindow::Main`’s `build_window` chain (`min_inner_size`); minimum height stays **500px**. Default open size (**910×600**) and Composer window settings are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7db364fd950d8f9e7402adf12cd7aba49f4b59d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->