### PR TITLE
Show empty-summary generate CTA

### DIFF
--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -16,6 +16,7 @@ const hoisted = vi.hoisted(() => ({
   hasTranscript: true,
   enhanceTaskStatus: undefined as string | undefined,
   enhancedContent: "Generated summary",
+  templateId: undefined as string | undefined,
   llmStatus: {
     status: "success",
     providerId: "hyprnote",
@@ -24,6 +25,8 @@ const hoisted = vi.hoisted(() => ({
   isCaretNearBottom: false,
   sessionMode: "inactive",
   sendEvent: vi.fn(),
+  enhance: vi.fn(),
+  updateSessionTabState: vi.fn(),
 }));
 
 vi.mock("./listen", () => ({
@@ -41,6 +44,8 @@ vi.mock("~/shared/chat-cta", () => ({
 vi.mock("~/session/components/shared", () => ({
   useCurrentNoteTab: () => hoisted.currentTab,
   useHasTranscript: () => hoisted.hasTranscript,
+  hasStoredNoteContent: (value: unknown) =>
+    typeof value === "string" && value.trim().length > 0,
 }));
 
 vi.mock("~/ai/contexts", () => ({
@@ -63,8 +68,29 @@ vi.mock("~/ai/hooks", () => ({
 vi.mock("~/store/tinybase/store/main", () => ({
   STORE_ID: "main",
   UI: {
-    useCell: () => hoisted.enhancedContent,
+    useCell: (_table: string, _row: string, cell: string) => {
+      if (cell === "content") {
+        return hoisted.enhancedContent;
+      }
+
+      if (cell === "template_id") {
+        return hoisted.templateId;
+      }
+
+      return undefined;
+    },
   },
+}));
+
+vi.mock("~/services/enhancer", () => ({
+  getEnhancerService: () => ({
+    enhance: hoisted.enhance,
+  }),
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: (selector: (state: unknown) => unknown) =>
+    selector({ updateSessionTabState: hoisted.updateSessionTabState }),
 }));
 
 vi.mock("../caret-position-context", () => ({
@@ -97,6 +123,7 @@ describe("FloatingActionButton", () => {
     hoisted.hasTranscript = true;
     hoisted.enhanceTaskStatus = undefined;
     hoisted.enhancedContent = "Generated summary";
+    hoisted.templateId = undefined;
     hoisted.llmStatus = {
       status: "success",
       providerId: "hyprnote",
@@ -105,6 +132,8 @@ describe("FloatingActionButton", () => {
     hoisted.isCaretNearBottom = false;
     hoisted.sessionMode = "inactive";
     hoisted.sendEvent.mockClear();
+    hoisted.enhance.mockReset();
+    hoisted.updateSessionTabState.mockClear();
   });
 
   afterEach(() => {
@@ -126,6 +155,47 @@ describe("FloatingActionButton", () => {
 
     expect(
       screen.queryByRole("button", { name: "Ask Anarlog anything" }),
+    ).not.toBeNull();
+  });
+
+  it("shows a generate summary FAB instead of chat for empty transcript-backed summaries", () => {
+    hoisted.currentTab = { type: "enhanced", id: "note-1" };
+    hoisted.enhancedContent = "";
+    hoisted.templateId = "template-1";
+    hoisted.enhance.mockReturnValue({
+      type: "started",
+      noteId: "note-1",
+    });
+
+    render(<FloatingActionButton tab={tab} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Ask Anarlog anything" }),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Generate summary" }));
+
+    expect(hoisted.enhance).toHaveBeenCalledWith("session-1", {
+      templateId: "template-1",
+    });
+    expect(hoisted.updateSessionTabState).toHaveBeenCalledWith(tab, {
+      ...tab.state,
+      view: { type: "enhanced", id: "note-1" },
+    });
+  });
+
+  it("keeps the generate summary FAB visible after an empty enhance success", () => {
+    hoisted.currentTab = { type: "enhanced", id: "note-1" };
+    hoisted.enhanceTaskStatus = "success";
+    hoisted.enhancedContent = "";
+
+    render(<FloatingActionButton tab={tab} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Ask Anarlog anything" }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Generate summary" }),
     ).not.toBeNull();
   });
 

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -1,20 +1,26 @@
+import { SparklesIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import type { CSSProperties } from "react";
+import { useCallback } from "react";
 
 import { cn } from "@hypr/utils";
 
 import { useCaretPosition } from "../caret-position-context";
 import { ListenButton } from "./listen";
+import { FloatingButton } from "./shared";
 
 import { useAITask } from "~/ai/contexts";
 import { type LLMConnectionStatus, useLLMConnectionStatus } from "~/ai/hooks";
+import { getEnhancerService } from "~/services/enhancer";
 import {
   useCurrentNoteTab,
+  hasStoredNoteContent,
   useHasTranscript,
 } from "~/session/components/shared";
 import { ChatCTA } from "~/shared/chat-cta";
 import * as main from "~/store/tinybase/store/main";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
+import { useTabs } from "~/store/zustand/tabs";
 import type { Tab } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
 
@@ -31,13 +37,21 @@ export function FloatingActionButton({
   const canShowListen = useShouldShowListeningFab(tab, sessionMode);
   const shouldShowListen = allowListening && canShowListen;
   const shouldShowChat = useShouldShowChatFab(tab, sessionMode);
+  const generateSummaryNoteId = useGenerateSummaryNoteId(tab, sessionMode);
+  const shouldShowGenerateSummary = generateSummaryNoteId !== null;
   const isCaretNearBottom = useCaretPosition()?.isCaretNearBottom ?? false;
   const showSkipReason = !!skipReason;
-  const useChatHoverArea = !showSkipReason && shouldShowChat;
+  const useChatHoverArea =
+    !showSkipReason && !shouldShowGenerateSummary && shouldShowChat;
   const tuckListenAction =
     !showSkipReason && shouldShowListen && isCaretNearBottom;
 
-  if (!showSkipReason && !shouldShowListen && !shouldShowChat) {
+  if (
+    !showSkipReason &&
+    !shouldShowListen &&
+    !shouldShowGenerateSummary &&
+    !shouldShowChat
+  ) {
     return null;
   }
 
@@ -70,7 +84,13 @@ export function FloatingActionButton({
           </motion.div>
         ) : (
           <motion.div
-            key={shouldShowListen ? "listen" : "chat"}
+            key={
+              shouldShowListen
+                ? "listen"
+                : shouldShowGenerateSummary
+                  ? "generate-summary"
+                  : "chat"
+            }
             aria-hidden={tuckListenAction}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -90,11 +110,63 @@ export function FloatingActionButton({
                 : "pointer-events-auto visible",
             ])}
           >
-            {shouldShowListen ? <ListenButton tab={tab} /> : <ChatCTA />}
+            {shouldShowListen ? (
+              <ListenButton tab={tab} />
+            ) : shouldShowGenerateSummary ? (
+              <GenerateSummaryButton
+                tab={tab}
+                enhancedNoteId={generateSummaryNoteId}
+              />
+            ) : (
+              <ChatCTA />
+            )}
           </motion.div>
         )}
       </AnimatePresence>
     </div>
+  );
+}
+
+function GenerateSummaryButton({
+  tab,
+  enhancedNoteId,
+}: {
+  tab: Extract<Tab, { type: "sessions" }>;
+  enhancedNoteId: string;
+}) {
+  const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
+  const templateId = main.UI.useCell(
+    "enhanced_notes",
+    enhancedNoteId,
+    "template_id",
+    main.STORE_ID,
+  ) as string | undefined;
+
+  const handleGenerateSummary = useCallback(() => {
+    const result = getEnhancerService()?.enhance(tab.id, {
+      templateId: templateId || undefined,
+    });
+
+    if (
+      (result?.type === "started" || result?.type === "already_active") &&
+      result.noteId
+    ) {
+      updateSessionTabState(tab, {
+        ...tab.state,
+        view: { type: "enhanced", id: result.noteId },
+      });
+    }
+  }, [tab, templateId, updateSessionTabState]);
+
+  return (
+    <FloatingButton
+      onClick={handleGenerateSummary}
+      className="w-[164px] justify-start gap-2 px-4"
+    >
+      <span className="flex items-center gap-1.5">
+        <SparklesIcon className="size-3.5" /> Generate summary
+      </span>
+    </FloatingButton>
   );
 }
 
@@ -108,6 +180,45 @@ function useShouldShowListeningFab(
   return (
     sessionMode === "inactive" && currentTab.type === "raw" && !hasTranscript
   );
+}
+
+function useGenerateSummaryNoteId(
+  tab: Extract<Tab, { type: "sessions" }>,
+  sessionMode: string,
+) {
+  const hasTranscript = useHasTranscript(tab.id);
+  const currentTab = useCurrentNoteTab(tab);
+  const enhancedNoteId = currentTab.type === "enhanced" ? currentTab.id : null;
+  const taskId = enhancedNoteId
+    ? createTaskId(enhancedNoteId, "enhance")
+    : null;
+  const taskStatus = useAITask((state) =>
+    taskId ? state.tasks[taskId]?.status : undefined,
+  );
+  const llmStatus = useLLMConnectionStatus();
+  const content = main.UI.useCell(
+    "enhanced_notes",
+    enhancedNoteId ?? "",
+    "content",
+    main.STORE_ID,
+  );
+  const canStartEnhance =
+    taskStatus === undefined ||
+    taskStatus === "idle" ||
+    taskStatus === "success";
+
+  if (
+    sessionMode === "inactive" &&
+    hasTranscript &&
+    enhancedNoteId &&
+    canStartEnhance &&
+    !hasStoredNoteContent(content) &&
+    !isBlockingLLMStatus(llmStatus)
+  ) {
+    return enhancedNoteId;
+  }
+
+  return null;
 }
 
 function useShouldShowChatFab(
@@ -131,7 +242,7 @@ function useShouldShowChatFab(
     main.STORE_ID,
   );
   const visibleTaskStatus = taskStatus ?? "idle";
-  const hasContent = typeof content === "string" && content.trim().length > 0;
+  const hasContent = hasStoredNoteContent(content);
   const hasVisibleIssue =
     currentTab.type === "enhanced" &&
     (visibleTaskStatus === "error" ||

--- a/apps/desktop/src/session/hooks/useEnhancedNotes.test.tsx
+++ b/apps/desktop/src/session/hooks/useEnhancedNotes.test.tsx
@@ -77,7 +77,7 @@ describe("useEnsureDefaultSummary", () => {
     hoisted.service.queueAutoEnhanceIfSummaryEmpty.mockClear();
   });
 
-  it("creates the summary row before queueing generation", async () => {
+  it("creates the summary row without queueing generation on open", async () => {
     renderHook(() => useEnsureDefaultSummary("session-1"));
 
     await waitFor(() => {
@@ -85,10 +85,10 @@ describe("useEnsureDefaultSummary", () => {
         "session-1",
         "template-1",
       );
-      expect(
-        hoisted.service.queueAutoEnhanceIfSummaryEmpty,
-      ).toHaveBeenCalledWith("session-1");
     });
+    expect(
+      hoisted.service.queueAutoEnhanceIfSummaryEmpty,
+    ).not.toHaveBeenCalled();
   });
 
   it("creates the summary row without queueing generation before transcript exists", async () => {

--- a/apps/desktop/src/session/hooks/useEnhancedNotes.ts
+++ b/apps/desktop/src/session/hooks/useEnhancedNotes.ts
@@ -1,14 +1,10 @@
 import { useEffect, useMemo } from "react";
 
-import { useHasTranscript } from "../components/shared";
-
 import { useAITask } from "~/ai/contexts";
-import { useLLMConnectionStatus } from "~/ai/hooks";
 import { getEnhancerService } from "~/services/enhancer";
 import * as main from "~/store/tinybase/store/main";
 import * as settings from "~/store/tinybase/store/settings";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
-import { useListener } from "~/stt/contexts";
 
 export function useEnhancedNotes(sessionId: string) {
   return main.UI.useSliceRowIds(
@@ -48,8 +44,6 @@ export function useEnhancedNote(enhancedNoteId: string) {
 }
 
 export function useEnsureDefaultSummary(sessionId: string) {
-  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
-  const hasTranscript = useHasTranscript(sessionId);
   const enhancedNoteIds = main.UI.useSliceRowIds(
     main.INDEXES.enhancedNotesBySession,
     sessionId,
@@ -59,7 +53,6 @@ export function useEnsureDefaultSummary(sessionId: string) {
     "selected_template_id",
     settings.STORE_ID,
   ) as string | undefined;
-  const llmStatus = useLLMConnectionStatus();
 
   useEffect(() => {
     const service = getEnhancerService();
@@ -73,29 +66,7 @@ export function useEnsureDefaultSummary(sessionId: string) {
     if (!hasEnhancedNotes) {
       service.ensureNote(sessionId, templateId);
     }
-
-    if (
-      !hasTranscript ||
-      sessionMode === "active" ||
-      sessionMode === "running_batch" ||
-      sessionMode === "finalizing"
-    ) {
-      return;
-    }
-
-    if (llmStatus.status !== "success") {
-      return;
-    }
-
-    service.queueAutoEnhanceIfSummaryEmpty(sessionId);
-  }, [
-    hasTranscript,
-    sessionMode,
-    sessionId,
-    enhancedNoteIds?.length,
-    selectedTemplateId,
-    llmStatus,
-  ]);
+  }, [sessionId, enhancedNoteIds?.length, selectedTemplateId]);
 }
 
 export function useIsSessionEnhancing(sessionId: string): boolean {


### PR DESCRIPTION
Summary
- Replaces the empty transcript-backed summary chat action with an explicit generate summary CTA.
- Stops automatically queueing summary generation when opening transcript-backed notes.

Tests
- Not run; stack metadata/push only.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #5669  
- <kbd>&nbsp;5&nbsp;</kbd> #5668  
- <kbd>&nbsp;4&nbsp;</kbd> #5674  
- <kbd>&nbsp;3&nbsp;</kbd> #5673  
- <kbd>&nbsp;2&nbsp;</kbd> #5671 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5667  
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when LLM enhance runs (manual vs automatic) and floating FAB visibility logic tied to task/LLM state; localized to session UI and hooks with solid test coverage.
> 
> **Overview**
> Stops **auto-queueing** summary generation when opening transcript-backed sessions; `useEnsureDefaultSummary` now only **ensures** the default enhanced note row exists.
> 
> On the session floating action button, when the user is on an **empty enhanced summary** with a transcript (and LLM is ready), the **chat FAB is replaced** by an explicit **Generate summary** control that calls `getEnhancerService().enhance` with the note’s `template_id` and keeps the tab on that enhanced view. The generate CTA **stays visible** after a successful enhance that still leaves content empty; chat remains for in-progress generation and other cases. Empty-content checks are centralized via `hasStoredNoteContent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa7c6c5df41dee37f5d05a86069e9416573a123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->