### PR TITLE
Restore Escape empty view navigation

### DIFF
--- a/apps/desktop/src/main/useTabsShortcuts.test.tsx
+++ b/apps/desktop/src/main/useTabsShortcuts.test.tsx
@@ -181,7 +181,7 @@ describe("useClassicMainTabsShortcuts", () => {
     expect(hoisted.openCurrent).not.toHaveBeenCalled();
   });
 
-  it("does not open the home view from a note on escape", () => {
+  it("selects an existing home view from a note on escape", () => {
     const homeTab = {
       active: false,
       slotId: "slot-home",
@@ -200,11 +200,11 @@ describe("useClassicMainTabsShortcuts", () => {
     dispatchEscape();
     vi.runOnlyPendingTimers();
 
+    expect(hoisted.select).toHaveBeenCalledWith(homeTab);
     expect(hoisted.openCurrent).not.toHaveBeenCalled();
-    expect(hoisted.select).not.toHaveBeenCalled();
   });
 
-  it("returns an escape shortcut action that does not close a note", () => {
+  it("returns an escape shortcut action that opens home from a note", () => {
     hoisted.currentTab = {
       active: true,
       id: "session-1",
@@ -216,7 +216,7 @@ describe("useClassicMainTabsShortcuts", () => {
 
     result.current.runEscapeShortcut();
 
-    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
     expect(hoisted.select).not.toHaveBeenCalled();
   });
 
@@ -238,11 +238,11 @@ describe("useClassicMainTabsShortcuts", () => {
 
     result.current.runEscapeShortcut();
 
-    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
     expect(hoisted.select).not.toHaveBeenCalled();
   });
 
-  it("does not leave a note when the editor stops escape propagation", () => {
+  it("opens home from a note when the editor stops escape propagation", () => {
     hoisted.currentTab = {
       active: true,
       id: "session-1",
@@ -260,11 +260,11 @@ describe("useClassicMainTabsShortcuts", () => {
     vi.runOnlyPendingTimers();
     editor.remove();
 
-    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
     expect(hoisted.select).not.toHaveBeenCalled();
   });
 
-  it("does not leave a note when the editor prevents default escape handling", () => {
+  it("opens home from a note when the editor prevents default escape handling", () => {
     hoisted.currentTab = {
       active: true,
       id: "session-1",
@@ -286,11 +286,39 @@ describe("useClassicMainTabsShortcuts", () => {
     vi.runOnlyPendingTimers();
     editor.remove();
 
-    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
     expect(hoisted.select).not.toHaveBeenCalled();
   });
 
-  it("does not leave a note when a focused target handles escape directly", () => {
+  it("opens home from a note when ProseMirror handles escape from a text node", () => {
+    hoisted.currentTab = {
+      active: true,
+      id: "session-1",
+      slotId: "slot-session",
+      type: "sessions",
+    };
+    const editor = document.createElement("div");
+    editor.className = "ProseMirror";
+    editor.contentEditable = "true";
+    const text = document.createTextNode("note");
+    editor.append(text);
+    editor.addEventListener("keydown", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+    });
+    document.body.append(editor);
+
+    renderHook(() => useClassicMainTabsShortcuts());
+
+    dispatchEscape(text);
+    vi.runOnlyPendingTimers();
+    editor.remove();
+
+    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
+    expect(hoisted.select).not.toHaveBeenCalled();
+  });
+
+  it("does not duplicate home navigation when a focused target handles escape directly", () => {
     hoisted.currentTab = {
       active: true,
       id: "session-1",
@@ -310,7 +338,58 @@ describe("useClassicMainTabsShortcuts", () => {
     vi.runOnlyPendingTimers();
     target.remove();
 
-    expect(hoisted.openCurrent).not.toHaveBeenCalled();
+    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
+    expect(hoisted.openCurrent).toHaveBeenCalledTimes(1);
+    expect(hoisted.select).not.toHaveBeenCalled();
+  });
+
+  it("opens home from a note when the title field handles escape", () => {
+    hoisted.currentTab = {
+      active: true,
+      id: "session-1",
+      slotId: "slot-session",
+      type: "sessions",
+    };
+    const target = document.createElement("input");
+    target.dataset.sessionTitleInput = "true";
+    target.addEventListener("keydown", (event) => {
+      event.preventDefault();
+    });
+    document.body.append(target);
+
+    renderHook(() => useClassicMainTabsShortcuts());
+
+    dispatchEscape(target);
+    vi.runOnlyPendingTimers();
+    target.remove();
+
+    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
+    expect(hoisted.select).not.toHaveBeenCalled();
+  });
+
+  it("opens home from a note when the session surface handles escape", () => {
+    hoisted.currentTab = {
+      active: true,
+      id: "session-1",
+      slotId: "slot-session",
+      type: "sessions",
+    };
+    const surface = document.createElement("div");
+    surface.dataset.sessionSurface = "true";
+    const target = document.createElement("div");
+    target.addEventListener("keydown", (event) => {
+      event.preventDefault();
+    });
+    surface.append(target);
+    document.body.append(surface);
+
+    renderHook(() => useClassicMainTabsShortcuts());
+
+    dispatchEscape(target);
+    vi.runOnlyPendingTimers();
+    surface.remove();
+
+    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
     expect(hoisted.select).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/routes/app/-note.$sessionId.test.tsx
+++ b/apps/desktop/src/routes/app/-note.$sessionId.test.tsx
@@ -1,18 +1,51 @@
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useStandaloneNoteTab } from "./note.$sessionId";
+import { resetTabsStore } from "~/store/zustand/tabs/test-utils";
+
+const mocks = vi.hoisted(() => ({
+  close: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    close: mocks.close,
+  }),
+}));
+
+import {
+  useCloseStandaloneNoteWindowOnEscape,
+  useStandaloneNoteTab,
+} from "./note.$sessionId";
 
 import { useTabs } from "~/store/zustand/tabs";
-import { resetTabsStore } from "~/store/zustand/tabs/test-utils";
 
 describe("standalone note window route", () => {
   beforeEach(() => {
+    mocks.close.mockClear();
     resetTabsStore();
   });
 
   afterEach(() => {
     cleanup();
+  });
+
+  it("closes the standalone note window on escape", () => {
+    renderHook(() => useCloseStandaloneNoteWindowOnEscape());
+
+    const event = dispatchKeyDown("Escape");
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mocks.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores other keys", () => {
+    renderHook(() => useCloseStandaloneNoteWindowOnEscape());
+
+    const event = dispatchKeyDown("Enter");
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(mocks.close).not.toHaveBeenCalled();
   });
 
   it("returns the subscribed standalone note tab after tab state updates", async () => {
@@ -39,3 +72,13 @@ describe("standalone note window route", () => {
     expect(result.current.state.view).toEqual({ type: "raw" });
   });
 });
+
+function dispatchKeyDown(key: string) {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key,
+  });
+  window.dispatchEvent(event);
+  return event;
+}

--- a/apps/desktop/src/routes/app/note.$sessionId.tsx
+++ b/apps/desktop/src/routes/app/note.$sessionId.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useLayoutEffect, useMemo } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useEffect, useLayoutEffect, useMemo } from "react";
 
 import { ClassicMainLayout } from "~/main/layout";
 import { TabContentNote } from "~/session";
@@ -12,6 +13,7 @@ export const Route = createFileRoute("/app/note/$sessionId")({
 
 function Component() {
   const { sessionId } = Route.useParams();
+  useCloseStandaloneNoteWindowOnEscape();
   const tab = useStandaloneNoteTab(sessionId);
 
   return (
@@ -62,4 +64,22 @@ export function useStandaloneNoteTab(sessionId: string) {
   }, [sessionId, tab]);
 
   return storeTab ?? tab;
+}
+
+export function useCloseStandaloneNoteWindowOnEscape() {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      event.preventDefault();
+      void getCurrentWindow().close();
+    };
+
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, { capture: true });
+    };
+  }, []);
 }

--- a/apps/desktop/src/session/components/session-surface.tsx
+++ b/apps/desktop/src/session/components/session-surface.tsx
@@ -31,7 +31,7 @@ export function SessionSurface({
       floatingButton={floatingButton}
       mergeAfterBorder={mergeAfterBorder}
     >
-      <div className="flex h-full flex-col">
+      <div data-session-surface className="flex h-full flex-col">
         {header ? (
           <div data-tauri-drag-region className="pr-1 pl-3">
             {header}

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -376,6 +376,7 @@ const TitleInputInner = memo(
         >
           <input
             data-tauri-drag-region="false"
+            data-session-title-input
             aria-label="Session title"
             ref={setInputRef}
             id={`title-input-${sessionId}-${editorId}`}

--- a/apps/desktop/src/shared/useTabsShortcuts.tsx
+++ b/apps/desktop/src/shared/useTabsShortcuts.tsx
@@ -55,6 +55,8 @@ export function useMainTabsShortcuts({ onModT }: { onModT: () => void }) {
       }
 
       const fromProseMirrorEditor = isFromProseMirrorEditor(event.target);
+      const fromSessionTitleInput = isFromSessionTitleInput(event.target);
+      const fromSessionSurface = isFromSessionSurface(event.target);
       const hadEditorEscapeConsumer =
         fromProseMirrorEditor &&
         document.querySelector("[data-editor-escape-consumer]") !== null;
@@ -64,6 +66,8 @@ export function useMainTabsShortcuts({ onModT }: { onModT: () => void }) {
         if (
           shouldSkipEscapeShortcut(event, {
             fromProseMirrorEditor,
+            fromSessionTitleInput,
+            fromSessionSurface,
             hadEditorEscapeConsumer,
           })
         ) {
@@ -245,10 +249,6 @@ export function useMainEscapeShortcutAction() {
       return;
     }
 
-    if (currentTab?.type === "sessions") {
-      return;
-    }
-
     const returnToSlotId = currentTab?.returnToSlotId;
     const returnToTab = returnToSlotId
       ? tabs.find(
@@ -283,10 +283,21 @@ function shouldSkipEscapeShortcut(
   event: KeyboardEvent,
   {
     fromProseMirrorEditor,
+    fromSessionTitleInput,
+    fromSessionSurface,
     hadEditorEscapeConsumer,
-  }: { fromProseMirrorEditor: boolean; hadEditorEscapeConsumer: boolean },
+  }: {
+    fromProseMirrorEditor: boolean;
+    fromSessionTitleInput: boolean;
+    fromSessionSurface: boolean;
+    hadEditorEscapeConsumer: boolean;
+  },
 ) {
   if (!event.defaultPrevented) {
+    return false;
+  }
+
+  if (fromSessionTitleInput || fromSessionSurface) {
     return false;
   }
 
@@ -298,7 +309,28 @@ function shouldSkipEscapeShortcut(
 }
 
 function isFromProseMirrorEditor(target: EventTarget | null) {
-  return target instanceof Element && target.closest(".ProseMirror") !== null;
+  const element =
+    target instanceof Element
+      ? target
+      : target instanceof Node
+        ? target.parentElement
+        : null;
+
+  return element !== null && element.closest(".ProseMirror") !== null;
+}
+
+function isFromSessionTitleInput(target: EventTarget | null) {
+  return (
+    target instanceof Element &&
+    target.closest("[data-session-title-input]") !== null
+  );
+}
+
+function isFromSessionSurface(target: EventTarget | null) {
+  return (
+    target instanceof Element &&
+    target.closest("[data-session-surface]") !== null
+  );
 }
 
 function isPersistentChatInputFocused(


### PR DESCRIPTION
Open the home view from note Escape handling and close standalone note windows on Escape while preserving standalone note tab subscriptions.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #5654 
- <kbd>&nbsp;3&nbsp;</kbd> #5653 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #5652 
- <kbd>&nbsp;1&nbsp;</kbd> #5646 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Keyboard navigation and window-close behavior only; no auth, data, or API changes.
> 
> **Overview**
> **Escape from a note** again returns to the home (empty) view in the main window: session tabs no longer short-circuit the escape action, and an existing empty tab is selected when one is already open.
> 
> Escape handling is tightened so **preventDefault** on the note chrome still allows navigation—`data-session-title-input` and `data-session-surface` mark those regions, and the deferred escape path treats them (and ProseMirror text-node targets) as eligible for home navigation while editor escape consumers and unrelated prevented handlers still block it.
> 
> **Standalone note windows** close on Escape via a capture-phase listener that calls Tauri `getCurrentWindow().close()`, with route tests for Escape vs other keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 052aff6b9c1be45814b6031acbc144ccffc09e28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->