### PR TITLE
Enforce note titles in editor

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
@@ -5,7 +5,9 @@ import { EnhancedEditor } from "./editor";
 
 const hoisted = vi.hoisted(() => ({
   content: JSON.stringify({ type: "doc", content: [] }),
-  handleChange: vi.fn(),
+  sessionTitle: "Weekly sync",
+  persistContent: vi.fn(),
+  persistSessionTitle: vi.fn(),
   noteEditorProps: [] as Record<string, unknown>[],
 }));
 
@@ -48,8 +50,17 @@ vi.mock("~/shared/hooks/useFileUpload", () => ({
 vi.mock("~/store/tinybase/store/main", () => ({
   STORE_ID: "main",
   UI: {
-    useCell: () => hoisted.content,
-    useSetPartialRowCallback: () => hoisted.handleChange,
+    useCell: (table: string, _row: string, cell: string) => {
+      if (table === "sessions" && cell === "title") {
+        return hoisted.sessionTitle;
+      }
+
+      return hoisted.content;
+    },
+    useSetPartialRowCallback: (table: string) =>
+      table === "sessions"
+        ? hoisted.persistSessionTitle
+        : hoisted.persistContent,
   },
 }));
 
@@ -61,17 +72,66 @@ describe("EnhancedEditor", () => {
   beforeEach(() => {
     hoisted.noteEditorProps = [];
     hoisted.content = JSON.stringify({ type: "doc", content: [] });
-    hoisted.handleChange = vi.fn();
+    hoisted.sessionTitle = "Weekly sync";
+    hoisted.persistContent = vi.fn();
+    hoisted.persistSessionTitle = vi.fn();
   });
 
-  it("keeps persisted notes from syncing external content while focused", () => {
+  it("shows the session title as the first line for persisted notes", () => {
+    hoisted.content = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Summary Section" }],
+        },
+      ],
+    });
+
     render(<EnhancedEditor sessionId="session-1" enhancedNoteId="note-1" />);
 
     const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
 
     expect(props?.syncContentWhenFocused).toBe(false);
-    expect(props?.handleChange).toBe(hoisted.handleChange);
+    expect(props?.handleChange).not.toBe(hoisted.persistContent);
     expect(props?.taskSource).toEqual({ type: "enhanced_note", id: "note-1" });
+    expect(props?.initialContent).toMatchObject({
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Weekly sync" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Summary Section" }],
+        },
+      ],
+    });
+  });
+
+  it("persists content and updates the session title from the first line", () => {
+    render(<EnhancedEditor sessionId="session-1" enhancedNoteId="note-1" />);
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+    const input = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Edited title" }],
+        },
+      ],
+    };
+
+    (props?.handleChange as (input: unknown) => void)(input);
+
+    expect(hoisted.persistContent).toHaveBeenCalledWith(input);
+    expect(hoisted.persistSessionTitle).toHaveBeenCalledWith("Edited title");
   });
 
   it("keeps streamed previews syncing while focused", () => {
@@ -95,6 +155,19 @@ describe("EnhancedEditor", () => {
     expect(props?.syncContentWhenFocused).toBe(true);
     expect(props?.handleChange).toBeUndefined();
     expect(props?.taskSource).toBeUndefined();
-    expect(props?.initialContent).toBe(contentOverride);
+    expect(props?.initialContent).toMatchObject({
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Weekly sync" }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Generating" }],
+        },
+      ],
+    });
   });
 });

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -1,5 +1,5 @@
 import type { EditorView } from "prosemirror-view";
-import { forwardRef, useMemo } from "react";
+import { forwardRef, useCallback, useMemo } from "react";
 
 import { parseJsonContent } from "@hypr/editor/markdown";
 import {
@@ -13,6 +13,11 @@ import { useMentionConfig } from "~/editor-bridge/mention-config";
 import { openEditorLink } from "~/editor-bridge/open-editor-link";
 import { sessionMentionDropConfig } from "~/editor-bridge/session-mention-drop";
 import { SessionNodeView } from "~/editor-bridge/session-view";
+import { hasStoredNoteContent } from "~/session/components/shared";
+import {
+  ensureFirstLineTitle,
+  extractFirstLineTitle,
+} from "~/session/title-content";
 import { useFileUpload } from "~/shared/hooks/useFileUpload";
 import * as main from "~/store/tinybase/store/main";
 
@@ -47,22 +52,50 @@ export const EnhancedEditor = forwardRef<
       "content",
       main.STORE_ID,
     );
