### PR TITLE
Handle no-focus Escape navigation

### DIFF
--- a/apps/desktop/src/main/useTabsShortcuts.test.tsx
+++ b/apps/desktop/src/main/useTabsShortcuts.test.tsx
@@ -647,7 +647,7 @@ describe("useClassicMainTabsShortcuts", () => {
     expect(hoisted.openCurrent).not.toHaveBeenCalled();
   });
 
-  it("lets earlier escape handlers consume the key", () => {
+  it("opens home from a note when escape is prevented without a focused target", () => {
     hoisted.currentTab = {
       active: true,
       slotId: "slot-session",
@@ -666,6 +666,29 @@ describe("useClassicMainTabsShortcuts", () => {
     dispatchEscape();
     vi.runOnlyPendingTimers();
     window.removeEventListener("keydown", preventEscape);
+
+    expect(hoisted.openCurrent).toHaveBeenCalledWith({ type: "empty" });
+    expect(hoisted.select).not.toHaveBeenCalled();
+  });
+
+  it("lets focused targets consume escape", () => {
+    hoisted.currentTab = {
+      active: true,
+      slotId: "slot-session",
+      type: "sessions",
+    };
+    const input = document.createElement("input");
+    input.addEventListener("keydown", (event) => {
+      event.preventDefault();
+    });
+    document.body.append(input);
+    input.focus();
+
+    renderHook(() => useClassicMainTabsShortcuts());
+
+    dispatchEscape(input);
+    vi.runOnlyPendingTimers();
+    input.remove();
 
     expect(hoisted.openCurrent).not.toHaveBeenCalled();
     expect(hoisted.select).not.toHaveBeenCalled();

--- a/apps/desktop/src/shared/useTabsShortcuts.tsx
+++ b/apps/desktop/src/shared/useTabsShortcuts.tsx
@@ -60,6 +60,7 @@ export function useMainTabsShortcuts({ onModT }: { onModT: () => void }) {
       const hadEditorEscapeConsumer =
         fromProseMirrorEditor &&
         document.querySelector("[data-editor-escape-consumer]") !== null;
+      const hadMeaningfulFocus = hasMeaningfulFocus(event.target);
       const hadOpenChat = chatRef.current.mode !== "FloatingClosed";
 
       window.setTimeout(() => {
@@ -69,6 +70,7 @@ export function useMainTabsShortcuts({ onModT }: { onModT: () => void }) {
             fromSessionTitleInput,
             fromSessionSurface,
             hadEditorEscapeConsumer,
+            hadMeaningfulFocus,
           })
         ) {
           return;
@@ -286,14 +288,20 @@ function shouldSkipEscapeShortcut(
     fromSessionTitleInput,
     fromSessionSurface,
     hadEditorEscapeConsumer,
+    hadMeaningfulFocus,
   }: {
     fromProseMirrorEditor: boolean;
     fromSessionTitleInput: boolean;
     fromSessionSurface: boolean;
     hadEditorEscapeConsumer: boolean;
+    hadMeaningfulFocus: boolean;
   },
 ) {
   if (!event.defaultPrevented) {
+    return false;
+  }
+
+  if (!hadMeaningfulFocus) {
     return false;
   }
 
@@ -306,6 +314,35 @@ function shouldSkipEscapeShortcut(
   }
 
   return hadEditorEscapeConsumer;
+}
+
+function hasMeaningfulFocus(target: EventTarget | null) {
+  if (isMeaningfulEscapeTarget(target)) {
+    return true;
+  }
+
+  const activeElement = document.activeElement;
+
+  return (
+    activeElement instanceof HTMLElement &&
+    activeElement !== document.body &&
+    activeElement !== document.documentElement
+  );
+}
+
+function isMeaningfulEscapeTarget(target: EventTarget | null) {
+  const element =
+    target instanceof Element
+      ? target
+      : target instanceof Node
+        ? target.parentElement
+        : null;
+
+  return (
+    element !== null &&
+    element !== document.body &&
+    element !== document.documentElement
+  );
 }
 
 function isFromProseMirrorEditor(target: EventTarget | null) {


### PR DESCRIPTION
Allow prevented Escape events without a focused target to return note tabs to the home view while preserving focused target handling.

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #5654 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #5653 
- <kbd>&nbsp;2&nbsp;</kbd> #5652 
- <kbd>&nbsp;1&nbsp;</kbd> #5646 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized keyboard shortcut gating with added unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> **Escape** tab shortcuts no longer treat every `defaultPrevented` Escape as “consumed” when nothing meaningful has focus.
> 
> `shouldSkipEscapeShortcut` now takes **`hadMeaningfulFocus`**, computed via new helpers that ignore `body` / `documentElement` on both the event target and `document.activeElement`. If Escape was prevented but focus is not on a real control, the deferred handler still runs (e.g. **open home** from a note tab). If a focused element (e.g. an **input**) prevents default, global navigation stays suppressed.
> 
> Tests replace the generic “earlier handlers consume escape” case with scenarios for **window-level** `preventDefault` without focus vs **focused** targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14ef561896019823ee3a07c162dc8e9b3976e617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->