### PR TITLE
Update speaker assignment selection flow

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
@@ -380,6 +380,7 @@ describe("DuringSessionAccessory", () => {
     expect(screen.getByRole("button", { name: "Speaker 1" })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Speaker 1" }));
     fireEvent.click(screen.getByText("Alex"));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
 
     expect(setCell).toHaveBeenCalledWith(
       "transcripts",

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
@@ -8,6 +8,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  buildEventSpeakerParticipantOptions,
   buildCreateSpeakerParticipantOption,
   buildSpeakerParticipantGroups,
   getAssignmentAnchorWordId,
@@ -24,6 +25,7 @@ const {
   useRowIdsMock,
   useSliceRowIdsMock,
   useStoreMock,
+  useTableMock,
   useValueMock,
 } = vi.hoisted(() => ({
   useCellMock: vi.fn(),
@@ -31,6 +33,7 @@ const {
   useRowIdsMock: vi.fn(),
   useSliceRowIdsMock: vi.fn(),
   useStoreMock: vi.fn(),
+  useTableMock: vi.fn(),
   useValueMock: vi.fn(),
 }));
 
@@ -97,6 +100,21 @@ vi.mock("@hypr/ui/components/ui/popover", async () => {
   };
 });
 
+vi.mock("@hypr/ui/components/ui/checkbox", () => ({
+  Checkbox: ({
+    checked,
+    onCheckedChange,
+  }: {
+    checked: boolean;
+    onCheckedChange: (checked: boolean) => void;
+  }) =>
+    createElement("input", {
+      type: "checkbox",
+      checked,
+      onChange: (event) => onCheckedChange(event.currentTarget.checked),
+    }),
+}));
+
 vi.mock("~/store/tinybase/store/main", () => ({
   STORE_ID: "main",
   INDEXES: {
@@ -111,6 +129,7 @@ vi.mock("~/store/tinybase/store/main", () => ({
     useRowIds: useRowIdsMock,
     useSliceRowIds: useSliceRowIdsMock,
     useStore: useStoreMock,
+    useTable: useTableMock,
     useValue: useValueMock,
   },
 }));
@@ -134,7 +153,7 @@ function option(
 }
 
 describe("SpeakerAssignPopover", () => {
-  it("resets assignment mode after the popover closes", () => {
+  it("assigns only after confirmation and defaults to all matching segments", () => {
     const cells = new Map([
       [
         "words",
@@ -171,6 +190,7 @@ describe("SpeakerAssignPopover", () => {
     useRowIdsMock.mockReturnValue(["human-1"]);
     useSliceRowIdsMock.mockReturnValue([]);
     useStoreMock.mockReturnValue(store);
+    useTableMock.mockReturnValue({});
     useValueMock.mockReturnValue("user-1");
 
     render(
@@ -203,26 +223,111 @@ describe("SpeakerAssignPopover", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Speaker 2" }));
-    fireEvent.click(screen.getByRole("button", { name: "This segment" }));
-    expect(
-      screen
-        .getByRole("button", { name: "This segment" })
-        .getAttribute("class"),
-    ).toContain("bg-background");
-
     fireEvent.click(screen.getByRole("button", { name: "Alice" }));
-    fireEvent.click(screen.getByRole("button", { name: "Speaker 2" }));
+    expect(cells.get("speaker_hints")).toBe(JSON.stringify([]));
 
-    expect(
-      screen
-        .getByRole("button", { name: "All matching" })
-        .getAttribute("class"),
-    ).toContain("bg-background");
-    expect(
-      screen
-        .getByRole("button", { name: "This segment" })
-        .getAttribute("class"),
-    ).not.toContain("bg-background");
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(cells.get("speaker_hints")).toBe(
+      JSON.stringify([
+        {
+          id: "word-1:user_speaker_assignment",
+          word_id: "word-1",
+          type: "user_speaker_assignment",
+          value: JSON.stringify({ human_id: "human-1" }),
+        },
+      ]),
+    );
+  });
+
+  it("uses segment scope when the matching-segments checkbox is off", () => {
+    const cells = new Map([
+      [
+        "words",
+        JSON.stringify([
+          {
+            id: "word-1",
+            text: "hello",
+            start_ms: 0,
+            end_ms: 100,
+            channel: 1,
+          },
+        ]),
+      ],
+      ["speaker_hints", JSON.stringify([])],
+    ]);
+    const store = {
+      getCell: vi.fn((_tableId: string, _rowId: string, cellId: string) =>
+        cells.get(cellId),
+      ),
+      setCell: vi.fn(
+        (_tableId: string, _rowId: string, cellId: string, value: string) => {
+          cells.set(cellId, value);
+        },
+      ),
+      getRow: vi.fn(() => ({
+        name: "Alice",
+        email: "",
+      })),
+      setRow: vi.fn(),
+    };
+
+    useCellMock.mockReturnValue("session-1");
+    useQueriesMock.mockReturnValue({ getResultRow: vi.fn() });
+    useRowIdsMock.mockReturnValue(["human-1"]);
+    useSliceRowIdsMock.mockReturnValue([]);
+    useStoreMock.mockReturnValue(store);
+    useTableMock.mockReturnValue({});
+    useValueMock.mockReturnValue("user-1");
+
+    render(
+      createElement(SpeakerAssignPopover, {
+        segment: {
+          id: "segment-1",
+          key: {
+            channel: "RemoteParty",
+            speaker_index: 2,
+            speaker_human_id: null,
+          },
+          start_ms: 0,
+          end_ms: 100,
+          text: "hello",
+          words: [
+            {
+              id: "word-1",
+              text: "hello",
+              start_ms: 0,
+              end_ms: 100,
+              channel: "RemoteParty",
+              is_final: true,
+            },
+          ],
+        } as Segment,
+        transcriptId: "transcript-1",
+        color: "red",
+        label: "Speaker 2",
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Speaker 2" }));
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: "Alice" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(cells.get("speaker_hints")).toBe(
+      JSON.stringify([
+        {
+          id: "word-1:user_speaker_assignment:segment",
+          word_id: "word-1",
+          type: "user_speaker_assignment",
+          value: JSON.stringify({
+            human_id: "human-1",
+            scope: "segment",
+            word_ids: ["word-1"],
+          }),
+        },
+      ]),
+    );
   });
 });
 
@@ -236,31 +341,99 @@ describe("buildSpeakerParticipantGroups", () => {
 
     expect(groups).toEqual([
       {
-        title: "Contacts",
+        title: "People",
         options: [option("human-1", "Alice")],
       },
     ]);
   });
 
-  it("keeps session participants first and excludes duplicate contacts", () => {
+  it("keeps participants first and excludes duplicate people", () => {
     const participant = option("human-1", "Alice", {
+      isSessionParticipant: true,
+    });
+    const eventParticipant = option("human-3", "Carol", {
       isSessionParticipant: true,
     });
     const groups = buildSpeakerParticipantGroups({
       sessionParticipants: [participant],
+      eventParticipants: [eventParticipant],
       contacts: [option("human-1", "Alice"), option("human-2", "Bob")],
       query: "",
     });
 
     expect(groups).toEqual([
       {
-        title: "Session participants",
-        options: [participant],
+        title: "Participants",
+        options: [participant, eventParticipant],
       },
       {
-        title: "Contacts",
+        title: "People",
         options: [option("human-2", "Bob")],
       },
+    ]);
+  });
+});
+
+describe("buildEventSpeakerParticipantOptions", () => {
+  it("matches event participants to existing people by email", () => {
+    expect(
+      buildEventSpeakerParticipantOptions({
+        eventParticipants: [{ name: "Alice A.", email: "alice@example.com" }],
+        contacts: [option("human-1", "Alice", { email: "alice@example.com" })],
+      }),
+    ).toEqual([
+      option("human-1", "Alice A.", {
+        email: "alice@example.com",
+        isSessionParticipant: true,
+      }),
+    ]);
+  });
+
+  it("creates pending participant options for event attendees without people", () => {
+    expect(
+      buildEventSpeakerParticipantOptions({
+        eventParticipants: [{ name: "Bob", email: "bob@example.com" }],
+        contacts: [],
+      }),
+    ).toEqual([
+      option("event:bob@example.com", "Bob", {
+        email: "bob@example.com",
+        isSessionParticipant: true,
+        isNew: true,
+      }),
+    ]);
+  });
+
+  it("does not match event attendees by name when their email differs", () => {
+    expect(
+      buildEventSpeakerParticipantOptions({
+        eventParticipants: [{ name: "Bob", email: "bob@example.com" }],
+        contacts: [option("human-1", "Bob", { email: "other@example.com" })],
+      }),
+    ).toEqual([
+      option("event:bob@example.com", "Bob", {
+        email: "bob@example.com",
+        isSessionParticipant: true,
+        isNew: true,
+      }),
+    ]);
+  });
+
+  it("keeps duplicate event attendees without emails selectable", () => {
+    expect(
+      buildEventSpeakerParticipantOptions({
+        eventParticipants: [{ name: "Bob" }, { name: "Bob" }],
+        contacts: [],
+      }),
+    ).toEqual([
+      option("event:Bob:0", "Bob", {
+        isSessionParticipant: true,
+        isNew: true,
+      }),
+      option("event:Bob:1", "Bob", {
+        isSessionParticipant: true,
+        isNew: true,
+      }),
     ]);
   });
 });
@@ -277,6 +450,7 @@ describe("buildCreateSpeakerParticipantOption", () => {
       name: "Charlie",
       isSessionParticipant: false,
       isNew: true,
+      isCreateOption: true,
     });
   });
 

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 
+import type { EventParticipant, SessionEvent } from "@hypr/store";
+import { Checkbox } from "@hypr/ui/components/ui/checkbox";
 import {
   AppFloatingPanel,
   Popover,
@@ -30,7 +32,6 @@ export function SpeakerAssignPopover({
   onAssigned?: (humanId: string) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const [assignmentMode, setAssignmentMode] = useState<AssignmentMode>("all");
   const store = main.UI.useStore(main.STORE_ID);
 
   const sessionId = main.UI.useCell(
@@ -42,13 +43,10 @@ export function SpeakerAssignPopover({
 
   const handleOpenChange = useCallback((nextOpen: boolean) => {
     setOpen(nextOpen);
-    if (!nextOpen) {
-      setAssignmentMode("all");
-    }
   }, []);
 
   const handleAssign = useCallback(
-    (humanId: string) => {
+    (humanId: string, assignmentMode: AssignmentMode) => {
       if (!store || segment.words.length === 0) return;
       const anchorWordId = getAssignmentAnchorWordId(segment);
       if (!anchorWordId) return;
@@ -66,14 +64,7 @@ export function SpeakerAssignPopover({
       onAssigned?.(humanId);
       handleOpenChange(false);
     },
-    [
-      assignmentMode,
-      handleOpenChange,
-      onAssigned,
-      store,
-      transcriptId,
-      segment,
-    ],
+    [handleOpenChange, onAssigned, store, transcriptId, segment],
   );
 
   return (
@@ -91,53 +82,10 @@ export function SpeakerAssignPopover({
           {label}
         </button>
       </PopoverTrigger>
-      <PopoverContent variant="app" align="start" className="w-64">
-        <AssignmentModePicker
-          mode={assignmentMode}
-          onChange={setAssignmentMode}
-        />
+      <PopoverContent variant="app" align="start" className="w-72">
         <ParticipantList sessionId={sessionId} onSelect={handleAssign} />
       </PopoverContent>
     </Popover>
-  );
-}
-
-function AssignmentModePicker({
-  mode,
-  onChange,
-}: {
-  mode: AssignmentMode;
-  onChange: (mode: AssignmentMode) => void;
-}) {
-  const options: Array<{ value: AssignmentMode; label: string }> = [
-    { value: "all", label: "All matching" },
-    { value: "segment", label: "This segment" },
-  ];
-
-  return (
-    <div className="border-border border-b p-2">
-      <div className="bg-muted grid h-8 grid-cols-2 rounded-md p-0.5">
-        {options.map((option) => {
-          const selected = mode === option.value;
-
-          return (
-            <button
-              key={option.value}
-              type="button"
-              className={cn([
-                "rounded-sm px-2 text-xs transition-colors",
-                selected
-                  ? "bg-background text-foreground shadow-xs"
-                  : "text-muted-foreground hover:text-foreground",
-              ])}
-              onClick={() => onChange(option.value)}
-            >
-              {option.label}
-            </button>
-          );
-        })}
-      </div>
-    </div>
   );
 }
 
@@ -165,14 +113,17 @@ export type SpeakerParticipantOption = {
   email?: string;
   isSessionParticipant: boolean;
   isNew?: boolean;
+  isCreateOption?: boolean;
 };
 
 export function buildSpeakerParticipantGroups({
   sessionParticipants,
+  eventParticipants = [],
   contacts,
   query,
 }: {
   sessionParticipants: SpeakerParticipantOption[];
+  eventParticipants?: SpeakerParticipantOption[];
   contacts: SpeakerParticipantOption[];
   query: string;
 }) {
@@ -187,27 +138,39 @@ export function buildSpeakerParticipantGroups({
     );
   };
 
-  const sessionParticipantIds = new Set(
-    sessionParticipants.map((option) => option.id),
-  );
-  const matchingSessionParticipants = sessionParticipants.filter(matches);
+  const participantKeys = new Set<string>();
+  const participantOptions = [...sessionParticipants, ...eventParticipants]
+    .filter((option) => {
+      const keys = getSpeakerParticipantDedupeKeys(option);
+      if (keys.some((key) => participantKeys.has(key))) {
+        return false;
+      }
+
+      keys.forEach((key) => participantKeys.add(key));
+      return true;
+    })
+    .filter(matches);
   const matchingContacts = contacts
-    .filter((option) => !sessionParticipantIds.has(option.id))
+    .filter((option) =>
+      getSpeakerParticipantDedupeKeys(option).every(
+        (key) => !participantKeys.has(key),
+      ),
+    )
     .filter(matches);
 
   return [
-    ...(matchingSessionParticipants.length > 0
+    ...(participantOptions.length > 0
       ? [
           {
-            title: "Session participants",
-            options: matchingSessionParticipants,
+            title: "Participants",
+            options: participantOptions,
           },
         ]
       : []),
     ...(matchingContacts.length > 0
       ? [
           {
-            title: "Contacts",
+            title: "People",
             options: matchingContacts,
           },
         ]
@@ -242,7 +205,60 @@ export function buildCreateSpeakerParticipantOption({
     name,
     isSessionParticipant: false,
     isNew: true,
+    isCreateOption: true,
   };
+}
+
+export function buildEventSpeakerParticipantOptions({
+  eventParticipants,
+  contacts,
+}: {
+  eventParticipants: EventParticipant[];
+  contacts: SpeakerParticipantOption[];
+}): SpeakerParticipantOption[] {
+  const contactByEmail = new Map(
+    contacts
+      .filter((contact) => contact.email)
+      .map((contact) => [contact.email!.toLowerCase(), contact]),
+  );
+  const contactByName = new Map(
+    contacts.map((contact) => [contact.name.toLowerCase(), contact]),
+  );
+
+  return eventParticipants
+    .map((participant, index): SpeakerParticipantOption | null => {
+      const name = (participant.name ?? "").trim();
+      const email = (participant.email ?? "").trim();
+      if (!name && !email) {
+        return null;
+      }
+
+      const contact = email
+        ? contactByEmail.get(email.toLowerCase())
+        : name
+          ? contactByName.get(name.toLowerCase())
+          : undefined;
+
+      if (contact) {
+        return {
+          ...contact,
+          name: name || contact.name,
+          email: email || contact.email,
+          isSessionParticipant: true,
+        };
+      }
+
+      const pendingId = email ? `event:${email}` : `event:${name}:${index}`;
+
+      return {
+        id: pendingId,
+        name: name || email,
+        email: email || undefined,
+        isSessionParticipant: true,
+        isNew: true,
+      };
+    })
+    .filter((option): option is SpeakerParticipantOption => option !== null);
 }
 
 function ParticipantList({
@@ -250,7 +266,7 @@ function ParticipantList({
   onSelect,
 }: {
   sessionId: string | undefined;
-  onSelect: (humanId: string) => void;
+  onSelect: (humanId: string, mode: AssignmentMode) => void;
 }) {
   const queries = main.UI.useQueries(main.STORE_ID);
   const store = main.UI.useStore(main.STORE_ID);
@@ -258,6 +274,13 @@ function ParticipantList({
     | string
     | undefined;
   const allHumanIds = main.UI.useRowIds("humans", main.STORE_ID) as string[];
+  const eventsTable = main.UI.useTable("events", main.STORE_ID);
+  const sessionEventJson = main.UI.useCell(
+    "sessions",
+    sessionId ?? "",
+    "event_json",
+    main.STORE_ID,
+  ) as string | undefined;
 
   const mappingIds = main.UI.useSliceRowIds(
     main.INDEXES.sessionParticipantsBySession,
@@ -266,6 +289,9 @@ function ParticipantList({
   ) as string[];
 
   const [query, setQuery] = useState("");
+  const [selectedOption, setSelectedOption] =
+    useState<SpeakerParticipantOption | null>(null);
+  const [applyToAllMatching, setApplyToAllMatching] = useState(true);
 
   const participants = useMemo(() => {
     if (!queries) return [];
@@ -319,24 +345,38 @@ function ParticipantList({
       .filter((p): p is SpeakerParticipantOption => p !== null);
   }, [allHumanIds, store]);
 
+  const eventParticipants = useMemo(
+    () =>
+      buildEventSpeakerParticipantOptions({
+        eventParticipants: getAttachedEventParticipants(
+          eventsTable,
+          sessionEventJson,
+        ),
+        contacts,
+      }),
+    [contacts, eventsTable, sessionEventJson],
+  );
+
   const groups = useMemo(
     () =>
       buildSpeakerParticipantGroups({
         sessionParticipants: participants,
+        eventParticipants,
         contacts,
         query,
       }),
-    [contacts, participants, query],
+    [contacts, eventParticipants, participants, query],
   );
 
   const createOption = useMemo(
     () =>
       buildCreateSpeakerParticipantOption({
         query,
-        existingOptions: [...participants, ...contacts],
+        existingOptions: [...participants, ...eventParticipants, ...contacts],
       }),
-    [contacts, participants, query],
+    [contacts, eventParticipants, participants, query],
   );
+  const hasPeopleGroup = groups.some((group) => group.title === "People");
 
   const linkHumanToSession = useCallback(
     (humanId: string) => {
@@ -355,7 +395,7 @@ function ParticipantList({
   );
 
   const createHuman = useCallback(
-    (name: string) => {
+    (name: string, email?: string) => {
       if (!store || !userId) {
         return null;
       }
@@ -365,7 +405,7 @@ function ParticipantList({
         user_id: userId,
         created_at: new Date().toISOString(),
         name,
-        email: "",
+        email: email ?? "",
         phone: "",
         org_id: "",
         job_title: "",
@@ -379,87 +419,216 @@ function ParticipantList({
     [store, userId],
   );
 
-  const handleSelect = useCallback(
+  const handleSelect = useCallback((option: SpeakerParticipantOption) => {
+    setSelectedOption(option);
+  }, []);
+
+  const getCurrentHumanId = useCallback(
     (option: SpeakerParticipantOption) => {
-      const humanId = option.isNew ? createHuman(option.name) : option.id;
-      if (!humanId) {
-        return;
+      if (!option.isNew) {
+        return option.id;
       }
 
-      linkHumanToSession(humanId);
-      onSelect(humanId);
+      const email = option.email?.trim().toLowerCase();
+      const name = option.name.trim().toLowerCase();
+      const existingContact = email
+        ? contacts.find(
+            (contact) => contact.email?.trim().toLowerCase() === email,
+          )
+        : contacts.find(
+            (contact) => contact.name.trim().toLowerCase() === name,
+          );
+
+      return existingContact?.id ?? createHuman(option.name, option.email);
     },
-    [createHuman, linkHumanToSession, onSelect],
+    [contacts, createHuman],
   );
 
-  return (
-    <AppFloatingPanel className="overflow-hidden">
-      <div className="border-border border-b p-2">
-        <input
-          autoFocus
-          type="search"
-          className={cn([
-            "border-border bg-card h-8 w-full rounded-md border px-2 text-sm outline-hidden",
-            "placeholder:text-muted-foreground focus:border-border",
-          ])}
-          placeholder="Search contacts"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-        />
-      </div>
-      <div className="max-h-56 overflow-auto py-1">
-        {createOption && (
-          <ParticipantOptionButton
-            option={createOption}
-            onSelect={handleSelect}
-          />
-        )}
+  const handleConfirm = useCallback(() => {
+    if (!selectedOption) {
+      return;
+    }
 
-        {groups.map((group) => (
-          <div key={group.title}>
-            <div className="text-muted-foreground px-3 pt-2 pb-1 text-[11px] font-medium uppercase">
-              {group.title}
+    const mode: AssignmentMode = applyToAllMatching ? "all" : "segment";
+    const humanId = getCurrentHumanId(selectedOption);
+    if (!humanId) {
+      return;
+    }
+
+    linkHumanToSession(humanId);
+    onSelect(humanId, mode);
+  }, [
+    applyToAllMatching,
+    getCurrentHumanId,
+    linkHumanToSession,
+    onSelect,
+    selectedOption,
+  ]);
+
+  return (
+    <AppFloatingPanel className="flex flex-col gap-2 p-2">
+      <div className="border-app-floating-border bg-app-floating-panel overflow-hidden rounded-2xl border">
+        <div className="p-2">
+          <input
+            autoFocus
+            type="search"
+            className={cn([
+              "border-border h-8 w-full rounded-md border bg-transparent px-2 text-sm outline-hidden",
+              "placeholder:text-muted-foreground focus:border-border",
+            ])}
+            placeholder="Search people"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setSelectedOption(null);
+            }}
+          />
+        </div>
+        <div className="max-h-60 overflow-auto py-1">
+          {groups.map((group) => (
+            <div key={group.title}>
+              <div className="text-muted-foreground px-3 pt-2 pb-1 text-[11px] font-medium uppercase">
+                {group.title}
+              </div>
+              {group.options.map((option) => (
+                <ParticipantOptionButton
+                  key={option.id}
+                  option={option}
+                  selected={selectedOption === option}
+                  onSelect={handleSelect}
+                />
+              ))}
             </div>
-            {group.options.map((option) => (
+          ))}
+
+          {createOption && (
+            <div>
+              {!hasPeopleGroup && (
+                <div className="text-muted-foreground px-3 pt-2 pb-1 text-[11px] font-medium uppercase">
+                  People
+                </div>
+              )}
               <ParticipantOptionButton
-                key={option.id}
-                option={option}
+                option={createOption}
+                selected={selectedOption === createOption}
                 onSelect={handleSelect}
               />
-            ))}
-          </div>
-        ))}
+            </div>
+          )}
 
-        {!createOption && groups.length === 0 && (
-          <p className="text-muted-foreground px-3 py-2 text-xs">
-            {query.trim() ? "No matching contacts" : "No contacts"}
-          </p>
-        )}
+          {!createOption && groups.length === 0 && (
+            <p className="text-muted-foreground px-3 py-2 text-xs">
+              {query.trim() ? "No matching people" : "No people"}
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center gap-3">
+        <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-2">
+          <Checkbox
+            checked={applyToAllMatching}
+            className={cn([
+              "border-white bg-white text-black",
+              "data-[state=checked]:border-white data-[state=checked]:bg-white data-[state=checked]:text-black",
+            ])}
+            onCheckedChange={(value) => setApplyToAllMatching(value === true)}
+          />
+          <span className="text-muted-foreground truncate text-xs">
+            Apply to all matching segments
+          </span>
+        </label>
+        <button
+          type="button"
+          className={cn([
+            "h-8 rounded-full bg-white px-3 text-xs font-medium text-black",
+            "hover:bg-white/90",
+            "disabled:pointer-events-none disabled:opacity-50",
+          ])}
+          disabled={!selectedOption}
+          onClick={handleConfirm}
+        >
+          Confirm
+        </button>
       </div>
     </AppFloatingPanel>
   );
 }
 
+function getSpeakerParticipantDedupeKeys(
+  option: SpeakerParticipantOption,
+): string[] {
+  return [
+    `id:${option.id}`,
+    option.email ? `email:${option.email.toLowerCase()}` : null,
+  ].filter((key): key is string => key !== null);
+}
+
+function getAttachedEventParticipants(
+  eventsTable: Record<string, Record<string, unknown>> | undefined,
+  sessionEventJson: string | undefined,
+): EventParticipant[] {
+  if (!eventsTable || !sessionEventJson) {
+    return [];
+  }
+
+  let sessionEvent: SessionEvent;
+  try {
+    sessionEvent = JSON.parse(sessionEventJson) as SessionEvent;
+  } catch {
+    return [];
+  }
+
+  if (!sessionEvent.tracking_id) {
+    return [];
+  }
+
+  for (const event of Object.values(eventsTable)) {
+    if (
+      event.tracking_id_event !== sessionEvent.tracking_id ||
+      event.calendar_id !== sessionEvent.calendar_id
+    ) {
+      continue;
+    }
+
+    const participantsJson = event.participants_json;
+    if (typeof participantsJson !== "string") {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(participantsJson);
+      return Array.isArray(parsed) ? (parsed as EventParticipant[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  return [];
+}
+
 function ParticipantOptionButton({
   option,
+  selected,
   onSelect,
 }: {
   option: SpeakerParticipantOption;
+  selected: boolean;
   onSelect: (option: SpeakerParticipantOption) => void;
 }) {
   return (
     <button
       type="button"
+      aria-pressed={selected}
       className={cn([
         "w-full px-3 py-1.5 text-left text-sm",
-        "hover:bg-accent",
+        selected ? "bg-accent text-accent-foreground" : "hover:bg-accent",
       ])}
       onClick={() => onSelect(option)}
     >
       <span className="block truncate">
-        {option.isNew ? `Add "${option.name}"` : option.name}
+        {option.isCreateOption ? `Add "${option.name}"` : option.name}
       </span>
-      {!option.isNew && option.email && (
+      {option.email && (
         <span className="text-muted-foreground block truncate text-xs">
           {option.email}
         </span>


### PR DESCRIPTION
Show participants before people and confirm assignment scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how speaker assignments persist to transcripts and when new humans/session links are created, though scope is limited to the speaker-assign UI and existing `upsertSpeakerAssignment` behavior.
> 
> **Overview**
> **Speaker assignment** in the transcript popover is now a two-step flow: pick a person, then **Confirm**. Choosing someone no longer writes `speaker_hints` until confirm. Scope moved from a top **All matching / This segment** toggle to an **Apply to all matching segments** checkbox (default on) beside Confirm.
> 
> The picker lists **Participants** first (session mappings plus calendar event attendees from the linked session event), then **People** (contacts), with dedupe by id/email. Event attendees are resolved via `buildEventSpeakerParticipantOptions` (email match to existing humans; otherwise pending `event:` options that can create/link humans on confirm). Copy shifts from “contacts” to “people”; add-new options use `isCreateOption`.
> 
> Tests cover confirm/default scope, segment-only scope via checkbox, event participant building, and live session assignment requiring Confirm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01c264df4841dd16a6e03a5cc79883f1d2182fb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->