### PR TITLE
Refine floating chat composer UX

### DIFF
--- a/apps/desktop/src/chat/components/body/empty.test.tsx
+++ b/apps/desktop/src/chat/components/body/empty.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/chat/hooks/use-chat-appearance", () => ({
+  useChatAppearance: () => ({
+    isDarkAppearance: false,
+  }),
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: () => vi.fn(),
+}));
+
+import { ChatBodyEmpty } from "./empty";
+
+describe("ChatBodyEmpty", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("renders context suggestions as short list rows without intro copy", () => {
+    const onSendMessage = vi.fn();
+
+    render(<ChatBodyEmpty hasContext onSendMessage={onSendMessage} />);
+
+    expect(screen.queryByText("Anarlog AI")).toBeNull();
+    expect(screen.queryByText(/Hi, I'm Anarlog AI/i)).toBeNull();
+
+    const actionItem = screen.getByRole("button", {
+      name: "List action items.",
+    });
+    const followUp = screen.getByRole("button", {
+      name: "Draft follow-up email.",
+    });
+    const decisions = screen.getByRole("button", {
+      name: "Find key decisions.",
+    });
+
+    expect(actionItem.className).toContain("w-full");
+    expect(actionItem.className).toContain("text-left");
+    expect(followUp.className).toContain("w-full");
+    expect(decisions.className).toContain("w-full");
+
+    fireEvent.click(decisions);
+
+    expect(onSendMessage).toHaveBeenCalledWith(
+      "What were the key decisions that have been made?",
+      [
+        {
+          type: "text",
+          text: "What were the key decisions that have been made?",
+        },
+      ],
+    );
+  });
+});

--- a/apps/desktop/src/chat/components/body/empty.tsx
+++ b/apps/desktop/src/chat/components/body/empty.tsx
@@ -14,17 +14,17 @@ import { useTabs } from "~/store/zustand/tabs";
 
 const SUGGESTIONS = [
   {
-    label: "Actions",
+    label: "List action items.",
     icon: ListChecksIcon,
     prompt: "What are my action items from this meeting?",
   },
   {
-    label: "Draft follow-up",
+    label: "Draft follow-up email.",
     icon: MailIcon,
     prompt: "Draft a follow-up email to the participants",
   },
   {
-    label: "Key decisions",
+    label: "Find key decisions.",
     icon: SearchIcon,
     prompt: "What were the key decisions that have been made?",
   },
@@ -103,44 +103,30 @@ export function ChatBodyEmpty({
   return (
     <div className="flex justify-start pb-1">
       <div className="flex w-full flex-col">
-        <div className="mb-2 flex items-center gap-2">
-          <span
-            className={cn([
-              "text-sm font-medium",
-              isDarkAppearance ? "text-primary-foreground" : "text-foreground",
-            ])}
-          >
-            Anarlog AI
-          </span>
-          <BetaChip isDarkAppearance={isDarkAppearance} />
-        </div>
-        <p
-          className={cn([
-            "mb-2 text-sm",
-            isDarkAppearance
-              ? "text-primary-foreground/80"
-              : "text-muted-foreground",
-          ])}
-        >
-          Hi, I'm Anarlog AI. I can help you pull context from your notes, find
-          key decisions, and draft what comes next.
-        </p>
         {hasContext && (
-          <div className="flex flex-wrap gap-1.5">
+          <div className="flex flex-col gap-1">
             {SUGGESTIONS.map(({ label, icon: Icon, prompt }) => (
               <button
                 key={label}
                 onClick={() => handleSuggestionClick(prompt)}
                 className={cn([
-                  "inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[11px]",
+                  "group flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm",
                   isDarkAppearance
-                    ? "border-border bg-accent text-accent-foreground hover:bg-accent/85"
-                    : "border-border bg-card text-muted-foreground hover:bg-accent",
+                    ? "text-primary-foreground/85 hover:bg-primary-foreground/7"
+                    : "text-muted-foreground hover:bg-card",
                   "transition-colors",
                 ])}
               >
-                <Icon size={12} />
-                {label}
+                <Icon
+                  size={15}
+                  className={cn([
+                    "shrink-0 transition-colors",
+                    isDarkAppearance
+                      ? "text-primary-foreground/55 group-hover:text-primary-foreground/80"
+                      : "text-muted-foreground/75 group-hover:text-foreground",
+                  ])}
+                />
+                <span>{label}</span>
               </button>
             ))}
           </div>

--- a/apps/desktop/src/chat/components/body/index.test.tsx
+++ b/apps/desktop/src/chat/components/body/index.test.tsx
@@ -50,8 +50,13 @@ describe("ChatBody", () => {
     render(<ChatBody messages={[]} status="ready" />);
 
     const content = screen.getByTestId("chat-body-empty").parentElement;
+    const scrollArea = content?.parentElement;
+    const root = scrollArea?.parentElement;
 
     expect(content?.className).toContain("px-3");
+    expect(content?.className).not.toContain("min-h-full");
+    expect(scrollArea?.className).toContain("max-h-[min(16rem,35vh)]");
+    expect(root?.className).toContain("shrink-0");
     expect(content?.className).not.toContain("px-2");
     expect(content?.className).not.toContain("pr-0");
   });
@@ -62,9 +67,14 @@ describe("ChatBody", () => {
     render(<ChatBody messages={[]} status="ready" />);
 
     const content = screen.getByTestId("chat-body-empty").parentElement;
+    const scrollArea = content?.parentElement;
+    const root = scrollArea?.parentElement;
 
     expect(content?.className).toContain("px-3");
     expect(content?.className).toContain("py-5");
+    expect(content?.className).toContain("min-h-full");
+    expect(scrollArea?.className).toContain("flex-1");
+    expect(root?.className).toContain("flex-1");
     expect(content?.className).not.toContain("px-5");
     expect(content?.className).not.toContain("px-2");
   });

--- a/apps/desktop/src/chat/components/body/index.tsx
+++ b/apps/desktop/src/chat/components/body/index.tsx
@@ -36,6 +36,7 @@ export function ChatBody({
 }) {
   const { chat } = useShell();
   const isRightPanel = chat.mode === "RightPanelOpen";
+  const isFloating = chat.mode === "FloatingOpen";
   const {
     contentRef,
     isAtBottom,
@@ -47,21 +48,30 @@ export function ChatBody({
   } = useChatAutoScroll(status);
 
   return (
-    <div className="relative flex min-h-0 flex-1 flex-col">
+    <div
+      className={cn([
+        "relative flex min-h-0 flex-col",
+        isRightPanel ? "flex-1" : "shrink-0",
+      ])}
+    >
       <div
         ref={scrollRef}
         onScroll={updateAutoScrollState}
         onWheel={handleWheel}
-        className="flex min-h-0 flex-1 flex-col overflow-y-auto"
+        className={cn([
+          "flex min-h-0 flex-col overflow-y-auto",
+          isRightPanel ? "flex-1" : "max-h-[min(16rem,35vh)] shrink-0",
+        ])}
       >
         <div
           ref={contentRef}
           className={cn([
-            "flex min-h-full flex-1 flex-col",
+            "flex flex-col",
+            isRightPanel && "min-h-full flex-1",
             isRightPanel ? "px-3 py-5" : "px-3 py-3",
           ])}
         >
-          <div className="flex-1" />
+          {!isFloating && <div className="flex-1" />}
           {messages.length === 0 ? (
             <ChatBodyEmpty
               isModelConfigured={isModelConfigured}

--- a/apps/desktop/src/chat/components/chat-panel.test.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.test.tsx
@@ -102,11 +102,11 @@ describe("ChatView", () => {
     );
   });
 
-  it("uses the warm shell in the floating layout", () => {
+  it("uses the neutral shell in the floating layout", () => {
     const { container } = render(<ChatView layout="floating" />);
     const root = container.firstElementChild;
 
-    expect(root?.className).toContain("bg-[#fff9ed]");
+    expect(root?.className).toContain("bg-[#f4f4f5]");
     expect(root?.className).toContain("text-card-foreground");
     expect(root?.className).toContain("max-h-full");
     expect(root?.className).not.toContain("bg-card");

--- a/apps/desktop/src/chat/components/chat-panel.test.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.test.tsx
@@ -88,6 +88,7 @@ describe("ChatView", () => {
 
     expect(root?.className).toContain("bg-card");
     expect(root?.className).toContain("text-card-foreground");
+    expect(root?.className).toContain("h-full");
     expect(root?.className).not.toContain("bg-primary");
     expect(root?.firstElementChild?.className).toContain("h-12");
     expect(root?.firstElementChild?.className).not.toContain("border-b");
@@ -107,6 +108,8 @@ describe("ChatView", () => {
 
     expect(root?.className).toContain("bg-card");
     expect(root?.className).toContain("text-card-foreground");
+    expect(root?.className).toContain("max-h-full");
+    expect(root?.className.split(" ")).not.toContain("h-full");
     expect(root?.firstElementChild?.className).toContain("h-11");
     expect(root?.firstElementChild?.className).not.toContain("border-b");
     expect(screen.getByTestId("chat-toolbar").dataset.surface).toBe("light");

--- a/apps/desktop/src/chat/components/chat-panel.test.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.test.tsx
@@ -102,13 +102,14 @@ describe("ChatView", () => {
     );
   });
 
-  it("uses the sidebar card shell in the floating layout", () => {
+  it("uses the warm shell in the floating layout", () => {
     const { container } = render(<ChatView layout="floating" />);
     const root = container.firstElementChild;
 
-    expect(root?.className).toContain("bg-card");
+    expect(root?.className).toContain("bg-[#fff9ed]");
     expect(root?.className).toContain("text-card-foreground");
     expect(root?.className).toContain("max-h-full");
+    expect(root?.className).not.toContain("bg-card");
     expect(root?.className.split(" ")).not.toContain("h-full");
     expect(root?.firstElementChild?.className).toContain("h-11");
     expect(root?.firstElementChild?.className).not.toContain("border-b");

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -11,6 +11,7 @@ import { useSessionTab } from "./use-session-tab";
 import { useLanguageModel } from "~/ai/hooks";
 import { useChatAppearance } from "~/chat/hooks/use-chat-appearance";
 import { useChatActions } from "~/chat/store/use-chat-actions";
+import { chatFloatingPanelClassNames } from "~/chat/surface";
 import { useShell } from "~/contexts/shell";
 import * as main from "~/store/tinybase/store/main";
 
@@ -99,7 +100,7 @@ export function ChatPanelFrame({
       className={cn([
         "flex min-h-0 flex-col overflow-hidden",
         isFloating ? "max-h-full" : "h-full",
-        panelClassName,
+        isFloating ? chatFloatingPanelClassNames() : panelClassName,
       ])}
     >
       <div

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -95,7 +95,8 @@ export function ChatPanelFrame({
   return (
     <div
       className={cn([
-        "flex h-full min-h-0 flex-col overflow-hidden",
+        "flex min-h-0 flex-col overflow-hidden",
+        isFloating ? "max-h-full" : "h-full",
         panelClassName,
       ])}
     >
@@ -119,6 +120,7 @@ export function ChatPanelFrame({
       {sessionProps && (
         <ChatContent
           {...sessionProps}
+          layout={layout}
           model={model}
           handleSendMessage={handleSendMessage}
         >

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -65,11 +65,13 @@ export function ChatSessionHost({
 
 export function ChatPanelFrame({
   layout = "floating",
+  onDraftContentChange,
   onOpenFloating,
   onOpenRightPanel,
   sessionProps,
 }: {
   layout?: "floating" | "right-panel";
+  onDraftContentChange?: (hasDraftContent: boolean) => void;
   onOpenFloating?: () => void;
   onOpenRightPanel?: () => void;
   sessionProps: ChatSessionRenderProps | null;
@@ -121,6 +123,7 @@ export function ChatPanelFrame({
         <ChatContent
           {...sessionProps}
           layout={layout}
+          onDraftContentChange={onDraftContentChange}
           model={model}
           handleSendMessage={handleSendMessage}
         >

--- a/apps/desktop/src/chat/components/content.test.tsx
+++ b/apps/desktop/src/chat/components/content.test.tsx
@@ -54,6 +54,37 @@ const renderContent = (onAddContextEntity = vi.fn()) => {
 };
 
 describe("ChatContent", () => {
+  it("uses shrink-wrapped layout by default for floating chat", () => {
+    const container = renderContent();
+
+    expect(container?.className).toContain("shrink-0");
+    expect(container?.className).not.toContain("flex-1");
+  });
+
+  it("fills available height in the right panel layout", () => {
+    const { container } = render(
+      <ChatContent
+        sessionId="active-session"
+        layout="right-panel"
+        messages={[]}
+        sendMessage={vi.fn()}
+        regenerate={vi.fn()}
+        stop={vi.fn()}
+        status="ready"
+        model={{} as never}
+        handleSendMessage={vi.fn()}
+        contextEntities={[]}
+        pendingRefs={[]}
+        isSystemPromptReady
+      />,
+    );
+
+    const content = container.querySelector("[data-chat-content]");
+
+    expect(content?.className).toContain("flex-1");
+    expect(content?.className).not.toContain("shrink-0");
+  });
+
   it("adds dropped session refs to chat context", () => {
     const onAddContextEntity = vi.fn();
     const container = renderContent(onAddContextEntity);

--- a/apps/desktop/src/chat/components/content.tsx
+++ b/apps/desktop/src/chat/components/content.tsx
@@ -14,6 +14,7 @@ import type { DisplayEntity } from "~/chat/context/use-chat-context-pipeline";
 import type { HyprUIMessage } from "~/chat/types";
 
 export function ChatContent({
+  layout = "floating",
   sessionId,
   messages,
   sendMessage,
@@ -31,6 +32,7 @@ export function ChatContent({
   isSystemPromptReady,
   children,
 }: {
+  layout?: "floating" | "right-panel";
   sessionId: string;
   messages: HyprUIMessage[];
   sendMessage: (message: HyprUIMessage) => void;
@@ -54,6 +56,7 @@ export function ChatContent({
   children?: React.ReactNode;
 }) {
   const isModelConfigured = !!model;
+  const isFloating = layout === "floating";
   const disabled = !isSystemPromptReady;
   const mergeContextRefs = (contextRefs?: ContextRef[]) =>
     contextRefs ? dedupeByKey([pendingRefs, contextRefs]) : pendingRefs;
@@ -83,7 +86,11 @@ export function ChatContent({
 
   return (
     <div
-      className="flex min-h-0 flex-1 flex-col overflow-hidden"
+      className={
+        isFloating
+          ? "flex min-h-0 shrink-0 flex-col overflow-hidden"
+          : "flex min-h-0 flex-1 flex-col overflow-hidden"
+      }
       data-chat-content
       onDragOver={handleDragOver}
       onDrop={handleDrop}

--- a/apps/desktop/src/chat/components/content.tsx
+++ b/apps/desktop/src/chat/components/content.tsx
@@ -28,6 +28,7 @@ export function ChatContent({
   pendingRefs,
   onRemoveContextEntity,
   onAddContextEntity,
+  onDraftContentChange,
   onDraftContextRefsChange,
   isSystemPromptReady,
   children,
@@ -51,6 +52,7 @@ export function ChatContent({
   pendingRefs: ContextRef[];
   onRemoveContextEntity?: (key: string) => void;
   onAddContextEntity?: (ref: ContextRef) => void;
+  onDraftContentChange?: (hasDraftContent: boolean) => void;
   onDraftContextRefsChange?: (refs: ContextRef[]) => void;
   isSystemPromptReady: boolean;
   children?: React.ReactNode;
@@ -131,6 +133,7 @@ export function ChatContent({
                 mergeContextRefs(contextRefs),
               );
             }}
+            onDraftContentChange={onDraftContentChange}
             onContextRefsChange={onDraftContextRefsChange}
             isStreaming={status === "streaming" || status === "submitted"}
             onStop={stop}

--- a/apps/desktop/src/chat/components/input/chat-input.css
+++ b/apps/desktop/src/chat/components/input/chat-input.css
@@ -1,14 +1,14 @@
 [data-chat-input-surface="elevated"] {
-  background-color: hsl(var(--accent));
-  color: hsl(var(--accent-foreground));
+  background-color: hsl(var(--card));
+  color: hsl(var(--card-foreground));
 }
 
 .dark [data-chat-input-surface="elevated"] .chat-input-editor.tiptap,
 .dark [data-chat-input-surface="elevated"] .chat-input-editor.tiptap p,
 [data-chat-input-surface="elevated"] .chat-input-editor.tiptap,
 [data-chat-input-surface="elevated"] .chat-input-editor.tiptap p {
-  color: hsl(var(--accent-foreground)) !important;
-  caret-color: hsl(var(--accent-foreground));
+  color: hsl(var(--card-foreground)) !important;
+  caret-color: hsl(var(--card-foreground));
 }
 
 [data-chat-input-surface="elevated"]

--- a/apps/desktop/src/chat/components/input/chat-input.css
+++ b/apps/desktop/src/chat/components/input/chat-input.css
@@ -3,6 +3,23 @@
   color: hsl(var(--card-foreground));
 }
 
+[data-chat-input-surface="floating"] .chat-input-editor.tiptap,
+[data-chat-input-surface="floating"] .chat-input-editor.tiptap p {
+  line-height: 20px;
+  margin-bottom: 0;
+  min-height: 20px !important;
+  padding: 0 !important;
+}
+
+[data-chat-input-surface="floating"]
+  .chat-input-editor.tiptap
+  .is-editor-empty:first-child::before,
+[data-chat-input-surface="floating"]
+  .chat-input-editor.tiptap
+  .is-empty::before {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
 .dark [data-chat-input-surface="elevated"] .chat-input-editor.tiptap,
 .dark [data-chat-input-surface="elevated"] .chat-input-editor.tiptap p,
 [data-chat-input-surface="elevated"] .chat-input-editor.tiptap,

--- a/apps/desktop/src/chat/components/input/hooks.ts
+++ b/apps/desktop/src/chat/components/input/hooks.ts
@@ -10,28 +10,33 @@ const draftsByKey = new Map<string, JSONContent>();
 
 export function useDraftState({
   draftKey,
+  onDraftContentChange,
   onContextRefsChange,
 }: {
   draftKey: string;
+  onDraftContentChange?: (hasDraftContent: boolean) => void;
   onContextRefsChange?: (refs: ContextRef[]) => void;
 }) {
-  const [hasContent, setHasContent] = useState(false);
   const initialContent = useRef(draftsByKey.get(draftKey) ?? EMPTY_DOC);
+  const [hasContent, setHasContent] = useState(() =>
+    hasTextContent(initialContent.current),
+  );
 
   useEffect(() => {
+    onDraftContentChange?.(hasDraftContent(initialContent.current));
     onContextRefsChange?.(
       extractContextRefsFromTiptapJson(initialContent.current),
     );
-  }, [onContextRefsChange]);
+  }, [onDraftContentChange, onContextRefsChange]);
 
   const handleEditorUpdate = useCallback(
     (json: JSONContent) => {
-      const text = tiptapJsonToText(json).trim();
-      setHasContent(text.length > 0);
+      setHasContent(hasTextContent(json));
       draftsByKey.set(draftKey, json);
+      onDraftContentChange?.(hasDraftContent(json));
       onContextRefsChange?.(extractContextRefsFromTiptapJson(json));
     },
-    [draftKey, onContextRefsChange],
+    [draftKey, onDraftContentChange, onContextRefsChange],
   );
 
   return {
@@ -47,6 +52,7 @@ export function useSubmit({
   disabled,
   isStreaming,
   onSendMessage,
+  onDraftContentChange,
   onContextRefsChange,
 }: {
   draftKey: string;
@@ -58,6 +64,7 @@ export function useSubmit({
     parts: Array<{ type: "text"; text: string }>,
     contextRefs?: ContextRef[],
   ) => void;
+  onDraftContentChange?: (hasDraftContent: boolean) => void;
   onContextRefsChange?: (refs: ContextRef[]) => void;
 }) {
   return useCallback(() => {
@@ -73,6 +80,7 @@ export function useSubmit({
     onSendMessage(text, [{ type: "text", text }], mentionRefs);
     editorRef.current?.clearContent();
     draftsByKey.delete(draftKey);
+    onDraftContentChange?.(false);
     onContextRefsChange?.([]);
   }, [
     draftKey,
@@ -80,6 +88,7 @@ export function useSubmit({
     disabled,
     isStreaming,
     onSendMessage,
+    onDraftContentChange,
     onContextRefsChange,
   ]);
 }
@@ -144,6 +153,30 @@ function tiptapJsonToText(json: any): string {
   }
 
   return "";
+}
+
+function hasTextContent(json: JSONContent | undefined): boolean {
+  return tiptapJsonToText(json).trim().length > 0;
+}
+
+function hasDraftContent(json: JSONContent | undefined): boolean {
+  if (hasTextContent(json)) {
+    return true;
+  }
+
+  return hasAttachmentNode(json);
+}
+
+function hasAttachmentNode(json: JSONContent | undefined): boolean {
+  if (!json || typeof json !== "object") {
+    return false;
+  }
+
+  if (json.type === "attachment") {
+    return true;
+  }
+
+  return Array.isArray(json.content) && json.content.some(hasAttachmentNode);
 }
 
 function extractContextRefsFromTiptapJson(

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -221,7 +221,7 @@ describe("ChatMessageInput", () => {
     expect(surface?.className).toContain("dark:bg-[#202020]");
     expect(surface?.className).toContain("text-muted-foreground");
     expect(surface?.className).toContain(
-      "shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.18)]",
+      "shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_12px_rgba(0,0,0,0.1),0_16px_40px_rgba(0,0,0,0.16)]",
     );
     expect(surface?.className).not.toContain("bg-card");
   });

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -31,8 +31,12 @@ vi.mock("@hypr/editor/chat", async () => {
         className: string;
         onSubmit: () => void;
         onUpdate: (json: unknown) => void;
+        placeholder: (props: {
+          node: { type: { name: string } };
+          pos: number;
+        }) => string;
       }
-    >(function ChatEditor({ className, onUpdate }, ref) {
+    >(function ChatEditor({ className, onUpdate, placeholder }, ref) {
       editorState.onUpdate = onUpdate;
 
       React.useImperativeHandle(ref, () => ({
@@ -41,7 +45,16 @@ vi.mock("@hypr/editor/chat", async () => {
         getJSON: () => editorState.json,
       }));
 
-      return <div className={className} data-testid="chat-editor" />;
+      return (
+        <div
+          className={className}
+          data-placeholder={placeholder({
+            node: { type: { name: "paragraph" } },
+            pos: 0,
+          })}
+          data-testid="chat-editor"
+        />
+      );
     }),
   };
 });
@@ -87,6 +100,7 @@ describe("ChatMessageInput", () => {
   });
 
   it("disables send until the draft has content", () => {
+    shellState.mode = "RightPanelOpen";
     const onSendMessage = vi.fn();
     const onDraftContentChange = vi.fn();
     render(
@@ -130,6 +144,7 @@ describe("ChatMessageInput", () => {
   });
 
   it("tracks attachment-only drafts without enabling text send", () => {
+    shellState.mode = "RightPanelOpen";
     const onDraftContentChange = vi.fn();
     render(
       <ChatMessageInput
@@ -172,6 +187,8 @@ describe("ChatMessageInput", () => {
   });
 
   it("marks the send control for disabled surface styling before the draft has content", () => {
+    shellState.mode = "RightPanelOpen";
+
     render(
       <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
     );
@@ -185,7 +202,7 @@ describe("ChatMessageInput", () => {
     expect(sendButton.className).not.toContain("bg-primary");
   });
 
-  it("uses the light card input surface for typed text", () => {
+  it("matches the hovered FAB surface while floating", () => {
     render(
       <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
     );
@@ -194,14 +211,40 @@ describe("ChatMessageInput", () => {
     const surface = editor.closest("[data-chat-message-input]")?.parentElement;
 
     expect(editor.className).toContain("chat-input-editor");
-    expect(editor.className).toContain("max-h-48");
+    expect(editor.className).toContain("max-h-6");
+    expect(editor.dataset.placeholder).toBe("Ask anything");
+    expect(screen.queryByRole("button", { name: /send/i })).toBeNull();
+    expect(surface?.getAttribute("data-chat-input-surface")).toBe("floating");
+    expect(surface?.className).toContain("h-10");
+    expect(surface?.className).toContain("rounded-full");
+    expect(surface?.className).toContain("bg-[#f4f4f5]");
+    expect(surface?.className).toContain("dark:bg-[#202020]");
+    expect(surface?.className).toContain("text-muted-foreground");
+    expect(surface?.className).toContain(
+      "shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.18)]",
+    );
+    expect(surface?.className).not.toContain("bg-card");
+  });
+
+  it("uses the light card input surface in the right panel", () => {
+    shellState.mode = "RightPanelOpen";
+
+    render(
+      <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
+    );
+
+    const editor = screen.getByTestId("chat-editor");
+    const surface = editor.closest("[data-chat-message-input]")?.parentElement;
+
+    expect(editor.className).toContain("chat-input-editor");
+    expect(editor.className).toContain("max-h-[40vh]");
     expect(surface?.getAttribute("data-chat-input-surface")).toBe("elevated");
     expect(surface?.className).toContain("bg-card");
     expect(surface?.className).toContain("text-card-foreground");
-    expect(surface?.className).toContain("rounded-[1.75rem]");
+    expect(surface?.className).toContain("rounded-xl");
   });
 
-  it("uses shared horizontal outer padding while floating", () => {
+  it("uses a thin outer shell gap while floating", () => {
     render(
       <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
     );
@@ -211,9 +254,9 @@ describe("ChatMessageInput", () => {
       .closest("[data-chat-message-input]");
     const outerContainer = messageInput?.parentElement?.parentElement;
 
-    expect(outerContainer?.className).toContain("px-3");
-    expect(outerContainer?.className).toContain("pb-2");
-    expect(outerContainer?.className).not.toContain("px-2");
+    expect(outerContainer?.className).toContain("px-1.5");
+    expect(outerContainer?.className).toContain("pb-1.5");
+    expect(outerContainer?.className).not.toContain("px-3");
     expect(outerContainer?.className).not.toContain("pr-0");
   });
 

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -88,9 +88,11 @@ describe("ChatMessageInput", () => {
 
   it("disables send until the draft has content", () => {
     const onSendMessage = vi.fn();
+    const onDraftContentChange = vi.fn();
     render(
       <ChatMessageInput
         draftKey="chat-input-test"
+        onDraftContentChange={onDraftContentChange}
         onSendMessage={onSendMessage}
       />,
     );
@@ -114,6 +116,7 @@ describe("ChatMessageInput", () => {
     });
 
     expect(sendButton.disabled).toBe(false);
+    expect(onDraftContentChange).toHaveBeenCalledWith(true);
 
     fireEvent.click(sendButton);
 
@@ -123,6 +126,49 @@ describe("ChatMessageInput", () => {
       [],
     );
     expect(clearContentMock).toHaveBeenCalled();
+    expect(onDraftContentChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("tracks attachment-only drafts without enabling text send", () => {
+    const onDraftContentChange = vi.fn();
+    render(
+      <ChatMessageInput
+        draftKey="chat-input-test"
+        onDraftContentChange={onDraftContentChange}
+        onSendMessage={vi.fn()}
+      />,
+    );
+
+    const sendButton = screen.getByRole<HTMLButtonElement>("button", {
+      name: /send/i,
+    });
+
+    editorState.json = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "attachment",
+              attrs: {
+                id: "attachment-1",
+                name: "image.png",
+                mimeType: "image/png",
+                url: "data:image/png;base64,abc",
+                size: 123,
+              },
+            },
+          ],
+        },
+      ],
+    };
+    act(() => {
+      editorState.onUpdate?.(editorState.json);
+    });
+
+    expect(onDraftContentChange).toHaveBeenCalledWith(true);
+    expect(sendButton.disabled).toBe(true);
   });
 
   it("marks the send control for disabled surface styling before the draft has content", () => {

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -211,12 +211,15 @@ describe("ChatMessageInput", () => {
     const surface = editor.closest("[data-chat-message-input]")?.parentElement;
 
     expect(editor.className).toContain("chat-input-editor");
-    expect(editor.className).toContain("max-h-6");
+    expect(editor.className).toContain("max-h-24");
+    expect(editor.className).toContain("overflow-y-auto");
     expect(editor.dataset.placeholder).toBe("Ask anything");
     expect(screen.queryByRole("button", { name: /send/i })).toBeNull();
     expect(surface?.getAttribute("data-chat-input-surface")).toBe("floating");
-    expect(surface?.className).toContain("h-10");
-    expect(surface?.className).toContain("rounded-full");
+    expect(surface?.className).toContain("min-h-10");
+    expect(surface?.className).toContain("max-h-32");
+    expect(surface?.className).toContain("rounded-[20px]");
+    expect(surface?.className).toContain("py-2");
     expect(surface?.className).toContain("bg-[#f4f4f5]");
     expect(surface?.className).toContain("dark:bg-[#202020]");
     expect(surface?.className).toContain("text-muted-foreground");
@@ -244,7 +247,7 @@ describe("ChatMessageInput", () => {
     expect(surface?.className).toContain("rounded-xl");
   });
 
-  it("uses a thin outer shell gap while floating", () => {
+  it("keeps the floating input inset from the clipped shell corners", () => {
     render(
       <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
     );
@@ -254,9 +257,10 @@ describe("ChatMessageInput", () => {
       .closest("[data-chat-message-input]");
     const outerContainer = messageInput?.parentElement?.parentElement;
 
-    expect(outerContainer?.className).toContain("px-1.5");
-    expect(outerContainer?.className).toContain("pb-1.5");
+    expect(outerContainer?.className).toContain("px-1");
+    expect(outerContainer?.className).toContain("pb-1");
     expect(outerContainer?.className).not.toContain("px-3");
+    expect(outerContainer?.className).not.toContain("px-2.5");
     expect(outerContainer?.className).not.toContain("pr-0");
   });
 

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -63,8 +63,8 @@ vi.mock("~/contexts/shell", () => ({
 vi.mock("~/chat/hooks/use-chat-appearance", () => ({
   useChatAppearance: () => ({
     isDarkAppearance: true,
-    elevatedSurfaceClassName: "bg-accent text-accent-foreground border-border",
-    inputEditorClassName: "chat-input-editor text-accent-foreground",
+    elevatedSurfaceClassName: "bg-card text-card-foreground border-border",
+    inputEditorClassName: "chat-input-editor text-card-foreground",
     sendButtonDisabledClassName:
       "cursor-default border-border text-muted-foreground/60",
     sendButtonShortcutDisabledClassName: "text-muted-foreground/60",
@@ -139,7 +139,7 @@ describe("ChatMessageInput", () => {
     expect(sendButton.className).not.toContain("bg-primary");
   });
 
-  it("uses the elevated dark input surface for typed text", () => {
+  it("uses the light card input surface for typed text", () => {
     render(
       <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
     );
@@ -148,9 +148,11 @@ describe("ChatMessageInput", () => {
     const surface = editor.closest("[data-chat-message-input]")?.parentElement;
 
     expect(editor.className).toContain("chat-input-editor");
+    expect(editor.className).toContain("max-h-48");
     expect(surface?.getAttribute("data-chat-input-surface")).toBe("elevated");
-    expect(surface?.className).toContain("bg-accent");
-    expect(surface?.className).toContain("text-accent-foreground");
+    expect(surface?.className).toContain("bg-card");
+    expect(surface?.className).toContain("text-card-foreground");
+    expect(surface?.className).toContain("rounded-[1.75rem]");
   });
 
   it("uses shared horizontal outer padding while floating", () => {
@@ -186,5 +188,18 @@ describe("ChatMessageInput", () => {
     expect(outerContainer?.className).not.toContain("px-5");
     expect(outerContainer?.className).not.toContain("px-2");
     expect(outerContainer?.className).not.toContain("pr-0");
+  });
+
+  it("caps the editor height in the right panel separately", () => {
+    shellState.mode = "RightPanelOpen";
+
+    render(
+      <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
+    );
+
+    const editor = screen.getByTestId("chat-editor");
+
+    expect(editor.className).toContain("max-h-[40vh]");
+    expect(editor.className).not.toContain("max-h-48");
   });
 });

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -59,20 +59,23 @@ export function ChatMessageInput({
   const mentionConfig = useMentionConfig();
   const isSendDisabled = Boolean(disabled) || !hasContent;
   const isRightPanel = chat.mode === "RightPanelOpen";
+  const isFloating = chat.mode === "FloatingOpen";
 
   return (
     <Container
       elevatedSurfaceClassName={elevatedSurfaceClassName}
       hasContextBar={hasContextBar}
+      isFloating={isFloating}
       isRightPanel={isRightPanel}
     >
       <div data-chat-message-input className="flex flex-col px-2 pt-3 pb-2">
-        <div className="mb-1 min-h-0 flex-1">
+        <div className="mb-1 min-h-0">
           <ChatEditor
             ref={editorRef}
             className={cn([
               "chat-input-editor",
-              "max-h-[40vh] overflow-y-auto overscroll-contain text-sm",
+              "overflow-y-auto overscroll-contain text-sm",
+              isRightPanel ? "max-h-[40vh]" : "max-h-48",
             ])}
             initialContent={initialContent}
             mentionConfig={mentionConfig}
@@ -128,11 +131,13 @@ function Container({
   children,
   elevatedSurfaceClassName,
   hasContextBar,
+  isFloating,
   isRightPanel,
 }: {
   children: React.ReactNode;
   elevatedSurfaceClassName: string;
   hasContextBar?: boolean;
+  isFloating: boolean;
   isRightPanel: boolean;
 }) {
   return (
@@ -147,8 +152,8 @@ function Container({
         className={cn([
           "flex max-h-full flex-col border",
           elevatedSurfaceClassName,
-          hasContextBar ? "rounded-t-none rounded-b-xl" : "rounded-xl",
-          hasContextBar && "border-t-0",
+          isFloating ? "rounded-[1.75rem]" : "rounded-xl",
+          hasContextBar && !isFloating && "rounded-t-none border-t-0",
         ])}
       >
         {children}

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -22,6 +22,7 @@ export function ChatMessageInput({
   hasContextBar,
   isStreaming,
   onStop,
+  onDraftContentChange,
   onContextRefsChange,
 }: {
   draftKey: string;
@@ -34,6 +35,7 @@ export function ChatMessageInput({
   hasContextBar?: boolean;
   isStreaming?: boolean;
   onStop?: () => void;
+  onDraftContentChange?: (hasDraftContent: boolean) => void;
   onContextRefsChange?: (refs: ContextRef[]) => void;
 }) {
   const { chat } = useShell();
@@ -45,6 +47,7 @@ export function ChatMessageInput({
 
   const { hasContent, initialContent, handleEditorUpdate } = useDraftState({
     draftKey,
+    onDraftContentChange,
     onContextRefsChange,
   });
   const handleSubmit = useSubmit({
@@ -53,6 +56,7 @@ export function ChatMessageInput({
     disabled,
     isStreaming,
     onSendMessage,
+    onDraftContentChange,
     onContextRefsChange,
   });
   useAutoFocusEditor({ editorRef, disabled, shouldFocus });

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -64,6 +64,7 @@ export function ChatMessageInput({
   const isSendDisabled = Boolean(disabled) || !hasContent;
   const isRightPanel = chat.mode === "RightPanelOpen";
   const isFloating = chat.mode === "FloatingOpen";
+  const showSendControl = !isFloating || isStreaming || hasContent;
 
   return (
     <Container
@@ -72,60 +73,77 @@ export function ChatMessageInput({
       isFloating={isFloating}
       isRightPanel={isRightPanel}
     >
-      <div data-chat-message-input className="flex flex-col px-2 pt-3 pb-2">
-        <div className="mb-1 min-h-0">
+      <div
+        data-chat-message-input
+        className={cn([
+          isFloating
+            ? "flex h-full w-full min-w-0 items-center"
+            : "flex flex-col px-2 pt-3 pb-2",
+        ])}
+      >
+        <div className={cn([isFloating ? "min-w-0 flex-1" : "mb-1 min-h-0"])}>
           <ChatEditor
             ref={editorRef}
             className={cn([
               "chat-input-editor",
-              "overflow-y-auto overscroll-contain text-sm",
-              isRightPanel ? "max-h-[40vh]" : "max-h-48",
+              "text-sm",
+              isFloating
+                ? "max-h-6 w-full min-w-0 overflow-hidden overscroll-contain"
+                : "overflow-y-auto overscroll-contain",
+              !isFloating && (isRightPanel ? "max-h-[40vh]" : "max-h-48"),
             ])}
             initialContent={initialContent}
             mentionConfig={mentionConfig}
-            placeholder={chatPlaceholder}
+            placeholder={isFloating ? floatingChatPlaceholder : chatPlaceholder}
             onUpdate={handleEditorUpdate}
             onSubmit={handleSubmit}
           />
         </div>
 
-        <div className="flex shrink-0 items-center justify-between">
-          <div />
-          {isStreaming ? (
-            <Button
-              onClick={onStop}
-              size="icon"
-              variant="ghost"
-              className="h-7 w-7 rounded-full"
-            >
-              <SquareIcon size={14} className="fill-current" />
-            </Button>
-          ) : (
-            <button
-              onClick={handleSubmit}
-              disabled={isSendDisabled}
-              className={cn([
-                "chat-input-send",
-                "inline-flex h-7 items-center gap-1.5 rounded-lg border pr-1.5 pl-2.5 text-xs font-medium transition-all duration-100",
-                !isSendDisabled && [
-                  "bg-primary text-primary-foreground border-stone-600",
-                  "hover:bg-primary/90",
-                  "active:bg-primary/80 active:scale-[0.97]",
-                ],
-              ])}
-            >
-              Send
-              <span
+        {showSendControl && (
+          <div
+            className={cn([
+              "flex shrink-0 items-center",
+              isFloating ? "ml-3" : "justify-between",
+            ])}
+          >
+            <div />
+            {isStreaming ? (
+              <Button
+                onClick={onStop}
+                size="icon"
+                variant="ghost"
+                className="h-7 w-7 rounded-full"
+              >
+                <SquareIcon size={14} className="fill-current" />
+              </Button>
+            ) : (
+              <button
+                onClick={handleSubmit}
+                disabled={isSendDisabled}
                 className={cn([
-                  "chat-input-send-shortcut font-mono text-xs",
-                  !isSendDisabled && "text-stone-400",
+                  "chat-input-send",
+                  "inline-flex h-7 items-center gap-1.5 rounded-lg border pr-1.5 pl-2.5 text-xs font-medium transition-all duration-100",
+                  !isSendDisabled && [
+                    "bg-primary text-primary-foreground border-stone-600",
+                    "hover:bg-primary/90",
+                    "active:bg-primary/80 active:scale-[0.97]",
+                  ],
                 ])}
               >
-                ⌘ ↩
-              </span>
-            </button>
-          )}
-        </div>
+                Send
+                <span
+                  className={cn([
+                    "chat-input-send-shortcut font-mono text-xs",
+                    !isSendDisabled && "text-stone-400",
+                  ])}
+                >
+                  ⌘ ↩
+                </span>
+              </button>
+            )}
+          </div>
+        )}
       </div>
     </Container>
   );
@@ -148,15 +166,20 @@ function Container({
     <div
       className={cn([
         "relative min-w-0 shrink-0",
-        isRightPanel ? "px-3 pb-4" : "px-3 pb-2",
+        isRightPanel ? "px-3 pb-4" : "px-1.5 pb-1.5",
       ])}
     >
       <div
-        data-chat-input-surface="elevated"
+        data-chat-input-surface={isFloating ? "floating" : "elevated"}
         className={cn([
-          "flex max-h-full flex-col border",
-          elevatedSurfaceClassName,
-          isFloating ? "rounded-[1.75rem]" : "rounded-xl",
+          "flex max-h-full border",
+          isFloating
+            ? [
+                "text-muted-foreground h-10 flex-row items-center overflow-hidden rounded-full border-0 bg-[#f4f4f5] px-4 text-sm",
+                "shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.18)]",
+                "dark:bg-[#202020] dark:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.55)]",
+              ]
+            : [elevatedSurfaceClassName, "flex-col rounded-xl"],
           hasContextBar && !isFloating && "rounded-t-none border-t-0",
         ])}
       >
@@ -169,6 +192,13 @@ function Container({
 const chatPlaceholder: PlaceholderFunction = ({ node, pos }) => {
   if (node.type.name === "paragraph" && pos === 0) {
     return "Ask & search about anything, or be creative!";
+  }
+  return "";
+};
+
+const floatingChatPlaceholder: PlaceholderFunction = ({ node, pos }) => {
+  if (node.type.name === "paragraph" && pos === 0) {
+    return "Ask anything";
   }
   return "";
 };

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -176,8 +176,8 @@ function Container({
           isFloating
             ? [
                 "text-muted-foreground h-10 flex-row items-center overflow-hidden rounded-full border-0 bg-[#f4f4f5] px-4 text-sm",
-                "shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.18)]",
-                "dark:bg-[#202020] dark:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.55)]",
+                "shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_12px_rgba(0,0,0,0.1),0_16px_40px_rgba(0,0,0,0.16)]",
+                "dark:bg-[#202020] dark:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_14px_rgba(0,0,0,0.35),0_16px_44px_rgba(0,0,0,0.55)]",
               ]
             : [elevatedSurfaceClassName, "flex-col rounded-xl"],
           hasContextBar && !isFloating && "rounded-t-none border-t-0",

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -77,7 +77,7 @@ export function ChatMessageInput({
         data-chat-message-input
         className={cn([
           isFloating
-            ? "flex h-full w-full min-w-0 items-center"
+            ? "flex min-h-10 w-full min-w-0 items-center"
             : "flex flex-col px-2 pt-3 pb-2",
         ])}
       >
@@ -88,7 +88,7 @@ export function ChatMessageInput({
               "chat-input-editor",
               "text-sm",
               isFloating
-                ? "max-h-6 w-full min-w-0 overflow-hidden overscroll-contain"
+                ? "max-h-24 w-full min-w-0 overflow-y-auto overscroll-contain"
                 : "overflow-y-auto overscroll-contain",
               !isFloating && (isRightPanel ? "max-h-[40vh]" : "max-h-48"),
             ])}
@@ -166,7 +166,7 @@ function Container({
     <div
       className={cn([
         "relative min-w-0 shrink-0",
-        isRightPanel ? "px-3 pb-4" : "px-1.5 pb-1.5",
+        isRightPanel ? "px-3 pb-4" : "px-1 pb-1",
       ])}
     >
       <div
@@ -175,7 +175,7 @@ function Container({
           "flex max-h-full border",
           isFloating
             ? [
-                "text-muted-foreground h-10 flex-row items-center overflow-hidden rounded-full border-0 bg-[#f4f4f5] px-4 text-sm",
+                "text-muted-foreground max-h-32 min-h-10 flex-row items-center overflow-hidden rounded-[20px] border-0 bg-[#f4f4f5] px-4 py-2 text-sm",
                 "shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_12px_rgba(0,0,0,0.1),0_16px_40px_rgba(0,0,0,0.16)]",
                 "dark:bg-[#202020] dark:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_14px_rgba(0,0,0,0.35),0_16px_44px_rgba(0,0,0,0.55)]",
               ]

--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -122,10 +122,12 @@ describe("PersistentChatPanel", () => {
     await waitFor(() => {
       expect(resizeFrame?.className).toContain("items-end");
       expect(resizeFrame?.className).toContain("justify-center");
-      expect(resizeFrame?.className).toContain("pb-0.5");
+      expect(resizeFrame?.className).toContain("px-3");
+      expect(resizeFrame?.className).toContain("pb-2");
       expect(resizeFrame?.className).not.toContain("pb-3");
-      expect(panel?.style.width).toBe("calc(100% - 2rem)");
-      expect(panel?.style.maxWidth).toBe("720px");
+      expect(panel?.style.width).toBe("calc(100% - 1.5rem)");
+      expect(panel?.style.minWidth).toBe("min(368px, calc(100% - 1.5rem))");
+      expect(panel?.style.maxWidth).toBe("648px");
       expect(panel?.style.height).toBe("");
       expect(panel?.style.transformOrigin).toBe("bottom center");
       expect(panel?.dataset.chatPanelReveal).toBe("bottom-up");

--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -122,11 +122,13 @@ describe("PersistentChatPanel", () => {
     await waitFor(() => {
       expect(resizeFrame?.className).toContain("items-end");
       expect(resizeFrame?.className).toContain("justify-center");
-      expect(resizeFrame?.className).toContain("pb-3");
+      expect(resizeFrame?.className).toContain("pb-0.5");
+      expect(resizeFrame?.className).not.toContain("pb-3");
       expect(panel?.style.width).toBe("calc(100% - 2rem)");
       expect(panel?.style.maxWidth).toBe("720px");
       expect(panel?.style.height).toBe("");
       expect(panel?.style.transformOrigin).toBe("bottom center");
+      expect(panel?.dataset.chatPanelReveal).toBe("bottom-up");
     });
   });
 

--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -114,6 +114,9 @@ describe("PersistentChatPanel", () => {
       expect(resizeFrame?.className).toContain("items-end");
       expect(resizeFrame?.className).toContain("justify-center");
       expect(resizeFrame?.className).toContain("pb-3");
+      expect(panel?.style.width).toBe("calc(100% - 2rem)");
+      expect(panel?.style.maxWidth).toBe("720px");
+      expect(panel?.style.height).toBe("");
       expect(panel?.style.transformOrigin).toBe("bottom center");
     });
   });

--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -49,10 +49,12 @@ vi.mock("~/contexts/shell", () => ({
 vi.mock("./chat-panel", () => ({
   ChatPanelFrame: ({
     layout,
+    onDraftContentChange,
     onOpenRightPanel,
     sessionProps,
   }: {
     layout?: "floating" | "right-panel";
+    onDraftContentChange?: (hasDraftContent: boolean) => void;
     onOpenRightPanel?: () => void;
     sessionProps: unknown;
   }) => (
@@ -65,6 +67,13 @@ vi.mock("./chat-panel", () => ({
         onClick={onOpenRightPanel}
       >
         Open right panel
+      </button>
+      <button
+        data-testid="mark-draft-content"
+        type="button"
+        onClick={() => onDraftContentChange?.(true)}
+      >
+        Mark draft content
       </button>
       <div data-testid="chat-view" />
     </>
@@ -131,6 +140,37 @@ describe("PersistentChatPanel", () => {
     expect(mocks.sendEvent).toHaveBeenCalledWith({
       type: "OPEN_RIGHT_PANEL",
     });
+  });
+
+  it("closes on backdrop click while the draft is empty", async () => {
+    render(<TestHost />);
+
+    await screen.findByTestId("chat-view");
+
+    const resizeFrame = document.querySelector<HTMLElement>(
+      "[data-chat-resize-frame]",
+    );
+
+    fireEvent.click(resizeFrame!);
+
+    expect(mocks.sendEvent).toHaveBeenCalledWith({ type: "CLOSE" });
+  });
+
+  it("keeps the expanded composer open on backdrop click when draft has content", async () => {
+    render(<TestHost />);
+
+    await screen.findByTestId("chat-view");
+
+    fireEvent.click(screen.getByTestId("mark-draft-content"));
+    mocks.sendEvent.mockClear();
+
+    const resizeFrame = document.querySelector<HTMLElement>(
+      "[data-chat-resize-frame]",
+    );
+
+    fireEvent.click(resizeFrame!);
+
+    expect(mocks.sendEvent).not.toHaveBeenCalledWith({ type: "CLOSE" });
   });
 
   it("resizes the bottom handle by the pointer movement", async () => {

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -85,6 +85,7 @@ export function PersistentChatPanel({
   const [hasBeenOpened, setHasBeenOpened] = useState(false);
   const [containerRect, setContainerRect] =
     useState<FloatingContainerRect | null>(null);
+  const [draftHasContent, setDraftHasContent] = useState(false);
   const [floatingSize, setFloatingSize] = useState<FloatingPanelSize | null>(
     null,
   );
@@ -298,6 +299,10 @@ export function PersistentChatPanel({
             ])}
             onClick={(event) => {
               if (event.target === event.currentTarget) {
+                if (draftHasContent) {
+                  return;
+                }
+
                 chat.sendEvent({ type: "CLOSE" });
               }
             }}
@@ -318,6 +323,7 @@ export function PersistentChatPanel({
             >
               <ChatPanelFrame
                 layout="floating"
+                onDraftContentChange={setDraftHasContent}
                 onOpenRightPanel={() =>
                   chat.sendEvent({ type: "OPEN_RIGHT_PANEL" })
                 }

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -181,15 +181,30 @@ export function PersistentChatPanel({
   }
 
   const panelMotion = {
-    initial: { y: 24, opacity: 0, scale: 0.96, filter: "blur(6px)" },
-    animate: { y: 0, opacity: 1, scale: 1, filter: "blur(0px)" },
-    exit: { y: 18, opacity: 0, scale: 0.97, filter: "blur(4px)" },
+    initial: {
+      y: 0,
+      opacity: 1,
+      scale: 1,
+      clipPath: "inset(calc(100% - 5rem) 0 0 0 round 1.75rem)",
+    },
+    animate: {
+      y: 0,
+      opacity: 1,
+      scale: 1,
+      clipPath: "inset(0 0 0 0 round 1.75rem)",
+    },
+    exit: {
+      y: 8,
+      opacity: 0,
+      scale: 0.99,
+      clipPath: "inset(calc(100% - 5rem) 0 0 0 round 1.75rem)",
+    },
   };
   const panelTransition = {
     opacity: { duration: 0.18, ease: [0.22, 1, 0.36, 1] },
-    scale: { duration: 0.24, ease: [0.22, 1, 0.36, 1] },
-    y: { duration: 0.28, ease: [0.22, 1, 0.36, 1] },
-    filter: { duration: 0.16, ease: "easeOut" },
+    scale: { duration: 0.2, ease: [0.22, 1, 0.36, 1] },
+    y: { duration: 0.22, ease: [0.22, 1, 0.36, 1] },
+    clipPath: { duration: 0.32, ease: [0.22, 1, 0.36, 1] },
   };
   const panelStyle =
     floatingSize && containerRect
@@ -295,7 +310,7 @@ export function PersistentChatPanel({
             data-chat-resize-frame
             className={cn([
               "pointer-events-auto relative flex h-full min-h-0",
-              "items-end justify-center px-4 pt-4 pb-3",
+              "items-end justify-center px-4 pt-4 pb-0.5",
             ])}
             onClick={(event) => {
               if (event.target === event.currentTarget) {
@@ -310,6 +325,7 @@ export function PersistentChatPanel({
             <motion.div
               ref={panelRef}
               data-chat-panel
+              data-chat-panel-reveal="bottom-up"
               data-chat-size="floating"
               className={cn([
                 "relative flex min-h-0 flex-col overflow-hidden",

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -17,9 +17,9 @@ import type { ChatSessionRenderProps } from "~/chat/components/session-provider"
 import { chatFloatingPanelShellClassNames } from "~/chat/surface";
 import { useShell } from "~/contexts/shell";
 
-const FLOATING_PANEL_MIN_WIDTH = 360;
+const FLOATING_PANEL_MIN_WIDTH = 368;
 const FLOATING_PANEL_MIN_HEIGHT = 320;
-const FLOATING_PANEL_MARGIN = 16;
+const FLOATING_PANEL_MARGIN = 12;
 
 type FloatingPanelSize = {
   width: number;
@@ -210,9 +210,9 @@ export function PersistentChatPanel({
     floatingSize && containerRect
       ? getFloatingPanelStyle(floatingSize, containerRect)
       : {
-          width: "calc(100% - 2rem)",
-          minWidth: "min(360px, calc(100% - 2rem))",
-          maxWidth: "720px",
+          width: "calc(100% - 1.5rem)",
+          minWidth: "min(368px, calc(100% - 1.5rem))",
+          maxWidth: "648px",
           maxHeight: "calc(100% - 1rem)",
           transformOrigin: "bottom center",
         };
@@ -310,7 +310,7 @@ export function PersistentChatPanel({
             data-chat-resize-frame
             className={cn([
               "pointer-events-auto relative flex h-full min-h-0",
-              "items-end justify-center px-4 pt-4 pb-0.5",
+              "items-end justify-center px-3 pt-4 pb-2",
             ])}
             onClick={(event) => {
               if (event.target === event.currentTarget) {

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -194,11 +194,9 @@ export function PersistentChatPanel({
     floatingSize && containerRect
       ? getFloatingPanelStyle(floatingSize, containerRect)
       : {
-          width: "min(640px, calc(100% - 2rem))",
-          height: "min(560px, calc(100% - 1rem))",
+          width: "calc(100% - 2rem)",
           minWidth: "min(360px, calc(100% - 2rem))",
-          minHeight: "min(320px, calc(100% - 1rem))",
-          maxWidth: "calc(100% - 2rem)",
+          maxWidth: "720px",
           maxHeight: "calc(100% - 1rem)",
           transformOrigin: "bottom center",
         };

--- a/apps/desktop/src/chat/components/toolbar-controls.test.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.test.tsx
@@ -45,7 +45,7 @@ describe("ChatToolbarControls", () => {
     cleanup();
   });
 
-  it("renders the dark chat title trigger as a pill", () => {
+  it("renders the dark chat history trigger as an icon button", () => {
     render(
       <ChatToolbarControls
         currentChatGroupId={undefined}
@@ -56,11 +56,14 @@ describe("ChatToolbarControls", () => {
       />,
     );
 
-    const title = screen.getByText("Ask Anarlog AI anything");
-    expect(title.closest("button")?.className).toContain("rounded-full");
+    const historyButton = screen.getByRole("button", { name: "Chat history" });
+    expect(historyButton.className).toContain("rounded-full");
+    expect(historyButton.className).toContain("size-8");
+    expect(historyButton.className).toContain("hover:bg-primary-foreground/7");
+    expect(screen.queryByText("Ask Anarlog AI anything")).toBeNull();
   });
 
-  it("keeps the light chat title readable on the card shell", () => {
+  it("renders the light chat history trigger without title text", () => {
     const { container } = render(
       <ChatToolbarControls
         currentChatGroupId={undefined}
@@ -71,16 +74,15 @@ describe("ChatToolbarControls", () => {
       />,
     );
 
-    const title = screen.getByText("Ask Anarlog AI anything");
-    const titleButton = title.closest("button");
+    const historyButton = screen.getByRole("button", { name: "Chat history" });
     expect(container.firstElementChild?.className).toContain("px-3");
     expect(container.firstElementChild?.className).not.toContain("pl-2");
     expect(container.firstElementChild?.className).not.toContain("pr-2");
-    expect(titleButton?.className).toContain("-ml-2");
-    expect(titleButton?.className).toContain("px-2");
-    expect(title.className).toContain("text-foreground");
-    expect(title.className).toContain("text-[15px]");
-    expect(title.className).not.toContain("text-muted-foreground");
+    expect(historyButton.className).toContain("-ml-2");
+    expect(historyButton.className).toContain("size-8");
+    expect(historyButton.className).toContain("text-muted-foreground");
+    expect(historyButton.textContent).toBe("");
+    expect(screen.queryByText("Ask Anarlog AI anything")).toBeNull();
   });
 
   it("renders dark toolbar action buttons as circles without tooltips", () => {
@@ -160,9 +162,7 @@ describe("ChatToolbarControls", () => {
       />,
     );
 
-    const titleButton = screen
-      .getByText("Ask Anarlog AI anything")
-      .closest("button");
+    const historyButton = screen.getByRole("button", { name: "Chat history" });
 
     expect(container.firstElementChild?.className).toContain("px-3");
     expect(container.firstElementChild?.className).not.toContain("px-5");
@@ -172,8 +172,9 @@ describe("ChatToolbarControls", () => {
     const actions = container.querySelector("[data-chat-toolbar-actions]");
     expect(actions?.className).toContain("gap-0");
     expect(actions?.className).not.toContain("gap-1");
-    expect(titleButton?.className).toContain("-ml-2");
-    expect(titleButton?.className).toContain("px-2");
+    expect(historyButton.className).toContain("-ml-2");
+    expect(historyButton.className).toContain("size-8");
+    expect(screen.queryByText("Ask Anarlog AI anything")).toBeNull();
     const floatButton = screen.getByRole("button", { name: "Float chat" });
     const closeButton = screen.getByRole("button", { name: "Close chat" });
     expect(floatButton.className).not.toContain("bg-muted");

--- a/apps/desktop/src/chat/components/toolbar-controls.test.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.test.tsx
@@ -45,7 +45,7 @@ describe("ChatToolbarControls", () => {
     cleanup();
   });
 
-  it("renders the dark chat history trigger as an icon button", () => {
+  it("renders the dark chat history trigger as a pill button", () => {
     render(
       <ChatToolbarControls
         currentChatGroupId={undefined}
@@ -58,7 +58,9 @@ describe("ChatToolbarControls", () => {
 
     const historyButton = screen.getByRole("button", { name: "Chat history" });
     expect(historyButton.className).toContain("rounded-full");
-    expect(historyButton.className).toContain("size-8");
+    expect(historyButton.className).toContain("h-8");
+    expect(historyButton.className).toContain("w-auto");
+    expect(historyButton.className).toContain("gap-1.5");
     expect(historyButton.className).toContain("hover:bg-primary-foreground/7");
     expect(screen.queryByText("Ask Anarlog AI anything")).toBeNull();
   });
@@ -79,7 +81,9 @@ describe("ChatToolbarControls", () => {
     expect(container.firstElementChild?.className).not.toContain("pl-2");
     expect(container.firstElementChild?.className).not.toContain("pr-2");
     expect(historyButton.className).toContain("-ml-2");
-    expect(historyButton.className).toContain("size-8");
+    expect(historyButton.className).toContain("h-8");
+    expect(historyButton.className).toContain("w-auto");
+    expect(historyButton.className).toContain("gap-1.5");
     expect(historyButton.className).toContain("text-muted-foreground");
     expect(historyButton.textContent).toBe("");
     expect(screen.queryByText("Ask Anarlog AI anything")).toBeNull();
@@ -173,7 +177,8 @@ describe("ChatToolbarControls", () => {
     expect(actions?.className).toContain("gap-0");
     expect(actions?.className).not.toContain("gap-1");
     expect(historyButton.className).toContain("-ml-2");
-    expect(historyButton.className).toContain("size-8");
+    expect(historyButton.className).toContain("h-8");
+    expect(historyButton.className).toContain("w-auto");
     expect(screen.queryByText("Ask Anarlog AI anything")).toBeNull();
     const floatButton = screen.getByRole("button", { name: "Float chat" });
     const closeButton = screen.getByRole("button", { name: "Close chat" });

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -1,5 +1,6 @@
 import {
   ChevronDown,
+  History,
   MessageCircle,
   PanelRight,
   PictureInPicture2,
@@ -137,12 +138,6 @@ function ChatGroups({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const isDark = surface === "dark";
 
-  const currentChatTitle = main.UI.useCell(
-    "chat_groups",
-    currentChatGroupId || "",
-    "title",
-    main.STORE_ID,
-  );
   const recentChatGroupIds = main.UI.useSortedRowIds(
     "chat_groups",
     "created_at",
@@ -156,29 +151,26 @@ function ChatGroups({
     <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
       <DropdownMenuTrigger asChild>
         <Button
+          aria-label="Chat history"
           variant="ghost"
+          size="icon"
           className={cn([
-            "group flex h-8 max-w-full min-w-0 justify-start gap-1.5 py-0 text-left",
-            "-ml-2 px-2",
+            "group relative -ml-2 size-8 shrink-0 rounded-full p-0",
             isDark
-              ? "text-primary-foreground hover:bg-primary-foreground/7 hover:text-primary-foreground data-[state=open]:bg-primary-foreground/7 w-fit rounded-full"
-              : "text-foreground hover:bg-accent hover:text-foreground data-[state=open]:bg-accent w-fit rounded-full",
+              ? "text-primary-foreground/70 hover:bg-primary-foreground/7 hover:text-primary-foreground data-[state=open]:bg-primary-foreground/7"
+              : "text-muted-foreground hover:bg-accent hover:text-foreground data-[state=open]:bg-accent",
           ])}
         >
-          <h3
+          <History
             className={cn([
-              "max-w-64 min-w-0 truncate text-left font-medium",
-              isDark
-                ? "text-primary-foreground text-[15px]"
-                : "text-foreground text-[15px]",
+              "h-4 w-4",
+              isDark ? "text-primary-foreground/70" : "text-muted-foreground",
             ])}
-          >
-            {currentChatTitle || "Ask Anarlog AI anything"}
-          </h3>
+          />
           <ChevronDown
             className={cn([
-              "h-3.5 w-3.5 shrink-0 transition-transform duration-200",
-              isDark ? "text-primary-foreground/60" : "text-muted-foreground",
+              "absolute right-1 bottom-1 h-2.5 w-2.5 shrink-0 transition-transform duration-200",
+              isDark ? "text-primary-foreground/50" : "text-muted-foreground",
               isDropdownOpen && "rotate-180",
             ])}
           />

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -153,9 +153,9 @@ function ChatGroups({
         <Button
           aria-label="Chat history"
           variant="ghost"
-          size="icon"
+          size="sm"
           className={cn([
-            "group relative -ml-2 size-8 shrink-0 rounded-full p-0",
+            "group -ml-2 h-8 w-auto shrink-0 gap-1.5 rounded-full px-2.5 py-0",
             isDark
               ? "text-primary-foreground/70 hover:bg-primary-foreground/7 hover:text-primary-foreground data-[state=open]:bg-primary-foreground/7"
               : "text-muted-foreground hover:bg-accent hover:text-foreground data-[state=open]:bg-accent",
@@ -169,7 +169,7 @@ function ChatGroups({
           />
           <ChevronDown
             className={cn([
-              "absolute right-1 bottom-1 h-2.5 w-2.5 shrink-0 transition-transform duration-200",
+              "h-3.5 w-3.5 shrink-0 transition-transform duration-200",
               isDark ? "text-primary-foreground/50" : "text-muted-foreground",
               isDropdownOpen && "rotate-180",
             ])}

--- a/apps/desktop/src/chat/surface.test.ts
+++ b/apps/desktop/src/chat/surface.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   chatElevatedSurfaceClassNames,
+  chatFloatingPanelClassNames,
   chatFloatingControlClassNames,
   chatFloatingPanelShellClassNames,
   chatInputEditorClassNames,
@@ -38,15 +39,24 @@ describe("chat surface tokens", () => {
     expect(chatFloatingControlClassNames()).toContain("text-accent-foreground");
   });
 
-  it("uses the card surface on the floating shell", () => {
+  it("uses a warm surface on the floating shell", () => {
     expect(chatFloatingPanelShellClassNames()).toContain(
       "shadow-[0_16px_48px_rgba(0,0,0,0.18)]",
     );
     expect(chatFloatingPanelShellClassNames()).toContain(
       "dark:shadow-[0_16px_48px_rgba(0,0,0,0.55)]",
     );
-    expect(chatFloatingPanelShellClassNames()).toContain("border-border");
-    expect(chatFloatingPanelShellClassNames()).toContain("bg-card");
+    expect(chatFloatingPanelShellClassNames()).toContain("bg-[#fff9ed]");
+    expect(chatFloatingPanelShellClassNames()).toContain("border-[#e4d8c8]");
+    expect(chatFloatingPanelShellClassNames()).toContain("dark:bg-[#211d18]");
+    expect(chatFloatingPanelShellClassNames()).not.toContain("bg-card");
+  });
+
+  it("uses a warm floating panel surface to separate it from white notes", () => {
+    expect(chatFloatingPanelClassNames()).toContain("bg-[#fff9ed]");
+    expect(chatFloatingPanelClassNames()).toContain("text-card-foreground");
+    expect(chatFloatingPanelClassNames()).toContain("dark:bg-[#211d18]");
+    expect(chatFloatingPanelClassNames()).not.toContain("bg-card");
   });
 
   it("styles disabled send controls on the elevated input surface", () => {

--- a/apps/desktop/src/chat/surface.test.ts
+++ b/apps/desktop/src/chat/surface.test.ts
@@ -39,23 +39,26 @@ describe("chat surface tokens", () => {
     expect(chatFloatingControlClassNames()).toContain("text-accent-foreground");
   });
 
-  it("uses a warm surface on the floating shell", () => {
+  it("uses a neutral surface on the floating shell", () => {
     expect(chatFloatingPanelShellClassNames()).toContain(
       "shadow-[0_16px_48px_rgba(0,0,0,0.18)]",
     );
     expect(chatFloatingPanelShellClassNames()).toContain(
       "dark:shadow-[0_16px_48px_rgba(0,0,0,0.55)]",
     );
-    expect(chatFloatingPanelShellClassNames()).toContain("bg-[#fff9ed]");
-    expect(chatFloatingPanelShellClassNames()).toContain("border-[#e4d8c8]");
-    expect(chatFloatingPanelShellClassNames()).toContain("dark:bg-[#211d18]");
+    expect(chatFloatingPanelShellClassNames()).toContain("bg-[#f4f4f5]");
+    expect(chatFloatingPanelShellClassNames()).toContain("border-[#dedede]");
+    expect(chatFloatingPanelShellClassNames()).toContain("dark:bg-[#202020]");
+    expect(chatFloatingPanelShellClassNames()).toContain(
+      "dark:border-[#3a3a3a]",
+    );
     expect(chatFloatingPanelShellClassNames()).not.toContain("bg-card");
   });
 
-  it("uses a warm floating panel surface to separate it from white notes", () => {
-    expect(chatFloatingPanelClassNames()).toContain("bg-[#fff9ed]");
+  it("uses a neutral floating panel surface to separate it from white notes", () => {
+    expect(chatFloatingPanelClassNames()).toContain("bg-[#f4f4f5]");
     expect(chatFloatingPanelClassNames()).toContain("text-card-foreground");
-    expect(chatFloatingPanelClassNames()).toContain("dark:bg-[#211d18]");
+    expect(chatFloatingPanelClassNames()).toContain("dark:bg-[#202020]");
     expect(chatFloatingPanelClassNames()).not.toContain("bg-card");
   });
 

--- a/apps/desktop/src/chat/surface.test.ts
+++ b/apps/desktop/src/chat/surface.test.ts
@@ -25,11 +25,11 @@ describe("chat surface tokens", () => {
     expect(chatPanelBorderClassNames()).toContain("border-border");
   });
 
-  it("maps elevated chat surfaces to dark accent tokens", () => {
-    expect(chatElevatedSurfaceClassNames()).toContain("bg-accent");
-    expect(chatElevatedSurfaceClassNames()).toContain("text-accent-foreground");
+  it("maps elevated chat surfaces to the card theme", () => {
+    expect(chatElevatedSurfaceClassNames()).toContain("bg-card");
+    expect(chatElevatedSurfaceClassNames()).toContain("text-card-foreground");
     expect(chatElevatedSurfaceClassNames()).toContain("border-border");
-    expect(chatInputEditorClassNames()).toContain("text-accent-foreground");
+    expect(chatInputEditorClassNames()).toContain("text-card-foreground");
     expect(chatInputEditorClassNames()).toContain("chat-input-editor");
   });
 

--- a/apps/desktop/src/chat/surface.ts
+++ b/apps/desktop/src/chat/surface.ts
@@ -8,12 +8,16 @@ export function chatPanelClassNames(): string {
   return "bg-card text-card-foreground";
 }
 
+export function chatFloatingPanelClassNames(): string {
+  return "bg-[#fff9ed] text-card-foreground dark:bg-[#211d18]";
+}
+
 export function chatPanelBorderClassNames(): string {
   return "border-border";
 }
 
 export function chatFloatingPanelShellClassNames(): string {
-  return "bg-card text-card-foreground rounded-2xl border-2 border-border shadow-[0_16px_48px_rgba(0,0,0,0.18)] dark:shadow-[0_16px_48px_rgba(0,0,0,0.55)]";
+  return "bg-[#fff9ed] text-card-foreground rounded-2xl border-2 border-[#e4d8c8] shadow-[0_16px_48px_rgba(0,0,0,0.18)] dark:border-[#39312a] dark:bg-[#211d18] dark:shadow-[0_16px_48px_rgba(0,0,0,0.55)]";
 }
 
 export function chatElevatedSurfaceClassNames(): string {

--- a/apps/desktop/src/chat/surface.ts
+++ b/apps/desktop/src/chat/surface.ts
@@ -9,7 +9,7 @@ export function chatPanelClassNames(): string {
 }
 
 export function chatFloatingPanelClassNames(): string {
-  return "bg-[#fff9ed] text-card-foreground dark:bg-[#211d18]";
+  return "bg-[#f4f4f5] text-card-foreground dark:bg-[#202020]";
 }
 
 export function chatPanelBorderClassNames(): string {
@@ -17,7 +17,7 @@ export function chatPanelBorderClassNames(): string {
 }
 
 export function chatFloatingPanelShellClassNames(): string {
-  return "bg-[#fff9ed] text-card-foreground rounded-2xl border-2 border-[#e4d8c8] shadow-[0_16px_48px_rgba(0,0,0,0.18)] dark:border-[#39312a] dark:bg-[#211d18] dark:shadow-[0_16px_48px_rgba(0,0,0,0.55)]";
+  return "bg-[#f4f4f5] text-card-foreground rounded-2xl border-2 border-[#dedede] shadow-[0_16px_48px_rgba(0,0,0,0.18)] dark:border-[#3a3a3a] dark:bg-[#202020] dark:shadow-[0_16px_48px_rgba(0,0,0,0.55)]";
 }
 
 export function chatElevatedSurfaceClassNames(): string {

--- a/apps/desktop/src/chat/surface.ts
+++ b/apps/desktop/src/chat/surface.ts
@@ -17,11 +17,11 @@ export function chatFloatingPanelShellClassNames(): string {
 }
 
 export function chatElevatedSurfaceClassNames(): string {
-  return "bg-accent text-accent-foreground border-border";
+  return "bg-card text-card-foreground border-border";
 }
 
 export function chatInputEditorClassNames(): string {
-  return "chat-input-editor text-accent-foreground";
+  return "chat-input-editor text-card-foreground";
 }
 
 export function chatSendButtonDisabledClassNames(): string {

--- a/apps/desktop/src/shared/chat-cta.test.tsx
+++ b/apps/desktop/src/shared/chat-cta.test.tsx
@@ -54,34 +54,50 @@ describe("ChatCTA", () => {
     expect(surface?.className).toContain("absolute");
     expect(surface?.className).toContain("bottom-0");
     expect(surface?.className).toContain("left-1/2");
+    expect(surface?.className).toContain("w-[min(640px,calc(100cqw_-_2rem))]");
     expect(surface?.className).toContain(
-      "max-w-[min(640px,calc(100cqw-2rem))]",
+      "[clip-path:inset(0_calc(50%_-_3rem)_0_calc(50%_-_3rem)_round_9999px)]",
+    );
+    expect(surface?.className).toContain(
+      "transition-[clip-path,height,padding,background-color,box-shadow]",
     );
     expect(surface?.className).toContain("origin-bottom");
     expect(surface?.className).toContain("h-2");
-    expect(surface?.className).toContain("w-24");
     expect(surface?.className).toContain("rounded-full");
     expect(surface?.className).toContain("bg-black");
+    expect(surface?.className).toContain("dark:bg-white");
     expect(surface?.className).toContain("shadow-none");
     expect(surface?.className).not.toContain("border-2");
     expect(surface?.className).toContain("pointer-events-none");
+    expect(surface?.className).toContain(
+      "group-hover/anarlog-chat-cta:bg-[#fff9ed]",
+    );
+    expect(surface?.className).toContain(
+      "dark:group-hover/anarlog-chat-cta:bg-[#211d18]",
+    );
     expect(surface?.className).toContain("group-hover/anarlog-chat-cta:h-10");
     expect(surface?.className).toContain(
-      "group-hover/anarlog-chat-cta:w-[640px]",
+      "group-hover/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
     );
     expect(surface?.className).toContain(
-      "group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.16)]",
+      "group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.18)]",
     );
     expect(surface?.className).toContain(
-      "group-focus-visible/anarlog-chat-cta:w-[640px]",
+      "dark:group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.55)]",
     );
     expect(surface?.className).toContain(
-      "group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.16)]",
+      "group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
+    );
+    expect(surface?.className).toContain(
+      "group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.18)]",
     );
     expect(button.querySelectorAll("svg")).toHaveLength(1);
     expect(label.className).toContain("max-w-0");
     expect(label.className).toContain("opacity-0");
     expect(label.className).toContain("text-white/55");
+    expect(label.className).toContain(
+      "group-hover/anarlog-chat-cta:text-muted-foreground",
+    );
     expect(label.className).toContain(
       "group-hover/anarlog-chat-cta:max-w-full",
     );

--- a/apps/desktop/src/shared/chat-cta.test.tsx
+++ b/apps/desktop/src/shared/chat-cta.test.tsx
@@ -70,31 +70,32 @@ describe("ChatCTA", () => {
     expect(surface?.className).not.toContain("border-2");
     expect(surface?.className).toContain("pointer-events-none");
     expect(surface?.className).toContain(
-      "group-hover/anarlog-chat-cta:bg-[#fff9ed]",
+      "group-hover/anarlog-chat-cta:bg-[#f4f4f5]",
     );
     expect(surface?.className).toContain(
-      "dark:group-hover/anarlog-chat-cta:bg-[#211d18]",
+      "dark:group-hover/anarlog-chat-cta:bg-[#202020]",
     );
     expect(surface?.className).toContain("group-hover/anarlog-chat-cta:h-10");
     expect(surface?.className).toContain(
       "group-hover/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
     );
     expect(surface?.className).toContain(
-      "group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.18)]",
+      "group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_12px_rgba(0,0,0,0.1),0_16px_40px_rgba(0,0,0,0.16)]",
     );
     expect(surface?.className).toContain(
-      "dark:group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.55)]",
+      "dark:group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_14px_rgba(0,0,0,0.35),0_16px_44px_rgba(0,0,0,0.55)]",
     );
     expect(surface?.className).toContain(
       "group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
     );
     expect(surface?.className).toContain(
-      "group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.18)]",
+      "group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_12px_rgba(0,0,0,0.1),0_16px_40px_rgba(0,0,0,0.16)]",
     );
-    expect(button.querySelectorAll("svg")).toHaveLength(1);
+    expect(button.querySelectorAll("svg")).toHaveLength(0);
     expect(label.className).toContain("max-w-0");
     expect(label.className).toContain("opacity-0");
     expect(label.className).toContain("text-white/55");
+    expect(label.className).not.toContain("ml-2");
     expect(label.className).toContain(
       "group-hover/anarlog-chat-cta:text-muted-foreground",
     );

--- a/apps/desktop/src/shared/chat-cta.test.tsx
+++ b/apps/desktop/src/shared/chat-cta.test.tsx
@@ -54,22 +54,34 @@ describe("ChatCTA", () => {
     expect(surface?.className).toContain("absolute");
     expect(surface?.className).toContain("bottom-0");
     expect(surface?.className).toContain("left-1/2");
+    expect(surface?.className).toContain(
+      "max-w-[min(640px,calc(100cqw-2rem))]",
+    );
     expect(surface?.className).toContain("origin-bottom");
-    expect(surface?.className).toContain("h-[10px]");
+    expect(surface?.className).toContain("h-2");
     expect(surface?.className).toContain("w-24");
     expect(surface?.className).toContain("rounded-full");
+    expect(surface?.className).toContain("bg-black");
+    expect(surface?.className).toContain("shadow-none");
+    expect(surface?.className).not.toContain("border-2");
     expect(surface?.className).toContain("pointer-events-none");
     expect(surface?.className).toContain("group-hover/anarlog-chat-cta:h-10");
     expect(surface?.className).toContain(
       "group-hover/anarlog-chat-cta:w-[640px]",
     );
     expect(surface?.className).toContain(
+      "group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.16)]",
+    );
+    expect(surface?.className).toContain(
       "group-focus-visible/anarlog-chat-cta:w-[640px]",
+    );
+    expect(surface?.className).toContain(
+      "group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.16)]",
     );
     expect(button.querySelectorAll("svg")).toHaveLength(1);
     expect(label.className).toContain("max-w-0");
     expect(label.className).toContain("opacity-0");
-    expect(label.className).toContain("text-background/55");
+    expect(label.className).toContain("text-white/55");
     expect(label.className).toContain(
       "group-hover/anarlog-chat-cta:max-w-full",
     );

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -3,7 +3,6 @@ import { MessageCircle } from "lucide-react";
 import { cn } from "@hypr/utils";
 
 import { useShell } from "~/contexts/shell";
-import { floatingActionSurfaceClassName } from "~/shared/floating-action-surface";
 
 export function ChatCTA({
   label = "Ask anything",
@@ -34,17 +33,17 @@ export function ChatCTA({
         data-chat-cta-surface
         aria-hidden="true"
         className={cn([
-          "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-[10px] w-24 max-w-[calc(100vw-2rem)] -translate-x-1/2 items-center overflow-hidden rounded-full border-2",
-          "origin-bottom px-0 text-sm transition-[width,height,padding,background-color,border-color,box-shadow] duration-200 ease-out",
+          "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-24 max-w-[min(640px,calc(100cqw-2rem))] -translate-x-1/2 items-center overflow-hidden rounded-full bg-black",
+          "origin-bottom px-0 text-sm shadow-none transition-[width,height,padding,background-color,box-shadow] duration-200 ease-out",
           "group-hover/anarlog-chat-cta:h-10 group-hover/anarlog-chat-cta:w-[640px] group-hover/anarlog-chat-cta:px-4",
           "group-focus-visible/anarlog-chat-cta:h-10 group-focus-visible/anarlog-chat-cta:w-[640px] group-focus-visible/anarlog-chat-cta:px-4",
+          "group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.16)] group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.16)]",
           "group-focus-visible/anarlog-chat-cta:ring-ring group-focus-visible/anarlog-chat-cta:ring-2 group-focus-visible/anarlog-chat-cta:ring-offset-2",
-          floatingActionSurfaceClassName,
         ])}
       >
         <MessageCircle
           className={cn([
-            "text-background/55 dark:text-primary/50 size-4 shrink-0 opacity-0 transition-opacity duration-150",
+            "size-4 shrink-0 text-white/55 opacity-0 transition-opacity duration-150",
             "group-focus-within/anarlog-chat-cta:opacity-100 group-hover/anarlog-chat-cta:opacity-100",
           ])}
           aria-hidden="true"
@@ -53,7 +52,7 @@ export function ChatCTA({
           aria-hidden="true"
           className={cn([
             "ml-2 max-w-0 min-w-0 flex-1 truncate text-left opacity-0",
-            "text-background/55 dark:text-primary/50",
+            "text-white/55",
             "transition-[max-width,opacity] duration-200 ease-out",
             "group-hover/anarlog-chat-cta:max-w-full group-hover/anarlog-chat-cta:opacity-100",
             "group-focus-within/anarlog-chat-cta:max-w-full group-focus-within/anarlog-chat-cta:opacity-100",

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -33,11 +33,13 @@ export function ChatCTA({
         data-chat-cta-surface
         aria-hidden="true"
         className={cn([
-          "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-24 max-w-[min(640px,calc(100cqw-2rem))] -translate-x-1/2 items-center overflow-hidden rounded-full bg-black",
-          "origin-bottom px-0 text-sm shadow-none transition-[width,height,padding,background-color,box-shadow] duration-200 ease-out",
-          "group-hover/anarlog-chat-cta:h-10 group-hover/anarlog-chat-cta:w-[640px] group-hover/anarlog-chat-cta:px-4",
-          "group-focus-visible/anarlog-chat-cta:h-10 group-focus-visible/anarlog-chat-cta:w-[640px] group-focus-visible/anarlog-chat-cta:px-4",
-          "group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.16)] group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.16)]",
+          "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-[min(640px,calc(100cqw_-_2rem))] -translate-x-1/2 items-center overflow-hidden rounded-full bg-black dark:bg-white",
+          "[clip-path:inset(0_calc(50%_-_3rem)_0_calc(50%_-_3rem)_round_9999px)]",
+          "origin-bottom px-0 text-sm shadow-none transition-[clip-path,height,padding,background-color,box-shadow] duration-200 ease-out",
+          "group-hover/anarlog-chat-cta:bg-[#fff9ed] group-focus-visible/anarlog-chat-cta:bg-[#fff9ed] dark:group-hover/anarlog-chat-cta:bg-[#211d18] dark:group-focus-visible/anarlog-chat-cta:bg-[#211d18]",
+          "group-hover/anarlog-chat-cta:h-10 group-hover/anarlog-chat-cta:px-4 group-hover/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
+          "group-focus-visible/anarlog-chat-cta:h-10 group-focus-visible/anarlog-chat-cta:px-4 group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
+          "group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.18)] group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.18)] dark:group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.55)] dark:group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.55)]",
           "group-focus-visible/anarlog-chat-cta:ring-ring group-focus-visible/anarlog-chat-cta:ring-2 group-focus-visible/anarlog-chat-cta:ring-offset-2",
         ])}
       >
@@ -45,6 +47,7 @@ export function ChatCTA({
           className={cn([
             "size-4 shrink-0 text-white/55 opacity-0 transition-opacity duration-150",
             "group-focus-within/anarlog-chat-cta:opacity-100 group-hover/anarlog-chat-cta:opacity-100",
+            "group-focus-within/anarlog-chat-cta:text-muted-foreground group-hover/anarlog-chat-cta:text-muted-foreground",
           ])}
           aria-hidden="true"
         />
@@ -52,7 +55,7 @@ export function ChatCTA({
           aria-hidden="true"
           className={cn([
             "ml-2 max-w-0 min-w-0 flex-1 truncate text-left opacity-0",
-            "text-white/55",
+            "group-focus-within/anarlog-chat-cta:text-muted-foreground group-hover/anarlog-chat-cta:text-muted-foreground text-white/55",
             "transition-[max-width,opacity] duration-200 ease-out",
             "group-hover/anarlog-chat-cta:max-w-full group-hover/anarlog-chat-cta:opacity-100",
             "group-focus-within/anarlog-chat-cta:max-w-full group-focus-within/anarlog-chat-cta:opacity-100",

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -1,5 +1,3 @@
-import { MessageCircle } from "lucide-react";
-
 import { cn } from "@hypr/utils";
 
 import { useShell } from "~/contexts/shell";
@@ -36,25 +34,17 @@ export function ChatCTA({
           "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-[min(640px,calc(100cqw_-_2rem))] -translate-x-1/2 items-center overflow-hidden rounded-full bg-black dark:bg-white",
           "[clip-path:inset(0_calc(50%_-_3rem)_0_calc(50%_-_3rem)_round_9999px)]",
           "origin-bottom px-0 text-sm shadow-none transition-[clip-path,height,padding,background-color,box-shadow] duration-200 ease-out",
-          "group-hover/anarlog-chat-cta:bg-[#fff9ed] group-focus-visible/anarlog-chat-cta:bg-[#fff9ed] dark:group-hover/anarlog-chat-cta:bg-[#211d18] dark:group-focus-visible/anarlog-chat-cta:bg-[#211d18]",
+          "group-hover/anarlog-chat-cta:bg-[#f4f4f5] group-focus-visible/anarlog-chat-cta:bg-[#f4f4f5] dark:group-hover/anarlog-chat-cta:bg-[#202020] dark:group-focus-visible/anarlog-chat-cta:bg-[#202020]",
           "group-hover/anarlog-chat-cta:h-10 group-hover/anarlog-chat-cta:px-4 group-hover/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
           "group-focus-visible/anarlog-chat-cta:h-10 group-focus-visible/anarlog-chat-cta:px-4 group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
-          "group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.18)] group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.18)] dark:group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.55)] dark:group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_16px_48px_rgba(0,0,0,0.55)]",
+          "group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_12px_rgba(0,0,0,0.1),0_16px_40px_rgba(0,0,0,0.16)] group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_12px_rgba(0,0,0,0.1),0_16px_40px_rgba(0,0,0,0.16)] dark:group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_14px_rgba(0,0,0,0.35),0_16px_44px_rgba(0,0,0,0.55)] dark:group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_14px_rgba(0,0,0,0.35),0_16px_44px_rgba(0,0,0,0.55)]",
           "group-focus-visible/anarlog-chat-cta:ring-ring group-focus-visible/anarlog-chat-cta:ring-2 group-focus-visible/anarlog-chat-cta:ring-offset-2",
         ])}
       >
-        <MessageCircle
-          className={cn([
-            "size-4 shrink-0 text-white/55 opacity-0 transition-opacity duration-150",
-            "group-focus-within/anarlog-chat-cta:opacity-100 group-hover/anarlog-chat-cta:opacity-100",
-            "group-focus-within/anarlog-chat-cta:text-muted-foreground group-hover/anarlog-chat-cta:text-muted-foreground",
-          ])}
-          aria-hidden="true"
-        />
         <span
           aria-hidden="true"
           className={cn([
-            "ml-2 max-w-0 min-w-0 flex-1 truncate text-left opacity-0",
+            "max-w-0 min-w-0 flex-1 truncate text-left opacity-0",
             "group-focus-within/anarlog-chat-cta:text-muted-foreground group-hover/anarlog-chat-cta:text-muted-foreground text-white/55",
             "transition-[max-width,opacity] duration-200 ease-out",
             "group-hover/anarlog-chat-cta:max-w-full group-hover/anarlog-chat-cta:opacity-100",

--- a/apps/desktop/src/shared/main/index.test.tsx
+++ b/apps/desktop/src/shared/main/index.test.tsx
@@ -98,6 +98,9 @@ describe("StandardTabWrapper", () => {
         ?.hasAttribute("data-main-has-after-border"),
     ).toBe(true);
     expect(
+      document.querySelector("[data-chat-floating-anchor]")?.className,
+    ).toContain("@container");
+    expect(
       document
         .querySelector("[data-chat-floating-anchor]")
         ?.hasAttribute("data-main-show-after-border-divider"),

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -153,7 +153,7 @@ function MainPanel({
         data-main-has-after-border={afterBorder ? "" : undefined}
         data-main-show-after-border-divider={afterBorder ? "" : undefined}
         className={cn([
-          "bg-card relative flex min-h-0 flex-1 flex-col overflow-hidden",
+          "bg-card @container relative flex min-h-0 flex-1 flex-col overflow-hidden",
           mergeAfterBorder && afterBorder
             ? "rounded-t-xl rounded-b-none"
             : "rounded-xl",


### PR DESCRIPTION
## Summary

- Constrain the floating chat CTA hover surface to the main area and smooth its expansion from the handle.
- Make the expanded floating composer grow with content, stay open when draft text or attachments exist, and reveal bottom-up from the input field.
- Update the expanded chat chrome with a warm surface, compact history pill trigger, short suggestion rows, and focused regression coverage.

## Validation

- `pnpm exec dprint fmt`
- `pnpm -F desktop exec vitest run src/shared/chat-cta.test.tsx src/shared/main/index.test.tsx`
- `pnpm -F desktop exec vitest run src/chat/components/body/empty.test.tsx src/chat/components/input/index.test.tsx src/chat/components/persistent-chat.test.tsx`
- `pnpm -F desktop exec vitest run src/chat/surface.test.ts src/chat/components/chat-panel.test.tsx src/chat/components/toolbar-controls.test.tsx`
- `pnpm -F desktop typecheck`
- `pnpm exec dprint check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop chat UI and layout only; behavior changes are localized to composer/dismiss and styling with regression tests added.
> 
> **Overview**
> Refines **floating chat** from the bottom CTA through the expanded panel: the CTA is a slim handle that expands via **clip-path** inside the main `@container` anchor; the open panel uses a **neutral** shell, **bottom-up** clip reveal, and default width caps without a fixed height so it can grow with content.
> 
> The **floating composer** gets a dedicated input surface (pill, “Ask anything”, send hidden until text or streaming), while the **right panel** keeps the card-themed elevated input. **`onDraftContentChange`** propagates from draft hooks (including **attachment-only** drafts) so backdrop dismiss does not close the panel when there is draft content.
> 
> **Empty state** drops intro copy and shows full-width suggestion rows; the toolbar **chat title** becomes a compact **Chat history** pill. Layout splits **floating** (`shrink-0`, capped message scroll) vs **right panel** (`flex-1` fill).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c339e2b3d037da845d1c8f1fe5122517d5e882bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->