### PR TITLE
Add Cal.com meeting join control

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon, HeadsetIcon, MicOff } from "lucide-react";
+import { ChevronDownIcon, HeadsetIcon, MicOff, VideoIcon } from "lucide-react";
 
 import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { DancingSticks } from "@hypr/ui/components/ui/dancing-sticks";
@@ -215,6 +215,11 @@ function getMeetingDisplay(type: RemoteMeeting["type"]) {
       return {
         name: "Teams",
         icon: <img src="/assets/teams.png" alt="" width={18} height={18} />,
+      };
+    case "cal-com":
+      return {
+        name: "Cal.com",
+        icon: <VideoIcon size={18} />,
       };
     default:
       return {

--- a/apps/desktop/src/session/hooks/useRemoteMeeting.test.ts
+++ b/apps/desktop/src/session/hooks/useRemoteMeeting.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+
+import { detectMeetingType, getRemoteMeeting } from "./useRemoteMeeting";
+
+describe("remote meeting detection", () => {
+  test("detects Cal.com video links", () => {
+    expect(
+      detectMeetingType("https://app.cal.com/video/d713v9w1d2krBptPtwUAnJ"),
+    ).toBe("cal-com");
+  });
+
+  test("keeps regular Cal.com booking links out of join controls", () => {
+    expect(detectMeetingType("https://cal.com/john/intro")).toBeNull();
+    expect(detectMeetingType("https://app.cal.com/john/intro")).toBeNull();
+  });
+
+  test("returns the remote meeting payload for recognized links", () => {
+    expect(
+      getRemoteMeeting("https://app.cal.com/video/d713v9w1d2krBptPtwUAnJ"),
+    ).toEqual({
+      type: "cal-com",
+      url: "https://app.cal.com/video/d713v9w1d2krBptPtwUAnJ",
+    });
+  });
+});

--- a/apps/desktop/src/session/hooks/useRemoteMeeting.ts
+++ b/apps/desktop/src/session/hooks/useRemoteMeeting.ts
@@ -1,13 +1,18 @@
 import { useSessionEvent } from "~/store/tinybase/hooks";
 
+export type RemoteMeetingType =
+  | "zoom"
+  | "google-meet"
+  | "webex"
+  | "teams"
+  | "cal-com";
+
 export type RemoteMeeting = {
-  type: "zoom" | "google-meet" | "webex" | "teams";
+  type: RemoteMeetingType;
   url: string;
 };
 
-export function detectMeetingType(
-  url: string,
-): "zoom" | "google-meet" | "webex" | "teams" | null {
+export function detectMeetingType(url: string): RemoteMeetingType | null {
   try {
     const parsed = new URL(url);
     const hostname = parsed.hostname.toLowerCase();
@@ -23,6 +28,9 @@ export function detectMeetingType(
     }
     if (hostname.includes("teams.microsoft.com")) {
       return "teams";
+    }
+    if (hostname === "app.cal.com" && parsed.pathname.startsWith("/video/")) {
+      return "cal-com";
     }
     return null;
   } catch {


### PR DESCRIPTION
Recognize Cal.com video links as remote meetings and render them in the session header join button.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, test-covered extension to URL parsing and session header display with no auth or data-path changes.
> 
> **Overview**
> **Cal.com video URLs** on session events now show the same **Join** control as Zoom, Meet, Teams, and Webex.
> 
> `detectMeetingType` treats only `app.cal.com` links whose path starts with `/video/` as remote meetings; ordinary Cal.com booking URLs stay excluded so they do not get a join button. The session outer header maps the new `cal-com` type to a **Cal.com** label and a `VideoIcon`. Types are centralized as `RemoteMeetingType`, and vitest coverage documents the positive and negative URL cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ac946729dec81eec840fcb15143d6e424ccb0e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->