### PR TITLE
Hide sidebar top fade at scroll boundary

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -301,6 +301,7 @@ describe("TimelineView", () => {
 
     expect(scroller).toBeInstanceOf(HTMLDivElement);
     expect(getSidebarActionTabsOrNull()).toBeNull();
+    expect(queryTopFade(container)).toBeNull();
 
     Object.defineProperty(scroller, "clientHeight", {
       configurable: true,
@@ -583,6 +584,9 @@ describe("TimelineView", () => {
     };
 
     const { container } = render(<TimelineView topChromeInset />);
+    const scroller = container.querySelector("[data-sidebar-timeline-scroll]");
+
+    expect(scroller).toBeInstanceOf(HTMLDivElement);
 
     expect(screen.getByRole("button", { name: "Go back to now" })).toBeTruthy();
     expect(
@@ -592,6 +596,18 @@ describe("TimelineView", () => {
       container.querySelector("[data-sidebar-timeline-bucket-header]")
         ?.className,
     ).toContain("top-8");
+
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 1200,
+    });
+    scroller!.scrollTop = 120;
+    fireEvent.scroll(scroller!);
+
     expect(getTopFade(container).className).toContain("h-16");
   });
 
@@ -808,11 +824,15 @@ function getSidebarActionTabsOrNull() {
 }
 
 function getTopFade(container: HTMLElement) {
-  const topFade = container.querySelector("[data-sidebar-timeline-top-fade]");
+  const topFade = queryTopFade(container);
 
   expect(topFade).toBeInstanceOf(HTMLDivElement);
 
   return topFade as HTMLDivElement;
+}
+
+function queryTopFade(container: HTMLElement) {
+  return container.querySelector("[data-sidebar-timeline-top-fade]");
 }
 
 function isBefore(first: Element, second: Element) {

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -159,6 +159,7 @@ export function TimelineView({
       ? "top-20"
       : "top-8"
     : "top-0";
+  const showTopChromeFade = topChromeInset && !isScrolledToTop;
   const selectedSessionScrollFrameRef = useRef<number | null>(null);
   const scrollSelectedSessionIntoView = useCallback<
     RefCallback<HTMLDivElement>
@@ -449,7 +450,7 @@ export function TimelineView({
           ))}
       </div>
 
-      {topChromeInset && (
+      {showTopChromeFade && (
         <div
           aria-hidden
           data-sidebar-timeline-top-fade


### PR DESCRIPTION
Render the timeline top fade only after the sidebar has scrolled down and cover the boundary in timeline tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional UI change in sidebar timeline chrome with updated unit tests; no data, auth, or API impact.
> 
> **Overview**
> The sidebar timeline **top chrome gradient overlay** (`data-sidebar-timeline-top-fade`) no longer renders when the list is at the top of the scroll area. It now appears only when `topChromeInset` is enabled **and** the user has scrolled down (`!isScrolledToTop`), matching the existing scroll-mask behavior for hidden future content.
> 
> Tests assert the fade is absent before scrolling, then simulate scroll and verify the fade still uses the expected compact `h-16` styling when the “Go back to now” chip path is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2583e7f2ee9099612ddf7f40d2c65d70dd2a46f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->