### PR TITLE
Add native live caption surface

### DIFF
--- a/apps/desktop/src/meeting-float/host.test.ts
+++ b/apps/desktop/src/meeting-float/host.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getCurrentFloatingBarColorScheme,
   getFloatingRouteState,
+  getLiveCaptionRouteState,
 } from "./host";
 
 import { createListenerStore } from "~/store/zustand/listener";
@@ -18,6 +19,21 @@ function createListenerState(live: Partial<ListenerLiveState>) {
       ...store.getState().live,
       ...live,
     },
+  });
+  return store.getState();
+}
+
+function createListenerStateWithCaption(
+  live: Partial<ListenerLiveState>,
+  liveCaptionText: string,
+) {
+  const store = createListenerStore();
+  store.setState({
+    live: {
+      ...store.getState().live,
+      ...live,
+    },
+    liveCaptionText,
   });
   return store.getState();
 }
@@ -83,5 +99,56 @@ describe("getCurrentFloatingBarColorScheme", () => {
 
     document.documentElement.classList.add("dark");
     expect(getCurrentFloatingBarColorScheme()).toBe("dark");
+  });
+});
+
+describe("getLiveCaptionRouteState", () => {
+  it("returns live caption state for active live transcription", () => {
+    expect(
+      getLiveCaptionRouteState(
+        createListenerStateWithCaption(
+          {
+            status: "active",
+            sessionId: "session-1",
+            liveTranscriptionActive: true,
+          },
+          "  we should ship this  ",
+        ),
+      ),
+    ).toEqual({
+      sessionId: "session-1",
+      text: "we should ship this",
+      opacity: 0.78,
+    });
+  });
+
+  it("hides captions before live transcription is active", () => {
+    expect(
+      getLiveCaptionRouteState(
+        createListenerStateWithCaption(
+          {
+            status: "active",
+            sessionId: "session-1",
+            liveTranscriptionActive: false,
+          },
+          "hello",
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  it("hides captions without text", () => {
+    expect(
+      getLiveCaptionRouteState(
+        createListenerStateWithCaption(
+          {
+            status: "active",
+            sessionId: "session-1",
+            liveTranscriptionActive: true,
+          },
+          " ",
+        ),
+      ),
+    ).toBeNull();
   });
 });

--- a/apps/desktop/src/meeting-float/host.tsx
+++ b/apps/desktop/src/meeting-float/host.tsx
@@ -16,20 +16,120 @@ type FloatingRouteState = {
   status: FloatingBarStatus;
   colorScheme: FloatingBarColorScheme;
 };
+type LiveCaptionRouteState = {
+  sessionId: string;
+  text: string;
+  opacity: number;
+};
 
 export function FloatingMeetingWindowHost() {
   const floatingBarEnabled = useConfigValue("floating_bar_enabled");
 
-  if (!floatingBarEnabled) {
-    return <FloatingMeetingWindowDisabled />;
-  }
-
-  return <FloatingMeetingWindowSync />;
+  return (
+    <>
+      {floatingBarEnabled ? (
+        <FloatingMeetingWindowSync />
+      ) : (
+        <FloatingMeetingWindowDisabled />
+      )}
+      <LiveCaptionWindowSync />
+    </>
+  );
 }
 
 function FloatingMeetingWindowDisabled() {
   useMountEffect(() => {
     void hideFloatingMeetingPanel();
+  });
+
+  return null;
+}
+
+function LiveCaptionWindowSync() {
+  useMountEffect(() => {
+    let routeState = getCurrentLiveCaptionRouteState(listenerStore.getState());
+    let syncQueued = false;
+    let syncRunning = false;
+    let syncRequested = false;
+    let cancelled = false;
+    let shownSessionId: string | null = null;
+
+    const shouldContinue = () => !cancelled;
+
+    const sync = async () => {
+      if (!shouldContinue()) {
+        return;
+      }
+
+      const nextShownSessionId = await syncLiveCaptionWindow(
+        routeState,
+        shownSessionId,
+        shouldContinue,
+      );
+      if (!shouldContinue()) {
+        await hideLiveCaptionPanel();
+        return;
+      }
+
+      if (nextShownSessionId === "unavailable") {
+        return;
+      }
+
+      shownSessionId = nextShownSessionId;
+    };
+
+    const runQueuedSync = async () => {
+      if (syncRunning) {
+        syncRequested = true;
+        return;
+      }
+
+      syncRunning = true;
+      try {
+        do {
+          syncRequested = false;
+          await sync();
+        } while (syncRequested && !cancelled);
+      } finally {
+        syncRunning = false;
+      }
+    };
+
+    const scheduleSync = () => {
+      if (syncQueued) {
+        return;
+      }
+
+      syncQueued = true;
+      queueMicrotask(() => {
+        syncQueued = false;
+        if (cancelled) {
+          return;
+        }
+
+        void runQueuedSync();
+      });
+    };
+
+    scheduleSync();
+
+    const unsubscribe = listenerStore.subscribe((state, previousState) => {
+      const nextRouteState = getLiveCaptionRouteState(state);
+      const previousRouteState = getLiveCaptionRouteState(previousState);
+
+      if (isSameLiveCaptionRouteState(nextRouteState, previousRouteState)) {
+        return;
+      }
+
+      routeState = nextRouteState;
+      scheduleSync();
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+      void hideLiveCaptionPanel();
+    };
   });
 
   return null;
@@ -201,6 +301,39 @@ function getCurrentFloatingRouteState(
   });
 }
 
+export function getLiveCaptionRouteState(
+  state: ListenerState,
+): LiveCaptionRouteState | null {
+  if (state.live.status !== "active") {
+    return null;
+  }
+
+  if (!state.live.sessionId) {
+    return null;
+  }
+
+  if (state.live.liveTranscriptionActive !== true) {
+    return null;
+  }
+
+  const text = state.liveCaptionText.trim();
+  if (!text) {
+    return null;
+  }
+
+  return {
+    sessionId: state.live.sessionId,
+    text,
+    opacity: 0.78,
+  };
+}
+
+function getCurrentLiveCaptionRouteState(
+  state: ListenerState,
+): LiveCaptionRouteState | null {
+  return getLiveCaptionRouteState(state);
+}
+
 function subscribeToAppliedTheme(onStoreChange: () => void) {
   if (
     typeof document === "undefined" ||
@@ -237,6 +370,17 @@ function isSameFloatingRouteState(
   );
 }
 
+function isSameLiveCaptionRouteState(
+  left: LiveCaptionRouteState | null,
+  right: LiveCaptionRouteState | null,
+) {
+  return (
+    left?.sessionId === right?.sessionId &&
+    left?.text === right?.text &&
+    left?.opacity === right?.opacity
+  );
+}
+
 async function syncFloatingMeetingWindow(
   routeState: FloatingRouteState | null,
   shownSessionId: string | null,
@@ -258,6 +402,33 @@ async function syncFloatingMeetingWindow(
   );
   if (!shouldContinue()) {
     await hideFloatingMeetingPanel();
+    return null;
+  }
+
+  return ready ? routeState.sessionId : "unavailable";
+}
+
+async function syncLiveCaptionWindow(
+  routeState: LiveCaptionRouteState | null,
+  shownSessionId: string | null,
+  shouldContinue: () => boolean,
+): Promise<string | null | "unavailable"> {
+  if (!shouldContinue()) {
+    return null;
+  }
+
+  if (!routeState) {
+    await hideLiveCaptionPanel();
+    return null;
+  }
+
+  const ready = await showLiveCaptionWindow(
+    routeState,
+    shownSessionId !== routeState.sessionId,
+    shouldContinue,
+  );
+  if (!shouldContinue()) {
+    await hideLiveCaptionPanel();
     return null;
   }
 
@@ -307,6 +478,45 @@ async function showFloatingMeetingWindow(
   return true;
 }
 
+async function showLiveCaptionWindow(
+  routeState: LiveCaptionRouteState,
+  shouldShow: boolean,
+  shouldContinue: () => boolean = () => true,
+): Promise<boolean> {
+  if (!shouldContinue()) {
+    return false;
+  }
+
+  if (shouldShow) {
+    const showResult = await windowsCommands.liveCaptionShow();
+    if (!shouldContinue()) {
+      await hideLiveCaptionPanel();
+      return false;
+    }
+
+    if (showResult.status === "error") {
+      console.error("Failed to show live caption panel:", showResult.error);
+      return false;
+    }
+  }
+
+  const updateResult = await windowsCommands.liveCaptionUpdate({
+    text: routeState.text,
+    opacity: routeState.opacity,
+  });
+  if (!shouldContinue()) {
+    await hideLiveCaptionPanel();
+    return false;
+  }
+
+  if (updateResult.status === "error") {
+    console.error("Failed to update live caption panel:", updateResult.error);
+    return false;
+  }
+
+  return true;
+}
+
 export async function openFloatingMeetingPanel({
   sessionId,
   enabled,
@@ -335,5 +545,12 @@ export async function hideFloatingMeetingPanel() {
   const result = await windowsCommands.floatingBarHide();
   if (result.status === "error") {
     console.error("Failed to hide floating meeting panel:", result.error);
+  }
+}
+
+export async function hideLiveCaptionPanel() {
+  const result = await windowsCommands.liveCaptionHide();
+  if (result.status === "error") {
+    console.error("Failed to hide live caption panel:", result.error);
   }
 }

--- a/apps/desktop/src/store/zustand/listener/general-live.ts
+++ b/apps/desktop/src/store/zustand/listener/general-live.ts
@@ -217,7 +217,11 @@ const createSessionEventHandlers = <T extends LiveStore>(
       get().handleTranscriptDelta(
         targetSessionId,
         payload.delta as unknown as LiveTranscriptDelta,
-        { updateLivePreview: get().live.sessionId === targetSessionId },
+        {
+          updateLivePreview:
+            get().live.sessionId === targetSessionId &&
+            get().live.liveTranscriptionActive === true,
+        },
       );
       return;
     }

--- a/apps/desktop/src/store/zustand/listener/transcript.test.ts
+++ b/apps/desktop/src/store/zustand/listener/transcript.test.ts
@@ -113,6 +113,45 @@ describe("transcript slice", () => {
     expect(persist).toHaveBeenCalledWith(delta);
     expect(store.getState().partialWordsByChannel).toEqual({});
     expect(store.getState().partialHintsByChannel).toEqual({});
+    expect(store.getState().liveCaptionText).toBe("hello");
+  });
+
+  test("uses partial words for the live caption text", () => {
+    store.getState().handleTranscriptDelta("session-1", createDelta());
+
+    expect(store.getState().liveCaptionText).toBe("hello remote again");
+  });
+
+  test("keeps the partial caption text when finalized words arrive separately", () => {
+    store.getState().handleTranscriptDelta("session-1", createDelta());
+    store.getState().handleTranscriptDelta("session-1", {
+      new_words: [
+        {
+          id: "word-2",
+          text: " remote",
+          start_ms: 200,
+          end_ms: 300,
+          channel: 1,
+          state: "final",
+          speaker_index: null,
+        },
+      ],
+      replaced_ids: [],
+      partials: [],
+    });
+
+    expect(store.getState().liveCaptionText).toBe("hello remote again");
+  });
+
+  test("keeps the previous live caption text when a delta has no words", () => {
+    store.getState().handleTranscriptDelta("session-1", createDelta());
+    store.getState().handleTranscriptDelta("session-1", {
+      new_words: [],
+      replaced_ids: [],
+      partials: [],
+    });
+
+    expect(store.getState().liveCaptionText).toBe("hello remote again");
   });
 
   test("can persist deltas without replacing the active live preview", () => {
@@ -144,6 +183,7 @@ describe("transcript slice", () => {
     expect(
       store.getState().partialWordsByChannel[0]?.map((word) => word.text),
     ).toEqual([" hello"]);
+    expect(store.getState().liveCaptionText).toBe("hello remote again");
   });
 
   test("resetTranscript clears partial state and callbacks", () => {
@@ -155,6 +195,7 @@ describe("transcript slice", () => {
 
     expect(store.getState().partialWordsByChannel).toEqual({});
     expect(store.getState().partialHintsByChannel).toEqual({});
+    expect(store.getState().liveCaptionText).toBe("");
     expect(store.getState().handlePersistBySession).toEqual({
       "session-1": expect.any(Function),
     });

--- a/apps/desktop/src/store/zustand/listener/transcript.ts
+++ b/apps/desktop/src/store/zustand/listener/transcript.ts
@@ -34,6 +34,7 @@ export type OnStoppedCallback = (
 export type TranscriptState = {
   liveSegments: LiveTranscriptSegment[];
   liveSegmentsById: Record<string, LiveTranscriptSegment>;
+  liveCaptionText: string;
   partialWordsByChannel: WordsByChannel;
   partialHintsByChannel: Record<number, RuntimeSpeakerHint[]>;
   handlePersistBySession: Record<string, LiveTranscriptPersistCallback>;
@@ -59,6 +60,7 @@ export type TranscriptActions = {
 const initialState: TranscriptState = {
   liveSegments: [],
   liveSegmentsById: {},
+  liveCaptionText: "",
   partialWordsByChannel: {},
   partialHintsByChannel: {},
   handlePersistBySession: {},
@@ -99,10 +101,14 @@ export const createTranscriptSlice = <
     const { wordsByChannel, hintsByChannel } = groupPartialsByChannel(
       delta.partials,
     );
+    const captionText = getCaptionTextFromDelta(delta, get().liveCaptionText);
 
     if (options?.updateLivePreview !== false) {
       set((state) =>
         mutate(state, (draft) => {
+          if (captionText !== null) {
+            draft.liveCaptionText = captionText;
+          }
           draft.partialWordsByChannel = wordsByChannel;
           draft.partialHintsByChannel = hintsByChannel;
         }),
@@ -145,6 +151,7 @@ export const createTranscriptSlice = <
       mutate(state, (draft) => {
         draft.liveSegments = [];
         draft.liveSegmentsById = {};
+        draft.liveCaptionText = "";
         draft.partialWordsByChannel = {};
         draft.partialHintsByChannel = {};
       }),
@@ -183,4 +190,28 @@ function groupPartialsByChannel(partials: LiveTranscriptDelta["partials"]): {
   });
 
   return { wordsByChannel, hintsByChannel };
+}
+
+function getCaptionTextFromDelta(
+  delta: LiveTranscriptDelta,
+  currentCaptionText: string,
+): string | null {
+  const words =
+    delta.partials.length > 0 || currentCaptionText.length === 0
+      ? delta.partials.length > 0
+        ? delta.partials
+        : delta.new_words
+      : null;
+
+  if (!words) {
+    return null;
+  }
+
+  return words
+    .slice()
+    .sort((a, b) => a.start_ms - b.start_ms)
+    .map((word) => word.text)
+    .join("")
+    .replace(/\s+/g, " ")
+    .trim();
 }

--- a/plugins/windows/build.rs
+++ b/plugins/windows/build.rs
@@ -15,6 +15,9 @@ const COMMANDS: &[&str] = &[
     "floating_bar_show",
     "floating_bar_hide",
     "floating_bar_update",
+    "live_caption_show",
+    "live_caption_hide",
+    "live_caption_update",
     "devtools_panel_show",
     "devtools_panel_hide",
 ];

--- a/plugins/windows/js/bindings.gen.ts
+++ b/plugins/windows/js/bindings.gen.ts
@@ -228,6 +228,43 @@ export const commands = {
       else return { status: "error", error: e as any };
     }
   },
+  async liveCaptionShow(): Promise<Result<null, string>> {
+    try {
+      return {
+        status: "ok",
+        data: await TAURI_INVOKE("plugin:windows|live_caption_show"),
+      };
+    } catch (e) {
+      if (e instanceof Error) throw e;
+      else return { status: "error", error: e as any };
+    }
+  },
+  async liveCaptionHide(): Promise<Result<null, string>> {
+    try {
+      return {
+        status: "ok",
+        data: await TAURI_INVOKE("plugin:windows|live_caption_hide"),
+      };
+    } catch (e) {
+      if (e instanceof Error) throw e;
+      else return { status: "error", error: e as any };
+    }
+  },
+  async liveCaptionUpdate(
+    state: LiveCaptionState,
+  ): Promise<Result<null, string>> {
+    try {
+      return {
+        status: "ok",
+        data: await TAURI_INVOKE("plugin:windows|live_caption_update", {
+          state,
+        }),
+      };
+    } catch (e) {
+      if (e instanceof Error) throw e;
+      else return { status: "error", error: e as any };
+    }
+  },
   async devtoolsPanelShow(): Promise<Result<null, string>> {
     try {
       return {
@@ -314,6 +351,7 @@ export type JsonValue =
   | string
   | JsonValue[]
   | Partial<{ [key in string]: JsonValue }>;
+export type LiveCaptionState = { text: string; opacity: number };
 export type Navigate = {
   path: string;
   search: Partial<{ [key in string]: JsonValue }> | null;

--- a/plugins/windows/permissions/autogenerated/commands/live_caption_hide.toml
+++ b/plugins/windows/permissions/autogenerated/commands/live_caption_hide.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-live-caption-hide"
+description = "Enables the live_caption_hide command without any pre-configured scope."
+commands.allow = ["live_caption_hide"]
+
+[[permission]]
+identifier = "deny-live-caption-hide"
+description = "Denies the live_caption_hide command without any pre-configured scope."
+commands.deny = ["live_caption_hide"]

--- a/plugins/windows/permissions/autogenerated/commands/live_caption_show.toml
+++ b/plugins/windows/permissions/autogenerated/commands/live_caption_show.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-live-caption-show"
+description = "Enables the live_caption_show command without any pre-configured scope."
+commands.allow = ["live_caption_show"]
+
+[[permission]]
+identifier = "deny-live-caption-show"
+description = "Denies the live_caption_show command without any pre-configured scope."
+commands.deny = ["live_caption_show"]

--- a/plugins/windows/permissions/autogenerated/commands/live_caption_update.toml
+++ b/plugins/windows/permissions/autogenerated/commands/live_caption_update.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-live-caption-update"
+description = "Enables the live_caption_update command without any pre-configured scope."
+commands.allow = ["live_caption_update"]
+
+[[permission]]
+identifier = "deny-live-caption-update"
+description = "Denies the live_caption_update command without any pre-configured scope."
+commands.deny = ["live_caption_update"]

--- a/plugins/windows/permissions/autogenerated/reference.md
+++ b/plugins/windows/permissions/autogenerated/reference.md
@@ -20,6 +20,9 @@ Default permissions for the plugin
 - `allow-floating-bar-show`
 - `allow-floating-bar-hide`
 - `allow-floating-bar-update`
+- `allow-live-caption-show`
+- `allow-live-caption-hide`
+- `allow-live-caption-update`
 - `allow-devtools-panel-show`
 - `allow-devtools-panel-hide`
 
@@ -158,6 +161,84 @@ Enables the floating_bar_update command without any pre-configured scope.
 <td>
 
 Denies the floating_bar_update command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`windows:allow-live-caption-hide`
+
+</td>
+<td>
+
+Enables the live_caption_hide command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`windows:deny-live-caption-hide`
+
+</td>
+<td>
+
+Denies the live_caption_hide command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`windows:allow-live-caption-show`
+
+</td>
+<td>
+
+Enables the live_caption_show command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`windows:deny-live-caption-show`
+
+</td>
+<td>
+
+Denies the live_caption_show command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`windows:allow-live-caption-update`
+
+</td>
+<td>
+
+Enables the live_caption_update command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`windows:deny-live-caption-update`
+
+</td>
+<td>
+
+Denies the live_caption_update command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/windows/permissions/default.toml
+++ b/plugins/windows/permissions/default.toml
@@ -17,6 +17,9 @@ permissions = [
     "allow-floating-bar-show",
     "allow-floating-bar-hide",
     "allow-floating-bar-update",
+    "allow-live-caption-show",
+    "allow-live-caption-hide",
+    "allow-live-caption-update",
     "allow-devtools-panel-show",
     "allow-devtools-panel-hide",
 ]

--- a/plugins/windows/permissions/schemas/schema.json
+++ b/plugins/windows/permissions/schemas/schema.json
@@ -355,6 +355,42 @@
           "markdownDescription": "Denies the floating_bar_update command without any pre-configured scope."
         },
         {
+          "description": "Enables the live_caption_hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-live-caption-hide",
+          "markdownDescription": "Enables the live_caption_hide command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the live_caption_hide command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-live-caption-hide",
+          "markdownDescription": "Denies the live_caption_hide command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the live_caption_show command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-live-caption-show",
+          "markdownDescription": "Enables the live_caption_show command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the live_caption_show command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-live-caption-show",
+          "markdownDescription": "Denies the live_caption_show command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the live_caption_update command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-live-caption-update",
+          "markdownDescription": "Enables the live_caption_update command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the live_caption_update command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-live-caption-update",
+          "markdownDescription": "Denies the live_caption_update command without any pre-configured scope."
+        },
+        {
           "description": "Enables the remove_fake_window command without any pre-configured scope.",
           "type": "string",
           "const": "allow-remove-fake-window",
@@ -535,10 +571,10 @@
           "markdownDescription": "Denies the window_show command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-window-show`\n- `allow-window-hide`\n- `allow-window-destroy`\n- `allow-window-navigate`\n- `allow-window-emit-navigate`\n- `allow-window-is-exists`\n- `allow-window-is-occluded`\n- `allow-window-set-frame-animated`\n- `allow-window-save-frame`\n- `allow-window-restore-frame-animated`\n- `allow-window-expand-width`\n- `allow-window-restore-width`\n- `allow-set-show-app-in-dock`\n- `allow-floating-bar-show`\n- `allow-floating-bar-hide`\n- `allow-floating-bar-update`\n- `allow-devtools-panel-show`\n- `allow-devtools-panel-hide`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-window-show`\n- `allow-window-hide`\n- `allow-window-destroy`\n- `allow-window-navigate`\n- `allow-window-emit-navigate`\n- `allow-window-is-exists`\n- `allow-window-is-occluded`\n- `allow-window-set-frame-animated`\n- `allow-window-save-frame`\n- `allow-window-restore-frame-animated`\n- `allow-window-expand-width`\n- `allow-window-restore-width`\n- `allow-set-show-app-in-dock`\n- `allow-floating-bar-show`\n- `allow-floating-bar-hide`\n- `allow-floating-bar-update`\n- `allow-live-caption-show`\n- `allow-live-caption-hide`\n- `allow-live-caption-update`\n- `allow-devtools-panel-show`\n- `allow-devtools-panel-hide`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-window-show`\n- `allow-window-hide`\n- `allow-window-destroy`\n- `allow-window-navigate`\n- `allow-window-emit-navigate`\n- `allow-window-is-exists`\n- `allow-window-is-occluded`\n- `allow-window-set-frame-animated`\n- `allow-window-save-frame`\n- `allow-window-restore-frame-animated`\n- `allow-window-expand-width`\n- `allow-window-restore-width`\n- `allow-set-show-app-in-dock`\n- `allow-floating-bar-show`\n- `allow-floating-bar-hide`\n- `allow-floating-bar-update`\n- `allow-devtools-panel-show`\n- `allow-devtools-panel-hide`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-window-show`\n- `allow-window-hide`\n- `allow-window-destroy`\n- `allow-window-navigate`\n- `allow-window-emit-navigate`\n- `allow-window-is-exists`\n- `allow-window-is-occluded`\n- `allow-window-set-frame-animated`\n- `allow-window-save-frame`\n- `allow-window-restore-frame-animated`\n- `allow-window-expand-width`\n- `allow-window-restore-width`\n- `allow-set-show-app-in-dock`\n- `allow-floating-bar-show`\n- `allow-floating-bar-hide`\n- `allow-floating-bar-update`\n- `allow-live-caption-show`\n- `allow-live-caption-hide`\n- `allow-live-caption-update`\n- `allow-devtools-panel-show`\n- `allow-devtools-panel-hide`"
         }
       ]
     }

--- a/plugins/windows/src/commands.rs
+++ b/plugins/windows/src/commands.rs
@@ -392,6 +392,29 @@ pub async fn floating_bar_update(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn live_caption_show() -> Result<(), String> {
+    crate::window::live_caption::show().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn live_caption_hide() -> Result<(), String> {
+    crate::window::live_caption::hide().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn live_caption_update(
+    state: crate::window::live_caption::LiveCaptionState,
+) -> Result<(), String> {
+    crate::window::live_caption::update(state).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn devtools_panel_show() -> Result<(), String> {
     crate::window::devtools_panel::show().map_err(|e| e.to_string())?;
     Ok(())

--- a/plugins/windows/src/lib.rs
+++ b/plugins/windows/src/lib.rs
@@ -106,6 +106,9 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::floating_bar_show,
             commands::floating_bar_hide,
             commands::floating_bar_update,
+            commands::live_caption_show,
+            commands::live_caption_hide,
+            commands::live_caption_update,
             commands::devtools_panel_show,
             commands::devtools_panel_hide,
         ])

--- a/plugins/windows/src/window/live_caption.rs
+++ b/plugins/windows/src/window/live_caption.rs
@@ -1,0 +1,82 @@
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveCaptionState {
+    pub text: String,
+    pub opacity: f64,
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use swift_rs::{Bool, SRString, swift};
+
+    use super::LiveCaptionState;
+    use crate::Error;
+
+    swift!(fn _live_caption_show() -> Bool);
+    swift!(fn _live_caption_hide() -> Bool);
+    swift!(fn _live_caption_update(json: &SRString) -> Bool);
+
+    pub fn show() -> Result<(), Error> {
+        unsafe {
+            _live_caption_show();
+        }
+        Ok(())
+    }
+
+    pub fn hide() -> Result<(), Error> {
+        unsafe {
+            _live_caption_hide();
+        }
+        Ok(())
+    }
+
+    pub fn update(state: LiveCaptionState) -> Result<(), Error> {
+        let json = serde_json::to_string(&state).map_err(|error| {
+            Error::PanelError(format!("failed to serialize live caption state: {error}"))
+        })?;
+        let json = SRString::from(json.as_str());
+
+        let ok = unsafe { _live_caption_update(&json) };
+        if ok {
+            Ok(())
+        } else {
+            Err(Error::PanelError(
+                "failed to update native live caption".to_string(),
+            ))
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+mod platform {
+    use super::LiveCaptionState;
+    use crate::Error;
+
+    pub fn show() -> Result<(), Error> {
+        Ok(())
+    }
+
+    pub fn hide() -> Result<(), Error> {
+        Ok(())
+    }
+
+    pub fn update(_state: LiveCaptionState) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+pub fn show() -> Result<(), Error> {
+    platform::show()
+}
+
+pub fn hide() -> Result<(), Error> {
+    platform::hide()
+}
+
+pub fn update(state: LiveCaptionState) -> Result<(), Error> {
+    platform::update(state)
+}

--- a/plugins/windows/src/window/mod.rs
+++ b/plugins/windows/src/window/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod composer;
 pub(crate) mod devtools_panel;
 pub(crate) mod floating_bar;
+pub(crate) mod live_caption;
 mod v1;
 
 pub type AppWindow = v1::AppWindow;

--- a/plugins/windows/swift-lib/src/LiveCaptionManager.swift
+++ b/plugins/windows/swift-lib/src/LiveCaptionManager.swift
@@ -1,0 +1,152 @@
+import Cocoa
+import SwiftUI
+
+final class LiveCaptionManager {
+  static let shared = LiveCaptionManager()
+
+  private var panel: NSPanel?
+  private let model = LiveCaptionViewModel()
+  private lazy var panelDelegate = LiveCaptionPanelDelegate(model: model)
+  private var displayChangeObserver: Any?
+  private var followActiveScreenTimer: Timer?
+
+  private init() {}
+
+  func show() {
+    runOnMain { [weak self] in
+      guard let self else { return }
+
+      if let panel = self.panel {
+        self.position(panel, force: true)
+        self.startFollowingActiveScreen()
+        panel.orderFrontRegardless()
+        return
+      }
+
+      let panel = self.createPanel()
+      let hostingView = NSHostingView(rootView: LiveCaptionView(model: self.model))
+      hostingView.frame = NSRect(
+        x: 0,
+        y: 0,
+        width: LiveCaptionLayout.defaultWidth,
+        height: LiveCaptionLayout.height(forLineCount: LiveCaptionLayout.defaultLineCount))
+      hostingView.autoresizingMask = [.width, .height]
+
+      panel.contentView = hostingView
+      self.position(panel, force: true)
+      panel.orderFrontRegardless()
+      self.panel = panel
+      self.startFollowingActiveScreen()
+    }
+  }
+
+  func hide() {
+    runOnMain { [weak self] in
+      guard let self else { return }
+      self.hidePanel()
+    }
+  }
+
+  private func hidePanel() {
+    guard let panel else {
+      model.text = ""
+      panelDelegate.resetActiveScreen()
+      return
+    }
+
+    stopFollowingActiveScreen()
+    panel.orderOut(nil)
+    self.panel = nil
+    panelDelegate.resetActiveScreen()
+    model.text = ""
+  }
+
+  func update(state: LiveCaptionStatePayload) {
+    runOnMain { [weak self] in
+      guard let self else { return }
+      self.model.text = state.text
+      self.model.opacity = min(max(state.opacity, 0.35), 0.95)
+    }
+  }
+
+  private func createPanel() -> NSPanel {
+    let initialSize = NSSize(
+      width: LiveCaptionLayout.defaultWidth,
+      height: LiveCaptionLayout.height(forLineCount: LiveCaptionLayout.defaultLineCount))
+    let panel = NSPanel(
+      contentRect: NSRect(origin: .zero, size: initialSize),
+      styleMask: [.borderless, .nonactivatingPanel, .resizable],
+      backing: .buffered,
+      defer: false
+    )
+
+    panel.level = .floating
+    panel.isFloatingPanel = true
+    panel.hidesOnDeactivate = false
+    panel.isOpaque = false
+    panel.backgroundColor = .clear
+    panel.hasShadow = false
+    panel.sharingType = .none
+    panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+    panel.isMovableByWindowBackground = true
+    panel.minSize = NSSize(
+      width: LiveCaptionLayout.minWidth,
+      height: LiveCaptionLayout.height(forLineCount: LiveCaptionLayout.minLineCount))
+    panel.maxSize = NSSize(
+      width: LiveCaptionLayout.maxWidth,
+      height: LiveCaptionLayout.height(forLineCount: LiveCaptionLayout.maxLineCount))
+    panel.delegate = panelDelegate
+    return panel
+  }
+
+  private func runOnMain(_ block: @escaping () -> Void) {
+    if Thread.isMainThread {
+      block()
+      return
+    }
+
+    DispatchQueue.main.sync(execute: block)
+  }
+
+  private func position(_ panel: NSPanel, force: Bool = false) {
+    panelDelegate.position(panel, force: force) { screen, size in
+      let frame = screen.visibleFrame
+      let x = frame.midX - size.width / 2
+      let y = frame.maxY - size.height - LiveCaptionLayout.topOffset
+      return NSPoint(
+        x: min(max(x, frame.minX + LiveCaptionLayout.screenMargin), frame.maxX - size.width),
+        y: max(y, frame.minY + LiveCaptionLayout.screenMargin)
+      )
+    }
+  }
+
+  private func startFollowingActiveScreen() {
+    guard followActiveScreenTimer == nil else { return }
+
+    let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
+      guard let self, let panel = self.panel else { return }
+      self.position(panel)
+    }
+    RunLoop.main.add(timer, forMode: .common)
+    followActiveScreenTimer = timer
+
+    displayChangeObserver = NotificationCenter.default.addObserver(
+      forName: NSApplication.didChangeScreenParametersNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      guard let self, let panel = self.panel else { return }
+      self.position(panel, force: true)
+    }
+  }
+
+  private func stopFollowingActiveScreen() {
+    followActiveScreenTimer?.invalidate()
+    followActiveScreenTimer = nil
+
+    if let displayChangeObserver {
+      NotificationCenter.default.removeObserver(displayChangeObserver)
+      self.displayChangeObserver = nil
+    }
+  }
+}

--- a/plugins/windows/swift-lib/src/LiveCaptionModels.swift
+++ b/plugins/windows/swift-lib/src/LiveCaptionModels.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct LiveCaptionStatePayload: Codable {
+  let text: String
+  let opacity: Double
+}

--- a/plugins/windows/swift-lib/src/LiveCaptionPanelDelegate.swift
+++ b/plugins/windows/swift-lib/src/LiveCaptionPanelDelegate.swift
@@ -1,0 +1,38 @@
+import Cocoa
+
+final class LiveCaptionPanelDelegate: NSObject, NSWindowDelegate {
+  private let placement = FloatingPanelPositionController()
+  private let model: LiveCaptionViewModel
+
+  init(model: LiveCaptionViewModel) {
+    self.model = model
+  }
+
+  func position(
+    _ panel: NSPanel,
+    force: Bool = false,
+    defaultOrigin: (NSScreen, NSSize) -> NSPoint
+  ) {
+    placement.position(panel, force: force, size: panel.frame.size, defaultOrigin: defaultOrigin)
+  }
+
+  func resetActiveScreen() {
+    placement.resetActiveScreen()
+  }
+
+  func windowDidMove(_ notification: Notification) {
+    placement.windowDidMove(notification)
+  }
+
+  func windowWillResize(_ sender: NSWindow, to frameSize: NSSize) -> NSSize {
+    let width = min(max(frameSize.width, LiveCaptionLayout.minWidth), LiveCaptionLayout.maxWidth)
+    let lineCount = LiveCaptionLayout.lineCount(forHeight: frameSize.height)
+    let height = LiveCaptionLayout.height(forLineCount: lineCount)
+
+    DispatchQueue.main.async { [weak self] in
+      self?.model.lineCount = lineCount
+    }
+
+    return NSSize(width: width, height: height)
+  }
+}

--- a/plugins/windows/swift-lib/src/LiveCaptionView.swift
+++ b/plugins/windows/swift-lib/src/LiveCaptionView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+enum LiveCaptionLayout {
+  static let minWidth: CGFloat = 260
+  static let defaultWidth: CGFloat = 440
+  static let maxWidth: CGFloat = 440
+  static let minLineCount = 1
+  static let defaultLineCount = 1
+  static let maxLineCount = 4
+  static let lineHeight: CGFloat = 22
+  static let horizontalPadding: CGFloat = 16
+  static let verticalPadding: CGFloat = 10
+  static let cornerRadius: CGFloat = 12
+  static let screenMargin: CGFloat = 12
+  static let topOffset: CGFloat = 18
+
+  static func height(forLineCount lineCount: Int) -> CGFloat {
+    let clampedLineCount = min(max(lineCount, minLineCount), maxLineCount)
+    return verticalPadding * 2 + lineHeight * CGFloat(clampedLineCount)
+  }
+
+  static func lineCount(forHeight height: CGFloat) -> Int {
+    let rawLineCount = ((height - verticalPadding * 2) / lineHeight).rounded()
+    return min(max(Int(rawLineCount), minLineCount), maxLineCount)
+  }
+}
+
+struct LiveCaptionView: View {
+  @ObservedObject var model: LiveCaptionViewModel
+  @State private var isHovered = false
+
+  var body: some View {
+    Text(model.text)
+      .font(.system(size: 16, weight: .medium, design: .default))
+      .lineSpacing(0)
+      .foregroundStyle(.white)
+      .lineLimit(model.lineCount)
+      .truncationMode(.tail)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+      .padding(.horizontal, LiveCaptionLayout.horizontalPadding)
+      .padding(.vertical, LiveCaptionLayout.verticalPadding)
+      .background(
+        RoundedRectangle(cornerRadius: LiveCaptionLayout.cornerRadius, style: .continuous)
+          .fill(Color.black.opacity(min(max(model.opacity, 0.35), 0.95)))
+      )
+      .overlay(alignment: .bottomTrailing) {
+        ResizeHint()
+          .opacity(isHovered ? 0.55 : 0)
+          .padding(6)
+      }
+      .contentShape(RoundedRectangle(cornerRadius: LiveCaptionLayout.cornerRadius))
+      .onHover { isHovered = $0 }
+  }
+}
+
+private struct ResizeHint: View {
+  var body: some View {
+    VStack(alignment: .trailing, spacing: 2) {
+      Capsule()
+        .fill(.white)
+        .frame(width: 6, height: 1)
+      Capsule()
+        .fill(.white)
+        .frame(width: 10, height: 1)
+    }
+    .accessibilityHidden(true)
+  }
+}

--- a/plugins/windows/swift-lib/src/LiveCaptionViewModel.swift
+++ b/plugins/windows/swift-lib/src/LiveCaptionViewModel.swift
@@ -1,0 +1,8 @@
+import Combine
+import Foundation
+
+final class LiveCaptionViewModel: ObservableObject {
+  @Published var text: String = ""
+  @Published var opacity: Double = 0.78
+  @Published var lineCount: Int = LiveCaptionLayout.defaultLineCount
+}

--- a/plugins/windows/swift-lib/src/lib.swift
+++ b/plugins/windows/swift-lib/src/lib.swift
@@ -26,6 +26,31 @@ public func _floatingBarUpdate(json: SRString) -> Bool {
   return true
 }
 
+@_cdecl("_live_caption_show")
+public func _liveCaptionShow() -> Bool {
+  LiveCaptionManager.shared.show()
+  return true
+}
+
+@_cdecl("_live_caption_hide")
+public func _liveCaptionHide() -> Bool {
+  LiveCaptionManager.shared.hide()
+  return true
+}
+
+@_cdecl("_live_caption_update")
+public func _liveCaptionUpdate(json: SRString) -> Bool {
+  let jsonString = json.toString()
+  guard let data = jsonString.data(using: .utf8),
+    let payload = try? JSONDecoder().decode(LiveCaptionStatePayload.self, from: data)
+  else {
+    return false
+  }
+
+  LiveCaptionManager.shared.update(state: payload)
+  return true
+}
+
 @_cdecl("_devtools_panel_show")
 public func _devtoolsPanelShow() -> Bool {
   DevtoolsPanelManager.shared.show()


### PR DESCRIPTION
Adds a separate Swift caption panel and wires live transcript text through the windows plugin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New always-on overlay sync path and live transcript text on screen during meetings; native panel lifecycle and caption derivation edge cases need manual QA on macOS.
> 
> **Overview**
> Adds a **macOS floating live-caption panel** (separate from the recording floating bar) that shows trimmed transcript text while live transcription is active.
> 
> The listener store now maintains **`liveCaptionText`** from transcript deltas (partials when present, otherwise new words; keeps prior text on empty deltas). Live preview updates only when the active session has **`liveTranscriptionActive`**.
> 
> **`FloatingMeetingWindowHost`** always runs **`LiveCaptionWindowSync`**, which subscribes to listener state and drives **`liveCaptionShow` / `liveCaptionUpdate` / `liveCaptionHide`** via the windows plugin. Captions appear only for an active session with live transcription on and non-empty text.
> 
> The windows plugin gains Rust commands, TS bindings, permissions, and a **SwiftUI `NSPanel`** (`sharingType = .none`) with screen-following placement and resizable multi-line layout. Non-macOS builds no-op the native calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 443e6a8e8440754aa8fdf583eb50724edd41f804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->