### PR TITLE
Remove unused Rust code

### DIFF
--- a/crates/api-research/src/mcp/server.rs
+++ b/crates/api-research/src/mcp/server.rs
@@ -1,7 +1,6 @@
 use rmcp::{
-    ErrorData as McpError, RoleServer, ServerHandler, handler::server::tool::ToolRouter,
-    handler::server::wrapper::Parameters, model::*, service::RequestContext, tool, tool_handler,
-    tool_router,
+    ErrorData as McpError, RoleServer, ServerHandler, handler::server::wrapper::Parameters,
+    model::*, service::RequestContext, tool, tool_handler, tool_router,
 };
 
 use crate::state::AppState;
@@ -12,15 +11,11 @@ use super::tools;
 #[derive(Clone)]
 pub struct ResearchMcpServer {
     state: AppState,
-    tool_router: ToolRouter<Self>,
 }
 
 impl ResearchMcpServer {
     pub(super) fn new(state: AppState) -> Self {
-        Self {
-            state,
-            tool_router: Self::tool_router(),
-        }
+        Self { state }
     }
 }
 

--- a/crates/api-support/src/mcp/server.rs
+++ b/crates/api-support/src/mcp/server.rs
@@ -1,8 +1,8 @@
 use rmcp::schemars::{self, JsonSchema};
 use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler, elicit_safe,
-    handler::server::tool::ToolRouter, handler::server::wrapper::Parameters, model::*,
-    service::RequestContext, tool, tool_handler, tool_router,
+    handler::server::wrapper::Parameters, model::*, service::RequestContext, tool, tool_handler,
+    tool_router,
 };
 use serde::Serialize;
 