+    const sessionTitle = main.UI.useCell(
+      "sessions",
+      sessionId,
+      "title",
+      main.STORE_ID,
+    ) as string | undefined;
 
     const initialContent = useMemo<JSONContent>(
-      () => contentOverride ?? parseJsonContent(content as string),
-      [content, contentOverride],
+      () =>
+        ensureFirstLineTitle(
+          contentOverride ?? parseJsonContent(content as string),
+          sessionTitle,
+        ),
+      [content, contentOverride, sessionTitle],
     );
     const persistChanges = contentOverride === undefined;
     const editorKey = persistChanges
       ? `enhanced-note-${enhancedNoteId}`
       : `enhanced-note-${enhancedNoteId}-preview`;
 
-    const handleChange = main.UI.useSetPartialRowCallback(
+    const persistContent = main.UI.useSetPartialRowCallback(
       "enhanced_notes",
       enhancedNoteId,
       (input: JSONContent) => ({ content: JSON.stringify(input) }),
       [],
       main.STORE_ID,
+    );
+    const persistSessionTitle = main.UI.useSetPartialRowCallback(
+      "sessions",
+      sessionId,
+      (title: string) => ({ title }),
+      [],
+      main.STORE_ID,
+    );
+    const handleChange = useCallback(
+      (input: JSONContent) => {
+        persistContent(input);
+
+        const title = extractFirstLineTitle(input);
+        if (title !== null || hasStoredNoteContent(content)) {
+          persistSessionTitle(title ?? "");
+        }
+      },
+      [content, persistContent, persistSessionTitle],
     );
 
     const fileHandlerConfig = useMemo(() => ({ onFileUpload }), [onFileUpload]);

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -14,7 +14,12 @@ import { useMentionConfig } from "~/editor-bridge/mention-config";
 import { openEditorLink } from "~/editor-bridge/open-editor-link";
 import { sessionMentionDropConfig } from "~/editor-bridge/session-mention-drop";
 import { SessionNodeView } from "~/editor-bridge/session-view";
+import { hasStoredNoteContent } from "~/session/components/shared";
 import { emitRawEditorSync } from "~/session/raw-editor-sync";
+import {
+  ensureFirstLineTitle,
+  extractFirstLineTitle,
+} from "~/session/title-content";
 import { useFileUpload } from "~/shared/hooks/useFileUpload";
 import * as main from "~/store/tinybase/store/main";
 
@@ -50,19 +55,34 @@ export const RawEditor = forwardRef<
       "raw_md",
       main.STORE_ID,
     );
+    const sessionTitle = main.UI.useCell(
+      "sessions",
+      sessionId,
+      "title",
+      main.STORE_ID,
+    ) as string | undefined;
     const onFileUpload = useFileUpload(sessionId);
     const syncSourceId = useRawEditorSyncSourceId();
 
     const initialContent = useMemo<JSONContent>(
-      () => parseJsonContent(rawMd as string),
-      [rawMd],
+      () =>
+        ensureFirstLineTitle(parseJsonContent(rawMd as string), sessionTitle),
+      [rawMd, sessionTitle],
     );
 
     const persistChange = main.UI.useSetPartialRowCallback(
       "sessions",
       sessionId,
-      (input: JSONContent) => ({ raw_md: JSON.stringify(input) }),
-      [],
+      (input: JSONContent) => {
+        const title = extractFirstLineTitle(input);
+        return {
+          raw_md: JSON.stringify(input),
+          ...(title !== null || hasStoredNoteContent(rawMd)
+            ? { title: title ?? "" }
+            : {}),
+        };
+      },
+      [rawMd],
       main.STORE_ID,
     );
 

