### PR TITLE
Set left sidebar default width

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -161,18 +161,18 @@ describe("ClassicMainBody", () => {
 
     const panels = screen.getAllByTestId("panel");
     expect(panels).toHaveLength(2);
-    expect(panels[0]?.dataset.defaultSize).toBe("18");
+    expect(panels[0]?.dataset.defaultSize).toBe("20");
     expect(panels[0]?.dataset.minSize).toBe("12");
     expect(panels[0]?.dataset.maxSize).toBe("32");
-    expect(panels[0]?.dataset.minWidth).toBe("180");
+    expect(panels[0]?.dataset.minWidth).toBe("200");
     expect(panels[0]?.dataset.maxWidth).toBe("360");
 
     const sidebarChrome = document.querySelector<HTMLElement>(
       "[data-left-sidebar-chrome]",
     );
 
-    expect(sidebarChrome?.style.width).toBe("18%");
-    expect(sidebarChrome?.style.minWidth).toBe("180px");
+    expect(sidebarChrome?.style.width).toBe("20%");
+    expect(sidebarChrome?.style.minWidth).toBe("200px");
     expect(sidebarChrome?.style.maxWidth).toBe("360px");
     expect(sidebarChrome?.className).not.toContain("w-[200px]");
 

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -47,10 +47,10 @@ import { type Tab, uniqueIdfromTab, useTabs } from "~/store/zustand/tabs";
 
 const MAIN_AREA_TOP_DRAG_HEIGHT_PX = 48;
 const MAIN_AREA_WINDOW_DRAG_THRESHOLD_PX = 5;
-const LEFT_SIDEBAR_DEFAULT_SIZE = 18;
+const LEFT_SIDEBAR_DEFAULT_SIZE = 20;
 const LEFT_SIDEBAR_MIN_SIZE = 12;
 const LEFT_SIDEBAR_MAX_SIZE = 32;
-const LEFT_SIDEBAR_MIN_WIDTH_PX = 180;
+const LEFT_SIDEBAR_MIN_WIDTH_PX = 200;
 const LEFT_SIDEBAR_MAX_WIDTH_PX = 360;
 
 type MainAreaWindowDragStart = {


### PR DESCRIPTION
Default the expanded left sidebar to 200px and update the layout regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic layout constant changes only; no auth, data, or business logic touched.
> 
> **Overview**
> Bumps the classic main layout’s **expanded left sidebar** defaults so new sessions open a bit wider: panel **default size** goes from **18%** to **20%**, and the **minimum width** from **180px** to **200px** (max width and percentage min/max unchanged).
> 
> The `ClassicMainBody` resizable panel and `[data-left-sidebar-chrome]` inline styles both read these constants, so the sidebar chrome and panel stay aligned. The layout regression test expectations were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ce32ac05d247f9c654be6758779efc7b2cfac60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->