### PR TITLE
Open notes in standalone windows

### DIFF
--- a/apps/desktop/src/routeTree.gen.ts
+++ b/apps/desktop/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as AppIndexRouteImport } from './routes/app/index'
 import { Route as AppOnboardingRouteImport } from './routes/app/onboarding'
 import { Route as AppInstructionRouteImport } from './routes/app/instruction'
 import { Route as AppComposerRouteImport } from './routes/app/composer'
+import { Route as AppNoteSessionIdRouteImport } from './routes/app/note.$sessionId'
 import { Route as AppMainLayoutRouteImport } from './routes/app/main/_layout'
 import { Route as AppMainLayoutIndexRouteImport } from './routes/app/main/_layout.index'
 
@@ -42,6 +43,11 @@ const AppComposerRoute = AppComposerRouteImport.update({
   path: '/composer',
   getParentRoute: () => AppRouteRoute,
 } as any)
+const AppNoteSessionIdRoute = AppNoteSessionIdRouteImport.update({
+  id: '/note/$sessionId',
+  path: '/note/$sessionId',
+  getParentRoute: () => AppRouteRoute,
+} as any)
 const AppMainLayoutRoute = AppMainLayoutRouteImport.update({
   id: '/main/_layout',
   path: '/main',
@@ -60,6 +66,7 @@ export interface FileRoutesByFullPath {
   '/app/onboarding': typeof AppOnboardingRoute
   '/app/': typeof AppIndexRoute
   '/app/main': typeof AppMainLayoutRouteWithChildren
+  '/app/note/$sessionId': typeof AppNoteSessionIdRoute
   '/app/main/': typeof AppMainLayoutIndexRoute
 }
 export interface FileRoutesByTo {
@@ -67,6 +74,7 @@ export interface FileRoutesByTo {
   '/app/instruction': typeof AppInstructionRoute
   '/app/onboarding': typeof AppOnboardingRoute
   '/app': typeof AppIndexRoute
+  '/app/note/$sessionId': typeof AppNoteSessionIdRoute
   '/app/main': typeof AppMainLayoutIndexRoute
 }
 export interface FileRoutesById {
@@ -77,6 +85,7 @@ export interface FileRoutesById {
   '/app/onboarding': typeof AppOnboardingRoute
   '/app/': typeof AppIndexRoute
   '/app/main/_layout': typeof AppMainLayoutRouteWithChildren
+  '/app/note/$sessionId': typeof AppNoteSessionIdRoute
   '/app/main/_layout/': typeof AppMainLayoutIndexRoute
 }
 export interface FileRouteTypes {
@@ -88,6 +97,7 @@ export interface FileRouteTypes {
     | '/app/onboarding'
     | '/app/'
     | '/app/main'
+    | '/app/note/$sessionId'
     | '/app/main/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -95,6 +105,7 @@ export interface FileRouteTypes {
     | '/app/instruction'
     | '/app/onboarding'
     | '/app'
+    | '/app/note/$sessionId'
     | '/app/main'
   id:
     | '__root__'
@@ -104,6 +115,7 @@ export interface FileRouteTypes {
     | '/app/onboarding'
     | '/app/'
     | '/app/main/_layout'
+    | '/app/note/$sessionId'
     | '/app/main/_layout/'
   fileRoutesById: FileRoutesById
 }
@@ -148,6 +160,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppComposerRouteImport
       parentRoute: typeof AppRouteRoute
     }
+    '/app/note/$sessionId': {
+      id: '/app/note/$sessionId'
+      path: '/note/$sessionId'
+      fullPath: '/app/note/$sessionId'
+      preLoaderRoute: typeof AppNoteSessionIdRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
     '/app/main/_layout': {
       id: '/app/main/_layout'
       path: '/main'
@@ -183,6 +202,7 @@ interface AppRouteRouteChildren {
   AppOnboardingRoute: typeof AppOnboardingRoute
   AppIndexRoute: typeof AppIndexRoute
   AppMainLayoutRoute: typeof AppMainLayoutRouteWithChildren
+  AppNoteSessionIdRoute: typeof AppNoteSessionIdRoute
 }
 
 const AppRouteRouteChildren: AppRouteRouteChildren = {
@@ -191,6 +211,7 @@ const AppRouteRouteChildren: AppRouteRouteChildren = {
   AppOnboardingRoute: AppOnboardingRoute,
   AppIndexRoute: AppIndexRoute,
   AppMainLayoutRoute: AppMainLayoutRouteWithChildren,
+  AppNoteSessionIdRoute: AppNoteSessionIdRoute,
 }
 
 const AppRouteRouteWithChildren = AppRouteRoute._addFileChildren(

--- a/apps/desktop/src/routes/app/note.$sessionId.tsx
+++ b/apps/desktop/src/routes/app/note.$sessionId.tsx
@@ -1,0 +1,37 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useMemo } from "react";
+
+import { ClassicMainLayout } from "~/main/layout";
+import { TabContentNote } from "~/session";
+import { StandaloneWindowShell } from "~/shared/window-shell";
+import type { Tab } from "~/store/zustand/tabs";
+
+export const Route = createFileRoute("/app/note/$sessionId")({
+  component: Component,
+});
+
+function Component() {
+  const { sessionId } = Route.useParams();
+  const tab = useMemo(
+    () =>
+      ({
+        active: true,
+        id: sessionId,
+        pinned: false,
+        slotId: `note-window-${sessionId}`,
+        state: { view: null, autoStart: null },
+        type: "sessions",
+      }) satisfies Extract<Tab, { type: "sessions" }>,
+    [sessionId],
+  );
+
+  return (
+    <ClassicMainLayout includeServices={false}>
+      <StandaloneWindowShell>
+        <div className="bg-background h-screen w-screen">
+          <TabContentNote tab={tab} standaloneWindow />
+        </div>
+      </StandaloneWindowShell>
+    </ClassicMainLayout>
+  );
+}

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -20,10 +20,12 @@ import { useListener } from "~/stt/contexts";
 export function OuterHeader({
   sessionId,
   currentView,
+  standaloneWindow = false,
   title,
 }: {
   sessionId: string;
   currentView: EditorView;
+  standaloneWindow?: boolean;
   title?: React.ReactNode;
 }) {
   const { leftsidebar } = useShell();
@@ -48,11 +50,13 @@ export function OuterHeader({
           className={cn([
             "pointer-events-none absolute inset-y-0 flex items-center",
             reserveCollapsedLiveControls ? "right-[153px]" : "right-[70px]",
-            showSidebarTimelineHeaderGutter
-              ? "left-[104px]"
-              : showExpandedSidebarTimelineHeader
-                ? "left-0"
-                : "left-[114px]",
+            standaloneWindow
+              ? "left-[68px]"
+              : showSidebarTimelineHeaderGutter
+                ? "left-[104px]"
+                : showExpandedSidebarTimelineHeader
+                  ? "left-0"
+                  : "left-[114px]",
           ])}
         >
           <div

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -26,8 +26,10 @@ import { useSTTConnection } from "~/stt/useSTTConnection";
 import { useUploadFile } from "~/stt/useUploadFile";
 
 export function TabContentNote({
+  standaloneWindow = false,
   tab,
 }: {
+  standaloneWindow?: boolean;
   tab: Extract<Tab, { type: "sessions" }>;
 }) {
   const sessionMode = useListener((state) => state.getSessionMode(tab.id));
@@ -89,6 +91,7 @@ export function TabContentNote({
         <AudioPlayer.Provider sessionId={tab.id} url={audioUrl ?? ""}>
           <TabContentNoteInner
             tab={tab}
+            standaloneWindow={standaloneWindow}
             audioUrlReady={Boolean(audioUrl)}
             isAudioUrlLoading={audioUrlQuery.isPending}
           />
@@ -100,10 +103,12 @@ export function TabContentNote({
 
 function TabContentNoteInner({
   tab,
+  standaloneWindow,
   audioUrlReady,
   isAudioUrlLoading,
 }: {
   tab: Extract<Tab, { type: "sessions" }>;
+  standaloneWindow: boolean;
   audioUrlReady: boolean;
   isAudioUrlLoading: boolean;
 }) {
@@ -228,6 +233,7 @@ function TabContentNoteInner({
         <OuterHeader
           sessionId={tab.id}
           currentView={currentView}
+          standaloneWindow={standaloneWindow}
           title={
             <TitleInput
               ref={titleInputRef}

--- a/apps/desktop/src/shared/ui/interactive-button.tsx
+++ b/apps/desktop/src/shared/ui/interactive-button.tsx
@@ -3,8 +3,10 @@ import {
   type MouseEvent,
   type ReactNode,
   useCallback,
+  useRef,
 } from "react";
 
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import {
   type MenuItemDef,
   useNativeContextMenu,
@@ -13,6 +15,7 @@ import {
 interface InteractiveButtonProps {
   children: ReactNode;
   onClick?: () => void;
+  onDoubleClick?: () => void;
   onCmdClick?: () => void;
   onShiftClick?: () => void;
   onMouseDown?: (e: MouseEvent<HTMLElement>) => void;
@@ -27,6 +30,7 @@ interface InteractiveButtonProps {
 export function InteractiveButton({
   children,
   onClick,
+  onDoubleClick,
   onCmdClick,
   onShiftClick,
   onMouseDown,
@@ -38,6 +42,16 @@ export function InteractiveButton({
   asChild = false,
 }: InteractiveButtonProps) {
   const showMenu = useNativeContextMenu(contextMenu ?? []);
+  const clickTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearPendingClick = useCallback(() => {
+    if (clickTimeoutRef.current) {
+      clearTimeout(clickTimeoutRef.current);
+      clickTimeoutRef.current = null;
+    }
+  }, []);
+
+  useMountEffect(() => clearPendingClick);
 
   const handleClick = useCallback(
     (e: MouseEvent<HTMLElement>) => {
@@ -46,16 +60,44 @@ export function InteractiveButton({
       }
 
       if (e.shiftKey) {
+        clearPendingClick();
         e.preventDefault();
         onShiftClick?.();
       } else if (e.metaKey || e.ctrlKey) {
+        clearPendingClick();
         e.preventDefault();
         onCmdClick?.();
+      } else if (onDoubleClick) {
+        clearPendingClick();
+        clickTimeoutRef.current = setTimeout(() => {
+          clickTimeoutRef.current = null;
+          onClick?.();
+        }, 200);
       } else {
         onClick?.();
       }
     },
-    [onClick, onCmdClick, onShiftClick, disabled],
+    [
+      onClick,
+      onDoubleClick,
+      onCmdClick,
+      onShiftClick,
+      disabled,
+      clearPendingClick,
+    ],
+  );
+
+  const handleDoubleClick = useCallback(
+    (e: MouseEvent<HTMLElement>) => {
+      if (disabled) {
+        return;
+      }
+
+      clearPendingClick();
+      e.preventDefault();
+      onDoubleClick?.();
+    },
+    [onDoubleClick, disabled, clearPendingClick],
   );
 
   const Element = asChild ? "div" : "button";
@@ -63,6 +105,7 @@ export function InteractiveButton({
   return (
     <Element
       onClick={handleClick}
+      onDoubleClick={onDoubleClick ? handleDoubleClick : undefined}
       onDragStart={onDragStart}
       onMouseDown={onMouseDown}
       onContextMenu={contextMenu ? showMenu : undefined}

--- a/apps/desktop/src/sidebar/timeline/item.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.test.tsx
@@ -13,12 +13,21 @@ const mocks = vi.hoisted(() => ({
   sessionMode: "inactive",
   stop: vi.fn(),
   storeTitle: "Live Note",
+  nativeContextMenus: [] as Array<
+    Array<{
+      id?: string;
+      text?: string;
+      action?: () => void;
+      separator?: boolean;
+    }>
+  >,
   timelineSelection: {
     selectedIds: [] as string[],
     setAnchor: vi.fn(),
     selectRange: vi.fn(),
     toggleSelect: vi.fn(),
   },
+  windowShow: vi.fn(() => Promise.resolve({ status: "ok", data: null })),
 }));
 
 vi.mock("@hypr/plugin-fs-sync", () => ({
@@ -30,6 +39,12 @@ vi.mock("@hypr/plugin-fs-sync", () => ({
 vi.mock("@hypr/plugin-opener2", () => ({
   commands: {
     openPath: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+vi.mock("@hypr/plugin-windows", () => ({
+  commands: {
+    windowShow: mocks.windowShow,
   },
 }));
 
@@ -60,7 +75,17 @@ vi.mock("~/session/hooks/useEnhancedNotes", () => ({
 }));
 
 vi.mock("~/shared/hooks/useNativeContextMenu", () => ({
-  useNativeContextMenu: () => vi.fn(),
+  useNativeContextMenu: (
+    menu: Array<{
+      id?: string;
+      text?: string;
+      action?: () => void;
+      separator?: boolean;
+    }>,
+  ) => {
+    mocks.nativeContextMenus.push(menu);
+    return vi.fn();
+  },
 }));
 
 vi.mock("~/store/tinybase/hooks", () => ({
@@ -151,6 +176,8 @@ describe("TimelineItemComponent", () => {
     mocks.stop.mockClear();
     mocks.openCurrent.mockClear();
     mocks.openNew.mockClear();
+    mocks.windowShow.mockClear();
+    mocks.nativeContextMenus = [];
     mocks.timelineSelection.selectedIds = [];
     mocks.timelineSelection.setAnchor.mockClear();
     mocks.timelineSelection.selectRange.mockClear();
@@ -321,5 +348,124 @@ describe("TimelineItemComponent", () => {
     expect(rowButton?.className).toContain("pr-10");
     expect(spinnerSlot?.className).toContain("absolute");
     expect(spinnerSlot?.className).toContain("right-3");
+  });
+
+  it("opens the current tab after a single-click on a session row", () => {
+    vi.useFakeTimers();
+
+    try {
+      render(
+        <TimelineItemComponent
+          item={{
+            type: "session",
+            id: "session-note",
+            data: {
+              title: "Window Note",
+              created_at: "2024-01-15T10:30:00.000Z",
+            },
+          }}
+          precision="time"
+          selected={false}
+          timezone="UTC"
+          multiSelected={false}
+          flatItemKeys={["session-session-note"]}
+        />,
+      );
+
+      const rowButton = screen.getByText("Live Note").closest("button");
+      fireEvent.click(rowButton!);
+
+      expect(mocks.openCurrent).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(200);
+
+      expect(mocks.timelineSelection.setAnchor).toHaveBeenCalledWith(
+        "session-session-note",
+      );
+      expect(mocks.openCurrent).toHaveBeenCalledWith({
+        id: "session-note",
+        type: "sessions",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("opens a standalone note window when a session row is double-clicked", () => {
+    vi.useFakeTimers();
+
+    try {
+      render(
+        <TimelineItemComponent
+          item={{
+            type: "session",
+            id: "session-note-window",
+            data: {
+              title: "Window Note",
+              created_at: "2024-01-15T10:30:00.000Z",
+            },
+          }}
+          precision="time"
+          selected={false}
+          timezone="UTC"
+          multiSelected={false}
+          flatItemKeys={["session-session-note-window"]}
+        />,
+      );
+
+      const rowButton = screen.getByText("Live Note").closest("button");
+      fireEvent.click(rowButton!);
+      fireEvent.click(rowButton!);
+      fireEvent.doubleClick(rowButton!);
+
+      expect(mocks.windowShow).toHaveBeenCalledWith({
+        type: "note",
+        value: "session-note-window",
+      });
+      vi.runAllTimers();
+      expect(mocks.openCurrent).not.toHaveBeenCalled();
+      expect(mocks.timelineSelection.setAnchor).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("offers a standalone window action instead of a new tab action for session rows", () => {
+    render(
+      <TimelineItemComponent
+        item={{
+          type: "session",
+          id: "session-note-window",
+          data: {
+            title: "Window Note",
+            created_at: "2024-01-15T10:30:00.000Z",
+          },
+        }}
+        precision="time"
+        selected={false}
+        timezone="UTC"
+        multiSelected={false}
+        flatItemKeys={["session-session-note-window"]}
+      />,
+    );
+
+    const menu = mocks.nativeContextMenus.find((items) =>
+      items.some((item) => item.id === "open-new-window"),
+    );
+
+    expect(menu?.some((item) => item.text === "Open in New Tab")).toBe(false);
+    const openWindowItem = menu?.find((item) => item.id === "open-new-window");
+
+    expect(openWindowItem).toMatchObject({
+      id: "open-new-window",
+      text: "Open in New Window",
+    });
+
+    openWindowItem?.action?.();
+
+    expect(mocks.windowShow).toHaveBeenCalledWith({
+      type: "note",
+      value: "session-note-window",
+    });
   });
 });

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -9,6 +9,7 @@ import {
 
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
+import { commands as windowsCommands } from "@hypr/plugin-windows";
 import { DancingSticks } from "@hypr/ui/components/ui/dancing-sticks";
 import { Spinner } from "@hypr/ui/components/ui/spinner";
 import { cn, format, getYear, safeParseDate, TZDate } from "@hypr/utils";
@@ -105,6 +106,7 @@ function ItemBase({
   muted,
   multiSelected,
   onClick,
+  onDoubleClick,
   onCmdClick,
   onShiftClick,
   onStop,
@@ -126,6 +128,7 @@ function ItemBase({
   muted?: boolean;
   multiSelected: boolean;
   onClick: () => void;
+  onDoubleClick?: () => void;
   onCmdClick: () => void;
   onShiftClick: () => void;
   onStop?: () => void;
@@ -156,6 +159,7 @@ function ItemBase({
     >
       <InteractiveButton
         onClick={ignored ? undefined : onClick}
+        onDoubleClick={ignored ? undefined : onDoubleClick}
         onCmdClick={ignored ? undefined : onCmdClick}
         onShiftClick={ignored ? undefined : onShiftClick}
         onDragStart={onDragStart}
@@ -447,7 +451,6 @@ const SessionItem = memo(
     const store = main.UI.useStore(main.STORE_ID);
     const indexes = main.UI.useIndexes(main.STORE_ID);
     const openCurrent = useTabs((state) => state.openCurrent);
-    const openNew = useTabs((state) => state.openNew);
     const invalidateResource = useTabs((state) => state.invalidateResource);
     const addDeletion = useUndoDelete((state) => state.addDeletion);
     const { ignoreEvent } = useIgnoredEvents();
@@ -507,6 +510,10 @@ const SessionItem = memo(
       useTimelineSelection.getState().selectRange(flatItemKeys, itemKey);
     }, [flatItemKeys, itemKey]);
 
+    const handleOpenStandaloneWindow = useCallback(() => {
+      void openStandaloneNoteWindow(sessionId);
+    }, [sessionId]);
+
     const handleDragStart = useCallback(
       (event: DragEvent<HTMLElement>) => {
         writeSessionContextDragData(
@@ -517,10 +524,6 @@ const SessionItem = memo(
       },
       [sessionId, title],
     );
-
-    const handleOpenNewTab = useCallback(() => {
-      openNew({ id: sessionId, type: "sessions" });
-    }, [sessionId, openNew]);
 
     const handleDelete = useCallback(() => {
       if (!store) {
@@ -563,9 +566,9 @@ const SessionItem = memo(
     const contextMenu = useMemo(
       () => [
         {
-          id: "open-new-tab",
-          text: "Open in New Tab",
-          action: handleOpenNewTab,
+          id: "open-new-window",
+          text: "Open in New Window",
+          action: handleOpenStandaloneWindow,
         },
         {
           id: "show",
@@ -579,7 +582,7 @@ const SessionItem = memo(
           action: handleDelete,
         },
       ],
-      [handleOpenNewTab, handleShowInFinder, handleDelete],
+      [handleOpenStandaloneWindow, handleShowInFinder, handleDelete],
     );
 
     return (
@@ -604,6 +607,7 @@ const SessionItem = memo(
           muted={muted}
           multiSelected={multiSelected}
           onClick={handleClick}
+          onDoubleClick={handleOpenStandaloneWindow}
           onCmdClick={handleCmdClick}
           onShiftClick={handleShiftClick}
           onStop={stop}
@@ -619,6 +623,17 @@ const SessionItem = memo(
     );
   },
 );
+
+async function openStandaloneNoteWindow(sessionId: string) {
+  const result = await windowsCommands.windowShow({
+    type: "note",
+    value: sessionId,
+  });
+
+  if (result.status === "error") {
+    console.error("Failed to open note window:", result.error);
+  }
+}
 
 function formatDisplayTime(
   timestamp: string | null | undefined,

--- a/plugins/windows/js/bindings.gen.ts
+++ b/plugins/windows/js/bindings.gen.ts
@@ -282,7 +282,10 @@ export type Anchor =
   | "BottomRight"
   | "BottomLeft"
   | "Center";
-export type AppWindow = { type: "main" } | { type: "composer" };
+export type AppWindow =
+  | { type: "main" }
+  | { type: "composer" }
+  | { type: "note"; value: string };
 export type ChangelogState = { previous: string | null; current: string };
 export type ContactsSelection =
   | { type: "person"; id: string }

--- a/plugins/windows/js/index.ts
+++ b/plugins/windows/js/index.ts
@@ -3,13 +3,11 @@ import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 export * from "./bindings.gen";
 import { commands } from "./bindings.gen";
 
-type UUID = `${string}-${string}-${string}-${string}-${string}`;
-
 export type WindowLabel =
   | "main"
   | "composer"
   | "floating"
-  | `note-${UUID}`
+  | `note-${string}`
   | "calendar"
   | "settings";
 

--- a/plugins/windows/src/window/v1.rs
+++ b/plugins/windows/src/window/v1.rs
@@ -7,6 +7,8 @@ pub enum AppWindow {
     Main,
     #[serde(rename = "composer")]
     Composer,
+    #[serde(rename = "note")]
+    Note(String),
 }
 
 impl std::fmt::Display for AppWindow {
@@ -14,6 +16,7 @@ impl std::fmt::Display for AppWindow {
         match self {
             Self::Main => write!(f, "main"),
             Self::Composer => write!(f, "composer"),
+            Self::Note(id) => write!(f, "note-{id}"),
         }
     }
 }
@@ -26,6 +29,10 @@ impl std::str::FromStr for AppWindow {
             "main" => return Ok(Self::Main),
             "composer" => return Ok(Self::Composer),
             _ => {}
+        }
+
+        if let Some(id) = s.strip_prefix("note-").filter(|id| !id.is_empty()) {
+            return Ok(Self::Note(id.to_string()));
         }
 
         Err(strum::ParseError::VariantNotFound)
@@ -100,6 +107,7 @@ impl WindowImpl for AppWindow {
         match self {
             Self::Main => "Anarlog".into(),
             Self::Composer => "Composer".into(),
+            Self::Note(_) => "Note".into(),
         }
     }
 
@@ -131,6 +139,18 @@ impl WindowImpl for AppWindow {
                     crate::window::composer::WIDTH,
                     crate::window::composer::HEIGHT,
                 ))?;
+                window
+            }
+            Self::Note(id) => {
+                let encoded_id: String =
+                    url::form_urlencoded::byte_serialize(id.as_bytes()).collect();
+                let builder = self
+                    .window_builder(app, format!("/app/note/{encoded_id}"))
+                    .maximizable(true)
+                    .minimizable(true)
+                    .min_inner_size(420.0, 500.0);
+                let window = builder.build()?;
+                window.set_size(LogicalSize::new(720.0, 820.0))?;
                 window
             }
         };


### PR DESCRIPTION
Adds a note-specific native window route and wires sidebar double-click to open the existing note view in that window. Includes regression coverage for the sidebar double-click path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new window lifecycle and route keyed by session id; behavior change for how users open notes from the sidebar, but reuses the existing note UI and STT/session store.
> 
> **Overview**
> Users can open a note in its own **native window** instead of only in the main app tab strip. The windows plugin gains an `AppWindow` **`note`** variant (session id) that loads `/app/note/{sessionId}` in a resizable window (~720×820).
> 
> A new TanStack route renders the existing **`TabContentNote`** inside **`StandaloneWindowShell`**, passing **`standaloneWindow`** so **`OuterHeader`** uses a tighter title drag region (no main-window sidebar gutters).
> 
> **Sidebar timeline** session rows now call **`windowShow({ type: "note", value: sessionId })`** on **double-click** and via **"Open in New Window"** in the context menu; **"Open in New Tab"** is removed for sessions (events unchanged). **`InteractiveButton`** delays single-click by 200ms when **`onDoubleClick`** is set so double-click does not also open the tab.
> 
> Regression tests cover delayed single-click, double-click, and the context-menu action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9894229d7363798d6361ba57990aeb99537d9a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5646 
- <kbd>&nbsp;1&nbsp;</kbd> #5642 👈 
<!-- GitButler Footer Boundary Bottom -->