--- a/apps/desktop/src/session/title-content.test.ts
+++ b/apps/desktop/src/session/title-content.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ensureFirstLineTitle,
+  ensureMarkdownFirstLineTitle,
+  extractFirstLineTitle,
+} from "./title-content";
+
+describe("extractFirstLineTitle", () => {
+  it("returns the first block text", () => {
+    expect(
+      extractFirstLineTitle({
+        type: "doc",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 1 },
+            content: [{ type: "text", text: "Planning" }],
+          },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Follow up" }],
+          },
+        ],
+      }),
+    ).toBe("Planning");
+  });
+
+  it("returns an empty title when the body has content but the title is blank", () => {
+    expect(
+      extractFirstLineTitle({
+        type: "doc",
+        content: [
+          { type: "heading", attrs: { level: 1 } },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Follow up" }],
+          },
+        ],
+      }),
+    ).toBe("");
+  });
+
+  it("does not update titles for an empty document", () => {
+    expect(
+      extractFirstLineTitle({
+        type: "doc",
+        content: [{ type: "heading", attrs: { level: 1 } }],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("ensureFirstLineTitle", () => {
+  it("prepends the session title before generated summary headings", () => {
+    expect(
+      ensureFirstLineTitle(
+        {
+          type: "doc",
+          content: [
+            {
+              type: "heading",
+              attrs: { level: 1 },
+              content: [{ type: "text", text: "Summary Section" }],
+            },
+          ],
+        },
+        "Meeting Title",
+      ),
+    ).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Meeting Title" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Summary Section" }],
+        },
+      ],
+    });
+  });
+
+  it("converts an existing first paragraph title without duplicating it", () => {
+    expect(
+      ensureFirstLineTitle(
+        {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Meeting Title" }],
+            },
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Follow up" }],
+            },
+          ],
+        },
+        "Meeting Title",
+      ),
+    ).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Meeting Title" }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Follow up" }],
+        },
+      ],
+    });
+  });
+
+  it("preserves a non-matching first heading by prepending the session title", () => {
+    expect(
+      ensureFirstLineTitle(
+        {
+          type: "doc",
+          content: [
+            {
+              type: "heading",
+              attrs: { level: 1 },
+              content: [{ type: "text", text: "Old Title" }],
+            },
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Follow up" }],
+            },
+          ],
+        },
+        "Meeting Title",
+      ),
+    ).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Meeting Title" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Old Title" }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Follow up" }],
+        },
+      ],
+    });
+  });
+
+  it("does not duplicate an existing title line", () => {
+    const content = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Meeting Title" }],
+        },
+      ],
+    };
+
+    expect(ensureFirstLineTitle(content, "Meeting Title")).toBe(content);
+  });
+});
+
+describe("ensureMarkdownFirstLineTitle", () => {
+  it("prepends the session title before markdown summary headings", () => {
+    expect(
+      ensureMarkdownFirstLineTitle(
+        "# Summary Section\n\n- Follow up",
+        "Meeting Title",
+      ),
+    ).toBe("# Meeting Title\n\n# Summary Section\n\n- Follow up");
+  });
+
+  it("does not duplicate an exact markdown heading without a trailing newline", () => {
+    expect(
+      ensureMarkdownFirstLineTitle("# Meeting Title", "Meeting Title"),
+    ).toBe("# Meeting Title");
+  });
+});

