### PR TITLE
Fix standalone note header hit testing

### DIFF
--- a/apps/desktop/src/routes/app/note.$sessionId.tsx
+++ b/apps/desktop/src/routes/app/note.$sessionId.tsx
@@ -16,7 +16,7 @@ function Component() {
 
   return (
     <ClassicMainLayout includeServices={false}>
-      <StandaloneWindowShell>
+      <StandaloneWindowShell topDragRegion={false}>
         <div className="bg-background h-screen w-screen">
           <TabContentNote tab={tab} standaloneWindow />
         </div>

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -193,7 +193,7 @@ describe("OuterHeader", () => {
 
     expect(titleSlot?.className).toContain("left-0");
     expect(titleSlot?.className).toContain("right-[70px]");
-    expect(titleSlot?.className).toContain("justify-center");
+    expect(titleSlot?.className).not.toContain("justify-center");
   });
 
   it("keeps sidebar header controls hidden while the sidebar is expanded", () => {

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -193,6 +193,7 @@ describe("OuterHeader", () => {
 
     expect(titleSlot?.className).toContain("left-0");
     expect(titleSlot?.className).toContain("right-[70px]");
+    expect(titleSlot?.className).toContain("justify-center");
   });
 
   it("keeps sidebar header controls hidden while the sidebar is expanded", () => {

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -49,7 +49,7 @@ export function OuterHeader({
         <div
           data-tauri-drag-region
           className={cn([
-            "pointer-events-none absolute inset-y-0 flex items-center justify-center",
+            "pointer-events-none absolute inset-y-0 flex items-center",
             reserveCollapsedLiveControls ? "right-[153px]" : "right-[70px]",
             standaloneWindow
               ? "left-[68px]"

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -49,7 +49,7 @@ export function OuterHeader({
         <div
           data-tauri-drag-region
           className={cn([
-            "pointer-events-none absolute inset-y-0 flex items-center",
+            "pointer-events-none absolute inset-y-0 flex items-center justify-center",
             reserveCollapsedLiveControls ? "right-[153px]" : "right-[70px]",
             standaloneWindow
               ? "left-[68px]"

--- a/apps/desktop/src/session/components/title-breadcrumb.test.tsx
+++ b/apps/desktop/src/session/components/title-breadcrumb.test.tsx
@@ -53,6 +53,9 @@ describe("NoteTitleBreadcrumb", () => {
 
     expect(screen.getByText("work")).not.toBeNull();
     expect(screen.getByText("meetings")).not.toBeNull();
+    expect(screen.getByText("work").parentElement?.className).toContain(
+      "min-w-0",
+    );
     expect(screen.getAllByText("/")).toHaveLength(2);
     expect(screen.getByLabelText("Session title")).not.toBeNull();
   });

--- a/apps/desktop/src/session/components/title-breadcrumb.test.tsx
+++ b/apps/desktop/src/session/components/title-breadcrumb.test.tsx
@@ -23,7 +23,7 @@ describe("NoteTitleBreadcrumb", () => {
     cleanup();
   });
 
-  it("renders the root folder crumb before the editable title", () => {
+  it("renders only the editable title when no folder is set", () => {
     render(
       <NoteTitleBreadcrumb
         sessionId="session-1"
@@ -36,7 +36,7 @@ describe("NoteTitleBreadcrumb", () => {
     });
     const title = screen.getByLabelText("Session title");
 
-    expect(screen.getByText("Select folder")).not.toBeNull();
+    expect(screen.queryByText("Select folder")).toBeNull();
     expect(breadcrumb.contains(title)).toBe(true);
     expect(breadcrumb.getAttribute("data-tauri-drag-region")).toBe("false");
   });
@@ -53,6 +53,7 @@ describe("NoteTitleBreadcrumb", () => {
 
     expect(screen.getByText("work")).not.toBeNull();
     expect(screen.getByText("meetings")).not.toBeNull();
+    expect(screen.getAllByText("/")).toHaveLength(2);
     expect(screen.getByLabelText("Session title")).not.toBeNull();
   });
 });

--- a/apps/desktop/src/session/components/title-breadcrumb.test.tsx
+++ b/apps/desktop/src/session/components/title-breadcrumb.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NoteTitleBreadcrumb } from "./title-breadcrumb";
+
+const mocks = vi.hoisted(() => ({
+  folderId: "",
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useCell: () => mocks.folderId,
+  },
+}));
+
+describe("NoteTitleBreadcrumb", () => {
+  beforeEach(() => {
+    mocks.folderId = "";
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the root folder crumb before the editable title", () => {
+    render(
+      <NoteTitleBreadcrumb
+        sessionId="session-1"
+        title={<input aria-label="Session title" />}
+      />,
+    );
+
+    const breadcrumb = screen.getByRole("navigation", {
+      name: "Note breadcrumb",
+    });
+    const title = screen.getByLabelText("Session title");
+
+    expect(screen.getByText("Select folder")).not.toBeNull();
+    expect(breadcrumb.contains(title)).toBe(true);
+    expect(breadcrumb.getAttribute("data-tauri-drag-region")).toBe("false");
+  });
+
+  it("renders persisted folder path crumbs before the editable title", () => {
+    mocks.folderId = "work/meetings";
+
+    render(
+      <NoteTitleBreadcrumb
+        sessionId="session-1"
+        title={<input aria-label="Session title" />}
+      />,
+    );
+
+    expect(screen.getByText("work")).not.toBeNull();
+    expect(screen.getByText("meetings")).not.toBeNull();
+    expect(screen.getByLabelText("Session title")).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/session/components/title-breadcrumb.tsx
+++ b/apps/desktop/src/session/components/title-breadcrumb.tsx
@@ -1,4 +1,4 @@
-import { ChevronRightIcon, FolderIcon } from "lucide-react";
+import { FolderIcon } from "lucide-react";
 import { useMemo } from "react";
 
 import { cn } from "@hypr/utils";
@@ -42,13 +42,9 @@ export function NoteTitleBreadcrumb({
                 showSeparator={index > 0}
               />
             ))}
+            <BreadcrumbSeparator />
           </>
-        ) : (
-          <li className="shrink-0">
-            <span className="text-neutral-500">Select folder</span>
-          </li>
-        )}
-        <BreadcrumbSeparator />
+        ) : null}
         <li className="min-w-0 overflow-hidden">
           <span aria-current="page" className="text-foreground font-normal">
             {title}
@@ -78,8 +74,8 @@ function BreadcrumbFolderCrumb({
 
 function BreadcrumbSeparator() {
   return (
-    <li aria-hidden="true" className="shrink-0">
-      <ChevronRightIcon className="text-muted-foreground size-3.5" />
+    <li aria-hidden="true" className="text-muted-foreground shrink-0 px-0.5">
+      /
     </li>
   );
 }

--- a/apps/desktop/src/session/components/title-breadcrumb.tsx
+++ b/apps/desktop/src/session/components/title-breadcrumb.tsx
@@ -1,0 +1,98 @@
+import { ChevronRightIcon, FolderIcon } from "lucide-react";
+import { useMemo } from "react";
+
+import { cn } from "@hypr/utils";
+
+import * as main from "~/store/tinybase/store/main";
+
+export function NoteTitleBreadcrumb({
+  sessionId,
+  title,
+}: {
+  sessionId: string;
+  title: React.ReactNode;
+}) {
+  const folderId = main.UI.useCell(
+    "sessions",
+    sessionId,
+    "folder_id",
+    main.STORE_ID,
+  ) as string | undefined;
+  const folderChain = useFolderChain(folderId);
+
+  return (
+    <nav
+      aria-label="Note breadcrumb"
+      data-tauri-drag-region="false"
+      className={cn([
+        "ml-1.5 flex max-w-full min-w-0 items-center overflow-hidden",
+        "text-xs text-neutral-700",
+      ])}
+    >
+      <ol className="flex min-w-0 flex-nowrap items-center gap-0.5 overflow-hidden">
+        {folderChain.length > 0 ? (
+          <>
+            <li className="mr-1 shrink-0">
+              <FolderIcon aria-hidden="true" className="size-3" />
+            </li>
+            {folderChain.map((folder, index) => (
+              <BreadcrumbFolderCrumb
+                key={folder.id}
+                name={folder.name}
+                showSeparator={index > 0}
+              />
+            ))}
+          </>
+        ) : (
+          <li className="shrink-0">
+            <span className="text-neutral-500">Select folder</span>
+          </li>
+        )}
+        <BreadcrumbSeparator />
+        <li className="min-w-0 overflow-hidden">
+          <span aria-current="page" className="text-foreground font-normal">
+            {title}
+          </span>
+        </li>
+      </ol>
+    </nav>
+  );
+}
+
+function BreadcrumbFolderCrumb({
+  name,
+  showSeparator,
+}: {
+  name: string;
+  showSeparator: boolean;
+}) {
+  return (
+    <>
+      {showSeparator ? <BreadcrumbSeparator /> : null}
+      <li className="overflow-hidden">
+        <span className="truncate text-neutral-600">{name}</span>
+      </li>
+    </>
+  );
+}
+
+function BreadcrumbSeparator() {
+  return (
+    <li aria-hidden="true" className="shrink-0">
+      <ChevronRightIcon className="text-muted-foreground size-3.5" />
+    </li>
+  );
+}
+
+function useFolderChain(folderId: string | undefined) {
+  return useMemo(() => {
+    const parts = (folderId ?? "").split("/").filter(Boolean);
+    return parts.map((_, index) => {
+      const id = parts.slice(0, index + 1).join("/");
+      return {
+        id,
+        name: parts[index] || "Untitled",
+      };
+    });
+  }, [folderId]);
+}

--- a/apps/desktop/src/session/components/title-breadcrumb.tsx
+++ b/apps/desktop/src/session/components/title-breadcrumb.tsx
@@ -65,7 +65,7 @@ function BreadcrumbFolderCrumb({
   return (
     <>
       {showSeparator ? <BreadcrumbSeparator /> : null}
-      <li className="overflow-hidden">
+      <li className="min-w-0 overflow-hidden">
         <span className="truncate text-neutral-600">{name}</span>
       </li>
     </>

--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -113,6 +113,17 @@ describe("TitleInput", () => {
     );
   });
 
+  it("uses sans-serif styling for breadcrumb titles", () => {
+    renderTitleInput({ variant: "breadcrumb" });
+
+    const input = screen.getByPlaceholderText("Untitled");
+
+    expect(input.parentElement?.className).toContain("text-xs");
+    expect(input.parentElement?.className).not.toContain("font-mono");
+    expect(input.className).toContain("text-xs");
+    expect(input.className).not.toContain("font-mono");
+  });
+
   it("uses the flexible title layout for whitespace-only titles", () => {
     hoisted.storeTitle = "          ";
 

--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -119,8 +119,10 @@ describe("TitleInput", () => {
     const input = screen.getByPlaceholderText("Untitled");
 
     expect(input.parentElement?.className).toContain("text-sm");
+    expect(input.parentElement?.className).toContain("leading-none");
     expect(input.parentElement?.className).not.toContain("font-mono");
     expect(input.className).toContain("text-sm");
+    expect(input.className).toContain("leading-none");
     expect(input.className).not.toContain("font-mono");
   });
 

--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -125,7 +125,19 @@ describe("TitleInput", () => {
     expect(input.className).toContain("leading-5");
     expect(input.className).toContain("appearance-none");
     expect(input.className).toContain("p-0");
+    expect(input.className).toContain("truncate");
     expect(input.className).not.toContain("font-mono");
+  });
+
+  it("keeps focused breadcrumb titles horizontally scrollable", () => {
+    renderTitleInput({ variant: "breadcrumb" });
+
+    const input = screen.getByPlaceholderText("Untitled");
+    fireEvent.focus(input);
+
+    expect(input.className).not.toContain("truncate");
+    expect(input.className).toContain("overflow-x-auto");
+    expect(input.className).toContain("whitespace-nowrap");
   });
 
   it("uses the flexible title layout for whitespace-only titles", () => {

--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -118,9 +118,9 @@ describe("TitleInput", () => {
 
     const input = screen.getByPlaceholderText("Untitled");
 
-    expect(input.parentElement?.className).toContain("text-xs");
+    expect(input.parentElement?.className).toContain("text-sm");
     expect(input.parentElement?.className).not.toContain("font-mono");
-    expect(input.className).toContain("text-xs");
+    expect(input.className).toContain("text-sm");
     expect(input.className).not.toContain("font-mono");
   });
 

--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -119,10 +119,12 @@ describe("TitleInput", () => {
     const input = screen.getByPlaceholderText("Untitled");
 
     expect(input.parentElement?.className).toContain("text-sm");
-    expect(input.parentElement?.className).toContain("leading-none");
+    expect(input.parentElement?.className).toContain("leading-5");
     expect(input.parentElement?.className).not.toContain("font-mono");
     expect(input.className).toContain("text-sm");
-    expect(input.className).toContain("leading-none");
+    expect(input.className).toContain("leading-5");
+    expect(input.className).toContain("appearance-none");
+    expect(input.className).toContain("p-0");
     expect(input.className).not.toContain("font-mono");
   });
 

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -82,13 +82,15 @@ export const TitleInput = forwardRef<
           data-tauri-drag-region="false"
           className={cn([
             "flex w-full items-center justify-start",
-            variant === "breadcrumb" ? "h-7" : "h-8",
+            variant === "breadcrumb" ? "h-5" : "h-8",
           ])}
         >
           <span
             className={cn([
               "text-muted-foreground animate-pulse",
-              variant === "breadcrumb" ? "text-sm" : "text-xl font-semibold",
+              variant === "breadcrumb"
+                ? "text-sm leading-none"
+                : "text-xl font-semibold",
             ])}
           >
             Generating title...
@@ -103,13 +105,15 @@ export const TitleInput = forwardRef<
           data-tauri-drag-region="false"
           className={cn([
             "flex w-full items-center justify-start overflow-hidden",
-            variant === "breadcrumb" ? "h-7" : "h-8",
+            variant === "breadcrumb" ? "h-5" : "h-8",
           ])}
         >
           <span
             className={cn([
               "animate-reveal-left whitespace-nowrap",
-              variant === "breadcrumb" ? "text-sm" : "text-xl font-semibold",
+              variant === "breadcrumb"
+                ? "text-sm leading-none"
+                : "text-xl font-semibold",
             ])}
           >
             {generatedTitle}
@@ -366,7 +370,7 @@ const TitleInputInner = memo(
           className={cn([
             "group/title-input relative flex max-w-full items-center overflow-hidden",
             variant === "breadcrumb"
-              ? "h-7 text-sm"
+              ? "h-5 text-sm leading-none"
               : "h-8 text-xl font-semibold",
           ])}
         >
@@ -407,7 +411,7 @@ const TitleInputInner = memo(
               "border-none bg-transparent focus:outline-hidden",
               "placeholder:text-muted-foreground text-left",
               variant === "breadcrumb"
-                ? "truncate text-sm text-neutral-700 focus:underline"
+                ? "h-5 truncate text-sm leading-none text-neutral-700 focus:underline"
                 : "text-xl font-semibold",
               showHoverReveal && "text-transparent caret-transparent",
             ])}
@@ -422,7 +426,7 @@ const TitleInputInner = memo(
                 className={cn([
                   "group-hover/title-input:animate-title-hover-scroll whitespace-nowrap group-hover/title-input:will-change-transform",
                   variant === "breadcrumb"
-                    ? "text-sm"
+                    ? "text-sm leading-none"
                     : "text-xl font-semibold",
                 ])}
               >

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -82,13 +82,13 @@ export const TitleInput = forwardRef<
           data-tauri-drag-region="false"
           className={cn([
             "flex w-full items-center justify-start",
-            variant === "breadcrumb" ? "h-6" : "h-8",
+            variant === "breadcrumb" ? "h-7" : "h-8",
           ])}
         >
           <span
             className={cn([
               "text-muted-foreground animate-pulse",
-              variant === "breadcrumb" ? "text-xs" : "text-xl font-semibold",
+              variant === "breadcrumb" ? "text-sm" : "text-xl font-semibold",
             ])}
           >
             Generating title...
@@ -103,13 +103,13 @@ export const TitleInput = forwardRef<
           data-tauri-drag-region="false"
           className={cn([
             "flex w-full items-center justify-start overflow-hidden",
-            variant === "breadcrumb" ? "h-6" : "h-8",
+            variant === "breadcrumb" ? "h-7" : "h-8",
           ])}
         >
           <span
             className={cn([
               "animate-reveal-left whitespace-nowrap",
-              variant === "breadcrumb" ? "text-xs" : "text-xl font-semibold",
+              variant === "breadcrumb" ? "text-sm" : "text-xl font-semibold",
             ])}
           >
             {generatedTitle}
@@ -366,7 +366,7 @@ const TitleInputInner = memo(
           className={cn([
             "group/title-input relative flex max-w-full items-center overflow-hidden",
             variant === "breadcrumb"
-              ? "h-6 text-xs"
+              ? "h-7 text-sm"
               : "h-8 text-xl font-semibold",
           ])}
         >
@@ -407,7 +407,7 @@ const TitleInputInner = memo(
               "border-none bg-transparent focus:outline-hidden",
               "placeholder:text-muted-foreground text-left",
               variant === "breadcrumb"
-                ? "truncate text-xs text-neutral-700 focus:underline"
+                ? "truncate text-sm text-neutral-700 focus:underline"
                 : "text-xl font-semibold",
               showHoverReveal && "text-transparent caret-transparent",
             ])}
@@ -422,7 +422,7 @@ const TitleInputInner = memo(
                 className={cn([
                   "group-hover/title-input:animate-title-hover-scroll whitespace-nowrap group-hover/title-input:will-change-transform",
                   variant === "breadcrumb"
-                    ? "text-xs"
+                    ? "text-sm"
                     : "text-xl font-semibold",
                 ])}
               >

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -411,8 +411,12 @@ const TitleInputInner = memo(
               "border-none bg-transparent focus:outline-hidden",
               "placeholder:text-muted-foreground text-left",
               variant === "breadcrumb"
-                ? "h-5 appearance-none truncate p-0 text-sm leading-5 text-neutral-700 focus:underline"
+                ? "h-5 appearance-none p-0 text-sm leading-5 text-neutral-700 focus:underline"
                 : "text-xl font-semibold",
+              variant === "breadcrumb" &&
+                (isTitleFocused
+                  ? "overflow-x-auto whitespace-nowrap"
+                  : "truncate"),
               showHoverReveal && "text-transparent caret-transparent",
             ])}
           />

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -32,6 +32,7 @@ export const TitleInput = forwardRef<
     onTransferContentToEditor?: (content: string) => void;
     onFocusEditorAtStart?: () => void;
     onFocusEditorAtPixelWidth?: (pixelWidth: number) => void;
+    variant?: "title" | "breadcrumb";
   }
 >(
   (
@@ -40,6 +41,7 @@ export const TitleInput = forwardRef<
       onTransferContentToEditor,
       onFocusEditorAtStart,
       onFocusEditorAtPixelWidth,
+      variant = "title",
     },
     ref,
   ) => {
@@ -78,9 +80,19 @@ export const TitleInput = forwardRef<
       return (
         <div
           data-tauri-drag-region="false"
-          className="flex h-8 w-full items-center justify-start"
+          className={cn([
+            "flex w-full items-center justify-start",
+            variant === "breadcrumb" ? "h-6" : "h-8",
+          ])}
         >
-          <span className="text-muted-foreground animate-pulse text-xl font-semibold">
+          <span
+            className={cn([
+              "text-muted-foreground animate-pulse",
+              variant === "breadcrumb"
+                ? "font-mono text-xs"
+                : "text-xl font-semibold",
+            ])}
+          >
             Generating title...
           </span>
         </div>
@@ -91,9 +103,19 @@ export const TitleInput = forwardRef<
       return (
         <div
           data-tauri-drag-region="false"
-          className="flex h-8 w-full items-center justify-start overflow-hidden"
+          className={cn([
+            "flex w-full items-center justify-start overflow-hidden",
+            variant === "breadcrumb" ? "h-6" : "h-8",
+          ])}
         >
-          <span className="animate-reveal-left text-xl font-semibold whitespace-nowrap">
+          <span
+            className={cn([
+              "animate-reveal-left whitespace-nowrap",
+              variant === "breadcrumb"
+                ? "font-mono text-xs"
+                : "text-xl font-semibold",
+            ])}
+          >
             {generatedTitle}
           </span>
         </div>
@@ -108,6 +130,7 @@ export const TitleInput = forwardRef<
         onTransferContentToEditor={onTransferContentToEditor}
         onFocusEditorAtStart={onFocusEditorAtStart}
         onFocusEditorAtPixelWidth={onFocusEditorAtPixelWidth}
+        variant={variant}
       />
     );
   },
@@ -122,6 +145,7 @@ const TitleInputInner = memo(
       onTransferContentToEditor?: (content: string) => void;
       onFocusEditorAtStart?: () => void;
       onFocusEditorAtPixelWidth?: (pixelWidth: number) => void;
+      variant: "title" | "breadcrumb";
     }
   >(
     (
@@ -131,6 +155,7 @@ const TitleInputInner = memo(
         onTransferContentToEditor,
         onFocusEditorAtStart,
         onFocusEditorAtPixelWidth,
+        variant,
       },
       ref,
     ) => {
@@ -342,7 +367,12 @@ const TitleInputInner = memo(
         <div
           data-tauri-drag-region="false"
           style={titleShellStyle}
-          className="group/title-input relative flex h-8 max-w-full items-center overflow-hidden text-xl font-semibold"
+          className={cn([
+            "group/title-input relative flex max-w-full items-center overflow-hidden",
+            variant === "breadcrumb"
+              ? "h-6 font-mono text-xs"
+              : "h-8 text-xl font-semibold",
+          ])}
         >
           <input
             data-tauri-drag-region="false"
@@ -379,7 +409,10 @@ const TitleInputInner = memo(
             className={cn([
               "w-full min-w-0 transition-opacity duration-200",
               "border-none bg-transparent focus:outline-hidden",
-              "placeholder:text-muted-foreground text-left text-xl font-semibold",
+              "placeholder:text-muted-foreground text-left",
+              variant === "breadcrumb"
+                ? "truncate text-xs text-neutral-700 focus:underline"
+                : "text-xl font-semibold",
               showHoverReveal && "text-transparent caret-transparent",
             ])}
           />
@@ -390,7 +423,12 @@ const TitleInputInner = memo(
             >
               <span
                 style={titleHoverScrollStyle}
-                className="group-hover/title-input:animate-title-hover-scroll text-xl font-semibold whitespace-nowrap group-hover/title-input:will-change-transform"
+                className={cn([
+                  "group-hover/title-input:animate-title-hover-scroll whitespace-nowrap group-hover/title-input:will-change-transform",
+                  variant === "breadcrumb"
+                    ? "font-mono text-xs"
+                    : "text-xl font-semibold",
+                ])}
               >
                 {title}
               </span>

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -89,7 +89,7 @@ export const TitleInput = forwardRef<
             className={cn([
               "text-muted-foreground animate-pulse",
               variant === "breadcrumb"
-                ? "text-sm leading-none"
+                ? "text-sm leading-5"
                 : "text-xl font-semibold",
             ])}
           >
@@ -112,7 +112,7 @@ export const TitleInput = forwardRef<
             className={cn([
               "animate-reveal-left whitespace-nowrap",
               variant === "breadcrumb"
-                ? "text-sm leading-none"
+                ? "text-sm leading-5"
                 : "text-xl font-semibold",
             ])}
           >
@@ -370,7 +370,7 @@ const TitleInputInner = memo(
           className={cn([
             "group/title-input relative flex max-w-full items-center overflow-hidden",
             variant === "breadcrumb"
-              ? "h-5 text-sm leading-none"
+              ? "h-5 text-sm leading-5"
               : "h-8 text-xl font-semibold",
           ])}
         >
@@ -411,7 +411,7 @@ const TitleInputInner = memo(
               "border-none bg-transparent focus:outline-hidden",
               "placeholder:text-muted-foreground text-left",
               variant === "breadcrumb"
-                ? "h-5 truncate text-sm leading-none text-neutral-700 focus:underline"
+                ? "h-5 appearance-none truncate p-0 text-sm leading-5 text-neutral-700 focus:underline"
                 : "text-xl font-semibold",
               showHoverReveal && "text-transparent caret-transparent",
             ])}
@@ -426,7 +426,7 @@ const TitleInputInner = memo(
                 className={cn([
                   "group-hover/title-input:animate-title-hover-scroll whitespace-nowrap group-hover/title-input:will-change-transform",
                   variant === "breadcrumb"
-                    ? "text-sm leading-none"
+                    ? "text-sm leading-5"
                     : "text-xl font-semibold",
                 ])}
               >

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -88,9 +88,7 @@ export const TitleInput = forwardRef<
           <span
             className={cn([
               "text-muted-foreground animate-pulse",
-              variant === "breadcrumb"
-                ? "font-mono text-xs"
-                : "text-xl font-semibold",
+              variant === "breadcrumb" ? "text-xs" : "text-xl font-semibold",
             ])}
           >
             Generating title...
@@ -111,9 +109,7 @@ export const TitleInput = forwardRef<
           <span
             className={cn([
               "animate-reveal-left whitespace-nowrap",
-              variant === "breadcrumb"
-                ? "font-mono text-xs"
-                : "text-xl font-semibold",
+              variant === "breadcrumb" ? "text-xs" : "text-xl font-semibold",
             ])}
           >
             {generatedTitle}
@@ -370,7 +366,7 @@ const TitleInputInner = memo(
           className={cn([
             "group/title-input relative flex max-w-full items-center overflow-hidden",
             variant === "breadcrumb"
-              ? "h-6 font-mono text-xs"
+              ? "h-6 text-xs"
               : "h-8 text-xl font-semibold",
           ])}
         >
@@ -426,7 +422,7 @@ const TitleInputInner = memo(
                 className={cn([
                   "group-hover/title-input:animate-title-hover-scroll whitespace-nowrap group-hover/title-input:will-change-transform",
                   variant === "breadcrumb"
-                    ? "font-mono text-xs"
+                    ? "text-xs"
                     : "text-xl font-semibold",
                 ])}
               >

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -12,6 +12,7 @@ import { SearchProvider } from "./components/note-input/search/context";
 import { OuterHeader } from "./components/outer-header";
 import { SessionSurface } from "./components/session-surface";
 import { useCurrentNoteTab, useHasTranscript } from "./components/shared";
+import { NoteTitleBreadcrumb } from "./components/title-breadcrumb";
 import { TitleInput, type TitleInputHandle } from "./components/title-input";
 import { useAutoEnhance } from "./hooks/useAutoEnhance";
 
@@ -189,12 +190,18 @@ function TabContentNoteInner({
           currentView={currentView}
           standaloneWindow={standaloneWindow}
           title={
-            <TitleInput
-              ref={titleInputRef}
-              tab={tab}
-              onTransferContentToEditor={handleTransferContentToEditor}
-              onFocusEditorAtStart={handleFocusEditorAtStart}
-              onFocusEditorAtPixelWidth={handleFocusEditorAtPixelWidth}
+            <NoteTitleBreadcrumb
+              sessionId={tab.id}
+              title={
+                <TitleInput
+                  ref={titleInputRef}
+                  tab={tab}
+                  variant="breadcrumb"
+                  onTransferContentToEditor={handleTransferContentToEditor}
+                  onFocusEditorAtStart={handleFocusEditorAtStart}
+                  onFocusEditorAtPixelWidth={handleFocusEditorAtPixelWidth}
+                />
+              }
             />
           }
         />

--- a/apps/desktop/src/shared/window-shell.test.tsx
+++ b/apps/desktop/src/shared/window-shell.test.tsx
@@ -1,0 +1,32 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StandaloneWindowShell } from "./window-shell";
+
+describe("StandaloneWindowShell", () => {
+  it("renders a top drag region by default", () => {
+    const { container } = render(
+      <StandaloneWindowShell>
+        <div>Content</div>
+      </StandaloneWindowShell>,
+    );
+
+    const dragRegion = container.querySelector(
+      "[data-standalone-window-top-drag-region]",
+    );
+
+    expect(dragRegion?.hasAttribute("data-tauri-drag-region")).toBe(true);
+  });
+
+  it("can omit the top drag region when nested controls own hit testing", () => {
+    const { container } = render(
+      <StandaloneWindowShell topDragRegion={false}>
+        <div>Content</div>
+      </StandaloneWindowShell>,
+    );
+
+    expect(
+      container.querySelector("[data-standalone-window-top-drag-region]"),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop/src/shared/window-shell.tsx
+++ b/apps/desktop/src/shared/window-shell.tsx
@@ -1,14 +1,19 @@
 export function StandaloneWindowShell({
   children,
+  topDragRegion = true,
 }: {
   children: React.ReactNode;
+  topDragRegion?: boolean;
 }) {
   return (
     <div className="relative flex h-full flex-col">
-      <div
-        data-tauri-drag-region
-        className="absolute inset-x-0 top-0 z-20 h-10"
-      />
+      {topDragRegion ? (
+        <div
+          data-tauri-drag-region
+          data-standalone-window-top-drag-region
+          className="absolute inset-x-0 top-0 z-20 h-10"
+        />
+      ) : null}
       {children}
     </div>
   );


### PR DESCRIPTION
Make the standalone window drag strip optional and disable it for note windows so title and header controls receive clicks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop UI and Tauri drag-region behavior only; no auth, data, or backend changes.
> 
> **Overview**
> Fixes **standalone note window** clicks being swallowed by a full-width top drag overlay by adding **`topDragRegion`** on `StandaloneWindowShell` (default on) and turning it **off** on the note route so header title and controls get hit testing.
> 
> The session header title is now a **`NoteTitleBreadcrumb`** that shows persisted **`folder_id`** path segments (when set) before the editable title, with **`TitleInput`** **`variant="breadcrumb"`** for smaller sans-serif styling, truncation when blurred, and horizontal scroll when focused. Breadcrumb/nav nodes mark **`data-tauri-drag-region="false"`** so they stay clickable inside draggable chrome.
> 
> Tests cover the shell drag flag, breadcrumb rendering, breadcrumb title input behavior, and that the expanded-sidebar title slot is **left-aligned** (not `justify-center`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2852562411d4bb59f8a4c8dd8c0b5ac6835cf4a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5660 
- <kbd>&nbsp;2&nbsp;</kbd> #5659 
- <kbd>&nbsp;1&nbsp;</kbd> #5658 👈 
<!-- GitButler Footer Boundary Bottom -->

