### PR TITLE
Refine floating chat expansion

### DIFF
--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -218,14 +218,15 @@ describe("ChatMessageInput", () => {
     expect(surface?.getAttribute("data-chat-input-surface")).toBe("floating");
     expect(surface?.className).toContain("min-h-10");
     expect(surface?.className).toContain("max-h-32");
-    expect(surface?.className).toContain("rounded-[20px]");
+    expect(surface?.className).toContain("rounded-full");
     expect(surface?.className).toContain("py-2");
     expect(surface?.className).toContain("bg-[#f4f4f5]");
     expect(surface?.className).toContain("dark:bg-[#202020]");
     expect(surface?.className).toContain("text-muted-foreground");
-    expect(surface?.className).toContain(
-      "shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_12px_rgba(0,0,0,0.1),0_16px_40px_rgba(0,0,0,0.16)]",
-    );
+    expect(surface?.className).toContain("border-border/70");
+    expect(surface?.className).toContain("shadow-none");
+    expect(surface?.className).not.toContain("shadow-[");
+    expect(surface?.className).not.toContain("inset_0_0_0_1px");
     expect(surface?.className).not.toContain("bg-card");
   });
 

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -175,9 +175,8 @@ function Container({
           "flex max-h-full border",
           isFloating
             ? [
-                "text-muted-foreground max-h-32 min-h-10 flex-row items-center overflow-hidden rounded-[20px] border-0 bg-[#f4f4f5] px-4 py-2 text-sm",
-                "shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_12px_rgba(0,0,0,0.1),0_16px_40px_rgba(0,0,0,0.16)]",
-                "dark:bg-[#202020] dark:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_14px_rgba(0,0,0,0.35),0_16px_44px_rgba(0,0,0,0.55)]",
+                "border-border/70 text-muted-foreground max-h-32 min-h-10 flex-row items-center overflow-hidden rounded-full bg-[#f4f4f5] px-4 py-2 text-sm shadow-none",
+                "dark:bg-[#202020]",
               ]
             : [elevatedSurfaceClassName, "flex-col rounded-xl"],
           hasContextBar && !isFloating && "rounded-t-none border-t-0",

--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -130,6 +130,7 @@ describe("PersistentChatPanel", () => {
       expect(panel?.style.maxWidth).toBe("648px");
       expect(panel?.style.height).toBe("");
       expect(panel?.style.transformOrigin).toBe("bottom center");
+      expect(panel?.className).toContain("rounded-[20px]");
       expect(panel?.dataset.chatPanelReveal).toBe("bottom-up");
     });
   });

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -20,6 +20,14 @@ import { useShell } from "~/contexts/shell";
 const FLOATING_PANEL_MIN_WIDTH = 368;
 const FLOATING_PANEL_MIN_HEIGHT = 320;
 const FLOATING_PANEL_MARGIN = 12;
