### PR TITLE
Replace title input with note tabs

### DIFF
--- a/apps/desktop/src/session/components/compute-note-tab.ts
+++ b/apps/desktop/src/session/components/compute-note-tab.ts
@@ -6,14 +6,26 @@ export function computeCurrentNoteTab(
   firstEnhancedNoteId: string | undefined,
 ): EditorView {
   if (isLiveSessionActive) {
-    if (tabView?.type === "raw") {
+    if (tabView?.type === "raw" || tabView?.type === "transcript") {
       return tabView;
     }
     return { type: "raw" };
   }
 
   if (tabView) {
-    if (tabView.type === "enhanced" || tabView.type === "raw") {
+    if (tabView.type === "enhanced") {
+      if (firstEnhancedNoteId && tabView.id === firstEnhancedNoteId) {
+        return tabView;
+      }
+
+      if (firstEnhancedNoteId) {
+        return { type: "enhanced", id: firstEnhancedNoteId };
+      }
+
+      return { type: "raw" };
+    }
+
+    if (tabView.type === "raw" || tabView.type === "transcript") {
       return tabView;
     }
 
@@ -25,4 +37,15 @@ export function computeCurrentNoteTab(
   }
 
   return { type: "raw" };
+}
+
+export function getPersistedNoteTabView(
+  tabView: EditorView,
+  isLiveSessionActive: boolean,
+): EditorView {
+  if (isLiveSessionActive && tabView.type === "enhanced") {
+    return { type: "raw" };
+  }
+
+  return tabView;
 }

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -1,11 +1,15 @@
 import {
+  AlignLeftIcon,
   AlertCircleIcon,
+  AudioLinesIcon,
+  ChevronDownIcon,
   ChevronRightIcon,
   HeartIcon,
   LightbulbIcon,
   PlusIcon,
   RefreshCwIcon,
   SearchIcon,
+  SparklesIcon,
   XIcon,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -36,7 +40,6 @@ import { useAITaskTask } from "~/ai/hooks";
 import { useLanguageModel, useLLMConnectionStatus } from "~/ai/hooks";
 import { extractPlainText } from "~/search/contexts/engine/utils";
 import { getEnhancerService } from "~/services/enhancer";
-import { useHasTranscript } from "~/session/components/shared";
 import { shouldShowEmptySummaryConfigError } from "~/session/enhance-config";
 import { useEnsureDefaultSummary } from "~/session/hooks/useEnhancedNotes";
 import {
@@ -48,7 +51,6 @@ import * as main from "~/store/tinybase/store/main";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { type EditorView } from "~/store/zustand/tabs/schema";
-import { useListener } from "~/stt/contexts";
 import {
   filterWebTemplatesAgainstUserTemplates,
   getTemplateCreatorLabel,
@@ -59,22 +61,6 @@ import {
   useUserTemplates,
   type WebTemplate,
 } from "~/templates";
-
-function TruncatedTitle({
-  title,
-  isActive,
-}: {
-  title: string;
-  isActive: boolean;
-}) {
-  return (
-    <span
-      className={cn(["truncate", isActive ? "max-w-[120px]" : "max-w-[60px]"])}
-    >
-      {title}
-    </span>
-  );
-}
 
 function getStoredNoteMarkdown(content: string | undefined) {
   const trimmed = content?.trim() ?? "";
@@ -204,8 +190,166 @@ function HeaderTabRaw({
       onClick={onClick}
       onContextMenu={showContextMenu}
     >
-      Memos
+      <AlignLeftIcon size={14} />
+      <span>Memos</span>
     </NoteTab>
+  );
+}
+
+function HeaderTabTranscript({
+  isActive,
+  onClick = () => {},
+  sessionId,
+}: {
+  isActive: boolean;
+  onClick?: () => void;
+  sessionId: string;
+}) {
+  const { data: transcriptSegments, isLoading } =
+    useTranscriptExportSegments(sessionId);
+  const transcriptMarkdown = useMemo(
+    () => formatTranscriptExportSegments(transcriptSegments),
+    [transcriptSegments],
+  );
+  const contextMenu = useMemo<MenuItemDef[]>(
+    () => [
+      {
+        id: `copy-transcript-${sessionId}`,
+        text: isLoading ? "Loading transcript..." : "Copy",
+        action: () => {
+          void copyTextToClipboard(transcriptMarkdown, {
+            success: "Transcript copied to clipboard",
+            error: "Failed to copy transcript",
+          });
+        },
+        disabled: isLoading || transcriptMarkdown.length === 0,
+      },
+    ],
+    [isLoading, sessionId, transcriptMarkdown],
+  );
+  const showContextMenu = useNativeContextMenu(contextMenu);
+
+  return (
+    <NoteTab
+      data-main-area-window-drag-region
+      data-tauri-drag-region="false"
+      className={SESSION_NOTE_TAB_CLASSNAME}
+      isActive={isActive}
+      onClick={onClick}
+      onContextMenu={showContextMenu}
+    >
+      <AudioLinesIcon size={14} />
+      <span>Transcript</span>
+    </NoteTab>
+  );
+}
+
+function HeaderTabSummaryPending({
+  isActive,
+  onActivate,
+  sessionId,
+}: {
+  isActive: boolean;
+  onActivate: (view: Extract<EditorView, { type: "enhanced" }>) => void;
+  sessionId: string;
+}) {
+  const ensureSummary = useCallback(
+    (templateId?: string | null) => {
+      const service = getEnhancerService();
+      if (!service) {
+        return;
+      }
+
+      const enhancedNoteId = service.ensureNote(
+        sessionId,
+        templateId || undefined,
+      );
+      onActivate({ type: "enhanced", id: enhancedNoteId });
+    },
+    [onActivate, sessionId],
+  );
+  const regenerateSummary = useCallback(
+    (templateId?: string | null) => {
+      const service = getEnhancerService();
+      if (!service) {
+        return;
+      }
+
+      const result = service.enhance(sessionId, {
+        templateId: templateId || undefined,
+      });
+      const enhancedNoteId =
+        "noteId" in result
+          ? result.noteId
+          : service.ensureNote(sessionId, templateId || undefined);
+      onActivate({ type: "enhanced", id: enhancedNoteId });
+    },
+    [onActivate, sessionId],
+  );
+  const contextMenu = useMemo<MenuItemDef[]>(
+    () => [
+      {
+        id: `copy-enhanced-pending-${sessionId}`,
+        text: "Copy",
+        action: () => {},
+        disabled: true,
+      },
+      {
+        id: `regenerate-enhanced-pending-${sessionId}`,
+        text: "Regenerate",
+        action: () => regenerateSummary(),
+      },
+    ],
+    [regenerateSummary, sessionId],
+  );
+  const showContextMenu = useNativeContextMenu(contextMenu);
+  const menuTrigger = (
+    <button
+      type="button"
+      data-main-area-window-drag-region
+      data-tauri-drag-region="false"
+      aria-label="Summary templates"
+      className="hover:bg-accent hover:text-foreground flex h-5 w-5 items-center justify-center rounded-xs transition-colors"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <ChevronDownIcon size={13} />
+    </button>
+  );
+
+  return (
+    <div
+      data-main-area-window-drag-region
+      data-tauri-drag-region="false"
+      className={cn([
+        "relative flex h-6 shrink-0 items-center border-b-2 py-0.5 text-xs font-medium transition-all duration-200 select-none",
+        isActive
+          ? ["border-foreground", "text-foreground"]
+          : [
+              "border-transparent",
+              "text-muted-foreground",
+              "hover:text-foreground",
+            ],
+        SESSION_NOTE_TAB_CLASSNAME,
+      ])}
+      onContextMenu={showContextMenu}
+    >
+      <button
+        type="button"
+        data-main-area-window-drag-region
+        data-tauri-drag-region="false"
+        className="flex h-5 items-center gap-1 px-1"
+        onClick={() => ensureSummary()}
+      >
+        <SparklesIcon size={14} />
+        <span>Summary</span>
+      </button>
+      <SummaryTemplateMenu
+        sessionId={sessionId}
+        isGenerating={false}
+        onRegenerate={regenerateSummary}
+        trigger={menuTrigger}
+      />
+    </div>
   );
 }
 
@@ -214,15 +358,11 @@ function HeaderTabEnhanced({
   onClick = () => {},
   sessionId,
   enhancedNoteId,
-  canRemove = false,
-  onRemove,
 }: {
   isActive: boolean;
   onClick?: () => void;
   sessionId: string;
   enhancedNoteId: string;
-  canRemove?: boolean;
-  onRemove?: () => void;
 }) {
   const { isGenerating, isError, onRegenerate } = useEnhanceLogic(
     sessionId,
@@ -262,18 +402,11 @@ function HeaderTabEnhanced({
       error: `Failed to copy ${tabTitle}`,
     });
   }, [noteMarkdown, tabTitle]);
-  const handleRegenerate = useCallback(() => {
-    void onRegenerate(null);
-  }, [onRegenerate]);
-  const handleRegenerateClick = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      if (isGenerating) {
-        return;
-      }
-      handleRegenerate();
+  const handleRegenerate = useCallback(
+    (templateId: string | null = null) => {
+      void onRegenerate(templateId);
     },
-    [handleRegenerate, isGenerating],
+    [onRegenerate],
   );
   const handleExploreTemplatesClick = useCallback(
     (e: React.MouseEvent) => {
@@ -333,7 +466,7 @@ function HeaderTabEnhanced({
     [handleExploreTemplatesClick, templateId, templateTitle],
   );
   const contextMenu = useMemo<MenuItemDef[]>(() => {
-    const items: MenuItemDef[] = [
+    return [
       {
         id: `copy-enhanced-${enhancedNoteId}`,
         text: "Copy",
@@ -349,76 +482,76 @@ function HeaderTabEnhanced({
         disabled: isGenerating,
       },
     ];
-
-    if (canRemove) {
-      items.push({ separator: true });
-      items.push({
-        id: `remove-enhanced-${enhancedNoteId}`,
-        text: "Remove",
-        action: () => {
-          onRemove?.();
-        },
-        disabled: isGenerating || !onRemove,
-      });
-    }
-
-    return items;
   }, [
-    canRemove,
     enhancedNoteId,
     handleCopy,
     handleRegenerate,
     isGenerating,
     noteMarkdown.length,
-    onRemove,
   ]);
   const showContextMenu = useNativeContextMenu(contextMenu);
 
-  const regenerateIcon = (
-    <span
+  const menuTrigger = (
+    <button
+      type="button"
       data-main-area-window-drag-region
       data-tauri-drag-region="false"
-      onClick={handleRegenerateClick}
+      aria-label="Summary templates"
       className={cn([
-        "group relative inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-xs transition-colors",
+        "flex h-5 w-5 items-center justify-center rounded-xs transition-colors",
         isError
           ? [
-              "hover:text-foreground focus-visible:text-foreground text-red-600 hover:bg-red-50 focus-visible:bg-red-50",
-              "dark:text-red-400 dark:hover:bg-red-950/50 dark:focus-visible:bg-red-950/50",
+              "text-red-600 hover:bg-red-50 hover:text-red-700",
+              "dark:text-red-400 dark:hover:bg-red-950/50 dark:hover:text-red-300",
             ]
-          : ["hover:bg-accent focus-visible:bg-muted"],
+          : "hover:bg-accent hover:text-foreground",
       ])}
+      onClick={(e) => e.stopPropagation()}
     >
-      {isError && (
-        <AlertCircleIcon
-          size={12}
-          className="pointer-events-none absolute inset-0 m-auto transition-opacity duration-200 group-hover:opacity-0 group-focus-visible:opacity-0"
-        />
+      {isError ? (
+        <AlertCircleIcon size={12} />
+      ) : isGenerating ? (
+        <RefreshCwIcon size={12} className="animate-spin" />
+      ) : (
+        <ChevronDownIcon size={13} />
       )}
-      <RefreshCwIcon
-        size={12}
-        className={cn([
-          "pointer-events-none absolute inset-0 m-auto transition-opacity duration-200",
-          isError
-            ? "opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100"
-            : "opacity-100",
-        ])}
-      />
-    </span>
+    </button>
   );
 
   return wrapWithTemplateTooltip(
-    <NoteTab
+    <div
       data-main-area-window-drag-region
       data-tauri-drag-region="false"
-      className={SESSION_NOTE_TAB_CLASSNAME}
-      isActive={isActive}
-      onClick={onClick}
+      className={cn([
+        "relative flex h-6 shrink-0 items-center border-b-2 py-0.5 text-xs font-medium transition-all duration-200 select-none",
+        isActive
+          ? ["border-foreground", "text-foreground"]
+          : [
+              "border-transparent",
+              "text-muted-foreground",
+              "hover:text-foreground",
+            ],
+        SESSION_NOTE_TAB_CLASSNAME,
+      ])}
       onContextMenu={showContextMenu}
     >
-      <TruncatedTitle title={tabTitle} isActive={isActive} />
-      {isActive && regenerateIcon}
-    </NoteTab>,
+      <button
+        type="button"
+        data-main-area-window-drag-region
+        data-tauri-drag-region="false"
+        className="flex h-5 items-center gap-1 px-1"
+        onClick={onClick}
+      >
+        <SparklesIcon size={14} />
+        <span>Summary</span>
+      </button>
+      <SummaryTemplateMenu
+        sessionId={sessionId}
+        isGenerating={isGenerating}
+        onRegenerate={handleRegenerate}
+        trigger={menuTrigger}
+      />
+    </div>,
   );
 }
 
@@ -450,12 +583,16 @@ function useOpenTemplatesTab() {
   );
 }
 
-function CreateOtherFormatButton({
+function SummaryTemplateMenu({
   sessionId,
-  handleTabChange,
+  isGenerating,
+  onRegenerate,
+  trigger,
 }: {
   sessionId: string;
-  handleTabChange: (view: EditorView) => void;
+  isGenerating: boolean;
+  onRegenerate: (templateId?: string | null) => void;
+  trigger: React.ReactNode;
 }) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -493,20 +630,27 @@ function CreateOtherFormatButton({
 
   const handleUseTemplate = useCallback(
     (templateId: string) => {
+      if (isGenerating) {
+        return;
+      }
+
       setOpen(false);
       setSearch("");
       resultRefs.current = [];
-
-      const service = getEnhancerService();
-      if (!service) return;
-
-      const result = service.enhance(sessionId, { templateId });
-      if (result.type === "started" || result.type === "already_active") {
-        handleTabChange({ type: "enhanced", id: result.noteId });
-      }
+      onRegenerate(templateId);
     },
-    [sessionId, handleTabChange],
+    [isGenerating, onRegenerate],
   );
+  const handleRegenerateCurrent = useCallback(() => {
+    if (isGenerating) {
+      return;
+    }
+
+    setOpen(false);
+    setSearch("");
+    resultRefs.current = [];
+    onRegenerate(null);
+  }, [isGenerating, onRegenerate]);
 
   const handleOpenChange = useCallback((nextOpen: boolean) => {
     setOpen(nextOpen);
@@ -729,6 +873,18 @@ function CreateOtherFormatButton({
     if (!hasSearch) {
       return [
         {
+          key: "current",
+          title: "Summary",
+          items: [
+            {
+              key: "regenerate-current-summary",
+              title: "Regenerate summary",
+              description: "Use the current template",
+              onClick: handleRegenerateCurrent,
+            },
+          ],
+        },
+        {
           key: "favorite",
           title: "Favorites",
           items: filteredFavoriteTemplates.map((template) => ({
@@ -819,6 +975,7 @@ function CreateOtherFormatButton({
     filteredFavoriteTemplates,
     filteredSuggestedTemplates,
     handleCreateTemplate,
+    handleRegenerateCurrent,
     handleSuggestedTemplateClick,
     handleUseTemplate,
     hasSearch,
@@ -877,22 +1034,7 @@ function CreateOtherFormatButton({
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <button
-          data-main-area-window-drag-region
-          data-tauri-drag-region="false"
-          className={cn([
-            "relative shrink-0 px-1 py-0.5 text-xs font-medium whitespace-nowrap transition-all duration-200 select-none",
-            SESSION_NOTE_TAB_CLASSNAME,
-            "text-muted-foreground hover:text-foreground",
-            "flex items-center gap-1",
-            "border-b-2 border-transparent",
-          ])}
-        >
-          <PlusIcon size={14} />
-          <span>Use template</span>
-        </button>
-      </PopoverTrigger>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent variant="app" className="w-80" align="start">
         <div className="flex flex-col gap-1">
           <AppFloatingPanel className="flex flex-col overflow-hidden">
@@ -999,17 +1141,12 @@ export function Header({
   currentTab: EditorView;
   handleTabChange: (view: EditorView) => void;
 }) {
-  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
-  const isLiveProcessing = sessionMode === "active";
-  const store = main.UI.useStore(main.STORE_ID);
-  const primaryEnhancedTabId = editorTabs.find(
+  const summaryTab = editorTabs.find(
     (view): view is Extract<EditorView, { type: "enhanced" }> =>
       view.type === "enhanced",
-  )?.id;
-
-  if (editorTabs.length === 1 && editorTabs[0].type === "raw") {
-    return null;
-  }
+  );
+  const memoTab = editorTabs.find((view) => view.type === "raw");
+  const transcriptTab = editorTabs.find((view) => view.type === "transcript");
 
   return (
     <div data-tauri-drag-region className="flex flex-col">
@@ -1022,58 +1159,41 @@ export function Header({
             data-tauri-drag-region
             className="scroll-fade-x scrollbar-hide flex items-center gap-1 overflow-x-auto"
           >
-            {editorTabs.map((view, index) => {
-              if (view.type === "enhanced") {
-                return (
-                  <HeaderTabEnhanced
-                    key={`enhanced-${view.id}`}
-                    sessionId={sessionId}
-                    enhancedNoteId={view.id}
-                    canRemove={view.id !== primaryEnhancedTabId}
-                    onRemove={
-                      view.id !== primaryEnhancedTabId
-                        ? () => {
-                            const previousView = editorTabs[index - 1];
-                            if (
-                              currentTab.type === "enhanced" &&
-                              currentTab.id === view.id &&
-                              previousView
-                            ) {
-                              handleTabChange(previousView);
-                            }
-
-                            store?.delRow("enhanced_notes", view.id);
-                          }
-                        : undefined
-                    }
-                    isActive={
-                      currentTab.type === "enhanced" &&
-                      currentTab.id === view.id
-                    }
-                    onClick={() => handleTabChange(view)}
-                  />
-                );
-              }
-
-              if (view.type === "raw") {
-                return (
-                  <HeaderTabRaw
-                    key={view.type}
-                    sessionId={sessionId}
-                    isActive={currentTab.type === view.type}
-                    onClick={() => handleTabChange(view)}
-                  />
-                );
-              }
-
-              return null;
-            })}
-            {!isLiveProcessing && (
-              <CreateOtherFormatButton
+            {summaryTab ? (
+              <HeaderTabEnhanced
+                key={`enhanced-${summaryTab.id}`}
                 sessionId={sessionId}
-                handleTabChange={handleTabChange}
+                enhancedNoteId={summaryTab.id}
+                isActive={
+                  currentTab.type === "enhanced" &&
+                  currentTab.id === summaryTab.id
+                }
+                onClick={() => handleTabChange(summaryTab)}
+              />
+            ) : (
+              <HeaderTabSummaryPending
+                key="summary-pending"
+                sessionId={sessionId}
+                isActive={false}
+                onActivate={handleTabChange}
               />
             )}
+            <HeaderTabRaw
+              key="raw"
+              sessionId={sessionId}
+              isActive={memoTab ? currentTab.type === memoTab.type : false}
+              onClick={() => handleTabChange(memoTab ?? { type: "raw" })}
+            />
+            <HeaderTabTranscript
+              key="transcript"
+              sessionId={sessionId}
+              isActive={
+                transcriptTab ? currentTab.type === transcriptTab.type : false
+              }
+              onClick={() =>
+                handleTabChange(transcriptTab ?? { type: "transcript" })
+              }
+            />
           </div>
         </div>
       </div>
@@ -1088,27 +1208,17 @@ export function useEditorTabs({
 }): EditorView[] {
   useEnsureDefaultSummary(sessionId);
 
-  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
-  const hasTranscript = useHasTranscript(sessionId);
   const enhancedNoteIds = main.UI.useSliceRowIds(
     main.INDEXES.enhancedNotesBySession,
     sessionId,
     main.STORE_ID,
   );
 
-  if (sessionMode === "active") {
-    return [{ type: "raw" }];
-  }
+  const summaryTab = enhancedNoteIds?.[0]
+    ? [{ type: "enhanced", id: enhancedNoteIds[0] } satisfies EditorView]
+    : [];
 
-  if (hasTranscript) {
-    const enhancedTabs: EditorView[] = (enhancedNoteIds || []).map((id) => ({
-      type: "enhanced",
-      id,
-    }));
-    return [...enhancedTabs, { type: "raw" }];
-  }
-
-  return [{ type: "raw" }];
+  return [...summaryTab, { type: "raw" }, { type: "transcript" }];
 }
 
 function useEnhanceLogic(sessionId: string, enhancedNoteId: string) {

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -13,14 +13,14 @@ import { useHotkeys } from "react-hotkeys-hook";
 import type { NoteEditorRef } from "@hypr/editor/note";
 import { cn } from "@hypr/utils";
 
+import { getPersistedNoteTabView } from "../compute-note-tab";
 import { Enhanced } from "./enhanced";
-import { Header, useEditorTabs } from "./header";
 import { RawEditor } from "./raw";
 import { SearchBar } from "./search/bar";
 import { useSearch } from "./search/context";
+import { Transcript } from "./transcript";
 
 import { useCaretNearBottom } from "~/session/components/caret-position-context";
-import { useCurrentNoteTab } from "~/session/components/shared";
 import { useScrollPreservation } from "~/shared/hooks/useScrollPreservation";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { type EditorView as TabEditorView } from "~/store/zustand/tabs/schema";
@@ -31,17 +31,19 @@ export interface NoteInputHandle {
   focusAtStart: () => void;
   focusAtPixelWidth: (pixelWidth: number) => void;
   insertAtStartAndFocus: (content: string) => void;
+  preserveScroll: () => void;
 }
 
 export const NoteInput = forwardRef<
   NoteInputHandle,
   {
     tab: Extract<Tab, { type: "sessions" }>;
+    currentTab: TabEditorView;
+    editorTabs: TabEditorView[];
     onNavigateToTitle?: (pixelWidth?: number) => void;
     onScroll?: UIEventHandler<HTMLDivElement>;
   }
->(({ tab, onNavigateToTitle, onScroll }, ref) => {
-  const editorTabs = useEditorTabs({ sessionId: tab.id });
+>(({ tab, currentTab, editorTabs, onNavigateToTitle, onScroll }, ref) => {
   const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
   const internalEditorRef = useRef<NoteEditorRef>(null);
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
@@ -51,21 +53,6 @@ export const NoteInput = forwardRef<
 
   const tabRef = useRef(tab);
   tabRef.current = tab;
-
-  const currentTab: TabEditorView = useCurrentNoteTab(tab);
-
-  useImperativeHandle(
-    ref,
-    () => ({
-      focus: () => internalEditorRef.current?.commands.focus(),
-      focusAtStart: () => internalEditorRef.current?.commands.focusAtStart(),
-      focusAtPixelWidth: (px) =>
-        internalEditorRef.current?.commands.focusAtPixelWidth(px),
-      insertAtStartAndFocus: (content) =>
-        internalEditorRef.current?.commands.insertAtStartAndFocus(content),
-    }),
-    [currentTab],
-  );
 
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const isMeetingInProgress =
@@ -79,15 +66,29 @@ export const NoteInput = forwardRef<
       : currentTab.type,
   );
 
+  useImperativeHandle(
+    ref,
+    () => ({
+      focus: () => internalEditorRef.current?.commands.focus(),
+      focusAtStart: () => internalEditorRef.current?.commands.focusAtStart(),
+      focusAtPixelWidth: (px) =>
+        internalEditorRef.current?.commands.focusAtPixelWidth(px),
+      insertAtStartAndFocus: (content) =>
+        internalEditorRef.current?.commands.insertAtStartAndFocus(content),
+      preserveScroll: onBeforeTabChange,
+    }),
+    [onBeforeTabChange],
+  );
+
   const handleTabChange = useCallback(
     (tabView: TabEditorView) => {
       onBeforeTabChange();
       updateSessionTabState(tabRef.current, {
         ...tabRef.current.state,
-        view: tabView,
+        view: getPersistedNoteTabView(tabView, sessionMode === "active"),
       });
     },
-    [onBeforeTabChange, updateSessionTabState],
+    [onBeforeTabChange, sessionMode, updateSessionTabState],
   );
 
   useTabShortcuts({
@@ -126,20 +127,13 @@ export const NoteInput = forwardRef<
   }, [currentTab]);
 
   const handleContainerClick = () => {
-    internalEditorRef.current?.commands.focus();
+    if (currentTab.type !== "transcript") {
+      internalEditorRef.current?.commands.focus();
+    }
   };
 
   return (
     <div className="-mx-2 flex h-full flex-col">
-      <div className="relative px-2">
-        <Header
-          sessionId={sessionId}
-          editorTabs={editorTabs}
-          currentTab={currentTab}
-          handleTabChange={handleTabChange}
-        />
-      </div>
-
       {showSearchBar && (
         <div className="px-3 pt-1">
           <SearchBar editorRef={internalEditorRef} />
@@ -149,16 +143,20 @@ export const NoteInput = forwardRef<
       <div className="relative flex-1 overflow-hidden">
         <div
           ref={(node) => {
-            scrollRef.current = node;
+            if (currentTab.type !== "transcript") {
+              scrollRef.current = node;
+            } else if (scrollRef.current === node) {
+              scrollRef.current = null;
+            }
             setContainer(node);
           }}
           onClick={handleContainerClick}
           onScroll={onScroll}
           className={cn([
             "h-full px-3",
-            "scroll-fade-y overflow-auto",
-            "pt-2",
-            "pb-6",
+            currentTab.type === "transcript"
+              ? "overflow-hidden pt-2 pb-0"
+              : ["scroll-fade-y overflow-auto", "pt-2", "pb-6"],
           ])}
         >
           {currentTab.type === "enhanced" && (
@@ -179,6 +177,9 @@ export const NoteInput = forwardRef<
               onViewReady={handleViewReady}
               onViewDisposed={handleViewDisposed}
             />
+          )}
+          {currentTab.type === "transcript" && (
+            <Transcript sessionId={sessionId} scrollRef={scrollRef} />
           )}
         </div>
       </div>
@@ -225,6 +226,22 @@ function useTabShortcuts({
       const rawTab = editorTabs.find((t) => t.type === "raw");
       if (rawTab && currentTab.type !== "raw") {
         handleTabChange(rawTab);
+      }
+    },
+    {
+      preventDefault: true,
+      enableOnFormTags: true,
+      enableOnContentEditable: true,
+    },
+    [currentTab, editorTabs, handleTabChange],
+  );
+
+  useHotkeys(
+    "alt+t",
+    () => {
+      const transcriptTab = editorTabs.find((t) => t.type === "transcript");
+      if (transcriptTab && currentTab.type !== "transcript") {
+        handleTabChange(transcriptTab);
       }
     },
     {

--- a/apps/desktop/src/session/components/shared.test.ts
+++ b/apps/desktop/src/session/components/shared.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { computeCurrentNoteTab } from "./compute-note-tab";
+import {
+  computeCurrentNoteTab,
+  getPersistedNoteTabView,
+} from "./compute-note-tab";
 import { hasStoredNoteContent } from "./shared";
 
 describe("hasStoredNoteContent", () => {
@@ -34,6 +37,20 @@ describe("hasStoredNoteContent", () => {
   });
 });
 
+describe("getPersistedNoteTabView", () => {
+  it("stores raw when summary is selected during a live session", () => {
+    expect(
+      getPersistedNoteTabView({ type: "enhanced", id: "note-1" }, true),
+    ).toEqual({ type: "raw" });
+  });
+
+  it("preserves enhanced views outside live sessions", () => {
+    expect(
+      getPersistedNoteTabView({ type: "enhanced", id: "note-1" }, false),
+    ).toEqual({ type: "enhanced", id: "note-1" });
+  });
+});
+
 describe("computeCurrentNoteTab", () => {
   describe("when listening is active", () => {
     it("returns raw view when current view is enhanced", () => {
@@ -50,13 +67,13 @@ describe("computeCurrentNoteTab", () => {
       expect(result).toEqual({ type: "raw" });
     });
 
-    it("returns raw view when current view is transcript", () => {
+    it("preserves transcript view", () => {
       const result = computeCurrentNoteTab(
         { type: "transcript" },
         true,
         "note-1",
       );
-      expect(result).toEqual({ type: "raw" });
+      expect(result).toEqual({ type: "transcript" });
     });
 
     it("returns raw view when no persisted view", () => {
@@ -80,13 +97,22 @@ describe("computeCurrentNoteTab", () => {
       expect(result).toEqual({ type: "raw" });
     });
 
-    it("normalizes persisted transcript view to raw", () => {
+    it("respects persisted transcript view", () => {
       const result = computeCurrentNoteTab(
         { type: "transcript" },
         false,
         "note-1",
       );
-      expect(result).toEqual({ type: "raw" });
+      expect(result).toEqual({ type: "transcript" });
+    });
+
+    it("normalizes non-primary enhanced view to primary enhanced view", () => {
+      const result = computeCurrentNoteTab(
+        { type: "enhanced", id: "note-2" },
+        false,
+        "note-1",
+      );
+      expect(result).toEqual({ type: "enhanced", id: "note-1" });
     });
 
     it("normalizes persisted attachments view to raw", () => {

--- a/apps/desktop/src/session/components/shared.tsx
+++ b/apps/desktop/src/session/components/shared.tsx
@@ -43,6 +43,7 @@ export function useCurrentNoteHasContent(
   currentView: EditorView,
 ): boolean {
   const rawMd = main.UI.useCell("sessions", sessionId, "raw_md", main.STORE_ID);
+  const hasTranscript = useHasTranscript(sessionId);
   const enhancedNoteId = currentView.type === "enhanced" ? currentView.id : "";
   const enhancedContent = main.UI.useCell(
     "enhanced_notes",
@@ -53,6 +54,10 @@ export function useCurrentNoteHasContent(
 
   if (currentView.type === "enhanced") {
     return hasStoredNoteContent(enhancedContent);
+  }
+
+  if (currentView.type === "transcript") {
+    return hasTranscript;
   }
 
   return hasStoredNoteContent(rawMd);

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -6,19 +6,19 @@ import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 
 import { useSessionBottomAccessory } from "./components/bottom-accessory";
 import { CaretPositionProvider } from "./components/caret-position-context";
+import { getPersistedNoteTabView } from "./components/compute-note-tab";
 import { FloatingActionButton } from "./components/floating";
 import { NoteInput, type NoteInputHandle } from "./components/note-input";
+import { Header, useEditorTabs } from "./components/note-input/header";
 import { SearchProvider } from "./components/note-input/search/context";
 import { OuterHeader } from "./components/outer-header";
 import { SessionSurface } from "./components/session-surface";
 import { useCurrentNoteTab, useHasTranscript } from "./components/shared";
-import { NoteTitleBreadcrumb } from "./components/title-breadcrumb";
-import { TitleInput, type TitleInputHandle } from "./components/title-input";
 import { useAutoEnhance } from "./hooks/useAutoEnhance";
 
 import * as AudioPlayer from "~/audio-player";
-import * as main from "~/store/tinybase/store/main";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
+import type { EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
 import { consumePendingUpload } from "~/stt/pending-upload";
 import { useStartListening } from "~/stt/useStartListening";
@@ -117,18 +117,17 @@ function TabContentNoteInner({
   audioUrlReady: boolean;
   isAudioUrlLoading: boolean;
 }) {
-  const titleInputRef = React.useRef<TitleInputHandle>(null);
   const noteInputRef = React.useRef<NoteInputHandle>(null);
-
   const currentView = useCurrentNoteTab(tab);
-  const hasTranscript = useHasTranscript(tab.id);
+  const editorTabs = useEditorTabs({ sessionId: tab.id });
+  const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
 
   const sessionId = tab.id;
   const { skipReason } = useAutoEnhance(tab);
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
+  const hasTranscript = useHasTranscript(sessionId);
   const { audioExists } = AudioPlayer.useAudioPlayer();
 
-  useAutoFocusTitle({ sessionId, titleInputRef });
   usePendingUpload(sessionId);
 
   const { bottomAccessory, bottomBorderHandle, bottomAccessoryState } =
@@ -141,27 +140,15 @@ function TabContentNoteInner({
       hasTranscript,
     });
 
-  const handleNavigateToTitle = React.useCallback((pixelWidth?: number) => {
-    if (pixelWidth !== undefined) {
-      titleInputRef.current?.focusAtPixelWidth(pixelWidth);
-    } else {
-      titleInputRef.current?.focusAtEnd();
-    }
-  }, []);
-
-  const handleTransferContentToEditor = React.useCallback((content: string) => {
-    noteInputRef.current?.insertAtStartAndFocus(content);
-  }, []);
-
-  const handleFocusEditorAtStart = React.useCallback(() => {
-    noteInputRef.current?.focusAtStart();
-  }, []);
-
-  const handleFocusEditorAtPixelWidth = React.useCallback(
-    (pixelWidth: number) => {
-      noteInputRef.current?.focusAtPixelWidth(pixelWidth);
+  const handleHeaderTabChange = React.useCallback(
+    (view: EditorView) => {
+      noteInputRef.current?.preserveScroll();
+      updateSessionTabState(tab, {
+        ...tab.state,
+        view: getPersistedNoteTabView(view, sessionMode === "active"),
+      });
     },
-    [],
+    [sessionMode, tab, updateSessionTabState],
   );
 
   const mergeTranscriptSurface =
@@ -190,18 +177,11 @@ function TabContentNoteInner({
           currentView={currentView}
           standaloneWindow={standaloneWindow}
           title={
-            <NoteTitleBreadcrumb
-              sessionId={tab.id}
-              title={
-                <TitleInput
-                  ref={titleInputRef}
-                  tab={tab}
-                  variant="breadcrumb"
-                  onTransferContentToEditor={handleTransferContentToEditor}
-                  onFocusEditorAtStart={handleFocusEditorAtStart}
-                  onFocusEditorAtPixelWidth={handleFocusEditorAtPixelWidth}
-                />
-              }
+            <Header
+              sessionId={sessionId}
+              editorTabs={editorTabs}
+              currentTab={currentView}
+              handleTabChange={handleHeaderTabChange}
             />
           }
         />
@@ -211,7 +191,6 @@ function TabContentNoteInner({
       afterBorderFlush={bottomAccessoryState?.mode === "live"}
       afterBorderResizable={canResizeTranscriptSurface}
       bottomBorderHandle={bottomBorderHandle}
-      mergeAfterBorder={mergeTranscriptSurface}
       floatingButton={
         <FloatingActionButton
           allowListening={!standaloneWindow}
@@ -219,11 +198,13 @@ function TabContentNoteInner({
           tab={tab}
         />
       }
+      mergeAfterBorder={mergeTranscriptSurface}
     >
       <NoteInput
         ref={noteInputRef}
         tab={tab}
-        onNavigateToTitle={handleNavigateToTitle}
+        currentTab={currentView}
+        editorTabs={editorTabs}
       />
     </SessionSurface>
   );
@@ -240,26 +221,4 @@ function usePendingUpload(sessionId: string) {
       processFileRef.current(pending.filePath, pending.kind);
     }
   }, [sessionId]);
-}
-
-function useAutoFocusTitle({
-  sessionId,
-  titleInputRef,
-}: {
-  sessionId: string;
-  titleInputRef: React.RefObject<TitleInputHandle | null>;
-}) {
-  // Prevent re-focusing when the user intentionally leaves the title empty.
-  const didAutoFocus = useRef(false);
-
-  const title = main.UI.useCell("sessions", sessionId, "title", main.STORE_ID);
-
-  useEffect(() => {
-    if (didAutoFocus.current) return;
-
-    if (!title) {
-      titleInputRef.current?.focus();
-      didAutoFocus.current = true;
-    }
-  }, [sessionId, title]);
 }


### PR DESCRIPTION
Removes the editable session title, moves Summary/Memos/Transcript into the header, and renders transcript content as a note tab.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5660 
- <kbd>&nbsp;2&nbsp;</kbd> #5659 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5658 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session tab persistence during live recording and summary/enhancer flows, so wrong tab state could confuse users mid-meeting; scope is UI/navigation rather than security-critical backend.
> 
> **Overview**
> Replaces the editable session **title** in the outer header with fixed **Summary**, **Memos**, and **Transcript** tabs (icons + labels), and drops the in-note tab row.
> 
> **Summary** is a single primary enhanced note (or a pending tab that creates/regenerates via the enhancer). Template pick/regenerate moves into a chevron **SummaryTemplateMenu** on that tab; multi-summary tabs, per-tab remove, and the separate “Use template” control are removed. **Transcript** is always listed and opens transcript content in the note area (with copy context menu on the tab).
> 
> Tab model updates: `useEditorTabs` always exposes summary (if any) + raw + transcript; `computeCurrentNoteTab` keeps transcript during live listening and maps non-primary enhanced IDs to the first summary; `getPersistedNoteTabView` stores **raw** when summary is chosen while a live session is active. Header and note body share tab state from `session/index.tsx`, with scroll preservation on header switches and **Alt+T** for transcript.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4720cbbceeec2cc66b0cd686c71018eb713f0eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->