### PR TITLE
Fix landing user count copy

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -340,9 +340,9 @@ function Component() {
               AI notepad for private meetings.
             </h1>
             <p className="mt-6 max-w-2xl text-xl leading-9 text-[#363029]">
-              The open-source Granola alternative for private meetings,
-              downloaded over 18k times. Record locally and choose where AI
-              runs.
+              The open-source Granola alternative for private meetings, with
+              over 18k accumulated users worldwide. Record locally and choose
+              where AI runs.
             </p>
             <div className="mt-8 flex flex-wrap gap-x-5 gap-y-3 text-sm">
               <DownloadButton />


### PR DESCRIPTION
Update homepage hero copy to describe the 18k figure as accumulated users instead of downloads.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single marketing string change on the landing page with no logic or data handling impact.
> 
> **Overview**
> Updates the homepage hero subcopy so the **18k** figure is described as **accumulated users worldwide** instead of **downloads**.
> 
> The rest of the hero message (Granola alternative, local recording, AI choice) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5c53a100f3d8fdd144de60e0a87f05ea66fc01d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->