### PR TITLE
Add speaker selector footer padding

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -531,7 +531,7 @@ function ParticipantList({
           )}
         </div>
       </AppFloatingPanel>
-      <div className="flex items-center gap-3 px-2 py-1">
+      <div className="flex items-center gap-3 px-2 pt-1 pb-3">
         <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-2">
           <Checkbox
             checked={applyToAllMatching}


### PR DESCRIPTION
Adds bottom padding below the apply-to-all and confirm controls.

<!-- GitButler Footer Boundary Top -->
---
This is **part 6 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #5669 👈 
- <kbd>&nbsp;5&nbsp;</kbd> #5668  
- <kbd>&nbsp;4&nbsp;</kbd> #5674  
- <kbd>&nbsp;3&nbsp;</kbd> #5673  
- <kbd>&nbsp;2&nbsp;</kbd> #5671  
- <kbd>&nbsp;1&nbsp;</kbd> #5667  
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on popover layout only; no logic or data-path impact.
> 
> **Overview**
> Adjusts spacing on the **speaker assignment** popover footer (the row with **Apply to all** and **Confirm**) in `speaker-assign.tsx`.
> 
> The footer container changes from uniform `py-1` to `pt-1 pb-3`, adding extra bottom padding so the controls sit farther from the popover edge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eaff05487488730504194e63949b8b6c64e6ee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->