### PR TITLE
Make transcript headers match page background

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
@@ -23,7 +23,7 @@ export function SegmentHeader({
   const label = useSpeakerLabel(segment.key, speakerLabelManager);
   const timestamp = getTimestampRange(segment);
   const headerClassName = cn([
-    "bg-muted sticky top-0 z-20",
+    "bg-card sticky top-0 z-20",
     "-mx-3 px-3 py-1",
     "text-xs font-light",
     "flex items-center justify-between",


### PR DESCRIPTION
Use the normal background token for sticky transcript segment headers so speaker labels no longer render on gray.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS class change on transcript UI with no logic or data impact.
> 
> **Overview**
> Sticky transcript segment headers in `segment-header.tsx` now use **`bg-card`** instead of **`bg-muted`**, so speaker labels and timestamps sit on the same surface as the surrounding page while scrolling.
> 
> No behavior or layout changes beyond the background token swap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 028354b0271376d7f8bee8097f5e7d56f51cfd99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->