### PR TITLE
Restore session transcript tabs

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -116,12 +116,7 @@ describe("useSessionBottomAccessory", () => {
     });
   });
 
-  it("collapses the post-session transcript panel on escape", () => {
-    type TranscriptToggleProps = {
-      collapsedClassName?: string;
-      onToggle: () => void;
-    };
-
+  it("shows collapsed playback chrome for inactive sessions with audio", () => {
     const { result } = renderHook(() =>
       useSessionBottomAccessory({
         sessionId: "session-1",
@@ -135,40 +130,12 @@ describe("useSessionBottomAccessory", () => {
       mode: "playback",
       expanded: false,
     });
-    expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
-
-    const toggle = result.current.bottomBorderHandle;
-    expect(isValidElement<TranscriptToggleProps>(toggle)).toBe(true);
-    if (!isValidElement<TranscriptToggleProps>(toggle)) {
-      return;
-    }
-
-    expect(toggle.props.collapsedClassName).toBe(
-      "bg-card dark:bg-app-floating-chrome",
-    );
-
-    act(() => {
-      toggle.props.onToggle();
-    });
-
-    expect(result.current.bottomAccessoryState).toEqual({
-      mode: "playback",
-      expanded: true,
-    });
-    expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(true);
-
-    act(() => {
-      hoisted.hotkeys.get("esc")?.handler();
-    });
-
-    expect(result.current.bottomAccessoryState).toEqual({
-      mode: "playback",
-      expanded: false,
-    });
+    expect(result.current.bottomAccessory).toBeNull();
+    expect(result.current.bottomBorderHandle).not.toBeNull();
     expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
   });
 
-  it("defers transcript escape handling while chat is open", () => {
+  it("does not register transcript escape handling while chat is open", () => {
     useShellMock.mockReturnValue({
       chat: {
         mode: "FloatingOpen",
@@ -184,24 +151,15 @@ describe("useSessionBottomAccessory", () => {
       }),
     );
 
-    const toggle = result.current.bottomBorderHandle;
-    expect(isValidElement<{ onToggle: () => void }>(toggle)).toBe(true);
-    if (!isValidElement<{ onToggle: () => void }>(toggle)) {
-      return;
-    }
-
-    act(() => {
-      toggle.props.onToggle();
-    });
-
     expect(result.current.bottomAccessoryState).toEqual({
       mode: "playback",
-      expanded: true,
+      expanded: false,
     });
+    expect(result.current.bottomBorderHandle).not.toBeNull();
     expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
   });
 
-  it("defers transcript escape handling while right panel chat is open", () => {
+  it("does not register transcript escape handling while right panel chat is open", () => {
     useShellMock.mockReturnValue({
       chat: {
         mode: "RightPanelOpen",
@@ -217,34 +175,27 @@ describe("useSessionBottomAccessory", () => {
       }),
     );
 
-    const toggle = result.current.bottomBorderHandle;
-    expect(isValidElement<{ onToggle: () => void }>(toggle)).toBe(true);
-    if (!isValidElement<{ onToggle: () => void }>(toggle)) {
-      return;
-    }
-
-    act(() => {
-      toggle.props.onToggle();
-    });
-
-    expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
-  });
-
-  it("hides the playback accessory while the transcript panel is collapsed", () => {
-    const { result } = renderHook(() =>
-      useSessionBottomAccessory({
-        sessionId: "session-1",
-        sessionMode: "inactive",
-        audioExists: true,
-        hasTranscript: true,
-      }),
-    );
-
     expect(result.current.bottomAccessoryState).toEqual({
       mode: "playback",
       expanded: false,
     });
+    expect(result.current.bottomBorderHandle).not.toBeNull();
+    expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
+  });
+
+  it("hides inactive transcript-only accessory without playback or insights", () => {
+    const { result } = renderHook(() =>
+      useSessionBottomAccessory({
+        sessionId: "session-1",
+        sessionMode: "inactive",
+        audioExists: false,
+        hasTranscript: true,
+      }),
+    );
+
+    expect(result.current.bottomAccessoryState).toBeNull();
     expect(result.current.bottomAccessory).toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
   });
 
   it("generates missing insights when the insights tab opens", () => {
@@ -324,7 +275,7 @@ describe("useSessionBottomAccessory", () => {
     });
   });
 
-  it("keeps the transcript panel available after batch transcription fails without words", () => {
+  it("does not render a bottom transcript panel after batch transcription fails without words", () => {
     hoisted.batch = {
       "session-1": {
         error: "batch start failed: connection refused",
@@ -340,14 +291,12 @@ describe("useSessionBottomAccessory", () => {
       }),
     );
 
-    expect(result.current.bottomAccessoryState).toEqual({
-      mode: "transcript_only",
-      expanded: false,
-    });
-    expect(result.current.bottomBorderHandle).not.toBeNull();
+    expect(result.current.bottomAccessoryState).toBeNull();
+    expect(result.current.bottomAccessory).toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
   });
 
-  it("keeps the transcript tab visible for batch errors next to related meetings", () => {
+  it("shows only the insights bottom tab for batch errors next to related meetings", () => {
     hoisted.batch = {
       "session-1": {
         error: "batch start failed: connection refused",
@@ -375,14 +324,14 @@ describe("useSessionBottomAccessory", () => {
     render(result.current.bottomBorderHandle);
 
     expect(
-      screen.getByRole("button", { name: "Expand Transcript" }),
-    ).not.toBeNull();
+      screen.queryByRole("button", { name: "Expand Transcript" }),
+    ).toBeNull();
     expect(
       screen.getByRole("button", { name: "Expand Insights" }),
     ).not.toBeNull();
   });
 
-  it("keeps playback disabled until the audio URL is ready", () => {
+  it("waits for the audio URL before showing inactive playback", () => {
     const { result, rerender } = renderHook(
       ({ audioUrlReady }: { audioUrlReady: boolean }) =>
         useSessionBottomAccessory({
@@ -399,11 +348,8 @@ describe("useSessionBottomAccessory", () => {
       },
     );
 
-    expect(result.current.bottomAccessoryState).toEqual({
-      mode: "transcript_only",
-      expanded: false,
-    });
-    expect(result.current.bottomBorderHandle).not.toBeNull();
+    expect(result.current.bottomAccessoryState).toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
 
     rerender({ audioUrlReady: true });
 
@@ -411,9 +357,10 @@ describe("useSessionBottomAccessory", () => {
       mode: "playback",
       expanded: false,
     });
+    expect(result.current.bottomBorderHandle).not.toBeNull();
   });
 
-  it("keeps the post-session handle visible while audio lookup is loading", () => {
+  it("hides the post-session handle while audio lookup is loading without insights", () => {
     const { result, rerender } = renderHook(
       ({ isAudioLoading }: { isAudioLoading: boolean }) =>
         useSessionBottomAccessory({
@@ -431,11 +378,8 @@ describe("useSessionBottomAccessory", () => {
       },
     );
 
-    expect(result.current.bottomAccessoryState).toEqual({
-      mode: "transcript_only",
-      expanded: false,
-    });
-    expect(result.current.bottomBorderHandle).not.toBeNull();
+    expect(result.current.bottomAccessoryState).toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
 
     rerender({ isAudioLoading: false });
 
@@ -533,7 +477,7 @@ describe("useSessionBottomAccessory", () => {
     expect(result.current.bottomBorderHandle).not.toBeNull();
   });
 
-  it("keeps the transcript panel expanded when regeneration starts", () => {
+  it("keeps collapsed inactive playback when regeneration starts", () => {
     const { result, rerender } = renderHook(
       ({ sessionMode }: { sessionMode: string }) =>
         useSessionBottomAccessory({
@@ -549,26 +493,17 @@ describe("useSessionBottomAccessory", () => {
       },
     );
 
-    const toggle = result.current.bottomBorderHandle;
-    expect(isValidElement<{ onToggle: () => void }>(toggle)).toBe(true);
-    if (!isValidElement<{ onToggle: () => void }>(toggle)) {
-      return;
-    }
-
-    act(() => {
-      toggle.props.onToggle();
-    });
-
     expect(result.current.bottomAccessoryState).toEqual({
       mode: "playback",
-      expanded: true,
+      expanded: false,
     });
+    expect(result.current.bottomBorderHandle).not.toBeNull();
 
     rerender({ sessionMode: "running_batch" });
 
     expect(result.current.bottomAccessoryState).toEqual({
       mode: "playback",
-      expanded: true,
+      expanded: false,
     });
     expect(result.current.bottomAccessory).not.toBeNull();
   });

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -34,8 +34,8 @@ export function useSessionBottomAccessory({
   sessionMode,
   audioExists,
   audioUrlReady = audioExists,
-  isAudioLoading = false,
   hasTranscript,
+  suppressTranscriptPanel = false,
 }: {
   sessionId: string;
   sessionMode: string;
@@ -43,6 +43,7 @@ export function useSessionBottomAccessory({
   audioUrlReady?: boolean;
   isAudioLoading?: boolean;
   hasTranscript: boolean;
+  suppressTranscriptPanel?: boolean;
 }): {
   bottomAccessory: ReactNode;
   bottomBorderHandle: ReactNode;
@@ -56,8 +57,6 @@ export function useSessionBottomAccessory({
   const isInactive = sessionMode === "inactive";
   const isRunningBatch = sessionMode === "running_batch";
   const canUsePlayback = audioUrlReady && (isInactive || isRunningBatch);
-  const mayHaveAudio =
-    (audioExists || isAudioLoading) && (isInactive || isRunningBatch);
   const batchError = useListener(
     (state) => state.batch[sessionId]?.error ?? null,
   );
@@ -115,7 +114,7 @@ export function useSessionBottomAccessory({
     isRunningBatch ||
     (!shouldDeferToGlobalLiveAccessory &&
       isInactive &&
-      (mayHaveAudio || hasTranscript || hasTranscriptError || hasPastNotes));
+      (canUsePlayback || hasPastNotes));
   const selectPostSessionTab = useCallback(
     (tab: PostSessionTab) => {
       const shouldExpand = activePostSessionTab !== tab || !isExpanded;
@@ -192,6 +191,7 @@ export function useSessionBottomAccessory({
           isTranscriptExpanded={isExpanded}
           activeTab={activePostSessionTab}
           pastNotes={pastNotes.notes}
+          suppressTranscriptPanel={suppressTranscriptPanel}
           onRegenerateInsights={
             pastNotes.canGenerate ? pastNotes.regenerateAll : undefined
           }
@@ -202,7 +202,7 @@ export function useSessionBottomAccessory({
         <PostSessionTabHandle
           isExpanded={isExpanded}
           activeTab={activePostSessionTab}
-          showTranscriptTab={canShowTranscriptTab}
+          showTranscriptTab={isRunningBatch && canShowTranscriptTab}
           onSelect={selectPostSessionTab}
         />
       ) : (

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -333,6 +333,21 @@ describe("PostSessionAccessory", () => {
     expect(screen.queryByTestId("transcript")).toBeNull();
   });
 
+  it("keeps the audio timeline when suppressing the expanded transcript panel", () => {
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio
+        hasTranscript
+        isTranscriptExpanded
+        suppressTranscriptPanel
+      />,
+    );
+
+    expect(screen.getByTestId("timeline")).toBeTruthy();
+    expect(screen.queryByTestId("transcript")).toBeNull();
+  });
+
   it("keeps batch status visible while the transcript panel is collapsed", () => {
     useTranscriptScreenMock.mockReturnValue({
       kind: "running_batch",

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -42,6 +42,7 @@ export function PostSessionAccessory({
   isTranscriptExpanded,
   activeTab = "transcript",
   pastNotes = [],
+  suppressTranscriptPanel = false,
   onRegenerateInsights,
   fillHeight = false,
 }: {
@@ -51,6 +52,7 @@ export function PostSessionAccessory({
   isTranscriptExpanded: boolean;
   activeTab?: PostSessionTab;
   pastNotes?: PastSessionNote[];
+  suppressTranscriptPanel?: boolean;
   onRegenerateInsights?: () => void;
   fillHeight?: boolean;
 }) {
@@ -80,7 +82,7 @@ export function PostSessionAccessory({
         shouldFillExpandedPanel && "h-full overflow-hidden",
       ])}
     >
-      {isTranscriptExpanded ? (
+      {isTranscriptExpanded && !suppressTranscriptPanel ? (
         <div
           className={cn([
             shouldFillExpandedPanel

--- a/apps/desktop/src/session/components/compute-note-tab.ts
+++ b/apps/desktop/src/session/components/compute-note-tab.ts
@@ -4,16 +4,25 @@ export function computeCurrentNoteTab(
   tabView: EditorView | null,
   isLiveSessionActive: boolean,
   firstEnhancedNoteId: string | undefined,
+  _canShowTranscript = false,
 ): EditorView {
   if (isLiveSessionActive) {
-    if (tabView?.type === "raw") {
+    if (
+      tabView?.type === "raw" ||
+      tabView?.type === "enhanced" ||
+      tabView?.type === "transcript"
+    ) {
       return tabView;
     }
     return { type: "raw" };
   }
 
   if (tabView) {
-    if (tabView.type === "enhanced" || tabView.type === "raw") {
+    if (
+      tabView.type === "enhanced" ||
+      tabView.type === "raw" ||
+      tabView.type === "transcript"
+    ) {
       return tabView;
     }
 

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -1,10 +1,10 @@
 import {
   AlertCircleIcon,
+  ChevronDownIcon,
   ChevronRightIcon,
   HeartIcon,
   LightbulbIcon,
   PlusIcon,
-  RefreshCwIcon,
   SearchIcon,
   XIcon,
 } from "lucide-react";
@@ -35,8 +35,6 @@ import {
 import { useAITaskTask } from "~/ai/hooks";
 import { useLanguageModel, useLLMConnectionStatus } from "~/ai/hooks";
 import { extractPlainText } from "~/search/contexts/engine/utils";
-import { getEnhancerService } from "~/services/enhancer";
-import { useHasTranscript } from "~/session/components/shared";
 import { shouldShowEmptySummaryConfigError } from "~/session/enhance-config";
 import { useEnsureDefaultSummary } from "~/session/hooks/useEnhancedNotes";
 import {
@@ -48,7 +46,6 @@ import * as main from "~/store/tinybase/store/main";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { type EditorView } from "~/store/zustand/tabs/schema";
-import { useListener } from "~/stt/contexts";
 import {
   filterWebTemplatesAgainstUserTemplates,
   getTemplateCreatorLabel,
@@ -228,6 +225,7 @@ function HeaderTabEnhanced({
     sessionId,
     enhancedNoteId,
   );
+  const store = main.UI.useStore(main.STORE_ID);
   const content = main.UI.useCell(
     "enhanced_notes",
     enhancedNoteId,
@@ -265,15 +263,19 @@ function HeaderTabEnhanced({
   const handleRegenerate = useCallback(() => {
     void onRegenerate(null);
   }, [onRegenerate]);
-  const handleRegenerateClick = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
+  const handleSelectTemplate = useCallback(
+    (selectedTemplateId: string) => {
       if (isGenerating) {
         return;
       }
-      handleRegenerate();
+
+      store?.setPartialRow("enhanced_notes", enhancedNoteId, {
+        template_id: selectedTemplateId,
+        title: "Summary",
+      });
+      void onRegenerate(selectedTemplateId);
     },
-    [handleRegenerate, isGenerating],
+    [enhancedNoteId, isGenerating, onRegenerate, store],
   );
   const handleExploreTemplatesClick = useCallback(
     (e: React.MouseEvent) => {
@@ -374,13 +376,19 @@ function HeaderTabEnhanced({
   ]);
   const showContextMenu = useNativeContextMenu(contextMenu);
 
-  const regenerateIcon = (
+  const templateMenuTrigger = (
     <span
       data-main-area-window-drag-region
       data-tauri-drag-region="false"
-      onClick={handleRegenerateClick}
+      role="button"
+      aria-label="Select summary template"
+      aria-disabled={isGenerating}
+      tabIndex={isGenerating ? -1 : 0}
+      onClick={(event) => event.stopPropagation()}
+      onPointerDown={(event) => event.stopPropagation()}
       className={cn([
-        "group relative inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-xs transition-colors",
+        "group relative -m-1 inline-flex size-7 items-center justify-center rounded-full transition-colors",
+        isGenerating ? "cursor-not-allowed opacity-70" : "cursor-pointer",
         isError
           ? [
               "hover:text-foreground focus-visible:text-foreground text-red-600 hover:bg-red-50 focus-visible:bg-red-50",
@@ -389,13 +397,13 @@ function HeaderTabEnhanced({
           : ["hover:bg-accent focus-visible:bg-muted"],
       ])}
     >
-      {isError && (
+      {isError ? (
         <AlertCircleIcon
           size={12}
           className="pointer-events-none absolute inset-0 m-auto transition-opacity duration-200 group-hover:opacity-0 group-focus-visible:opacity-0"
         />
-      )}
-      <RefreshCwIcon
+      ) : null}
+      <ChevronDownIcon
         size={12}
         className={cn([
           "pointer-events-none absolute inset-0 m-auto transition-opacity duration-200",
@@ -417,8 +425,34 @@ function HeaderTabEnhanced({
       onContextMenu={showContextMenu}
     >
       <TruncatedTitle title={tabTitle} isActive={isActive} />
-      {isActive && regenerateIcon}
+      {isActive ? (
+        <TemplatePickerPopover
+          sessionId={sessionId}
+          onSelectTemplate={handleSelectTemplate}
+          trigger={templateMenuTrigger}
+        />
+      ) : null}
     </NoteTab>,
+  );
+}
+
+function HeaderTabTranscript({
+  isActive,
+  onClick = () => {},
+}: {
+  isActive: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <NoteTab
+      data-main-area-window-drag-region
+      data-tauri-drag-region="false"
+      className={SESSION_NOTE_TAB_CLASSNAME}
+      isActive={isActive}
+      onClick={onClick}
+    >
+      Transcript
+    </NoteTab>
   );
 }
 
@@ -450,12 +484,14 @@ function useOpenTemplatesTab() {
   );
 }
 
-function CreateOtherFormatButton({
+function TemplatePickerPopover({
   sessionId,
-  handleTabChange,
+  onSelectTemplate,
+  trigger,
 }: {
   sessionId: string;
-  handleTabChange: (view: EditorView) => void;
+  onSelectTemplate: (templateId: string) => void;
+  trigger: React.ReactNode;
 }) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -497,15 +533,9 @@ function CreateOtherFormatButton({
       setSearch("");
       resultRefs.current = [];
 
-      const service = getEnhancerService();
-      if (!service) return;
-
-      const result = service.enhance(sessionId, { templateId });
-      if (result.type === "started" || result.type === "already_active") {
-        handleTabChange({ type: "enhanced", id: result.noteId });
-      }
+      onSelectTemplate(templateId);
     },
-    [sessionId, handleTabChange],
+    [onSelectTemplate],
   );
 
   const handleOpenChange = useCallback((nextOpen: boolean) => {
@@ -877,30 +907,13 @@ function CreateOtherFormatButton({
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <button
-          data-main-area-window-drag-region
-          data-tauri-drag-region="false"
-          className={cn([
-            "relative shrink-0 px-1 py-0.5 text-xs font-medium whitespace-nowrap transition-all duration-200 select-none",
-            SESSION_NOTE_TAB_CLASSNAME,
-            "text-muted-foreground hover:text-foreground",
-            "flex items-center gap-1",
-            "border-b-2 border-transparent",
-          ])}
-        >
-          <PlusIcon size={14} />
-          <span>Use template</span>
-        </button>
-      </PopoverTrigger>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent variant="app" className="w-80" align="start">
         <div className="flex flex-col gap-1">
           <AppFloatingPanel className="flex flex-col overflow-hidden">
             <div className="border-border border-b py-2">
               <div
-                className={cn([
-                  "bg-card flex h-9 items-center gap-2 rounded-md px-3",
-                ])}
+                className={cn(["flex h-9 items-center gap-2 rounded-md px-3"])}
               >
                 <SearchIcon className="text-muted-foreground h-4 w-4" />
                 <input
@@ -999,8 +1012,6 @@ export function Header({
   currentTab: EditorView;
   handleTabChange: (view: EditorView) => void;
 }) {
-  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
-  const isLiveProcessing = sessionMode === "active";
   const store = main.UI.useStore(main.STORE_ID);
   const primaryEnhancedTabId = editorTabs.find(
     (view): view is Extract<EditorView, { type: "enhanced" }> =>
@@ -1066,14 +1077,18 @@ export function Header({
                 );
               }
 
+              if (view.type === "transcript") {
+                return (
+                  <HeaderTabTranscript
+                    key={view.type}
+                    isActive={currentTab.type === view.type}
+                    onClick={() => handleTabChange(view)}
+                  />
+                );
+              }
+
               return null;
             })}
-            {!isLiveProcessing && (
-              <CreateOtherFormatButton
-                sessionId={sessionId}
-                handleTabChange={handleTabChange}
-              />
-            )}
           </div>
         </div>
       </div>
@@ -1088,27 +1103,17 @@ export function useEditorTabs({
 }): EditorView[] {
   useEnsureDefaultSummary(sessionId);
 
-  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
-  const hasTranscript = useHasTranscript(sessionId);
   const enhancedNoteIds = main.UI.useSliceRowIds(
     main.INDEXES.enhancedNotesBySession,
     sessionId,
     main.STORE_ID,
   );
+  const enhancedTabs: EditorView[] = (enhancedNoteIds || []).map((id) => ({
+    type: "enhanced",
+    id,
+  }));
 
-  if (sessionMode === "active") {
-    return [{ type: "raw" }];
-  }
-
-  if (hasTranscript) {
-    const enhancedTabs: EditorView[] = (enhancedNoteIds || []).map((id) => ({
-      type: "enhanced",
-      id,
-    }));
-    return [...enhancedTabs, { type: "raw" }];
-  }
-
-  return [{ type: "raw" }];
+  return [...enhancedTabs, { type: "raw" }, { type: "transcript" }];
 }
 
 function useEnhanceLogic(sessionId: string, enhancedNoteId: string) {

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -18,6 +18,7 @@ import { Header, useEditorTabs } from "./header";
 import { RawEditor } from "./raw";
 import { SearchBar } from "./search/bar";
 import { useSearch } from "./search/context";
+import { Transcript } from "./transcript";
 
 import { useCaretNearBottom } from "~/session/components/caret-position-context";
 import { useCurrentNoteTab } from "~/session/components/shared";
@@ -31,6 +32,7 @@ export interface NoteInputHandle {
   focusAtStart: () => void;
   focusAtPixelWidth: (pixelWidth: number) => void;
   insertAtStartAndFocus: (content: string) => void;
+  prepareForTabChange: () => void;
 }
 
 export const NoteInput = forwardRef<
@@ -39,152 +41,191 @@ export const NoteInput = forwardRef<
     tab: Extract<Tab, { type: "sessions" }>;
     onNavigateToTitle?: (pixelWidth?: number) => void;
     onScroll?: UIEventHandler<HTMLDivElement>;
+    editorTabs?: TabEditorView[];
+    currentTab?: TabEditorView;
+    handleTabChange?: (view: TabEditorView) => void;
+    hideHeader?: boolean;
   }
->(({ tab, onNavigateToTitle, onScroll }, ref) => {
-  const editorTabs = useEditorTabs({ sessionId: tab.id });
-  const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
-  const internalEditorRef = useRef<NoteEditorRef>(null);
-  const [container, setContainer] = useState<HTMLDivElement | null>(null);
-  const [view, setView] = useState<EditorView | null>(null);
-
-  const sessionId = tab.id;
-
-  const tabRef = useRef(tab);
-  tabRef.current = tab;
-
-  const currentTab: TabEditorView = useCurrentNoteTab(tab);
-
-  useImperativeHandle(
-    ref,
-    () => ({
-      focus: () => internalEditorRef.current?.commands.focus(),
-      focusAtStart: () => internalEditorRef.current?.commands.focusAtStart(),
-      focusAtPixelWidth: (px) =>
-        internalEditorRef.current?.commands.focusAtPixelWidth(px),
-      insertAtStartAndFocus: (content) =>
-        internalEditorRef.current?.commands.insertAtStartAndFocus(content),
-    }),
-    [currentTab],
-  );
-
-  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
-  const isMeetingInProgress =
-    sessionMode === "active" ||
-    sessionMode === "finalizing" ||
-    sessionMode === "running_batch";
-
-  const { scrollRef, onBeforeTabChange } = useScrollPreservation(
-    currentTab.type === "enhanced"
-      ? `enhanced-${currentTab.id}`
-      : currentTab.type,
-  );
-
-  const handleTabChange = useCallback(
-    (tabView: TabEditorView) => {
-      onBeforeTabChange();
-      updateSessionTabState(tabRef.current, {
-        ...tabRef.current.state,
-        view: tabView,
-      });
+>(
+  (
+    {
+      tab,
+      onNavigateToTitle,
+      onScroll,
+      editorTabs: providedEditorTabs,
+      currentTab: providedCurrentTab,
+      handleTabChange: providedHandleTabChange,
+      hideHeader = false,
     },
-    [onBeforeTabChange, updateSessionTabState],
-  );
+    ref,
+  ) => {
+    const fallbackEditorTabs = useEditorTabs({ sessionId: tab.id });
+    const updateSessionTabState = useTabs(
+      (state) => state.updateSessionTabState,
+    );
+    const internalEditorRef = useRef<NoteEditorRef>(null);
+    const [container, setContainer] = useState<HTMLDivElement | null>(null);
+    const [view, setView] = useState<EditorView | null>(null);
 
-  useTabShortcuts({
-    editorTabs,
-    currentTab,
-    handleTabChange,
-  });
+    const sessionId = tab.id;
 
-  useEffect(() => {
-    if (currentTab.type === "raw" && isMeetingInProgress) {
-      requestAnimationFrame(() => {
-        internalEditorRef.current?.commands.focus();
-      });
-    }
-  }, [currentTab, isMeetingInProgress]);
+    const tabRef = useRef(tab);
+    tabRef.current = tab;
 
-  const handleViewReady = useCallback((editorView: EditorView) => {
-    setView(editorView);
-  }, []);
+    const fallbackCurrentTab: TabEditorView = useCurrentNoteTab(tab);
+    const editorTabs = providedEditorTabs ?? fallbackEditorTabs;
+    const currentTab = providedCurrentTab ?? fallbackCurrentTab;
 
-  const handleViewDisposed = useCallback((editorView: EditorView) => {
-    setView((currentView) => (currentView === editorView ? null : currentView));
-  }, []);
+    const sessionMode = useListener((state) => state.getSessionMode(sessionId));
+    const isMeetingInProgress =
+      sessionMode === "active" ||
+      sessionMode === "finalizing" ||
+      sessionMode === "running_batch";
 
-  useCaretNearBottom({
-    view,
-    container,
-    enabled: true,
-  });
+    const { scrollRef, onBeforeTabChange } = useScrollPreservation(
+      currentTab.type === "enhanced"
+        ? `enhanced-${currentTab.id}`
+        : currentTab.type,
+    );
 
-  const search = useSearch();
-  const showSearchBar = search?.isVisible ?? false;
+    useImperativeHandle(
+      ref,
+      () => ({
+        focus: () => internalEditorRef.current?.commands.focus(),
+        focusAtStart: () => internalEditorRef.current?.commands.focusAtStart(),
+        focusAtPixelWidth: (px) =>
+          internalEditorRef.current?.commands.focusAtPixelWidth(px),
+        insertAtStartAndFocus: (content) =>
+          internalEditorRef.current?.commands.insertAtStartAndFocus(content),
+        prepareForTabChange: onBeforeTabChange,
+      }),
+      [currentTab, onBeforeTabChange],
+    );
 
-  useEffect(() => {
-    search?.close();
-  }, [currentTab]);
+    const handleTabChange = useCallback(
+      (tabView: TabEditorView) => {
+        onBeforeTabChange();
+        if (providedHandleTabChange) {
+          providedHandleTabChange(tabView);
+        } else {
+          updateSessionTabState(tabRef.current, {
+            ...tabRef.current.state,
+            view: tabView,
+          });
+        }
+      },
+      [onBeforeTabChange, providedHandleTabChange, updateSessionTabState],
+    );
 
-  const handleContainerClick = () => {
-    internalEditorRef.current?.commands.focus();
-  };
+    useTabShortcuts({
+      editorTabs,
+      currentTab,
+      handleTabChange,
+    });
 
-  return (
-    <div className="-mx-2 flex h-full flex-col">
-      <div className="relative px-2">
-        <Header
-          sessionId={sessionId}
-          editorTabs={editorTabs}
-          currentTab={currentTab}
-          handleTabChange={handleTabChange}
-        />
-      </div>
+    useEffect(() => {
+      if (currentTab.type === "raw" && isMeetingInProgress) {
+        requestAnimationFrame(() => {
+          internalEditorRef.current?.commands.focus();
+        });
+      }
+    }, [currentTab, isMeetingInProgress]);
 
-      {showSearchBar && (
-        <div className="px-3 pt-1">
-          <SearchBar editorRef={internalEditorRef} />
-        </div>
-      )}
+    const handleViewReady = useCallback((editorView: EditorView) => {
+      setView(editorView);
+    }, []);
 
-      <div className="relative flex-1 overflow-hidden">
-        <div
-          ref={(node) => {
-            scrollRef.current = node;
-            setContainer(node);
-          }}
-          onClick={handleContainerClick}
-          onScroll={onScroll}
-          className={cn([
-            "h-full px-3",
-            "scroll-fade-y overflow-auto",
-            "pt-2",
-            "pb-6",
-          ])}
-        >
-          {currentTab.type === "enhanced" && (
-            <Enhanced
-              ref={internalEditorRef}
+    const handleViewDisposed = useCallback((editorView: EditorView) => {
+      setView((currentView) =>
+        currentView === editorView ? null : currentView,
+      );
+    }, []);
+
+    useCaretNearBottom({
+      view,
+      container,
+      enabled: true,
+    });
+
+    const search = useSearch();
+    const showSearchBar = search?.isVisible ?? false;
+    const isEditableTab =
+      currentTab.type === "enhanced" || currentTab.type === "raw";
+
+    useEffect(() => {
+      search?.close();
+    }, [currentTab]);
+
+    const handleContainerClick = () => {
+      if (!isEditableTab) {
+        return;
+      }
+
+      internalEditorRef.current?.commands.focus();
+    };
+
+    return (
+      <div className="-mx-2 flex h-full flex-col">
+        {!hideHeader && (
+          <div className="relative px-2">
+            <Header
               sessionId={sessionId}
-              enhancedNoteId={currentTab.id}
-              onNavigateToTitle={onNavigateToTitle}
-              onViewReady={handleViewReady}
-              onViewDisposed={handleViewDisposed}
+              editorTabs={editorTabs}
+              currentTab={currentTab}
+              handleTabChange={handleTabChange}
             />
-          )}
-          {currentTab.type === "raw" && (
-            <RawEditor
-              ref={internalEditorRef}
-              sessionId={sessionId}
-              onNavigateToTitle={onNavigateToTitle}
-              onViewReady={handleViewReady}
-              onViewDisposed={handleViewDisposed}
-            />
-          )}
+          </div>
+        )}
+
+        {showSearchBar && isEditableTab && (
+          <div className="px-3 pt-1">
+            <SearchBar editorRef={internalEditorRef} />
+          </div>
+        )}
+
+        <div className="relative flex-1 overflow-hidden">
+          <div
+            ref={(node) => {
+              scrollRef.current = node;
+              setContainer(node);
+            }}
+            onClick={handleContainerClick}
+            onScroll={onScroll}
+            className={cn([
+              "h-full px-3",
+              "scroll-fade-y overflow-auto",
+              "pt-2",
+              "pb-6",
+            ])}
+          >
+            {currentTab.type === "enhanced" && (
+              <Enhanced
+                ref={internalEditorRef}
+                sessionId={sessionId}
+                enhancedNoteId={currentTab.id}
+                onNavigateToTitle={onNavigateToTitle}
+                onViewReady={handleViewReady}
+                onViewDisposed={handleViewDisposed}
+              />
+            )}
+            {currentTab.type === "raw" && (
+              <RawEditor
+                ref={internalEditorRef}
+                sessionId={sessionId}
+                onNavigateToTitle={onNavigateToTitle}
+                onViewReady={handleViewReady}
+                onViewDisposed={handleViewDisposed}
+              />
+            )}
+            {currentTab.type === "transcript" && (
+              <Transcript sessionId={sessionId} scrollRef={scrollRef} />
+            )}
+          </div>
         </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);
 
 function useTabShortcuts({
   editorTabs,

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -1,3 +1,4 @@
+import { SearchIcon } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
 import type { EventParticipant, SessionEvent } from "@hypr/store";
@@ -82,7 +83,14 @@ export function SpeakerAssignPopover({
           {label}
         </button>
       </PopoverTrigger>
-      <PopoverContent variant="app" align="start" className="w-72">
+      <PopoverContent
+        variant="app"
+        side="right"
+        align="start"
+        sideOffset={8}
+        collisionPadding={16}
+        className="max-h-[min(var(--radix-popover-content-available-height),28rem)] w-80"
+      >
         <ParticipantList sessionId={sessionId} onSelect={handleAssign} />
       </PopoverContent>
     </Popover>
@@ -466,25 +474,25 @@ function ParticipantList({
   ]);
 
   return (
-    <AppFloatingPanel className="flex flex-col gap-2 p-2">
-      <div className="border-app-floating-border bg-app-floating-panel overflow-hidden rounded-2xl border">
-        <div className="p-2">
-          <input
-            autoFocus
-            type="search"
-            className={cn([
-              "border-border h-8 w-full rounded-md border bg-transparent px-2 text-sm outline-hidden",
-              "placeholder:text-muted-foreground focus:border-border",
-            ])}
-            placeholder="Search people"
-            value={query}
-            onChange={(e) => {
-              setQuery(e.target.value);
-              setSelectedOption(null);
-            }}
-          />
+    <div className="flex max-h-[min(var(--radix-popover-content-available-height),28rem)] flex-col gap-1 overflow-hidden">
+      <AppFloatingPanel className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="border-border border-b py-2">
+          <div className="flex h-9 items-center gap-2 px-3">
+            <SearchIcon size={16} className="text-muted-foreground shrink-0" />
+            <input
+              autoFocus
+              type="search"
+              className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-sm outline-hidden"
+              placeholder="Search people"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setSelectedOption(null);
+              }}
+            />
+          </div>
         </div>
-        <div className="max-h-60 overflow-auto py-1">
+        <div className="min-h-0 flex-1 overflow-auto py-1">
           {groups.map((group) => (
             <div key={group.title}>
               <div className="text-muted-foreground px-3 pt-2 pb-1 text-[11px] font-medium uppercase">
@@ -522,26 +530,22 @@ function ParticipantList({
             </p>
           )}
         </div>
-      </div>
-      <div className="flex items-center gap-3">
+      </AppFloatingPanel>
+      <div className="flex items-center gap-3 px-2 py-1">
         <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-2">
           <Checkbox
             checked={applyToAllMatching}
-            className={cn([
-              "border-white bg-white text-black",
-              "data-[state=checked]:border-white data-[state=checked]:bg-white data-[state=checked]:text-black",
-            ])}
             onCheckedChange={(value) => setApplyToAllMatching(value === true)}
           />
-          <span className="text-muted-foreground truncate text-xs">
-            Apply to all matching segments
+          <span className="text-muted-foreground text-sm whitespace-nowrap">
+            Apply to all
           </span>
         </label>
         <button
           type="button"
           className={cn([
-            "h-8 rounded-full bg-white px-3 text-xs font-medium text-black",
-            "hover:bg-white/90",
+            "bg-primary text-primary-foreground h-8 rounded-full px-3 text-xs font-medium",
+            "hover:bg-primary/90",
             "disabled:pointer-events-none disabled:opacity-50",
           ])}
           disabled={!selectedOption}
@@ -550,7 +554,7 @@ function ParticipantList({
           Confirm
         </button>
       </div>
-    </AppFloatingPanel>
+    </div>
   );
 }
 

--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -96,7 +96,7 @@ function ContentInner({ sessionId }: { sessionId: string }) {
         {!eventDisplayData && <DateEditor sessionId={sessionId} />}
         {eventDisplayData && <EventDisplay event={eventDisplayData} />}
       </div>
-      <div className="p-4">
+      <div className="px-4 pt-2 pb-4">
         <ParticipantsDisplay sessionId={sessionId} />
       </div>
     </div>

--- a/apps/desktop/src/session/components/shared.test.ts
+++ b/apps/desktop/src/session/components/shared.test.ts
@@ -36,13 +36,14 @@ describe("hasStoredNoteContent", () => {
 
 describe("computeCurrentNoteTab", () => {
   describe("when listening is active", () => {
-    it("returns raw view when current view is enhanced", () => {
+    it("preserves enhanced view", () => {
       const result = computeCurrentNoteTab(
         { type: "enhanced", id: "note-1" },
         true,
         "note-1",
+        false,
       );
-      expect(result).toEqual({ type: "raw" });
+      expect(result).toEqual({ type: "enhanced", id: "note-1" });
     });
 
     it("preserves raw view", () => {
@@ -50,13 +51,14 @@ describe("computeCurrentNoteTab", () => {
       expect(result).toEqual({ type: "raw" });
     });
 
-    it("returns raw view when current view is transcript", () => {
+    it("preserves transcript view", () => {
       const result = computeCurrentNoteTab(
         { type: "transcript" },
         true,
         "note-1",
+        true,
       );
-      expect(result).toEqual({ type: "raw" });
+      expect(result).toEqual({ type: "transcript" });
     });
 
     it("returns raw view when no persisted view", () => {
@@ -71,6 +73,7 @@ describe("computeCurrentNoteTab", () => {
         { type: "enhanced", id: "note-1" },
         false,
         "note-1",
+        false,
       );
       expect(result).toEqual({ type: "enhanced", id: "note-1" });
     });
@@ -80,13 +83,24 @@ describe("computeCurrentNoteTab", () => {
       expect(result).toEqual({ type: "raw" });
     });
 
-    it("normalizes persisted transcript view to raw", () => {
+    it("respects persisted transcript view", () => {
       const result = computeCurrentNoteTab(
         { type: "transcript" },
         false,
         "note-1",
+        true,
       );
-      expect(result).toEqual({ type: "raw" });
+      expect(result).toEqual({ type: "transcript" });
+    });
+
+    it("preserves persisted transcript view even before transcript content exists", () => {
+      const result = computeCurrentNoteTab(
+        { type: "transcript" },
+        false,
+        "note-1",
+        false,
+      );
+      expect(result).toEqual({ type: "transcript" });
     });
 
     it("normalizes persisted attachments view to raw", () => {
@@ -94,6 +108,7 @@ describe("computeCurrentNoteTab", () => {
         { type: "attachments" },
         false,
         "note-1",
+        false,
       );
       expect(result).toEqual({ type: "raw" });
     });

--- a/apps/desktop/src/session/components/shared.tsx
+++ b/apps/desktop/src/session/components/shared.tsx
@@ -42,6 +42,7 @@ export function useCurrentNoteHasContent(
   sessionId: string,
   currentView: EditorView,
 ): boolean {
+  const hasTranscript = useHasTranscript(sessionId);
   const rawMd = main.UI.useCell("sessions", sessionId, "raw_md", main.STORE_ID);
   const enhancedNoteId = currentView.type === "enhanced" ? currentView.id : "";
   const enhancedContent = main.UI.useCell(
@@ -55,6 +56,10 @@ export function useCurrentNoteHasContent(
     return hasStoredNoteContent(enhancedContent);
   }
 
+  if (currentView.type === "transcript") {
+    return hasTranscript;
+  }
+
   return hasStoredNoteContent(rawMd);
 }
 
@@ -63,6 +68,10 @@ export function useCurrentNoteTab(
 ): EditorView {
   const sessionMode = useListener((state) => state.getSessionMode(tab.id));
   const isLiveSessionActive = sessionMode === "active";
+  const batchError = useListener((state) => state.batch[tab.id]?.error ?? null);
+  const hasTranscript = useHasTranscript(tab.id);
+  const canShowTranscript =
+    hasTranscript || sessionMode === "running_batch" || Boolean(batchError);
 
   const enhancedNoteIds = main.UI.useSliceRowIds(
     main.INDEXES.enhancedNotesBySession,
@@ -77,8 +86,14 @@ export function useCurrentNoteTab(
         tab.state.view ?? null,
         isLiveSessionActive,
         firstEnhancedNoteId,
+        canShowTranscript,
       ),
-    [tab.state.view, isLiveSessionActive, firstEnhancedNoteId],
+    [
+      tab.state.view,
+      isLiveSessionActive,
+      firstEnhancedNoteId,
+      canShowTranscript,
+    ],
   );
 }
 

--- a/apps/desktop/src/session/hooks/useEnhancedNotes.test.tsx
+++ b/apps/desktop/src/session/hooks/useEnhancedNotes.test.tsx
@@ -77,15 +77,34 @@ describe("useEnsureDefaultSummary", () => {
     hoisted.service.queueAutoEnhanceIfSummaryEmpty.mockClear();
   });
 
-  it("queues generation instead of creating an empty summary", async () => {
+  it("creates the summary row before queueing generation", async () => {
     renderHook(() => useEnsureDefaultSummary("session-1"));
 
     await waitFor(() => {
+      expect(hoisted.service.ensureNote).toHaveBeenCalledWith(
+        "session-1",
+        "template-1",
+      );
       expect(
         hoisted.service.queueAutoEnhanceIfSummaryEmpty,
       ).toHaveBeenCalledWith("session-1");
     });
-    expect(hoisted.service.ensureNote).not.toHaveBeenCalled();
+  });
+
+  it("creates the summary row without queueing generation before transcript exists", async () => {
+    hoisted.hasTranscript = false;
+
+    renderHook(() => useEnsureDefaultSummary("session-1"));
+
+    await waitFor(() => {
+      expect(hoisted.service.ensureNote).toHaveBeenCalledWith(
+        "session-1",
+        "template-1",
+      );
+    });
+    expect(
+      hoisted.service.queueAutoEnhanceIfSummaryEmpty,
+    ).not.toHaveBeenCalled();
   });
 
   it("creates the summary row when a hosted subscription blocks generation", async () => {

--- a/apps/desktop/src/session/hooks/useEnhancedNotes.ts
+++ b/apps/desktop/src/session/hooks/useEnhancedNotes.ts
@@ -62,6 +62,18 @@ export function useEnsureDefaultSummary(sessionId: string) {
   const llmStatus = useLLMConnectionStatus();
 
   useEffect(() => {
+    const service = getEnhancerService();
+    if (!service) {
+      return;
+    }
+
+    const hasEnhancedNotes = enhancedNoteIds && enhancedNoteIds.length > 0;
+    const templateId = selectedTemplateId || undefined;
+
+    if (!hasEnhancedNotes) {
+      service.ensureNote(sessionId, templateId);
+    }
+
     if (
       !hasTranscript ||
       sessionMode === "active" ||
@@ -71,17 +83,7 @@ export function useEnsureDefaultSummary(sessionId: string) {
       return;
     }
 
-    const service = getEnhancerService();
-    if (!service) {
-      return;
-    }
-
-    const hasEnhancedNotes = enhancedNoteIds && enhancedNoteIds.length > 0;
-
     if (llmStatus.status !== "success") {
-      if (!hasEnhancedNotes) {
-        service.ensureNote(sessionId, selectedTemplateId || undefined);
-      }
       return;
     }
 

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -8,6 +8,10 @@ import { useSessionBottomAccessory } from "./components/bottom-accessory";
 import { CaretPositionProvider } from "./components/caret-position-context";
 import { FloatingActionButton } from "./components/floating";
 import { NoteInput, type NoteInputHandle } from "./components/note-input";
+import {
+  Header as NoteInputHeader,
+  useEditorTabs,
+} from "./components/note-input/header";
 import { SearchProvider } from "./components/note-input/search/context";
 import { OuterHeader } from "./components/outer-header";
 import { SessionSurface } from "./components/session-surface";
@@ -120,7 +124,9 @@ function TabContentNoteInner({
   const titleInputRef = React.useRef<TitleInputHandle>(null);
   const noteInputRef = React.useRef<NoteInputHandle>(null);
 
+  const editorTabs = useEditorTabs({ sessionId: tab.id });
   const currentView = useCurrentNoteTab(tab);
+  const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
   const hasTranscript = useHasTranscript(tab.id);
 
   const sessionId = tab.id;
@@ -139,8 +145,16 @@ function TabContentNoteInner({
       audioUrlReady,
       isAudioLoading: isAudioUrlLoading,
       hasTranscript,
+      suppressTranscriptPanel: currentView.type === "transcript",
     });
 
+  const handleTabChange = React.useCallback(
+    (view: typeof currentView) => {
+      noteInputRef.current?.prepareForTabChange();
+      updateSessionTabState(tab, { ...tab.state, view });
+    },
+    [tab, updateSessionTabState],
+  );
   const handleNavigateToTitle = React.useCallback((pixelWidth?: number) => {
     if (pixelWidth !== undefined) {
       titleInputRef.current?.focusAtPixelWidth(pixelWidth);
@@ -148,15 +162,12 @@ function TabContentNoteInner({
       titleInputRef.current?.focusAtEnd();
     }
   }, []);
-
   const handleTransferContentToEditor = React.useCallback((content: string) => {
     noteInputRef.current?.insertAtStartAndFocus(content);
   }, []);
-
   const handleFocusEditorAtStart = React.useCallback(() => {
     noteInputRef.current?.focusAtStart();
   }, []);
-
   const handleFocusEditorAtPixelWidth = React.useCallback(
     (pixelWidth: number) => {
       noteInputRef.current?.focusAtPixelWidth(pixelWidth);
@@ -181,6 +192,11 @@ function TabContentNoteInner({
     bottomAccessoryState?.expanded === true &&
     canResizeTranscriptSurface &&
     hasResizableTranscriptSurface;
+  const showBottomAccessory =
+    currentView.type !== "transcript" ||
+    bottomAccessoryState?.mode === "playback";
+  const showBottomTranscriptSurface =
+    showBottomAccessory && currentView.type !== "transcript";
 
   return (
     <SessionSurface
@@ -190,28 +206,46 @@ function TabContentNoteInner({
           currentView={currentView}
           standaloneWindow={standaloneWindow}
           title={
-            <NoteTitleBreadcrumb
-              sessionId={tab.id}
-              title={
-                <TitleInput
-                  ref={titleInputRef}
-                  tab={tab}
-                  variant="breadcrumb"
-                  onTransferContentToEditor={handleTransferContentToEditor}
-                  onFocusEditorAtStart={handleFocusEditorAtStart}
-                  onFocusEditorAtPixelWidth={handleFocusEditorAtPixelWidth}
+            <div className="flex min-w-0 items-center gap-2">
+              <div className="min-w-0 flex-1">
+                <NoteTitleBreadcrumb
+                  sessionId={tab.id}
+                  title={
+                    <TitleInput
+                      ref={titleInputRef}
+                      tab={tab}
+                      variant="breadcrumb"
+                      onTransferContentToEditor={handleTransferContentToEditor}
+                      onFocusEditorAtStart={handleFocusEditorAtStart}
+                      onFocusEditorAtPixelWidth={handleFocusEditorAtPixelWidth}
+                    />
+                  }
                 />
-              }
-            />
+              </div>
+              <div className="shrink-0">
+                <NoteInputHeader
+                  sessionId={tab.id}
+                  editorTabs={editorTabs}
+                  currentTab={currentView}
+                  handleTabChange={handleTabChange}
+                />
+              </div>
+            </div>
           }
         />
       }
-      afterBorder={bottomAccessory}
-      afterBorderExpanded={resizeTranscriptSurface}
-      afterBorderFlush={bottomAccessoryState?.mode === "live"}
-      afterBorderResizable={canResizeTranscriptSurface}
-      bottomBorderHandle={bottomBorderHandle}
-      mergeAfterBorder={mergeTranscriptSurface}
+      afterBorder={showBottomAccessory ? bottomAccessory : null}
+      afterBorderExpanded={
+        showBottomTranscriptSurface && resizeTranscriptSurface
+      }
+      afterBorderFlush={
+        showBottomTranscriptSurface && bottomAccessoryState?.mode === "live"
+      }
+      afterBorderResizable={
+        showBottomTranscriptSurface && canResizeTranscriptSurface
+      }
+      bottomBorderHandle={showBottomAccessory ? bottomBorderHandle : null}
+      mergeAfterBorder={showBottomTranscriptSurface && mergeTranscriptSurface}
       floatingButton={
         <FloatingActionButton
           allowListening={!standaloneWindow}
@@ -224,6 +258,10 @@ function TabContentNoteInner({
         ref={noteInputRef}
         tab={tab}
         onNavigateToTitle={handleNavigateToTitle}
+        editorTabs={editorTabs}
+        currentTab={currentView}
+        handleTabChange={handleTabChange}
+        hideHeader
       />
     </SessionSurface>
   );
@@ -249,9 +287,7 @@ function useAutoFocusTitle({
   sessionId: string;
   titleInputRef: React.RefObject<TitleInputHandle | null>;
 }) {
-  // Prevent re-focusing when the user intentionally leaves the title empty.
   const didAutoFocus = useRef(false);
-
   const title = main.UI.useCell("sessions", sessionId, "title", main.STORE_ID);
 
   useEffect(() => {

--- a/packages/ui/src/components/ui/floating-content.tsx
+++ b/packages/ui/src/components/ui/floating-content.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@hypr/utils";
 
 export const appFloatingContentClassName =
-  "bg-app-floating-chrome text-popover-foreground border-app-floating-border overflow-hidden rounded-2xl border p-1 shadow-lg";
+  "bg-app-floating-chrome text-popover-foreground border-app-floating-border overflow-hidden rounded-[18px] border p-1 shadow-lg";
 
 export type FloatingContentVariant = "default" | "app";
 


### PR DESCRIPTION
Moves template selection into the summary tab and removes the inactive bottom transcript panel.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5677
- <kbd>&nbsp;1&nbsp;</kbd> #5667 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session navigation, bottom accessory visibility, and summary auto-creation/regeneration paths—user-visible behavior changes across live, batch, and inactive sessions, though logic is covered by updated tests.
> 
> **Overview**
> **Restores transcript in the main session editor** and pulls note tabs into the outer header next to the title, so users switch between summary, memos, and transcript in the primary note area instead of expanding a bottom transcript panel.
> 
> **Inactive post-session bottom UI is narrowed:** playback chrome (collapsed timeline + expand) only when audio is ready; insights when related meetings exist; transcript-only / batch-error / loading states no longer get a bottom transcript handle. While the **Transcript** editor tab is active, the bottom panel can still show playback but **`suppressTranscriptPanel`** hides the duplicate expanded transcript there. Bottom **Transcript** tab appears only during **`running_batch`**.
> 
> **Summary workflow:** default summary row is **`ensureNote`**’d earlier (even before transcript); auto-enhance still waits on transcript + LLM readiness. Active summary tab gets a **template picker** (chevron) instead of a separate “Use template” control or one-click refresh icon—selection updates `template_id` and regenerates.
> 
> Tab persistence allows **transcript** (and enhanced during live) via **`computeCurrentNoteTab`** / **`useEditorTabs`**. Minor UI tweaks: speaker-assign popover layout, metadata padding, floating panel radius.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbf84e0a8150916bbda6a57ecde6a9f73ab90b20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->