### PR TITLE
Show memo tab for empty notes

### DIFF
--- a/apps/desktop/src/session/components/compute-note-tab.ts
+++ b/apps/desktop/src/session/components/compute-note-tab.ts
@@ -4,25 +4,26 @@ export function computeCurrentNoteTab(
   tabView: EditorView | null,
   isLiveSessionActive: boolean,
   firstEnhancedNoteId: string | undefined,
-  _canShowTranscript = false,
+  canShowTranscript = false,
 ): EditorView {
   if (isLiveSessionActive) {
-    if (
-      tabView?.type === "raw" ||
-      tabView?.type === "enhanced" ||
-      tabView?.type === "transcript"
-    ) {
+    if (tabView?.type === "raw" || tabView?.type === "transcript") {
+      return tabView;
+    }
+    if (tabView?.type === "enhanced" && firstEnhancedNoteId) {
       return tabView;
     }
     return { type: "raw" };
   }
 
   if (tabView) {
-    if (
-      tabView.type === "enhanced" ||
-      tabView.type === "raw" ||
-      tabView.type === "transcript"
-    ) {
+    if (tabView.type === "raw") {
+      return tabView;
+    }
+    if (tabView.type === "enhanced" && firstEnhancedNoteId) {
+      return tabView;
+    }
+    if (tabView.type === "transcript" && canShowTranscript) {
       return tabView;
     }
 

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -1020,10 +1020,6 @@ export function Header({
       view.type === "enhanced",
   )?.id;
 
-  if (editorTabs.length === 1 && editorTabs[0].type === "raw") {
-    return null;
-  }
-
   return (
     <div data-tauri-drag-region className="flex flex-col">
       <div

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -35,6 +35,7 @@ import {
 import { useAITaskTask } from "~/ai/hooks";
 import { useLanguageModel, useLLMConnectionStatus } from "~/ai/hooks";
 import { extractPlainText } from "~/search/contexts/engine/utils";
+import { useHasTranscript } from "~/session/components/shared";
 import { shouldShowEmptySummaryConfigError } from "~/session/enhance-config";
 import { useEnsureDefaultSummary } from "~/session/hooks/useEnhancedNotes";
 import {
@@ -46,6 +47,7 @@ import * as main from "~/store/tinybase/store/main";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { type EditorView } from "~/store/zustand/tabs/schema";
+import { useListener } from "~/stt/contexts";
 import {
   filterWebTemplatesAgainstUserTemplates,
   getTemplateCreatorLabel,
@@ -1102,18 +1104,45 @@ export function useEditorTabs({
   sessionId: string;
 }): EditorView[] {
   useEnsureDefaultSummary(sessionId);
+  const hasTranscript = useHasTranscript(sessionId);
+  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
+  const batchError = useListener((state) => state.batch[sessionId]?.error);
+  const canShowTranscript =
+    hasTranscript ||
+    sessionMode === "active" ||
+    sessionMode === "finalizing" ||
+    sessionMode === "running_batch" ||
+    Boolean(batchError);
 
   const enhancedNoteIds = main.UI.useSliceRowIds(
     main.INDEXES.enhancedNotesBySession,
     sessionId,
     main.STORE_ID,
   );
-  const enhancedTabs: EditorView[] = (enhancedNoteIds || []).map((id) => ({
+
+  return createEditorTabs({
+    enhancedNoteIds: enhancedNoteIds || [],
+    canShowTranscript,
+  });
+}
+
+function createEditorTabs({
+  enhancedNoteIds,
+  canShowTranscript,
+}: {
+  enhancedNoteIds: string[];
+  canShowTranscript: boolean;
+}): EditorView[] {
+  const enhancedTabs: EditorView[] = enhancedNoteIds.map((id) => ({
     type: "enhanced",
     id,
   }));
 
-  return [...enhancedTabs, { type: "raw" }, { type: "transcript" }];
+  return [
+    ...enhancedTabs,
+    { type: "raw" },
+    ...(canShowTranscript ? [{ type: "transcript" } as const] : []),
+  ];
 }
 
 function useEnhanceLogic(sessionId: string, enhancedNoteId: string) {

--- a/apps/desktop/src/session/components/shared.test.ts
+++ b/apps/desktop/src/session/components/shared.test.ts
@@ -56,7 +56,7 @@ describe("computeCurrentNoteTab", () => {
         { type: "transcript" },
         true,
         "note-1",
-        true,
+        false,
       );
       expect(result).toEqual({ type: "transcript" });
     });
@@ -93,14 +93,14 @@ describe("computeCurrentNoteTab", () => {
       expect(result).toEqual({ type: "transcript" });
     });
 
-    it("preserves persisted transcript view even before transcript content exists", () => {
+    it("normalizes persisted transcript view before transcript content exists", () => {
       const result = computeCurrentNoteTab(
         { type: "transcript" },
         false,
         "note-1",
         false,
       );
-      expect(result).toEqual({ type: "transcript" });
+      expect(result).toEqual({ type: "raw" });
     });
 
     it("normalizes persisted attachments view to raw", () => {
@@ -108,6 +108,16 @@ describe("computeCurrentNoteTab", () => {
         { type: "attachments" },
         false,
         "note-1",
+        false,
+      );
+      expect(result).toEqual({ type: "raw" });
+    });
+
+    it("normalizes persisted enhanced view when no enhanced notes exist", () => {
+      const result = computeCurrentNoteTab(
+        { type: "enhanced", id: "note-1" },
+        false,
+        undefined,
         false,
       );
       expect(result).toEqual({ type: "raw" });

--- a/apps/desktop/src/session/components/shared.tsx
+++ b/apps/desktop/src/session/components/shared.tsx
@@ -71,7 +71,11 @@ export function useCurrentNoteTab(
   const batchError = useListener((state) => state.batch[tab.id]?.error ?? null);
   const hasTranscript = useHasTranscript(tab.id);
   const canShowTranscript =
-    hasTranscript || sessionMode === "running_batch" || Boolean(batchError);
+    hasTranscript ||
+    sessionMode === "active" ||
+    sessionMode === "finalizing" ||
+    sessionMode === "running_batch" ||
+    Boolean(batchError);
 
   const enhancedNoteIds = main.UI.useSliceRowIds(
     main.INDEXES.enhancedNotesBySession,

--- a/apps/desktop/src/session/hooks/useEnhancedNotes.test.tsx
+++ b/apps/desktop/src/session/hooks/useEnhancedNotes.test.tsx
@@ -6,6 +6,7 @@ import type { LLMConnectionStatus } from "~/ai/hooks";
 const hoisted = vi.hoisted(() => ({
   hasTranscript: true,
   sessionMode: "inactive",
+  batchError: null as string | null,
   enhancedNoteIds: [] as string[],
   selectedTemplateId: "template-1" as string | undefined,
   llmStatus: {
@@ -56,6 +57,11 @@ vi.mock("~/stt/contexts", () => ({
   useListener: (selector: (state: unknown) => unknown) =>
     selector({
       getSessionMode: () => hoisted.sessionMode,
+      batch: {
+        "session-1": {
+          error: hoisted.batchError,
+        },
+      },
     }),
 }));
 
@@ -66,6 +72,7 @@ describe("useEnsureDefaultSummary", () => {
     cleanup();
     hoisted.hasTranscript = true;
     hoisted.sessionMode = "inactive";
+    hoisted.batchError = null;
     hoisted.enhancedNoteIds = [];
     hoisted.selectedTemplateId = "template-1";
     hoisted.llmStatus = {
@@ -91,8 +98,39 @@ describe("useEnsureDefaultSummary", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("creates the summary row without queueing generation before transcript exists", async () => {
+  it("does not create the summary row before transcript exists", async () => {
     hoisted.hasTranscript = false;
+
+    renderHook(() => useEnsureDefaultSummary("session-1"));
+
+    await waitFor(() => {
+      expect(hoisted.service.ensureNote).not.toHaveBeenCalled();
+    });
+    expect(
+      hoisted.service.queueAutoEnhanceIfSummaryEmpty,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("creates the summary row while batch transcription is running", async () => {
+    hoisted.hasTranscript = false;
+    hoisted.sessionMode = "running_batch";
+
+    renderHook(() => useEnsureDefaultSummary("session-1"));
+
+    await waitFor(() => {
+      expect(hoisted.service.ensureNote).toHaveBeenCalledWith(
+        "session-1",
+        "template-1",
+      );
+    });
+    expect(
+      hoisted.service.queueAutoEnhanceIfSummaryEmpty,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("creates the summary row after batch transcription fails", async () => {
+    hoisted.hasTranscript = false;
+    hoisted.batchError = "Transcription failed";
 
     renderHook(() => useEnsureDefaultSummary("session-1"));
 

--- a/apps/desktop/src/session/hooks/useEnhancedNotes.ts
+++ b/apps/desktop/src/session/hooks/useEnhancedNotes.ts
@@ -2,9 +2,11 @@ import { useEffect, useMemo } from "react";
 
 import { useAITask } from "~/ai/contexts";
 import { getEnhancerService } from "~/services/enhancer";
+import { useHasTranscript } from "~/session/components/shared";
 import * as main from "~/store/tinybase/store/main";
 import * as settings from "~/store/tinybase/store/settings";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
+import { useListener } from "~/stt/contexts";
 
 export function useEnhancedNotes(sessionId: string) {
   return main.UI.useSliceRowIds(
@@ -44,6 +46,9 @@ export function useEnhancedNote(enhancedNoteId: string) {
 }
 
 export function useEnsureDefaultSummary(sessionId: string) {
+  const hasTranscript = useHasTranscript(sessionId);
+  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
+  const batchError = useListener((state) => state.batch[sessionId]?.error);
   const enhancedNoteIds = main.UI.useSliceRowIds(
     main.INDEXES.enhancedNotesBySession,
     sessionId,
@@ -62,11 +67,23 @@ export function useEnsureDefaultSummary(sessionId: string) {
 
     const hasEnhancedNotes = enhancedNoteIds && enhancedNoteIds.length > 0;
     const templateId = selectedTemplateId || undefined;
+    const canCreateSummary =
+      hasTranscript ||
+      sessionMode === "finalizing" ||
+      sessionMode === "running_batch" ||
+      Boolean(batchError);
 
-    if (!hasEnhancedNotes) {
+    if (!hasEnhancedNotes && canCreateSummary) {
       service.ensureNote(sessionId, templateId);
     }
-  }, [sessionId, enhancedNoteIds?.length, selectedTemplateId]);
+  }, [
+    sessionId,
+    enhancedNoteIds?.length,
+    selectedTemplateId,
+    hasTranscript,
+    sessionMode,
+    batchError,
+  ]);
 }
 
 export function useIsSessionEnhancing(sessionId: string): boolean {


### PR DESCRIPTION
Summary
- Keeps the note tab header visible when only the memo tab exists.
- Adds regression coverage for the raw-only empty-note state.

Tests
- Not run; stack metadata/push only.

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #5669  
- <kbd>&nbsp;5&nbsp;</kbd> #5668  
- <kbd>&nbsp;4&nbsp;</kbd> #5674 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #5673  
- <kbd>&nbsp;2&nbsp;</kbd> #5671  
- <kbd>&nbsp;1&nbsp;</kbd> #5667  
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tab selection normalization and when enhanced notes are auto-created, which affects default UX on session open and during live/batch transcription.
> 
> **Overview**
> **Keeps the note tab bar visible when a session only has the Memos tab**, by removing the header shortcut that returned `null` for a single raw-only tab list.
> 
> **Transcript and enhanced tab behavior is tightened to match what the session can actually show.** The transcript tab is omitted unless there is transcript content or the session is live, finalizing, batch-transcribing, or has a batch error; persisted transcript/enhanced selections are normalized to Memos when those tabs are not available. Default summary row creation via `useEnsureDefaultSummary` now waits until transcript exists or batch/finalize/error paths apply, instead of creating a summary row on every open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 452bf63330f9371204f00a996826d605fefa81a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->