### PR TITLE
Make left sidebar resizable

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -1,0 +1,205 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  currentTab: {
+    active: true,
+    pinned: false,
+    slotId: "slot-home",
+    type: "empty",
+  } as ({ type: string } & Record<string, unknown>) | null,
+  leftsidebar: {
+    expanded: true,
+    toggleExpanded: vi.fn(),
+  },
+  onPanelLayout: null as null | ((sizes: number[]) => void),
+}));
+
+vi.mock("@hypr/ui/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({
+    autoSaveId,
+    children,
+    className,
+    direction,
+    onLayout,
+  }: {
+    autoSaveId?: string;
+    children: React.ReactNode;
+    className?: string;
+    direction: string;
+    onLayout?: (sizes: number[]) => void;
+  }) => {
+    mocks.onPanelLayout = onLayout ?? null;
+
+    return (
+      <div
+        data-auto-save-id={autoSaveId}
+        data-class-name={className}
+        data-direction={direction}
+        data-testid="panel-group"
+      >
+        {children}
+      </div>
+    );
+  },
+  ResizablePanel: ({
+    children,
+    className,
+    defaultSize,
+    maxSize,
+    minSize,
+    style,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    defaultSize?: number;
+    maxSize?: number;
+    minSize?: number;
+    style?: React.CSSProperties;
+  }) => (
+    <div
+      data-class-name={className}
+      data-default-size={defaultSize}
+      data-max-size={maxSize}
+      data-min-size={minSize}
+      data-max-width={style?.maxWidth}
+      data-min-width={style?.minWidth}
+      data-testid="panel"
+    >
+      {children}
+    </div>
+  ),
+  ResizableHandle: ({ className }: { className?: string }) => (
+    <div data-class-name={className} data-testid="resize-handle" />
+  ),
+}));
+
+vi.mock("~/contexts/shell", () => ({
+  useShell: () => ({
+    leftsidebar: mocks.leftsidebar,
+  }),
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  uniqueIdfromTab: (tab: { type: string }) => tab.type,
+  useTabs: (
+    selector: (state: { currentTab: typeof mocks.currentTab }) => unknown,
+  ) => selector({ currentTab: mocks.currentTab }),
+}));
+
+vi.mock("./shell-sidebar", () => ({
+  ClassicMainSidebar: () =>
+    mocks.leftsidebar.expanded && mocks.currentTab?.type !== "onboarding" ? (
+      <aside data-testid="classic-main-sidebar" />
+    ) : null,
+}));
+
+vi.mock("./tab-content", () => ({
+  ClassicMainTabContent: ({ tab }: { tab: { type: string } }) => (
+    <div data-tab-type={tab.type} data-testid="tab-content" />
+  ),
+}));
+
+vi.mock("./update-banner", () => ({
+  SidebarTimelineUpdateButton: () => <button type="button">Update</button>,
+  useDesktopUpdateControl: () => ({ status: null, version: null }),
+}));
+
+vi.mock("./useTabsShortcuts", () => ({
+  useClassicMainTabsShortcuts: () => ({ runEscapeShortcut: vi.fn() }),
+}));
+
+vi.mock("~/session/components/bottom-accessory/global-live", () => ({
+  GlobalLiveTranscriptAccessory: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <div data-testid="global-live-accessory">{children}</div>,
+}));
+
+vi.mock("~/shared/open-note-dialog", () => ({
+  useOpenNoteDialog: () => ({ open: vi.fn() }),
+}));
+
+vi.mock("~/shared/useNewNote", () => ({
+  useNewNote: () => vi.fn(),
+}));
+
+vi.mock("~/sidebar/timeline/upcoming-meeting", () => ({
+  useSidebarUpcomingMeetingStatus: () => null,
+}));
+
+import { ClassicMainBody } from "./body";
+
+describe("ClassicMainBody", () => {
+  beforeEach(() => {
+    cleanup();
+    mocks.currentTab = {
+      active: true,
+      pinned: false,
+      slotId: "slot-home",
+      type: "empty",
+    };
+    mocks.leftsidebar.expanded = true;
+    mocks.leftsidebar.toggleExpanded.mockClear();
+    mocks.onPanelLayout = null;
+  });
+
+  it("wraps the expanded left sidebar in a persistent resizable panel", () => {
+    render(<ClassicMainBody />);
+
+    expect(screen.getByTestId("panel-group").dataset.direction).toBe(
+      "horizontal",
+    );
+    expect(screen.getByTestId("panel-group").dataset.autoSaveId).toBe(
+      "classic-main-sidebar",
+    );
+    expect(screen.getByTestId("classic-main-sidebar")).toBeTruthy();
+    expect(screen.getByTestId("resize-handle").dataset.className).toContain(
+      "after:w-2",
+    );
+
+    const panels = screen.getAllByTestId("panel");
+    expect(panels).toHaveLength(2);
+    expect(panels[0]?.dataset.defaultSize).toBe("18");
+    expect(panels[0]?.dataset.minSize).toBe("12");
+    expect(panels[0]?.dataset.maxSize).toBe("32");
+    expect(panels[0]?.dataset.minWidth).toBe("180");
+    expect(panels[0]?.dataset.maxWidth).toBe("360");
+
+    const sidebarChrome = document.querySelector<HTMLElement>(
+      "[data-left-sidebar-chrome]",
+    );
+
+    expect(sidebarChrome?.style.width).toBe("18%");
+    expect(sidebarChrome?.style.minWidth).toBe("180px");
+    expect(sidebarChrome?.style.maxWidth).toBe("360px");
+    expect(sidebarChrome?.className).not.toContain("w-[200px]");
+
+    act(() => {
+      mocks.onPanelLayout?.([24, 76]);
+    });
+
+    expect(sidebarChrome?.style.width).toBe("24%");
+  });
+
+  it("keeps the collapsed layout free of the sidebar resize handle", () => {
+    mocks.leftsidebar.expanded = false;
+
+    render(<ClassicMainBody />);
+
+    expect(screen.queryByTestId("classic-main-sidebar")).toBeNull();
+    expect(screen.queryByTestId("resize-handle")).toBeNull();
+    expect(screen.getAllByTestId("panel")).toHaveLength(1);
+  });
+
+  it("does not reserve a sidebar panel during onboarding", () => {
+    mocks.currentTab = { type: "onboarding" };
+
+    render(<ClassicMainBody />);
+
+    expect(screen.queryByTestId("classic-main-sidebar")).toBeNull();
+    expect(screen.queryByTestId("resize-handle")).toBeNull();
+    expect(screen.getAllByTestId("panel")).toHaveLength(1);
+  });
+});

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -7,8 +7,21 @@ import {
   SearchIcon,
   SquarePenIcon,
 } from "lucide-react";
