### PR TITLE
Stop resizing chat modal

### DIFF
--- a/apps/desktop/src/chat/components/input/chat-input.css
+++ b/apps/desktop/src/chat/components/input/chat-input.css
@@ -5,6 +5,8 @@
 
 [data-chat-input-surface="floating"] .chat-input-editor.tiptap,
 [data-chat-input-surface="floating"] .chat-input-editor.tiptap p {
+  caret-color: hsl(var(--card-foreground));
+  color: hsl(var(--card-foreground)) !important;
   line-height: 20px;
   margin-bottom: 0;
   min-height: 20px !important;

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -202,32 +202,36 @@ describe("ChatMessageInput", () => {
     expect(sendButton.className).not.toContain("bg-primary");
   });
 
-  it("matches the hovered FAB surface while floating", () => {
+  it("uses a white input surface while floating", () => {
     render(
       <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
     );
 
     const editor = screen.getByTestId("chat-editor");
-    const surface = editor.closest("[data-chat-message-input]")?.parentElement;
+    const messageInput = editor.closest("[data-chat-message-input]");
+    const surface = messageInput?.parentElement;
 
     expect(editor.className).toContain("chat-input-editor");
     expect(editor.className).toContain("max-h-24");
     expect(editor.className).toContain("overflow-y-auto");
     expect(editor.dataset.placeholder).toBe("Ask anything");
+    expect(messageInput?.className).toContain("h-full");
+    expect(messageInput?.className).not.toContain("min-h-10");
     expect(screen.queryByRole("button", { name: /send/i })).toBeNull();
     expect(surface?.getAttribute("data-chat-input-surface")).toBe("floating");
+    expect(surface?.className).toContain("h-10");
     expect(surface?.className).toContain("min-h-10");
-    expect(surface?.className).toContain("max-h-32");
+    expect(surface?.className).toContain("max-h-10");
     expect(surface?.className).toContain("rounded-full");
-    expect(surface?.className).toContain("py-2");
-    expect(surface?.className).toContain("bg-[#f4f4f5]");
-    expect(surface?.className).toContain("dark:bg-[#202020]");
-    expect(surface?.className).toContain("text-muted-foreground");
+    expect(surface?.className).toContain("py-0");
+    expect(surface?.className).toContain("bg-white");
+    expect(surface?.className).toContain("text-card-foreground");
+    expect(surface?.className).toContain("dark:bg-card");
+    expect(surface?.className).toContain("dark:text-card-foreground");
     expect(surface?.className).toContain("border-border/70");
     expect(surface?.className).toContain("shadow-none");
     expect(surface?.className).not.toContain("shadow-[");
     expect(surface?.className).not.toContain("inset_0_0_0_1px");
-    expect(surface?.className).not.toContain("bg-card");
   });
 
   it("uses the light card input surface in the right panel", () => {

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -77,7 +77,7 @@ export function ChatMessageInput({
         data-chat-message-input
         className={cn([
           isFloating
-            ? "flex min-h-10 w-full min-w-0 items-center"
+            ? "flex h-full min-h-0 w-full min-w-0 items-center"
             : "flex flex-col px-2 pt-3 pb-2",
         ])}
       >
@@ -175,8 +175,8 @@ function Container({
           "flex max-h-full border",
           isFloating
             ? [
-                "border-border/70 text-muted-foreground max-h-32 min-h-10 flex-row items-center overflow-hidden rounded-full bg-[#f4f4f5] px-4 py-2 text-sm shadow-none",
-                "dark:bg-[#202020]",
+                "border-border/70 text-card-foreground h-10 max-h-10 min-h-10 flex-row items-center overflow-hidden rounded-full bg-white px-4 py-0 text-sm shadow-none",
+                "dark:bg-card dark:text-card-foreground",
               ]
             : [elevatedSurfaceClassName, "flex-col rounded-xl"],
           hasContextBar && !isFloating && "rounded-t-none border-t-0",

--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -116,21 +116,21 @@ describe("PersistentChatPanel", () => {
     expect(screen.getByTestId("open-right-panel").dataset.hasSession).toBe(
       "true",
     );
-    const resizeFrame = document.querySelector("[data-chat-resize-frame]");
+    const floatingFrame = document.querySelector("[data-chat-floating-frame]");
     const panel = document.querySelector<HTMLElement>("[data-chat-panel]");
 
     await waitFor(() => {
-      expect(resizeFrame?.className).toContain("items-end");
-      expect(resizeFrame?.className).toContain("justify-center");
-      expect(resizeFrame?.className).toContain("px-3");
-      expect(resizeFrame?.className).toContain("pb-2");
-      expect(resizeFrame?.className).not.toContain("pb-3");
+      expect(floatingFrame?.className).toContain("items-end");
+      expect(floatingFrame?.className).toContain("justify-center");
+      expect(floatingFrame?.className).toContain("px-3");
+      expect(floatingFrame?.className).toContain("pb-2");
+      expect(floatingFrame?.className).not.toContain("pb-3");
       expect(panel?.style.width).toBe("calc(100% - 1.5rem)");
       expect(panel?.style.minWidth).toBe("min(368px, calc(100% - 1.5rem))");
       expect(panel?.style.maxWidth).toBe("648px");
       expect(panel?.style.height).toBe("");
       expect(panel?.style.transformOrigin).toBe("bottom center");
-      expect(panel?.className).toContain("rounded-[20px]");
+      expect(panel?.className).toContain("rounded-[28px]");
       expect(panel?.dataset.chatPanelReveal).toBe("bottom-up");
     });
   });
@@ -152,11 +152,11 @@ describe("PersistentChatPanel", () => {
 
     await screen.findByTestId("chat-view");
 
-    const resizeFrame = document.querySelector<HTMLElement>(
-      "[data-chat-resize-frame]",
+    const floatingFrame = document.querySelector<HTMLElement>(
+      "[data-chat-floating-frame]",
     );
 
-    fireEvent.click(resizeFrame!);
+    fireEvent.click(floatingFrame!);
 
     expect(mocks.sendEvent).toHaveBeenCalledWith({ type: "CLOSE" });
   });
@@ -169,175 +169,25 @@ describe("PersistentChatPanel", () => {
     fireEvent.click(screen.getByTestId("mark-draft-content"));
     mocks.sendEvent.mockClear();
 
-    const resizeFrame = document.querySelector<HTMLElement>(
-      "[data-chat-resize-frame]",
+    const floatingFrame = document.querySelector<HTMLElement>(
+      "[data-chat-floating-frame]",
     );
 
-    fireEvent.click(resizeFrame!);
+    fireEvent.click(floatingFrame!);
 
     expect(mocks.sendEvent).not.toHaveBeenCalledWith({ type: "CLOSE" });
   });
 
-  it("resizes the bottom handle by the pointer movement", async () => {
-    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
-      function (this: HTMLElement) {
-        if (this.matches("[data-chat-panel]")) {
-          return {
-            bottom: 600,
-            height: 360,
-            left: 240,
-            right: 660,
-            top: 240,
-            width: 420,
-            x: 240,
-            y: 240,
-            toJSON: () => ({}),
-          };
-        }
-
-        return {
-          bottom: 720,
-          height: 720,
-          left: 0,
-          right: 900,
-          top: 0,
-          width: 900,
-          x: 0,
-          y: 0,
-          toJSON: () => ({}),
-        };
-      },
-    );
-
-    render(<TestHost />);
-
-    await screen.findByTestId("chat-view");
-
-    const resizeFrame = document.querySelector<HTMLElement>(
-      "[data-chat-resize-frame]",
-    );
-    const panel = document.querySelector<HTMLElement>("[data-chat-panel]");
-    const bottomHandle = document.querySelector<HTMLElement>(
-      '[data-chat-resize-handle="bottom"]',
-    );
-
-    expect(resizeFrame).toBeTruthy();
-    expect(panel).toBeTruthy();
-    expect(bottomHandle).toBeTruthy();
-
-    fireEvent.pointerDown(bottomHandle!, {
-      clientX: 450,
-      clientY: 600,
-      pointerId: 1,
-    });
-    fireEvent.pointerMove(bottomHandle!, {
-      clientX: 450,
-      clientY: 640,
-      pointerId: 1,
-    });
-
-    expect(panel?.style.height).toBe("400px");
-  });
-
-  it("resizes from side, top, and top corner handles", async () => {
-    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
-      function (this: HTMLElement) {
-        if (this.matches("[data-chat-panel]")) {
-          return {
-            bottom: 600,
-            height: 360,
-            left: 240,
-            right: 660,
-            top: 240,
-            width: 420,
-            x: 240,
-            y: 240,
-            toJSON: () => ({}),
-          };
-        }
-
-        return {
-          bottom: 720,
-          height: 720,
-          left: 0,
-          right: 900,
-          top: 0,
-          width: 900,
-          x: 0,
-          y: 0,
-          toJSON: () => ({}),
-        };
-      },
-    );
-
+  it("does not expose resize handles on the floating panel", async () => {
     render(<TestHost />);
 
     await screen.findByTestId("chat-view");
 
     const panel = document.querySelector<HTMLElement>("[data-chat-panel]");
+
     expect(panel).toBeTruthy();
-
-    const dragHandle = (
-      handle: string,
-      start: { x: number; y: number },
-      end: { x: number; y: number },
-    ) => {
-      const resizeHandle = document.querySelector<HTMLElement>(
-        `[data-chat-resize-handle="${handle}"]`,
-      );
-
-      expect(resizeHandle).toBeTruthy();
-
-      fireEvent.pointerDown(resizeHandle!, {
-        clientX: start.x,
-        clientY: start.y,
-        pointerId: 1,
-      });
-      fireEvent.pointerMove(resizeHandle!, {
-        clientX: end.x,
-        clientY: end.y,
-        pointerId: 1,
-      });
-      fireEvent.pointerUp(resizeHandle!, {
-        clientX: end.x,
-        clientY: end.y,
-        pointerId: 1,
-      });
-    };
-
-    dragHandle("right", { x: 660, y: 420 }, { x: 700, y: 420 });
-    expect(panel?.style.width).toBe("460px");
-    expect(panel?.style.height).toBe("360px");
-
-    dragHandle("left", { x: 240, y: 420 }, { x: 200, y: 420 });
-    expect(panel?.style.width).toBe("460px");
-    expect(panel?.style.height).toBe("360px");
-
-    dragHandle("top", { x: 450, y: 240 }, { x: 450, y: 200 });
-    expect(panel?.style.width).toBe("420px");
-    expect(panel?.style.height).toBe("400px");
-
-    dragHandle("top-left", { x: 240, y: 240 }, { x: 200, y: 200 });
-    expect(panel?.style.width).toBe("460px");
-    expect(panel?.style.height).toBe("400px");
-
-    dragHandle("top-right", { x: 660, y: 240 }, { x: 700, y: 200 });
-    expect(panel?.style.width).toBe("460px");
-    expect(panel?.style.height).toBe("400px");
-  });
-
-  it("does not render bottom corner handles or visible corner indicators", async () => {
-    render(<TestHost />);
-
-    await screen.findByTestId("chat-view");
-
-    expect(
-      document.querySelector('[data-chat-resize-handle="bottom-left"]'),
-    ).toBeNull();
-    expect(
-      document.querySelector('[data-chat-resize-handle="bottom-right"]'),
-    ).toBeNull();
-    expect(document.querySelector("[data-chat-resize-handle] span")).toBeNull();
+    expect(document.querySelector("[data-chat-resize-frame]")).toBeNull();
+    expect(document.querySelector("[data-chat-resize-handle]")).toBeNull();
   });
 
   it("hides the floating panel when the chat moves to the right panel", async () => {

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -1,12 +1,5 @@
 import { AnimatePresence, motion } from "motion/react";
-import {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type CSSProperties,
-  type PointerEvent,
-} from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import { cn } from "@hypr/utils";
@@ -17,9 +10,6 @@ import type { ChatSessionRenderProps } from "~/chat/components/session-provider"
 import { chatFloatingPanelShellClassNames } from "~/chat/surface";
 import { useShell } from "~/contexts/shell";
 
-const FLOATING_PANEL_MIN_WIDTH = 368;
-const FLOATING_PANEL_MIN_HEIGHT = 320;
-const FLOATING_PANEL_MARGIN = 12;
 const FLOATING_CHAT_INPUT_MAX_WIDTH = 640;
 const FLOATING_CHAT_INPUT_HEIGHT = 40;
 const FLOATING_CHAT_SHELL_INSET = 4;
@@ -27,57 +17,13 @@ const FLOATING_PANEL_DEFAULT_MAX_WIDTH =
   FLOATING_CHAT_INPUT_MAX_WIDTH + FLOATING_CHAT_SHELL_INSET * 2;
 const FLOATING_PANEL_REVEAL_HEIGHT =
   FLOATING_CHAT_INPUT_HEIGHT + FLOATING_CHAT_SHELL_INSET;
-const FLOATING_PANEL_RADIUS = 20;
-
-type FloatingPanelSize = {
-  width: number;
-  height: number;
-};
+const FLOATING_PANEL_RADIUS = 28;
 
 type FloatingContainerRect = {
   top: number;
   left: number;
   width: number;
   height: number;
-};
-
-const RESIZE_HANDLES = [
-  {
-    id: "top-left",
-    className: "top-0 left-0 h-4 w-7 cursor-nwse-resize",
-  },
-  {
-    id: "top",
-    className: "top-0 right-7 left-7 h-3 cursor-row-resize",
-  },
-  {
-    id: "top-right",
-    className: "top-0 right-0 h-4 w-7 cursor-nesw-resize",
-  },
-  {
-    id: "right",
-    className: "top-7 right-0 bottom-7 w-3 cursor-ew-resize",
-  },
-  {
-    id: "bottom",
-    className: "right-7 bottom-0 left-7 h-3 cursor-row-resize",
-  },
-  {
-    id: "left",
-    className: "top-7 bottom-7 left-0 w-3 cursor-ew-resize",
-  },
-] as const;
-
-type ResizeHandle = (typeof RESIZE_HANDLES)[number]["id"];
-
-type ResizeState = {
-  pointerId: number;
-  handle: ResizeHandle;
-  startX: number;
-  startY: number;
-  startSize: FloatingPanelSize;
-  containerWidth: number;
-  containerHeight: number;
 };
 
 export function PersistentChatPanel({
@@ -94,12 +40,6 @@ export function PersistentChatPanel({
   const [containerRect, setContainerRect] =
     useState<FloatingContainerRect | null>(null);
   const [draftHasContent, setDraftHasContent] = useState(false);
-  const [floatingSize, setFloatingSize] = useState<FloatingPanelSize | null>(
-    null,
-  );
-  const resizeFrameRef = useRef<HTMLDivElement>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
-  const resizeStateRef = useRef<ResizeState | null>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
 
   const getActiveContainer = () => {
@@ -123,10 +63,6 @@ export function PersistentChatPanel({
   useEffect(() => {
     if (isVisible && !hasBeenOpened) {
       setHasBeenOpened(true);
-    }
-
-    if (!isVisible) {
-      resizeStateRef.current = null;
     }
   }, [isVisible, hasBeenOpened]);
 
@@ -214,83 +150,12 @@ export function PersistentChatPanel({
     y: { duration: 0.22, ease: [0.22, 1, 0.36, 1] },
     clipPath: { duration: 0.32, ease: [0.22, 1, 0.36, 1] },
   };
-  const panelStyle =
-    floatingSize && containerRect
-      ? getFloatingPanelStyle(floatingSize, containerRect)
-      : {
-          width: "calc(100% - 1.5rem)",
-          minWidth: "min(368px, calc(100% - 1.5rem))",
-          maxWidth: `${FLOATING_PANEL_DEFAULT_MAX_WIDTH}px`,
-          maxHeight: "calc(100% - 1rem)",
-          transformOrigin: "bottom center",
-        };
-
-  const handleResizeStart = (
-    handle: ResizeHandle,
-    event: PointerEvent<HTMLDivElement>,
-  ) => {
-    const panel = panelRef.current;
-    const frame = resizeFrameRef.current;
-
-    if (!panel || !frame) {
-      return;
-    }
-
-    event.preventDefault();
-    event.stopPropagation();
-    event.currentTarget.setPointerCapture?.(event.pointerId);
-
-    const panelRect = panel.getBoundingClientRect();
-    const frameRect = frame.getBoundingClientRect();
-
-    resizeStateRef.current = {
-      pointerId: event.pointerId,
-      handle,
-      startX: event.clientX,
-      startY: event.clientY,
-      startSize: {
-        width: panelRect.width,
-        height: panelRect.height,
-      },
-      containerWidth: frameRect.width,
-      containerHeight: frameRect.height,
-    };
-  };
-
-  const handleResizeMove = (event: PointerEvent<HTMLDivElement>) => {
-    const resizeState = resizeStateRef.current;
-
-    if (!resizeState || resizeState.pointerId !== event.pointerId) {
-      return;
-    }
-
-    event.preventDefault();
-    event.stopPropagation();
-
-    const deltaX = event.clientX - resizeState.startX;
-    const deltaY = event.clientY - resizeState.startY;
-    const nextSize = getResizedSize(resizeState, deltaX, deltaY);
-
-    setFloatingSize(
-      clampFloatingPanelSize(
-        nextSize,
-        resizeState.containerWidth,
-        resizeState.containerHeight,
-      ),
-    );
-  };
-
-  const handleResizeEnd = (event: PointerEvent<HTMLDivElement>) => {
-    const resizeState = resizeStateRef.current;
-
-    if (!resizeState || resizeState.pointerId !== event.pointerId) {
-      return;
-    }
-
-    event.preventDefault();
-    event.stopPropagation();
-    event.currentTarget.releasePointerCapture?.(event.pointerId);
-    resizeStateRef.current = null;
+  const panelStyle = {
+    width: "calc(100% - 1.5rem)",
+    minWidth: "min(368px, calc(100% - 1.5rem))",
+    maxWidth: `${FLOATING_PANEL_DEFAULT_MAX_WIDTH}px`,
+    maxHeight: "calc(100% - 1rem)",
+    transformOrigin: "bottom center",
   };
 
   return (
@@ -314,8 +179,7 @@ export function PersistentChatPanel({
           transition={{ duration: 0.2 }}
         >
           <div
-            ref={resizeFrameRef}
-            data-chat-resize-frame
+            data-chat-floating-frame
             className={cn([
               "pointer-events-auto relative flex h-full min-h-0",
               "items-end justify-center px-3 pt-4 pb-2",
@@ -331,7 +195,6 @@ export function PersistentChatPanel({
             }}
           >
             <motion.div
-              ref={panelRef}
               data-chat-panel
               data-chat-panel-reveal="bottom-up"
               data-chat-size="floating"
@@ -353,43 +216,12 @@ export function PersistentChatPanel({
                 }
                 sessionProps={sessionProps}
               />
-              {RESIZE_HANDLES.map((handle) => (
-                <div
-                  key={handle.id}
-                  data-chat-resize-handle={handle.id}
-                  className={cn([
-                    "absolute z-20 touch-none select-none",
-                    handle.className,
-                  ])}
-                  onPointerDown={(event) => handleResizeStart(handle.id, event)}
-                  onPointerMove={handleResizeMove}
-                  onPointerUp={handleResizeEnd}
-                  onPointerCancel={handleResizeEnd}
-                />
-              ))}
             </motion.div>
           </div>
         </motion.div>
       )}
     </AnimatePresence>
   );
-}
-
-function getFloatingPanelStyle(
-  size: FloatingPanelSize,
-  containerRect: FloatingContainerRect,
-): CSSProperties {
-  const clampedSize = clampFloatingPanelSize(
-    size,
-    containerRect.width,
-    containerRect.height,
-  );
-
-  return {
-    width: `${clampedSize.width}px`,
-    height: `${clampedSize.height}px`,
-    transformOrigin: "bottom center",
-  };
 }
 
 function toFloatingContainerRect(rect: DOMRect): FloatingContainerRect {
@@ -399,49 +231,4 @@ function toFloatingContainerRect(rect: DOMRect): FloatingContainerRect {
     width: rect.width,
     height: rect.height,
   };
-}
-
-function getResizedSize(
-  resizeState: ResizeState,
-  deltaX: number,
-  deltaY: number,
-): FloatingPanelSize {
-  const nextSize = { ...resizeState.startSize };
-
-  if (resizeState.handle.includes("left")) {
-    nextSize.width -= deltaX;
-  }
-
-  if (resizeState.handle.includes("right")) {
-    nextSize.width += deltaX;
-  }
-
-  if (resizeState.handle.includes("top")) {
-    nextSize.height -= deltaY;
-  }
-
-  if (resizeState.handle.includes("bottom")) {
-    nextSize.height += deltaY;
-  }
-
-  return nextSize;
-}
-
-function clampFloatingPanelSize(
-  size: FloatingPanelSize,
-  containerWidth: number,
-  containerHeight: number,
-): FloatingPanelSize {
-  const maxWidth = Math.max(0, containerWidth - FLOATING_PANEL_MARGIN * 2);
-  const maxHeight = Math.max(0, containerHeight - FLOATING_PANEL_MARGIN * 2);
-  const minWidth = Math.min(FLOATING_PANEL_MIN_WIDTH, maxWidth);
-  const minHeight = Math.min(FLOATING_PANEL_MIN_HEIGHT, maxHeight);
-  const width = clamp(size.width, minWidth, maxWidth);
-  const height = clamp(size.height, minHeight, maxHeight);
-
-  return { width, height };
-}
-
-function clamp(value: number, min: number, max: number) {
-  return Math.min(Math.max(value, min), max);
 }

--- a/apps/desktop/src/chat/surface.test.ts
+++ b/apps/desktop/src/chat/surface.test.ts
@@ -41,18 +41,21 @@ describe("chat surface tokens", () => {
 
   it("uses a neutral surface on the floating shell", () => {
     expect(chatFloatingPanelShellClassNames()).toContain(
-      "shadow-[0_16px_48px_rgba(0,0,0,0.18)]",
+      "shadow-[0_18px_56px_rgba(0,0,0,0.22)]",
     );
     expect(chatFloatingPanelShellClassNames()).toContain(
-      "dark:shadow-[0_16px_48px_rgba(0,0,0,0.55)]",
+      "dark:shadow-[0_18px_64px_rgba(0,0,0,0.6)]",
     );
     expect(chatFloatingPanelShellClassNames()).toContain("bg-[#f4f4f5]");
-    expect(chatFloatingPanelShellClassNames()).toContain("rounded-[20px]");
-    expect(chatFloatingPanelShellClassNames()).toContain("border-0");
+    expect(chatFloatingPanelShellClassNames()).toContain("rounded-[28px]");
+    expect(chatFloatingPanelShellClassNames()).toContain("border");
+    expect(chatFloatingPanelShellClassNames()).toContain("border-border/70");
+    expect(chatFloatingPanelShellClassNames()).toContain(
+      "dark:border-white/10",
+    );
     expect(chatFloatingPanelShellClassNames()).toContain("dark:bg-[#202020]");
     expect(chatFloatingPanelShellClassNames()).not.toContain("after:border");
     expect(chatFloatingPanelShellClassNames()).not.toContain("after:inset");
-    expect(chatFloatingPanelShellClassNames()).not.toContain("border-2");
     expect(chatFloatingPanelShellClassNames()).not.toContain("bg-card");
   });
 

--- a/apps/desktop/src/chat/surface.ts
+++ b/apps/desktop/src/chat/surface.ts
@@ -17,7 +17,7 @@ export function chatPanelBorderClassNames(): string {
 }
 
 export function chatFloatingPanelShellClassNames(): string {
-  return "bg-[#f4f4f5] text-card-foreground rounded-[20px] border-0 shadow-[0_16px_48px_rgba(0,0,0,0.18)] dark:bg-[#202020] dark:shadow-[0_16px_48px_rgba(0,0,0,0.55)]";
+  return "bg-[#f4f4f5] text-card-foreground rounded-[28px] border border-border/70 shadow-[0_18px_56px_rgba(0,0,0,0.22)] dark:border-white/10 dark:bg-[#202020] dark:shadow-[0_18px_64px_rgba(0,0,0,0.6)]";
 }
 
 export function chatElevatedSurfaceClassNames(): string {

--- a/apps/desktop/src/shared/chat-cta.test.tsx
+++ b/apps/desktop/src/shared/chat-cta.test.tsx
@@ -59,14 +59,17 @@ describe("ChatCTA", () => {
       "[clip-path:inset(0_calc(50%_-_3rem)_0_calc(50%_-_3rem)_round_9999px)]",
     );
     expect(surface?.className).toContain(
-      "transition-[clip-path,height,padding,background-color,border-color]",
+      "transition-[clip-path,height,padding,background-color,border-color,box-shadow]",
     );
     expect(surface?.className).toContain("origin-bottom");
     expect(surface?.className).toContain("h-2");
     expect(surface?.className).toContain("rounded-full");
     expect(surface?.className).toContain("bg-black");
     expect(surface?.className).toContain("dark:bg-white");
-    expect(surface?.className).toContain("shadow-none");
+    expect(surface?.className).toContain("shadow-[0_8px_22px_rgba(0,0,0,0.2)]");
+    expect(surface?.className).toContain(
+      "dark:shadow-[0_8px_24px_rgba(0,0,0,0.45)]",
+    );
     expect(surface?.className).toContain("border");
     expect(surface?.className).toContain("border-transparent");
     expect(surface?.className).not.toContain("border-2");
@@ -87,7 +90,6 @@ describe("ChatCTA", () => {
     expect(surface?.className).toContain(
       "group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
     );
-    expect(surface?.className).not.toContain("shadow-[");
     expect(surface?.className).not.toContain("inset_0_0_0_1px");
     expect(button.querySelectorAll("svg")).toHaveLength(0);
     expect(label.className).toContain("max-w-0");

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -33,7 +33,7 @@ export function ChatCTA({
         className={cn([
           "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-[min(640px,calc(100cqw_-_2rem))] -translate-x-1/2 items-center overflow-hidden rounded-full border border-transparent bg-black dark:bg-white",
           "[clip-path:inset(0_calc(50%_-_3rem)_0_calc(50%_-_3rem)_round_9999px)]",
-          "origin-bottom px-0 text-sm shadow-none transition-[clip-path,height,padding,background-color,border-color] duration-200 ease-out",
+          "origin-bottom px-0 text-sm shadow-[0_8px_22px_rgba(0,0,0,0.2)] transition-[clip-path,height,padding,background-color,border-color,box-shadow] duration-200 ease-out dark:shadow-[0_8px_24px_rgba(0,0,0,0.45)]",
           "group-hover/anarlog-chat-cta:border-border/70 group-focus-visible/anarlog-chat-cta:border-border/70 group-hover/anarlog-chat-cta:bg-[#f4f4f5] group-focus-visible/anarlog-chat-cta:bg-[#f4f4f5] dark:group-hover/anarlog-chat-cta:bg-[#202020] dark:group-focus-visible/anarlog-chat-cta:bg-[#202020]",
           "group-hover/anarlog-chat-cta:h-10 group-hover/anarlog-chat-cta:px-4 group-hover/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
           "group-focus-visible/anarlog-chat-cta:h-10 group-focus-visible/anarlog-chat-cta:px-4 group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",


### PR DESCRIPTION
Remove floating chat resize handles and related state. Update persistent chat tests to assert the modal stays fixed-size.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop chat UI and styling only; no auth, data, or session logic changes.
> 
> **Overview**
> Removes user-resizable floating chat: pointer handles, `floatingSize` state, and clamp/resize helpers are deleted so the panel always uses fixed width/max-height layout. The backdrop wrapper is renamed to `data-chat-floating-frame` (replacing `data-chat-resize-frame`); tests drop drag-resize cases and assert no resize DOM.
> 
> **Visual polish** for the fixed floating experience: shell corner radius **20px → 28px**, stronger drop shadow, and a visible border on the neutral shell (`surface.ts`). The floating composer becomes a **fixed 40px-tall white/card pill** (`bg-white` / `dark:bg-card`) with card-foreground text and matching caret/color in `chat-input.css`, instead of the previous gray muted FAB styling. The note-surface **Chat CTA** handle gains resting box shadows and includes `box-shadow` in its hover transition.
> 
> Right-panel / elevated input behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35d04ea2cd595a85c79b732d469dd6dc83b20721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->