### PR TITLE
Polish calendar popover metadata

### DIFF
--- a/apps/desktop/src/session/components/outer-header/metadata/date.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/date.tsx
@@ -24,7 +24,7 @@ export function DateEditor({ sessionId }: { sessionId: string }) {
 
   if (!isEditing) {
     return (
-      <div className="flex h-9 items-center justify-between gap-3">
+      <div className="flex h-7 items-center justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="text-muted-foreground text-sm">{noteDate}</div>
         </div>
@@ -113,11 +113,11 @@ function EditableDateForm({
     <div className="flex flex-col gap-2">
       <form.Field name="createdAt">
         {(field) => (
-          <div className="flex h-9 items-center gap-0">
+          <div className="flex h-7 items-center gap-0">
             <Input
               autoFocus
               type="datetime-local"
-              className="flex-1 border-0 px-0 shadow-none focus-visible:ring-0"
+              className="h-7 flex-1 border-0 px-0 py-0 shadow-none focus-visible:ring-0"
               value={field.state.value}
               onChange={(e) => field.handleChange(e.target.value)}
               onKeyDown={(e) => {

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/chip.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/chip.tsx
@@ -57,7 +57,7 @@ export function ParticipantChip({
     <Badge
       variant="secondary"
       className={cn([
-        "bg-muted hover:bg-muted/80 relative flex cursor-pointer items-center gap-1 overflow-hidden px-2 py-0.5 text-xs",
+        "bg-foreground/10 hover:bg-foreground/15 relative flex cursor-pointer items-center gap-1 overflow-hidden px-2 py-0.5 text-xs",
         isEnhancing && "ring-ring/20 ring-1",
       ])}
       onClick={handleClick}


### PR DESCRIPTION
Compact the date editor row and increase participant chip contrast with theme-aware backgrounds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind-only styling in session header metadata UI; no data, auth, or behavior changes.
> 
> **Overview**
> Tightens the session metadata popover by shrinking the **date** row from `h-9` to `h-7` in both read-only and edit modes, and matching the `datetime-local` input height with `h-7` / `py-0` so it lines up with the adjacent icon buttons.
> 
> Participant chips in the same popover swap `bg-muted` for **`bg-foreground/10`** (and a slightly stronger hover) so chip contrast tracks the active theme instead of the generic muted surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7744f4f82f443cb8346f3d4a640b41a914844ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->