### PR TITLE
Fix consistent editor title scale

### DIFF
--- a/packages/tiptap/src/styles/nodes/heading.css
+++ b/packages/tiptap/src/styles/nodes/heading.css
@@ -74,11 +74,6 @@
   margin-bottom: 1rem;
 }
 
-.tiptap.enhanced-summary-editor.note-title-editor > h1:first-child {
-  font-size: 1.5rem;
-  line-height: 1.875rem;
-}
-
 .blog-editor .tiptap {
   h1 {
     font-size: 1.875rem;


### PR DESCRIPTION
## Summary
- Remove the summary-only first-title scale override so summary and memo titles share the same editor heading style.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS change with no logic or data impact.
> 
> **Overview**
> Removes the **enhanced-summary**-specific override for the first `h1` in `.note-title-editor`, so summary and memo title editors both use the shared **1.75rem / 2.125rem** title styling instead of the smaller **1.5rem / 1.875rem** scale that only applied to summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e4b9aafae42b6d44e038d4a897a2a138a4525b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->