--- a/apps/desktop/src/session/title-content.ts
+++ b/apps/desktop/src/session/title-content.ts
@@ -1,0 +1,88 @@
+import type { JSONContent } from "@hypr/editor/note";
+
+export function extractFirstLineTitle(content: JSONContent) {
+  const firstBlock = content.content?.[0];
+  const title = collectText(firstBlock).trim();
+
+  if (title) {
+    return title;
+  }
+
+  return collectText(content).trim() ? "" : null;
+}
+
+export function ensureFirstLineTitle(
+  content: JSONContent,
+  title: string | null | undefined,
+) {
+  const trimmedTitle = title?.trim();
+  if (!trimmedTitle) {
+    return content;
+  }
+
+  const blocks = content.content ?? [];
+  const firstBlock = blocks[0];
+  const titleBlock = buildTitleBlock(trimmedTitle);
+
+  if (
+    (firstBlock?.type === "heading" && firstBlock.attrs?.level === 1) ||
+    firstBlock?.type === "paragraph"
+  ) {
+    if (collectText(firstBlock).trim() === trimmedTitle) {
+      return firstBlock.type === "heading" && firstBlock.attrs?.level === 1
+        ? content
+        : { ...content, content: [titleBlock, ...blocks.slice(1)] };
+    }
+  }
+
+  if (
+    firstBlock?.type === "heading" &&
+    firstBlock.attrs?.level === 1 &&
+    !collectText(firstBlock).trim()
+  ) {
+    return { ...content, content: [titleBlock, ...blocks.slice(1)] };
+  }
+
+  return { ...content, content: [titleBlock, ...blocks] };
+}
+
+export function ensureMarkdownFirstLineTitle(
+  markdown: string,
+  title: string | null | undefined,
+) {
+  const trimmedTitle = title?.trim();
+  if (!trimmedTitle) {
+    return markdown;
+  }
+
+  const trimmedMarkdown = markdown.trimStart();
+  const firstLineEnd = trimmedMarkdown.indexOf("\n");
+  const firstLine =
+    firstLineEnd === -1
+      ? trimmedMarkdown
+      : trimmedMarkdown.slice(0, firstLineEnd);
+
+  if (firstLine === `# ${trimmedTitle}`) {
+    return markdown;
+  }
+
+  return `# ${trimmedTitle}\n\n${markdown.trimStart()}`.trim();
+}
+
+function buildTitleBlock(title: string): JSONContent {
+  return {
+    type: "heading",
+    attrs: { level: 1 },
+    content: [{ type: "text", text: title }],
+  };
+}
+
+function collectText(node?: JSONContent): string {
+  if (!node) {
+    return "";
+  }
+
+  const ownText = typeof node.text === "string" ? node.text : "";
+  const childText = node.content?.map(collectText).join("") ?? "";
+  return ownText + childText;
+}

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
@@ -115,7 +115,7 @@ describe("enhanceSuccess.onSuccess", () => {
     const markdown = json2md(JSON.parse(persisted)).trim();
 
     expect(markdown).toBe(
-      "# Summary\n\nDiscussed launch plan #Launch.\n\n#launch #prep #next_steps #template #owners",
+      "# Existing title\n\n# Summary\n\nDiscussed launch plan #Launch.\n\n#launch #prep #next_steps #template #owners",
     );
     expect(store.setRow).toHaveBeenCalledWith("tags", "launch", {
       user_id: "user-1",
@@ -164,6 +164,27 @@ describe("enhanceSuccess.onSuccess", () => {
     await enhanceSuccess.onSuccess?.(params);
 
     expect(startTask).not.toHaveBeenCalled();
+  });
+
+  it("stores the existing session title before generated summary sections", async () => {
+    const store = {
+      setPartialRow: vi.fn(),
+      getCell: vi.fn().mockReturnValue("OpenCode Interface Type and GUI"),
+      getValue: vi.fn().mockReturnValue("user-1"),
+      setRow: vi.fn(),
+    } as unknown as EnhanceSuccessParams["store"];
+    const params = createParams({
+      store,
+      text: "# OpenCode Tool Discussion\n\n- Speakers discussed OpenCode.",
+    });
+
+    await enhanceSuccess.onSuccess?.(params);
+
+    const persisted = (store.setPartialRow as ReturnType<typeof vi.fn>).mock
+      .calls[0][2].content;
+    expect(json2md(JSON.parse(persisted)).trim()).toBe(
+      "# OpenCode Interface Type and GUI\n\n# OpenCode Tool Discussion\n\n- Speakers discussed OpenCode.",
+    );
   });
 
   it("does not start title generation while the title is being edited", async () => {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
@@ -7,6 +7,7 @@ import {
   upsertSessionTags,
 } from "./summary-tags";
 
+import { ensureMarkdownFirstLineTitle } from "~/session/title-content";
 import { hasLiveSessionTitleDraft } from "~/store/zustand/live-title";
 
 const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = ({
@@ -24,9 +25,13 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = ({
 
   const tagNames = extractEnhanceTagNames(text, transformedArgs);
   const textWithTags = appendTagLineToMarkdown(text, tagNames);
+  const currentTitle = store.getCell("sessions", args.sessionId, "title");
+  const trimmedTitle =
+    typeof currentTitle === "string" ? currentTitle.trim() : "";
+  const titledText = ensureMarkdownFirstLineTitle(textWithTags, trimmedTitle);
 
   try {
-    const jsonContent = md2json(textWithTags);
+    const jsonContent = md2json(titledText);
     store.setPartialRow("enhanced_notes", args.enhancedNoteId, {
       content: JSON.stringify(jsonContent),
     });
@@ -36,9 +41,6 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = ({
     return;
   }
 
-  const currentTitle = store.getCell("sessions", args.sessionId, "title");
-  const trimmedTitle =
-    typeof currentTitle === "string" ? currentTitle.trim() : "";
   if (trimmedTitle || hasLiveSessionTitleDraft(args.sessionId)) {
     return;
   }

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.test.ts
@@ -16,6 +16,7 @@ function createParams(
   const store = {
     setPartialRow: vi.fn(),
     getCell: vi.fn().mockReturnValue(""),
+    forEachRow: vi.fn(),
   } as unknown as TitleSuccessParams["store"];
 
   return {
@@ -47,6 +48,60 @@ describe("titleSuccess.onSuccess", () => {
       "session-1",
       { title: "Weekly sync" },
     );
+  });
+
+  it("backfills generated titles into existing enhanced note content", () => {
+    const store = {
+      setPartialRow: vi.fn(),
+      getCell: vi.fn((table, row, cell) => {
+        if (table === "sessions" && cell === "title") return "";
+        if (table === "sessions" && cell === "raw_md") return "";
+        if (table === "enhanced_notes" && cell === "session_id") {
+          return row === "note-1" ? "session-1" : "other-session";
+        }
+        if (table === "enhanced_notes" && cell === "content") {
+          return JSON.stringify({
+            type: "doc",
+            content: [
+              {
+                type: "heading",
+                attrs: { level: 1 },
+                content: [{ type: "text", text: "Summary Section" }],
+              },
+            ],
+          });
+        }
+        return "";
+      }),
+      forEachRow: vi.fn((_table, callback) => {
+        callback("note-1");
+        callback("note-2");
+      }),
+    } as unknown as TitleSuccessParams["store"];
+    const params = createParams({ store, text: "  Weekly sync  " });
+
+    titleSuccess.onSuccess?.(params);
+
+    const enhancedUpdate = (
+      store.setPartialRow as ReturnType<typeof vi.fn>
+    ).mock.calls.find(([table]) => table === "enhanced_notes");
+    expect(enhancedUpdate?.[0]).toBe("enhanced_notes");
+    expect(enhancedUpdate?.[1]).toBe("note-1");
+    expect(JSON.parse(enhancedUpdate?.[2].content)).toMatchObject({
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Weekly sync" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Summary Section" }],
+        },
+      ],
+    });
   });
 
   it("does not overwrite an existing session title", () => {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.ts
@@ -1,5 +1,8 @@
+import { parseJsonContent } from "@hypr/editor/markdown";
+
 import type { TaskConfig } from ".";
 
+import { ensureFirstLineTitle } from "~/session/title-content";
 import { hasLiveSessionTitleDraft } from "~/store/zustand/live-title";
 
 const onSuccess: NonNullable<TaskConfig<"title">["onSuccess"]> = ({
@@ -25,7 +28,36 @@ const onSuccess: NonNullable<TaskConfig<"title">["onSuccess"]> = ({
     return;
   }
 
-  store.setPartialRow("sessions", args.sessionId, { title: trimmed });
+  const row: { title: string; raw_md?: string } = { title: trimmed };
+  const rawMd = store.getCell("sessions", args.sessionId, "raw_md");
+  if (typeof rawMd === "string" && rawMd.trim()) {
+    row.raw_md = JSON.stringify(
+      ensureFirstLineTitle(parseJsonContent(rawMd), trimmed),
+    );
+  }
+
+  store.setPartialRow("sessions", args.sessionId, row);
+  store.forEachRow("enhanced_notes", (enhancedNoteId, _forEachCell) => {
+    const sessionId = store.getCell(
+      "enhanced_notes",
+      enhancedNoteId,
+      "session_id",
+    );
+    if (sessionId !== args.sessionId) {
+      return;
+    }
+
+    const content = store.getCell("enhanced_notes", enhancedNoteId, "content");
+    if (typeof content !== "string" || !content.trim()) {
+      return;
+    }
+
+    store.setPartialRow("enhanced_notes", enhancedNoteId, {
+      content: JSON.stringify(
+        ensureFirstLineTitle(parseJsonContent(content), trimmed),
+      ),
+    });
+  });
 };
 
 export const titleSuccess: Pick<TaskConfig<"title">, "onSuccess"> = {

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -91,6 +91,7 @@ import {
   useLinkedItemOpenBehavior,
 } from "./linked-item-open-behavior";
 import { schema } from "./schema";
+import { normalizeTitleHeadingDoc, titleHeadingPlugin } from "./title-layout";
 
 export type { MentionConfig, FileHandlerConfig, PlaceholderFunction };
 export { schema };
@@ -163,6 +164,7 @@ export interface NoteEditorProps {
   onViewReady?: (view: EditorView) => void;
   onViewDisposed?: (view: EditorView) => void;
   syncContentWhenFocused?: boolean;
+  enforceTitleHeading?: boolean;
 }
 
 const baseNodeViews = {
@@ -475,6 +477,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       onViewReady: onViewReadyProp,
       onViewDisposed,
       syncContentWhenFocused = false,
+      enforceTitleHeading = true,
     } = props;
 
     const taskStorage = useTaskStorageOptional();
@@ -553,6 +556,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       () => [
         reactKeys(),
         buildInputRules(),
+        ...(enforceTitleHeading ? [titleHeadingPlugin()] : []),
         taskIdentityPlugin(),
         buildKeymap(onNavigateToTitle),
         history(),
@@ -582,6 +586,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         sessionMentionDropConfig,
         onNavigateToTitle,
         onLinkOpen,
+        enforceTitleHeading,
       ],
     );
     const nodeViews = useMemo(
@@ -596,11 +601,18 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
           reconciledInitialContent && reconciledInitialContent.type === "doc"
             ? PMNode.fromJSON(schema, reconciledInitialContent)
             : schema.node("doc", null, [schema.node("paragraph")]);
+        if (enforceTitleHeading) {
+          doc = normalizeTitleHeadingDoc(doc);
+        }
       } catch {
-        doc = schema.node("doc", null, [schema.node("paragraph")]);
+        doc = schema.node("doc", null, [
+          enforceTitleHeading
+            ? schema.node("heading", { level: 1 })
+            : schema.node("paragraph"),
+        ]);
       }
       return EditorState.create({ doc, plugins });
-    }, [reconciledInitialContent, plugins]);
+    }, [reconciledInitialContent, plugins, enforceTitleHeading]);
 
     useEffect(() => {
       const view = viewRef.current;
@@ -626,7 +638,10 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       }
 
       try {
-        const doc = PMNode.fromJSON(schema, reconciledInitialContent);
+        let doc = PMNode.fromJSON(schema, reconciledInitialContent);
+        if (enforceTitleHeading) {
+          doc = normalizeTitleHeadingDoc(doc);
+        }
         const state = EditorState.create({
           doc,
           plugins: view.state.plugins,
@@ -636,14 +651,14 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       } catch {
         // invalid content
       }
-    }, [reconciledInitialContent, syncContentWhenFocused]);
+    }, [reconciledInitialContent, syncContentWhenFocused, enforceTitleHeading]);
 
     const onViewReady = useCallback(
       (view: EditorView) => {
-        onUpdate(view.state.doc.toJSON() as JSONContent);
         onViewReadyProp?.(view);
+        syncTasks(view.state.doc.toJSON() as JSONContent);
       },
-      [onUpdate, onViewReadyProp],
+      [onViewReadyProp, syncTasks],
     );
 
     return (
@@ -674,7 +689,11 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
                 autoCorrect: "off",
                 autoCapitalize: "off",
                 role: "textbox",
-                class: cn(["tiptap", className]),
+                class: cn([
+                  "tiptap",
+                  enforceTitleHeading && "note-title-editor",
+                  className,
+                ]),
               }}
             >
               <ProseMirrorDoc />

--- a/packages/editor/src/note/title-layout.test.ts
+++ b/packages/editor/src/note/title-layout.test.ts
@@ -1,0 +1,68 @@
+import { EditorState } from "prosemirror-state";
+import { describe, expect, it } from "vitest";
+
+import { schema } from "./schema";
+import { normalizeTitleHeadingDoc, titleHeadingPlugin } from "./title-layout";
+
+describe("normalizeTitleHeadingDoc", () => {
+  it("converts the first paragraph into a title heading", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("Planning")]),
+      schema.node("paragraph", null, [schema.text("Follow up")]),
+    ]);
+
+    expect(normalizeTitleHeadingDoc(doc).toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Planning" }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Follow up" }],
+        },
+      ],
+    });
+  });
+
+  it("inserts an empty title heading before non-text blocks", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("bulletList", null, [
+        schema.node("listItem", null, [
+          schema.node("paragraph", null, [schema.text("Follow up")]),
+        ]),
+      ]),
+    ]);
+
+    expect(normalizeTitleHeadingDoc(doc).toJSON()).toMatchObject({
+      type: "doc",
+      content: [
+        { type: "heading", attrs: { level: 1 } },
+        { type: "bulletList" },
+      ],
+    });
+  });
+});
+
+describe("titleHeadingPlugin", () => {
+  it("restores the first block to a title heading after edits", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("heading", { level: 1 }, [schema.text("Planning")]),
+      schema.node("paragraph", null, [schema.text("Follow up")]),
+    ]);
+    const state = EditorState.create({
+      schema,
+      doc,
+      plugins: [titleHeadingPlugin()],
+    });
+
+    const result = state.applyTransaction(
+      state.tr.setNodeMarkup(0, schema.nodes.paragraph),
+    );
+
+    expect(result.state.doc.firstChild?.type).toBe(schema.nodes.heading);
+    expect(result.state.doc.firstChild?.attrs.level).toBe(1);
+  });
+});

