### PR TITLE
Make speaker hover target pill shaped

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
@@ -222,7 +222,12 @@ describe("SpeakerAssignPopover", () => {
       }),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Speaker 2" }));
+    const trigger = screen.getByRole("button", { name: "Speaker 2" });
+    expect(trigger.className).toContain("rounded-full");
+    expect(trigger.className).toContain("px-2");
+    expect(trigger.className).toContain("-ml-2");
+
+    fireEvent.click(trigger);
     fireEvent.click(screen.getByRole("button", { name: "Alice" }));
     expect(cells.get("speaker_hints")).toBe(JSON.stringify([]));
 

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -73,7 +73,7 @@ export function SpeakerAssignPopover({
         <button
           type="button"
           className={cn([
-            "-ml-1 cursor-pointer rounded-xs px-1",
+            "-my-0.5 -ml-2 cursor-pointer rounded-full px-2 py-0.5",
             "hover:bg-accent transition-colors",
             className,
           ])}


### PR DESCRIPTION
Use padded rounded trigger styling for transcript speaker labels and cover it with the popover test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only trigger styling and test assertions; no logic or data-path changes.
> 
> **Overview**
> Updates the **SpeakerAssignPopover** click target in transcript segment headers from a small square-ish label (`rounded-xs`, tight `px-1` / `-ml-1`) to a **pill-shaped** control with more padding (`rounded-full`, `px-2`, `py-0.5`, `-ml-2`, `-my-0.5`) so hover/click is easier without changing assignment behavior.
> 
> The popover confirmation test now asserts those classes on the speaker trigger before opening the menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 475ef1e5a496cd4c521550d71a0d18ca36937cdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->