+const FLOATING_CHAT_INPUT_MAX_WIDTH = 640;
+const FLOATING_CHAT_INPUT_HEIGHT = 40;
+const FLOATING_CHAT_SHELL_INSET = 4;
+const FLOATING_PANEL_DEFAULT_MAX_WIDTH =
+  FLOATING_CHAT_INPUT_MAX_WIDTH + FLOATING_CHAT_SHELL_INSET * 2;
+const FLOATING_PANEL_REVEAL_HEIGHT =
+  FLOATING_CHAT_INPUT_HEIGHT + FLOATING_CHAT_SHELL_INSET;
+const FLOATING_PANEL_RADIUS = 20;
 
 type FloatingPanelSize = {
   width: number;
@@ -185,19 +193,19 @@ export function PersistentChatPanel({
       y: 0,
       opacity: 1,
       scale: 1,
-      clipPath: "inset(calc(100% - 5rem) 0 0 0 round 1.75rem)",
+      clipPath: `inset(calc(100% - ${FLOATING_PANEL_REVEAL_HEIGHT}px) 0 0 0 round ${FLOATING_PANEL_RADIUS}px)`,
     },
     animate: {
       y: 0,
       opacity: 1,
       scale: 1,
-      clipPath: "inset(0 0 0 0 round 1.75rem)",
+      clipPath: `inset(0 0 0 0 round ${FLOATING_PANEL_RADIUS}px)`,
     },
     exit: {
       y: 8,
       opacity: 0,
       scale: 0.99,
-      clipPath: "inset(calc(100% - 5rem) 0 0 0 round 1.75rem)",
+      clipPath: `inset(calc(100% - ${FLOATING_PANEL_REVEAL_HEIGHT}px) 0 0 0 round ${FLOATING_PANEL_RADIUS}px)`,
     },
   };
   const panelTransition = {
@@ -212,7 +220,7 @@ export function PersistentChatPanel({
       : {
           width: "calc(100% - 1.5rem)",
           minWidth: "min(368px, calc(100% - 1.5rem))",
-          maxWidth: "648px",
+          maxWidth: `${FLOATING_PANEL_DEFAULT_MAX_WIDTH}px`,
           maxHeight: "calc(100% - 1rem)",
           transformOrigin: "bottom center",
         };

--- a/apps/desktop/src/chat/components/toolbar-controls.test.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.test.tsx
@@ -105,7 +105,6 @@ describe("ChatToolbarControls", () => {
     const rightPanelButton = screen.getByRole("button", {
       name: "Open in right panel",
     });
-    const closeButton = screen.getByRole("button", { name: "Close chat" });
 
     expect(newChatButton.className).toContain("rounded-full");
     expect(newChatButton.className).toContain("hover:!bg-primary-foreground/7");
@@ -115,12 +114,10 @@ describe("ChatToolbarControls", () => {
       "hover:!bg-primary-foreground/7",
     );
     expect(rightPanelButton.getAttribute("title")).toBeNull();
-    expect(closeButton.className).toContain("rounded-full");
-    expect(closeButton.className).toContain("hover:!bg-primary-foreground/7");
-    expect(closeButton.getAttribute("title")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Close chat" })).toBeNull();
   });
 
-  it("renders and wires close in the floating toolbar", () => {
+  it("renders floating toolbar actions without a close button", () => {
     const onClose = vi.fn();
     const onOpenRightPanel = vi.fn();
 
@@ -139,16 +136,15 @@ describe("ChatToolbarControls", () => {
     const rightPanelButton = screen.getByRole("button", {
       name: "Open in right panel",
     });
-    const closeButton = screen.getByRole("button", { name: "Close chat" });
     const actions = container.querySelector("[data-chat-toolbar-actions]");
 
     fireEvent.click(rightPanelButton);
-    fireEvent.click(closeButton);
 
     expect(actions?.className).toContain("gap-0");
     expect(actions?.className).not.toContain("gap-1");
     expect(onOpenRightPanel).toHaveBeenCalled();
-    expect(onClose).toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "Close chat" })).toBeNull();
   });
 
   it("uses the shared toolbar padding in the right panel", () => {

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -86,12 +86,6 @@ export function ChatToolbarControls({
               onClick={onOpenRightPanel ?? (() => {})}
               className={isDark ? darkToolbarButtonClassName : undefined}
             />
-            <ChatActionButton
-              icon={<X size={16} />}
-              label="Close chat"
-              onClick={onClose ?? (() => {})}
-              className={isDark ? darkToolbarButtonClassName : undefined}
-            />
           </>
         )}
       </div>

--- a/apps/desktop/src/chat/surface.test.ts
+++ b/apps/desktop/src/chat/surface.test.ts
@@ -47,11 +47,12 @@ describe("chat surface tokens", () => {
       "dark:shadow-[0_16px_48px_rgba(0,0,0,0.55)]",
     );
     expect(chatFloatingPanelShellClassNames()).toContain("bg-[#f4f4f5]");
-    expect(chatFloatingPanelShellClassNames()).toContain("border-[#dedede]");
+    expect(chatFloatingPanelShellClassNames()).toContain("rounded-[20px]");
+    expect(chatFloatingPanelShellClassNames()).toContain("border-0");
     expect(chatFloatingPanelShellClassNames()).toContain("dark:bg-[#202020]");
-    expect(chatFloatingPanelShellClassNames()).toContain(
-      "dark:border-[#3a3a3a]",
-    );
+    expect(chatFloatingPanelShellClassNames()).not.toContain("after:border");
+    expect(chatFloatingPanelShellClassNames()).not.toContain("after:inset");
+    expect(chatFloatingPanelShellClassNames()).not.toContain("border-2");
     expect(chatFloatingPanelShellClassNames()).not.toContain("bg-card");
   });
 

--- a/apps/desktop/src/chat/surface.ts
+++ b/apps/desktop/src/chat/surface.ts
@@ -17,7 +17,7 @@ export function chatPanelBorderClassNames(): string {
 }
 
 export function chatFloatingPanelShellClassNames(): string {
-  return "bg-[#f4f4f5] text-card-foreground rounded-2xl border-2 border-[#dedede] shadow-[0_16px_48px_rgba(0,0,0,0.18)] dark:border-[#3a3a3a] dark:bg-[#202020] dark:shadow-[0_16px_48px_rgba(0,0,0,0.55)]";
+  return "bg-[#f4f4f5] text-card-foreground rounded-[20px] border-0 shadow-[0_16px_48px_rgba(0,0,0,0.18)] dark:bg-[#202020] dark:shadow-[0_16px_48px_rgba(0,0,0,0.55)]";
 }
 
 export function chatElevatedSurfaceClassNames(): string {

--- a/apps/desktop/src/shared/chat-cta.test.tsx
+++ b/apps/desktop/src/shared/chat-cta.test.tsx
@@ -59,7 +59,7 @@ describe("ChatCTA", () => {
       "[clip-path:inset(0_calc(50%_-_3rem)_0_calc(50%_-_3rem)_round_9999px)]",
     );
     expect(surface?.className).toContain(
-      "transition-[clip-path,height,padding,background-color,box-shadow]",
+      "transition-[clip-path,height,padding,background-color,border-color]",
     );
     expect(surface?.className).toContain("origin-bottom");
     expect(surface?.className).toContain("h-2");
@@ -67,8 +67,13 @@ describe("ChatCTA", () => {
     expect(surface?.className).toContain("bg-black");
     expect(surface?.className).toContain("dark:bg-white");
     expect(surface?.className).toContain("shadow-none");
+    expect(surface?.className).toContain("border");
+    expect(surface?.className).toContain("border-transparent");
     expect(surface?.className).not.toContain("border-2");
     expect(surface?.className).toContain("pointer-events-none");
+    expect(surface?.className).toContain(
+      "group-hover/anarlog-chat-cta:border-border/70",
+    );
     expect(surface?.className).toContain(
       "group-hover/anarlog-chat-cta:bg-[#f4f4f5]",
     );
@@ -80,17 +85,10 @@ describe("ChatCTA", () => {
       "group-hover/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
     );
     expect(surface?.className).toContain(
-      "group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_12px_rgba(0,0,0,0.1),0_16px_40px_rgba(0,0,0,0.16)]",
-    );
-    expect(surface?.className).toContain(
-      "dark:group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_14px_rgba(0,0,0,0.35),0_16px_44px_rgba(0,0,0,0.55)]",
-    );
-    expect(surface?.className).toContain(
       "group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
     );
-    expect(surface?.className).toContain(
-      "group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_12px_rgba(0,0,0,0.1),0_16px_40px_rgba(0,0,0,0.16)]",
-    );
+    expect(surface?.className).not.toContain("shadow-[");
+    expect(surface?.className).not.toContain("inset_0_0_0_1px");
     expect(button.querySelectorAll("svg")).toHaveLength(0);
     expect(label.className).toContain("max-w-0");
     expect(label.className).toContain("opacity-0");

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -31,13 +31,12 @@ export function ChatCTA({
         data-chat-cta-surface
         aria-hidden="true"
         className={cn([
-          "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-[min(640px,calc(100cqw_-_2rem))] -translate-x-1/2 items-center overflow-hidden rounded-full bg-black dark:bg-white",
+          "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-[min(640px,calc(100cqw_-_2rem))] -translate-x-1/2 items-center overflow-hidden rounded-full border border-transparent bg-black dark:bg-white",
           "[clip-path:inset(0_calc(50%_-_3rem)_0_calc(50%_-_3rem)_round_9999px)]",
-          "origin-bottom px-0 text-sm shadow-none transition-[clip-path,height,padding,background-color,box-shadow] duration-200 ease-out",
-          "group-hover/anarlog-chat-cta:bg-[#f4f4f5] group-focus-visible/anarlog-chat-cta:bg-[#f4f4f5] dark:group-hover/anarlog-chat-cta:bg-[#202020] dark:group-focus-visible/anarlog-chat-cta:bg-[#202020]",
+          "origin-bottom px-0 text-sm shadow-none transition-[clip-path,height,padding,background-color,border-color] duration-200 ease-out",
+          "group-hover/anarlog-chat-cta:border-border/70 group-focus-visible/anarlog-chat-cta:border-border/70 group-hover/anarlog-chat-cta:bg-[#f4f4f5] group-focus-visible/anarlog-chat-cta:bg-[#f4f4f5] dark:group-hover/anarlog-chat-cta:bg-[#202020] dark:group-focus-visible/anarlog-chat-cta:bg-[#202020]",
           "group-hover/anarlog-chat-cta:h-10 group-hover/anarlog-chat-cta:px-4 group-hover/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
           "group-focus-visible/anarlog-chat-cta:h-10 group-focus-visible/anarlog-chat-cta:px-4 group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
-          "group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_12px_rgba(0,0,0,0.1),0_16px_40px_rgba(0,0,0,0.16)] group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_12px_rgba(0,0,0,0.1),0_16px_40px_rgba(0,0,0,0.16)] dark:group-hover/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_14px_rgba(0,0,0,0.35),0_16px_44px_rgba(0,0,0,0.55)] dark:group-focus-visible/anarlog-chat-cta:shadow-[inset_0_0_0_1px_hsl(var(--border)),0_4px_14px_rgba(0,0,0,0.35),0_16px_44px_rgba(0,0,0,0.55)]",
           "group-focus-visible/anarlog-chat-cta:ring-ring group-focus-visible/anarlog-chat-cta:ring-2 group-focus-visible/anarlog-chat-cta:ring-offset-2",
         ])}
       >


### PR DESCRIPTION
Preserve the hovered input width during floating chat expansion, start the reveal from the wrapped input footprint, and remove the extra modal shell border.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop chat UI and styling only; close behavior for floating chat still uses backdrop/Esc.
> 
> **Overview**
> Aligns the **floating chat** open animation and default sizing with the **640px-wide pill input** (plus shell inset), so the panel reveals from a **44px-tall** strip with **20px** corner radius instead of a fixed `5rem` clip.
> 
> **Visual polish:** floating composer and the note **Chat CTA** use **rounded-full**, a light **`border-border/70`**, and **no inset/drop shadows**; the floating **panel shell** drops the thick border in favor of **`border-0`** and **`rounded-[20px]`**. Default floating **max width** is now **648px** (640 + inset).
> 
> **Toolbar:** **Close chat** is removed from the **floating** toolbar (right-panel float/close unchanged); dismissal stays via backdrop and **Esc**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef7957554d4b83b9bb52cf34ed952ade33f81438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->