--- a/packages/editor/src/note/title-layout.ts
+++ b/packages/editor/src/note/title-layout.ts
@@ -1,0 +1,64 @@
+import { type Node as PMNode } from "prosemirror-model";
+import { Plugin, PluginKey } from "prosemirror-state";
+
+import { schema } from "./schema";
+
+const titleHeadingPluginKey = new PluginKey("titleHeading");
+
+export function normalizeTitleHeadingDoc(doc: PMNode) {
+  const first = doc.firstChild;
+  const heading = schema.nodes.heading;
+
+  if (!first) {
+    return schema.node("doc", null, [heading.create({ level: 1 })]);
+  }
+
+  if (first.type === heading && first.attrs.level === 1) {
+    return doc;
+  }
+
+  const children: PMNode[] = [];
+  doc.forEach((child) => children.push(child));
+
+  if (first.type === schema.nodes.paragraph || first.type === heading) {
+    children[0] = heading.create({ level: 1 }, first.content, first.marks);
+  } else {
+    children.unshift(heading.create({ level: 1 }));
+  }
+
+  return schema.node("doc", null, children);
+}
+
+export function titleHeadingPlugin() {
+  return new Plugin({
+    key: titleHeadingPluginKey,
+    appendTransaction(transactions, _oldState, newState) {
+      if (!transactions.some((transaction) => transaction.docChanged)) {
+        return null;
+      }
+
+      const first = newState.doc.firstChild;
+      const heading = newState.schema.nodes.heading;
+      if (!heading) {
+        return null;
+      }
+
+      if (first?.type === heading && first.attrs.level === 1) {
+        return null;
+      }
+
+      const tr = newState.tr;
+      if (
+        first &&
+        (first.type === newState.schema.nodes.paragraph ||
+          first.type === heading)
+      ) {
+        tr.setNodeMarkup(0, heading, { level: 1 });
+      } else {
+        tr.insert(0, heading.create({ level: 1 }));
+      }
+
+      return tr;
+    },
+  });
+}

