### PR TITLE
Fix standalone note title hydration

### DIFF
--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -9,9 +9,8 @@ import { TitleInput } from "./title-input";
 const hoisted = vi.hoisted(() => ({
   clearLiveTitle: vi.fn(),
   setLiveTitle: vi.fn(),
+  storeTitle: "Untitled" as string | undefined,
   store: {
-    addCellListener: vi.fn(() => "listener-id"),
-    delListener: vi.fn(),
     getCell: vi.fn(() => "Untitled"),
   },
 }));
@@ -27,6 +26,7 @@ vi.mock("~/ai/hooks", () => ({
 vi.mock("~/store/tinybase/store/main", () => ({
   STORE_ID: "main",
   UI: {
+    useCell: () => hoisted.storeTitle,
     useSetPartialRowCallback: () => vi.fn(),
     useStore: () => hoisted.store,
   },
@@ -67,6 +67,7 @@ const renderTitleInput = (
 describe("TitleInput", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    hoisted.storeTitle = "Untitled";
     hoisted.store.getCell.mockImplementation(() => "Untitled");
   });
 
@@ -85,7 +86,7 @@ describe("TitleInput", () => {
   });
 
   it("left-aligns the empty title field without a generate button", () => {
-    hoisted.store.getCell.mockReturnValueOnce("");
+    hoisted.storeTitle = "";
 
     renderTitleInput();
 
@@ -113,7 +114,7 @@ describe("TitleInput", () => {
   });
 
   it("uses the flexible title layout for whitespace-only titles", () => {
-    hoisted.store.getCell.mockReturnValueOnce("          ");
+    hoisted.storeTitle = "          ";
 
     renderTitleInput();
 
@@ -156,6 +157,35 @@ describe("TitleInput", () => {
     expect(
       hoverTitle.style.getPropertyValue("--title-hover-scroll-distance"),
     ).toBe("-260px");
+  });
+
+  it("updates when the persisted title loads after mount", () => {
+    hoisted.storeTitle = undefined;
+
+    const { rerender } = renderTitleInput();
+
+    const input = screen.getByPlaceholderText("Untitled");
+    expect((input as HTMLInputElement).value).toBe("");
+
+    hoisted.storeTitle = "Spotify Leadership Transition";
+    rerender(
+      <TooltipProvider>
+        <TitleInput
+          tab={{
+            active: true,
+            id: "session-1",
+            pinned: false,
+            slotId: "slot-1",
+            state: { autoStart: null, view: { type: "raw" } },
+            type: "sessions",
+          }}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(
+      (screen.getByPlaceholderText("Untitled") as HTMLInputElement).value,
+    ).toBe("Spotify Leadership Transition");
   });
 
   it("updates title fades based on horizontal scroll position", () => {

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -46,11 +47,16 @@ export const TitleInput = forwardRef<
       id: sessionId,
       state: { view },
     } = tab;
-    const store = main.UI.useStore(main.STORE_ID);
     const isGenerating = useTitleGenerating(sessionId);
     const wasGenerating = usePrevious(isGenerating);
     const [showRevealAnimation, setShowRevealAnimation] = useState(false);
     const [generatedTitle, setGeneratedTitle] = useState<string | null>(null);
+    const storeTitle = main.UI.useCell(
+      "sessions",
+      sessionId,
+      "title",
+      main.STORE_ID,
+    ) as string | undefined;
 
     const editorId = view ? "active" : "inactive";
     const inputRef = useRef<TitleInputHandle>(null);
@@ -59,21 +65,14 @@ export const TitleInput = forwardRef<
 
     useEffect(() => {
       if (wasGenerating && !isGenerating) {
-        const title = store?.getCell("sessions", sessionId, "title") as
-          | string
-          | undefined;
-        setGeneratedTitle(title ?? null);
+        setGeneratedTitle(storeTitle ?? null);
         setShowRevealAnimation(true);
         const timer = setTimeout(() => {
           setShowRevealAnimation(false);
         }, 1000);
         return () => clearTimeout(timer);
       }
-    }, [wasGenerating, isGenerating, store, sessionId]);
-
-    const getInitialTitle = useCallback(() => {
-      return (store?.getCell("sessions", sessionId, "title") as string) ?? "";
-    }, [store, sessionId]);
+    }, [wasGenerating, isGenerating, storeTitle]);
 
     if (isGenerating) {
       return (
@@ -106,7 +105,6 @@ export const TitleInput = forwardRef<
         ref={inputRef}
         sessionId={sessionId}
         editorId={editorId}
-        getInitialTitle={getInitialTitle}
         onTransferContentToEditor={onTransferContentToEditor}
         onFocusEditorAtStart={onFocusEditorAtStart}
         onFocusEditorAtPixelWidth={onFocusEditorAtPixelWidth}
@@ -121,7 +119,6 @@ const TitleInputInner = memo(
     {
       sessionId: string;
       editorId: string;
-      getInitialTitle: () => string;
       onTransferContentToEditor?: (content: string) => void;
       onFocusEditorAtStart?: () => void;
       onFocusEditorAtPixelWidth?: (pixelWidth: number) => void;
@@ -131,24 +128,28 @@ const TitleInputInner = memo(
       {
         sessionId,
         editorId,
-        getInitialTitle,
         onTransferContentToEditor,
         onFocusEditorAtStart,
         onFocusEditorAtPixelWidth,
       },
       ref,
     ) => {
-      const [localTitle, setLocalTitle] = useState(() => getInitialTitle());
+      const storeTitle = main.UI.useCell(
+        "sessions",
+        sessionId,
+        "title",
+        main.STORE_ID,
+      ) as string | undefined;
+      const [draftTitle, setDraftTitle] = useState<string | null>(null);
       const [isOverflowing, setIsOverflowing] = useState(false);
       const [overflowDistance, setOverflowDistance] = useState(0);
       const [showStartFade, setShowStartFade] = useState(false);
       const [showEndFade, setShowEndFade] = useState(false);
       const [isTitleFocused, setIsTitleFocused] = useState(false);
-      const isFocused = useRef(false);
       const internalRef = useRef<HTMLInputElement>(null);
-      const store = main.UI.useStore(main.STORE_ID);
       const setLiveTitle = useLiveTitle((s) => s.setTitle);
       const clearLiveTitle = useLiveTitle((s) => s.clearTitle);
+      const title = draftTitle ?? storeTitle ?? "";
 
       const updateOverflowState = useCallback(
         (node?: HTMLInputElement | null) => {
@@ -206,7 +207,7 @@ const TitleInputInner = memo(
             }
           : undefined;
       const showHoverReveal =
-        isOverflowing && !isTitleFocused && localTitle.length > 0;
+        isOverflowing && !isTitleFocused && title.length > 0;
       const titleHoverScrollStyle = showHoverReveal
         ? ({
             "--title-hover-scroll-distance": `-${Math.ceil(
@@ -219,7 +220,7 @@ const TitleInputInner = memo(
           } as CSSProperties)
         : undefined;
       const visibleTitleLength = Math.max(
-        localTitle.length || "Untitled".length,
+        title.length || "Untitled".length,
         "Untitled".length,
       );
       const titleShellStyle = {
@@ -268,25 +269,9 @@ const TitleInputInner = memo(
         [],
       );
 
-      useEffect(() => {
-        if (!store) return;
-
-        const listenerId = store.addCellListener(
-          "sessions",
-          sessionId,
-          "title",
-          (_store, _tableId, _rowId, _cellId, newValue) => {
-            if (!isFocused.current) {
-              setLocalTitle((newValue as string) ?? "");
-              requestAnimationFrame(() => updateOverflowState());
-            }
-          },
-        );
-
-        return () => {
-          store.delListener(listenerId);
-        };
-      }, [store, sessionId, updateOverflowState]);
+      useLayoutEffect(() => {
+        requestAnimationFrame(() => updateOverflowState());
+      }, [title, updateOverflowState]);
 
       const setStoreTitle = main.UI.useSetPartialRowCallback(
         "sessions",
@@ -311,7 +296,7 @@ const TitleInputInner = memo(
           const beforeCursor = input.value.slice(0, cursorPos);
           const afterCursor = input.value.slice(cursorPos);
 
-          setLocalTitle(beforeCursor);
+          setDraftTitle(beforeCursor);
           setStoreTitle(beforeCursor);
           clearLiveTitle(sessionId);
 
@@ -368,7 +353,7 @@ const TitleInputInner = memo(
             type="text"
             onChange={(e) => {
               const value = e.target.value;
-              setLocalTitle(value);
+              setDraftTitle(value);
               setLiveTitle(sessionId, value);
               updateOverflowState(e.target);
             }}
@@ -376,20 +361,20 @@ const TitleInputInner = memo(
             onKeyDown={handleKeyDown}
             onKeyUp={(e) => updateOverflowState(e.currentTarget)}
             onFocus={() => {
-              isFocused.current = true;
+              setDraftTitle(title);
               setIsTitleFocused(true);
               updateOverflowState();
             }}
             onBlur={(e) => {
-              isFocused.current = false;
               setIsTitleFocused(false);
-              setStoreTitle(localTitle);
+              setStoreTitle(e.target.value);
+              setDraftTitle(null);
               clearLiveTitle(sessionId);
               updateOverflowState(e.target);
             }}
             onScroll={(e) => updateOverflowState(e.currentTarget)}
             onSelect={(e) => updateOverflowState(e.currentTarget)}
-            value={localTitle}
+            value={title}
             size={visibleTitleLength}
             className={cn([
               "w-full min-w-0 transition-opacity duration-200",
@@ -407,7 +392,7 @@ const TitleInputInner = memo(
                 style={titleHoverScrollStyle}
                 className="group-hover/title-input:animate-title-hover-scroll text-xl font-semibold whitespace-nowrap group-hover/title-input:will-change-transform"
               >
-                {localTitle}
+                {title}
               </span>
             </div>
           ) : null}


### PR DESCRIPTION
Render the note title from the reactive TinyBase cell and keep local draft state only while editing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to session title UI and test mocks; no auth, persistence, or API changes beyond how the title field reads the existing cell.
> 
> **Overview**
> Fixes **standalone note titles staying empty** after the persisted value arrives by driving the field from **`useCell`** on `sessions.title` instead of a one-time `getCell` read and a manual **`addCellListener`**.
> 
> While editing, the input keeps a **`draftTitle`** overlay on the store value (`draftTitle ?? storeTitle ?? ""`); blur/Enter still persist and clear the draft. Overflow/hover layout now re-runs in a **`useLayoutEffect`** when the displayed title changes.
> 
> Tests mock **`useCell`**, set titles via **`storeTitle`**, and add coverage for **late-loaded titles after mount**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9871cbdaa391201a52b316ad14dabc0700676f5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->