### PR TITLE
Handle no-focus Escape navigation

### DIFF
--- a/apps/desktop/src/main/useTabsShortcuts.test.tsx
+++ b/apps/desktop/src/main/useTabsShortcuts.test.tsx
@@ -647,7 +647,7 @@ describe("useClassicMainTabsShortcuts", () => {
     expect(hoisted.openCurrent).not.toHaveBeenCalled();
   });
 
-  it("lets earlier escape handlers consume the key", () => {
+  it("opens home from a note when escape is prevented without a focused target", () => {
     hoisted.currentTab = {
       active: true,
       slotId: "slot-session",
@@ -666,6 +666,29 @@ describe("useClassicMainTabsShortcuts", () => {
     dispatchEscape();
     vi.runOnlyPendingTimers();
     window.removeEventListener("keydown", preventEscape);
+
+    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
+    expect(hoisted.select).not.toHaveBeenCalled();
+  });
+
+  it("lets focused targets consume escape", () => {
+    hoisted.currentTab = {
+      active: true,
+      slotId: "slot-session",
+      type: "sessions",
+    };
+    const input = document.createElement("input");
+    input.addEventListener("keydown", (event) => {
+      event.preventDefault();
+    });
+    document.body.append(input);
+    input.focus();
+
+    renderHook(() => useClassicMainTabsShortcuts());
+
+    dispatchEscape(input);
+    vi.runOnlyPendingTimers();
+    input.remove();
 
     expect(hoisted.openCurrent).not.toHaveBeenCalled();
     expect(hoisted.select).not.toHaveBeenCalled();

--- a/apps/desktop/src/shared/useTabsShortcuts.tsx
+++ b/apps/desktop/src/shared/useTabsShortcuts.tsx
@@ -60,6 +60,7 @@ export function useMainTabsShortcuts({ onModT }: { onModT: () => void }) {
       const hadEditorEscapeConsumer =
         fromProseMirrorEditor &&
         document.querySelector("[data-editor-escape-consumer]") !== null;
+      const hadMeaningfulFocus = hasMeaningfulFocus(event.target);
       const hadOpenChat = chatRef.current.mode !== "FloatingClosed";
 
       window.setTimeout(() => {
@@ -69,6 +70,7 @@ export function useMainTabsShortcuts({ onModT }: { onModT: () => void }) {
             fromSessionTitleInput,
             fromSessionSurface,
             hadEditorEscapeConsumer,
+            hadMeaningfulFocus,
           })
         ) {
           return;
@@ -286,14 +288,20 @@ function shouldSkipEscapeShortcut(
     fromSessionTitleInput,
     fromSessionSurface,
     hadEditorEscapeConsumer,
+    hadMeaningfulFocus,
   }: {
     fromProseMirrorEditor: boolean;
     fromSessionTitleInput: boolean;
     fromSessionSurface: boolean;
     hadEditorEscapeConsumer: boolean;
+    hadMeaningfulFocus: boolean;
   },
 ) {
   if (!event.defaultPrevented) {
+    return false;
+  }
+
+  if (!hadMeaningfulFocus) {
     return false;
   }
 
@@ -306,6 +314,35 @@ function shouldSkipEscapeShortcut(
   }
 
   return hadEditorEscapeConsumer;
+}
+
+function hasMeaningfulFocus(target: EventTarget | null) {
+  if (isMeaningfulEscapeTarget(target)) {
+    return true;
+  }
+
+  const activeElement = document.activeElement;
+
+  return (
+    activeElement instanceof HTMLElement &&
+    activeElement !== document.body &&
+    activeElement !== document.documentElement
+  );
+}
+
+function isMeaningfulEscapeTarget(target: EventTarget | null) {
+  const element =
+    target instanceof Element
+      ? target
+      : target instanceof Node
+        ? target.parentElement
+        : null;
+
+  return (
+    element !== null &&
+    element !== document.body &&
+    element !== document.documentElement
+  );
 }
 
 function isFromProseMirrorEditor(target: EventTarget | null) {


### PR DESCRIPTION
Allow prevented Escape events without a focused target to navigate home while preserving focused target opt-outs.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5651 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #5650 
- <kbd>&nbsp;1&nbsp;</kbd> #5646 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized keyboard shortcut behavior in the desktop app with expanded unit tests; no auth or data-path changes.
> 
> **Overview**
> **Escape** global shortcut handling no longer treats every `defaultPrevented` Escape as “consumed” when nothing meaningful has focus.
> 
> `shouldSkipEscapeShortcut` now takes **`hadMeaningfulFocus`**, computed from the event target and `document.activeElement` (excluding `body` / `documentElement`). If Escape was prevented but focus is not meaningful, deferred handling still runs (e.g. navigate home from a note). If a focused control (such as an input) prevents default, global navigation is still skipped.
> 
> Tests cover prevented Escape on `window` without a focused target (expects home) versus a focused input that prevents default (no tab change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8450ad4c8d21161ffaee2f995ae6ecd13f3993e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->