-import { type MouseEvent, type PointerEvent, useCallback, useRef } from "react";
+import {
+  type CSSProperties,
+  type MouseEvent,
+  type PointerEvent,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@hypr/ui/components/ui/resizable";
 import { cn } from "@hypr/utils";
 
 import { resolveMainSurfaceChrome } from "./main-surface-chrome";
@@ -34,6 +47,11 @@ import { type Tab, uniqueIdfromTab, useTabs } from "~/store/zustand/tabs";
 
 const MAIN_AREA_TOP_DRAG_HEIGHT_PX = 48;
 const MAIN_AREA_WINDOW_DRAG_THRESHOLD_PX = 5;
+const LEFT_SIDEBAR_DEFAULT_SIZE = 18;
+const LEFT_SIDEBAR_MIN_SIZE = 12;
+const LEFT_SIDEBAR_MAX_SIZE = 32;
+const LEFT_SIDEBAR_MIN_WIDTH_PX = 180;
+const LEFT_SIDEBAR_MAX_WIDTH_PX = 360;
 
 type MainAreaWindowDragStart = {
   pointerId: number;
@@ -46,6 +64,9 @@ export function ClassicMainBody() {
   const { leftsidebar } = useShell();
   const currentTab = useTabs((state) => state.currentTab);
   const { runEscapeShortcut } = useClassicMainTabsShortcuts();
+  const [leftSidebarPanelSize, setLeftSidebarPanelSize] = useState(
+    LEFT_SIDEBAR_DEFAULT_SIZE,
+  );
 
   const isOnboarding = currentTab?.type === "onboarding";
   const isChangelog = currentTab?.type === "changelog";
@@ -54,6 +75,7 @@ export function ClassicMainBody() {
     hasLeftSurfaceCustomSidebarTab(currentTab);
   const showSidebarTimelineChrome = !hasCustomSidebar && !isOnboarding;
   const showSidebarTimeline = showSidebarTimelineChrome && leftsidebar.expanded;
+  const showLeftSidebarPanel = leftsidebar.expanded && !isOnboarding;
   const showLeftSurfaceChromeBack = hasLeftSurfaceCustomSidebar;
   const enableMainAreaTopDrag =
     showSidebarTimelineChrome || hasLeftSurfaceCustomSidebar;
@@ -76,14 +98,38 @@ export function ClassicMainBody() {
   const handleOpenNoteDialog = useCallback(() => {
     openNoteDialog.open();
   }, [openNoteDialog]);
+  const handlePanelLayout = useCallback(
+    (sizes: number[]) => {
+      if (!showLeftSidebarPanel) {
+        return;
+      }
+
+      const sidebarSize = sizes[0];
+      if (typeof sidebarSize === "number") {
+        setLeftSidebarPanelSize(sidebarSize);
+      }
+    },
+    [showLeftSidebarPanel],
+  );
+  const leftSidebarChromeStyle = useMemo(
+    () =>
+      ({
+        width: `${leftSidebarPanelSize}%`,
+        minWidth: LEFT_SIDEBAR_MIN_WIDTH_PX,
+        maxWidth: LEFT_SIDEBAR_MAX_WIDTH_PX,
+      }) satisfies CSSProperties,
+    [leftSidebarPanelSize],
+  );
 
   return (
     <div className="relative flex h-full min-w-0 flex-1 flex-col">
       {isOnboarding ? null : showSidebarTimelineChrome ? (
         <div
           data-tauri-drag-region
+          data-left-sidebar-chrome
+          style={leftSidebarChromeStyle}
           className={cn([
-            "absolute top-0 z-40 h-12 w-[200px]",
+            "absolute top-0 z-40 h-12",
             leftsidebar.expanded ? "left-0" : "left-1",
             !leftsidebar.expanded && "pointer-events-none",
           ])}
@@ -105,7 +151,9 @@ export function ClassicMainBody() {
       ) : hasLeftSurfaceCustomSidebar ? (
         <div
           data-tauri-drag-region
-          className="absolute top-0 left-0 z-40 h-10 w-[200px]"
+          data-left-sidebar-chrome
+          style={leftSidebarChromeStyle}
+          className="absolute top-0 left-0 z-40 h-10"
         />
       ) : (
         <div data-tauri-drag-region className="relative h-10 shrink-0">
@@ -118,7 +166,9 @@ export function ClassicMainBody() {
       {showLeftSurfaceChromeBack ? (
         <div
           data-tauri-drag-region
-          className="absolute top-0 left-0 z-50 h-12 w-[200px]"
+          data-left-sidebar-chrome
+          style={leftSidebarChromeStyle}
+          className="absolute top-0 left-0 z-50 h-12"
         >
           <div
             data-tauri-drag-region
@@ -133,29 +183,54 @@ export function ClassicMainBody() {
           </div>
         </div>
       ) : null}
-      <div className="flex min-h-0 min-w-0 flex-1 gap-1">
-        <ClassicMainSidebar />
-        <div
-          className="min-h-0 min-w-0 flex-1 overflow-auto"
-          onClickCapture={mainAreaTopDrag.onClickCapture}
-          onPointerCancel={mainAreaTopDrag.onPointerEnd}
-          onPointerDown={mainAreaTopDrag.onPointerDown}
-          onPointerMove={mainAreaTopDrag.onPointerMove}
-          onPointerUp={mainAreaTopDrag.onPointerEnd}
-        >
-          <GlobalLiveTranscriptAccessory
-            currentTab={currentTab}
-            surfaceChrome={mainSurfaceChrome}
+      <ResizablePanelGroup
+        autoSaveId={showLeftSidebarPanel ? "classic-main-sidebar" : undefined}
+        direction="horizontal"
+        className="min-h-0 flex-1 overflow-hidden"
+        onLayout={handlePanelLayout}
+      >
+        {showLeftSidebarPanel ? (
+          <>
+            <ResizablePanel
+              defaultSize={LEFT_SIDEBAR_DEFAULT_SIZE}
+              minSize={LEFT_SIDEBAR_MIN_SIZE}
+              maxSize={LEFT_SIDEBAR_MAX_SIZE}
+              className="min-h-0 overflow-hidden"
+              style={{
+                minWidth: LEFT_SIDEBAR_MIN_WIDTH_PX,
+                maxWidth: LEFT_SIDEBAR_MAX_WIDTH_PX,
+              }}
+            >
+              <ClassicMainSidebar />
+            </ResizablePanel>
+            <ResizableHandle className="z-10 w-1 !bg-transparent after:w-2" />
+          </>
+        ) : (
+          <ClassicMainSidebar />
+        )}
+        <ResizablePanel className="min-h-0 flex-1 overflow-hidden">
+          <div
+            className="h-full min-h-0 min-w-0 flex-1 overflow-auto"
+            onClickCapture={mainAreaTopDrag.onClickCapture}
+            onPointerCancel={mainAreaTopDrag.onPointerEnd}
+            onPointerDown={mainAreaTopDrag.onPointerDown}
+            onPointerMove={mainAreaTopDrag.onPointerMove}
+            onPointerUp={mainAreaTopDrag.onPointerEnd}
           >
-            {currentTab ? (
-              <ClassicMainTabContent
-                key={uniqueIdfromTab(currentTab)}
-                tab={currentTab as Tab}
-              />
-            ) : null}
-          </GlobalLiveTranscriptAccessory>
-        </div>
-      </div>
+            <GlobalLiveTranscriptAccessory
+              currentTab={currentTab}
+              surfaceChrome={mainSurfaceChrome}
+            >
+              {currentTab ? (
+                <ClassicMainTabContent
+                  key={uniqueIdfromTab(currentTab)}
+                  tab={currentTab as Tab}
+                />
+              ) : null}
+            </GlobalLiveTranscriptAccessory>
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
     </div>
   );
 }

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -250,9 +250,8 @@ describe("ClassicMainBody", () => {
 
     expect(screen.queryByTestId("timeline-update-banner")).toBeNull();
     expect(screen.queryByTestId("toast-area")).toBeNull();
-    expect(firstBodyChild?.className).toContain(
-      "flex min-h-0 min-w-0 flex-1 gap-1",
-    );
+    expect(firstBodyChild?.className).toContain("min-h-0 flex-1");
+    expect(firstBodyChild?.className).toContain("overflow-hidden");
     expect(firstBodyChild?.hasAttribute("data-tauri-drag-region")).toBe(false);
     expect(screen.getByTestId("main-tab-content").textContent).toContain(
       "onboarding",
@@ -278,9 +277,8 @@ describe("ClassicMainBody", () => {
     expect(topArea?.className).toContain("h-12");
     expect(topArea?.className).toContain("left-1");
     expect(topArea?.className).toContain("pointer-events-none");
-    expect(contentRow?.className).toContain(
-      "flex min-h-0 min-w-0 flex-1 gap-1",
-    );
+    expect(contentRow?.className).toContain("min-h-0 flex-1");
+    expect(contentRow?.className).toContain("overflow-hidden");
     expect(contentRow?.hasAttribute("data-tauri-drag-region")).toBe(false);
     expect(mocks.toggleLeftSidebar).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop/src/sidebar/index.tsx
+++ b/apps/desktop/src/sidebar/index.tsx
@@ -22,7 +22,7 @@ export function LeftSidebar() {
   return (
     <div
       className={cn([
-        "flex h-full w-[200px] shrink-0 flex-col gap-1 overflow-hidden",
+        "flex h-full w-full shrink-0 flex-col gap-1 overflow-hidden",
         isTimelineSidebarLayout ? "pt-0" : "pt-11",
       ])}
     >


### PR DESCRIPTION
Wrap the desktop left sidebar in a persistent resizable panel and cover expanded/collapsed layout states with tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI layout change with tests; no auth, data, or API impact. Minor risk of drag-region or chrome misalignment during resize.
> 
> **Overview**
> The desktop **classic main** layout replaces a fixed **200px** sidebar with a **horizontal resizable panel** when the left sidebar is expanded and the user is not on onboarding.
> 
> `ClassicMainBody` wraps sidebar and main content in `ResizablePanelGroup` with persisted layout (`autoSaveId` `classic-main-sidebar`), default **18%** width, **12–32%** bounds, and **180–360px** min/max width. A resize handle appears only in that expanded state; collapsed and onboarding flows keep a single main panel with no handle. Top **left sidebar chrome** (`data-left-sidebar-chrome`) now tracks panel size via inline width instead of `w-[200px]`.
> 
> `LeftSidebar` switches from `w-[200px]` to **`w-full`** so it fills the resizable panel. New **`body.test.tsx`** covers expanded panel behavior, chrome sync on layout, collapsed layout, and onboarding; shared **`body.test.tsx`** expectations update for the resizable root classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df5d3e9679b3c8866dde4a6bf41a158bd491db83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->