--- a/packages/tiptap/src/styles/nodes/heading.css
+++ b/packages/tiptap/src/styles/nodes/heading.css
@@ -68,6 +68,17 @@
   }
 }
 
+.tiptap.note-title-editor > h1:first-child {
+  font-size: 1.75rem;
+  line-height: 2.125rem;
+  margin-bottom: 1rem;
+}
+
+.tiptap.enhanced-summary-editor.note-title-editor > h1:first-child {
+  font-size: 1.5rem;
+  line-height: 1.875rem;
+}
+
 .blog-editor .tiptap {
   h1 {
     font-size: 1.875rem;


### PR DESCRIPTION
Adds first-line title heading normalization for note documents and syncs note row titles from that first line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistence for sessions, raw notes, and enhanced notes plus default NoteEditor behavior; title sync edge cases could affect existing notes or AI output formatting.
> 
> **Overview**
> Session notes now treat the **first line as the title**: a dedicated `title-content` layer prepends or normalizes an H1 from `sessions.title` when loading raw/enhanced notes and streams, and writes edits back to `sessions.title` from the first line (with guards so empty docs do not clobber titles).
> 
> **NoteEditor** gains optional **`enforceTitleHeading`** (default on): ProseMirror normalizes the first block to H1 and a plugin keeps it that way; styling uses `note-title-editor` for a larger first heading. **AI enhance/title success** paths prepend existing or generated titles into markdown/JSON so summaries no longer start without the session title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2498577262ddc188cab70097d3a73c92f9c36871. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->