@@ -26,15 +26,11 @@ use super::tools::{
 #[derive(Clone)]
 pub(crate) struct SupportMcpServer {
     state: AppState,
-    tool_router: ToolRouter<Self>,
 }
 
 impl SupportMcpServer {
     pub(super) fn new(state: AppState) -> Self {
-        Self {
-            state,
-            tool_router: Self::tool_router(),
-        }
+        Self { state }
     }
 }
 

--- a/crates/owhisper-client/src/adapter/smallestai/live.rs
+++ b/crates/owhisper-client/src/adapter/smallestai/live.rs
@@ -211,8 +211,6 @@ struct SmallestRealtimeWord {
     #[serde(default)]
     speaker: Option<SmallestSpeaker>,
     #[serde(default)]
-    speaker_confidence: Option<f64>,
-    #[serde(default)]
     language: Option<String>,
 }
 

--- a/plugins/detect/src/timer_registry.rs
+++ b/plugins/detect/src/timer_registry.rs
@@ -37,14 +37,6 @@ impl TimerRegistry {
         generation
     }
 
-    pub fn start_if_absent(&mut self, key: String, token: CancellationToken) -> Option<u64> {
-        if self.timers.contains_key(&key) {
-            return None;
-        }
-
-        Some(self.start_replace(key, token))
-    }
-
     pub fn cancel(&mut self, key: &str) -> bool {
         if let Some(entry) = self.timers.remove(key) {
             entry.token.cancel();
@@ -81,20 +73,6 @@ mod tests {
         assert!(token0_clone.is_cancelled());
         assert_eq!(generation_0, 0);
         assert_eq!(generation_1, 1);
-    }
-
-    #[test]
-    fn start_if_absent_does_not_replace_existing_timer() {
-        let mut registry = TimerRegistry::default();
-        let token0 = CancellationToken::new();
-        let token0_clone = token0.clone();
-
-        let generation_0 = registry.start_if_absent("app.x".to_string(), token0);
-        let generation_1 = registry.start_if_absent("app.x".to_string(), CancellationToken::new());
-
-        assert_eq!(generation_0, Some(0));
-        assert_eq!(generation_1, None);
-        assert!(!token0_clone.is_cancelled());
     }
 
     #[test]

--- a/plugins/icon/examples/test_overlay.rs
+++ b/plugins/icon/examples/test_overlay.rs
@@ -26,7 +26,6 @@ fn main() {
 
         for (overlay, name) in [
             (Overlay::Recording, "recording"),
-            (Overlay::Degraded, "degraded"),
             (Overlay::Notification(1), "notification_1"),
             (Overlay::Notification(9), "notification_9"),
             (Overlay::Notification(10), "notification_10"),

--- a/plugins/icon/src/overlay.rs
+++ b/plugins/icon/src/overlay.rs
@@ -14,7 +14,6 @@ use objc2_foundation::{NSCopying, NSDictionary, NSPoint, NSRect, NSSize, NSStrin
 
 pub enum Overlay {
     Recording,
-    Degraded,
     Notification(u8),
 }
 
@@ -24,7 +23,6 @@ impl Overlay {
     pub fn draw(&self, base_image: &NSImage) -> Retained<NSImage> {
         match self {
             Overlay::Recording => draw_recording(base_image),
-            Overlay::Degraded => draw_degraded(base_image),
             Overlay::Notification(count) => draw_notification(base_image, *count),
         }
     }
@@ -113,36 +111,6 @@ fn draw_recording(base_image: &NSImage) -> Retained<NSImage> {
         );
         let center_path = NSBezierPath::bezierPathWithOvalInRect(center_rect);
         center_path.fill();
-    })
-}
-
-#[cfg(target_os = "macos")]
-fn draw_degraded(base_image: &NSImage) -> Retained<NSImage> {
-    draw_badge(base_image, &NSColor::systemOrangeColor(), |geo| {
-        let stem_width = geo.inner_size * 0.15;
-        let stem_height = geo.inner_size * 0.35;
-        let stem_x = geo.inner_origin.x + (geo.inner_size - stem_width) / 2.0;
-        let stem_y = geo.inner_origin.y + geo.inner_size * 0.42;
-        let stem_rect = NSRect::new(
-            NSPoint::new(stem_x, stem_y),
-            NSSize::new(stem_width, stem_height),
-        );
-        let stem_path = NSBezierPath::bezierPathWithRoundedRect_xRadius_yRadius(
-            stem_rect,
-            stem_width / 2.0,
-            stem_width / 2.0,
-        );
-        stem_path.fill();
-
-        let dot_diameter = geo.inner_size * 0.15;
-        let dot_cx = geo.inner_origin.x + (geo.inner_size - dot_diameter) / 2.0;
-        let dot_cy = geo.inner_origin.y + geo.inner_size * 0.18;
-        let excl_dot_rect = NSRect::new(
-            NSPoint::new(dot_cx, dot_cy),
-            NSSize::new(dot_diameter, dot_diameter),
-        );
-        let excl_dot_path = NSBezierPath::bezierPathWithOvalInRect(excl_dot_rect);
-        excl_dot_path.fill();
     })
 }
 


### PR DESCRIPTION
Deletes unused warning sources from MCP servers, timer registry, SmallestAI word parsing, and the icon overlay example path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure dead-code removal with no remaining call sites; icon degraded overlay removal only matters if something still referenced that enum variant externally.
> 
> **Overview**
> Removes unused fields, APIs, and drawing paths across several crates with **no intended behavior change** for live features.
> 
> **MCP servers** (`api-research`, `api-support`): Drops the stored `ToolRouter` field and manual `tool_router()` wiring in `new`; routing still comes from the `#[tool_router]` / `#[tool_handler]` macros on the impl blocks.
> 
> **Detect plugin**: Deletes `TimerRegistry::start_if_absent` and its unit test; timer lifecycle stays on `start_replace`, `cancel`, and `claim`.
> 
> **SmallestAI live adapter**: Stops deserializing `speaker_confidence` on realtime words (it was never passed through to `WordBuilder`).
> 
> **Icon plugin**: Removes the `Overlay::Degraded` variant, `draw_degraded`, and the degraded case from the overlay example loop—recording and notification badges remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daea3393225c6a9fdd0d286ba33a41604b3c8977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->