### PR TITLE
Keep note title inside editor

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -196,6 +196,22 @@ describe("OuterHeader", () => {
     expect(titleSlot?.className).not.toContain("justify-center");
   });
 
+  it("can center the title slot for toolbar controls", () => {
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        centerTitle
+        title={<span>Toolbar controls</span>}
+      />,
+    );
+
+    const title = screen.getByText("Toolbar controls");
+    const titleSlot = title.parentElement?.parentElement;
+
+    expect(titleSlot?.className).toContain("justify-center");
+  });
+
   it("keeps sidebar header controls hidden while the sidebar is expanded", () => {
     mocks.sessionModes = { "session-1": "active" };
 

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -22,11 +22,13 @@ export function OuterHeader({
   currentView,
   standaloneWindow = false,
   title,
+  centerTitle = false,
 }: {
   sessionId: string;
   currentView: EditorView;
   standaloneWindow?: boolean;
   title?: React.ReactNode;
+  centerTitle?: boolean;
 }) {
   const { leftsidebar } = useShell();
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
@@ -50,6 +52,7 @@ export function OuterHeader({
           data-tauri-drag-region
           className={cn([
             "pointer-events-none absolute inset-y-0 flex items-center",
+            centerTitle && "justify-center",
             reserveCollapsedLiveControls ? "right-[153px]" : "right-[70px]",
             standaloneWindow
               ? "left-[68px]"

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -16,8 +16,6 @@ import { SearchProvider } from "./components/note-input/search/context";
 import { OuterHeader } from "./components/outer-header";
 import { SessionSurface } from "./components/session-surface";
 import { useCurrentNoteTab, useHasTranscript } from "./components/shared";
-import { NoteTitleBreadcrumb } from "./components/title-breadcrumb";
-import { TitleInput, type TitleInputHandle } from "./components/title-input";
 import { useAutoEnhance } from "./hooks/useAutoEnhance";
 
 import * as AudioPlayer from "~/audio-player";
@@ -121,7 +119,6 @@ function TabContentNoteInner({
   audioUrlReady: boolean;
   isAudioUrlLoading: boolean;
 }) {
-  const titleInputRef = React.useRef<TitleInputHandle>(null);
   const noteInputRef = React.useRef<NoteInputHandle>(null);
 
   const editorTabs = useEditorTabs({ sessionId: tab.id });
@@ -134,7 +131,7 @@ function TabContentNoteInner({
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const { audioExists } = AudioPlayer.useAudioPlayer();
 
-  useAutoFocusTitle({ sessionId, titleInputRef });
+  useAutoFocusTitle({ sessionId, noteInputRef });
   usePendingUpload(sessionId);
 
   const { bottomAccessory, bottomBorderHandle, bottomAccessoryState } =
@@ -155,26 +152,6 @@ function TabContentNoteInner({
     },
     [tab, updateSessionTabState],
   );
-  const handleNavigateToTitle = React.useCallback((pixelWidth?: number) => {
-    if (pixelWidth !== undefined) {
-      titleInputRef.current?.focusAtPixelWidth(pixelWidth);
-    } else {
-      titleInputRef.current?.focusAtEnd();
-    }
-  }, []);
-  const handleTransferContentToEditor = React.useCallback((content: string) => {
-    noteInputRef.current?.insertAtStartAndFocus(content);
-  }, []);
-  const handleFocusEditorAtStart = React.useCallback(() => {
-    noteInputRef.current?.focusAtStart();
-  }, []);
-  const handleFocusEditorAtPixelWidth = React.useCallback(
-    (pixelWidth: number) => {
-      noteInputRef.current?.focusAtPixelWidth(pixelWidth);
-    },
-    [],
-  );
-
   const mergeTranscriptSurface =
     bottomAccessoryState?.expanded === true &&
     (bottomAccessoryState.mode === "playback" ||
@@ -205,32 +182,14 @@ function TabContentNoteInner({
           sessionId={tab.id}
           currentView={currentView}
           standaloneWindow={standaloneWindow}
+          centerTitle
           title={
-            <div className="flex min-w-0 items-center gap-2">
-              <div className="min-w-0 flex-1">
-                <NoteTitleBreadcrumb
-                  sessionId={tab.id}
-                  title={
-                    <TitleInput
-                      ref={titleInputRef}
-                      tab={tab}
-                      variant="breadcrumb"
-                      onTransferContentToEditor={handleTransferContentToEditor}
-                      onFocusEditorAtStart={handleFocusEditorAtStart}
-                      onFocusEditorAtPixelWidth={handleFocusEditorAtPixelWidth}
-                    />
-                  }
-                />
-              </div>
-              <div className="shrink-0">
-                <NoteInputHeader
-                  sessionId={tab.id}
-                  editorTabs={editorTabs}
-                  currentTab={currentView}
-                  handleTabChange={handleTabChange}
-                />
-              </div>
-            </div>
+            <NoteInputHeader
+              sessionId={tab.id}
+              editorTabs={editorTabs}
+              currentTab={currentView}
+              handleTabChange={handleTabChange}
+            />
           }
         />
       }
@@ -257,7 +216,6 @@ function TabContentNoteInner({
       <NoteInput
         ref={noteInputRef}
         tab={tab}
-        onNavigateToTitle={handleNavigateToTitle}
         editorTabs={editorTabs}
         currentTab={currentView}
         handleTabChange={handleTabChange}
@@ -282,20 +240,20 @@ function usePendingUpload(sessionId: string) {
 
 function useAutoFocusTitle({
   sessionId,
-  titleInputRef,
+  noteInputRef,
 }: {
   sessionId: string;
-  titleInputRef: React.RefObject<TitleInputHandle | null>;
+  noteInputRef: React.RefObject<NoteInputHandle | null>;
 }) {
-  const didAutoFocus = useRef(false);
+  const autoFocusedSessionRef = useRef<string | null>(null);
   const title = main.UI.useCell("sessions", sessionId, "title", main.STORE_ID);
 
   useEffect(() => {
-    if (didAutoFocus.current) return;
+    if (autoFocusedSessionRef.current === sessionId) return;
 
     if (!title) {
-      titleInputRef.current?.focus();
-      didAutoFocus.current = true;
+      noteInputRef.current?.focusAtStart();
+      autoFocusedSessionRef.current = sessionId;
     }
   }, [sessionId, title]);
 }


### PR DESCRIPTION
Remove the toolbar title editor, keep note tab controls centered, and focus empty notes at the editor title line.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5677 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5667
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session editing, title persistence, and tab routing across live and post-session states; live caption native integration adds platform surface area but is mostly additive.
> 
> **Overview**
> Moves the **session title into the note editor** as a enforced first-line H1, syncing edits to `sessions.title` for raw and enhanced notes and prepending that title when AI enhance/title tasks write content. The separate toolbar **title breadcrumb/input is removed**; note tabs (raw, enhanced, **Transcript**) sit in a **centered** outer header, and empty sessions **focus the editor title line** instead of a header field.
> 
> Adds a **Transcript** main-area tab and hides the redundant bottom transcript panel while that tab is active (`suppressTranscriptPanel`). Post-session bottom chrome is **narrowed**: inactive sessions generally need **playback-ready audio or insights** before showing handles, and transcript-only bottom UI is mostly limited to **batch** runs.
> 
> Ships a **native live caption overlay** (macOS) driven by `liveCaptionText` when live transcription is active, plus **Cal.com `/video/`** join-link detection. Smaller UX tweaks include an enhanced-tab **template picker** (replacing inline regenerate), speaker-assign popover layout, and earlier **default summary row** creation via `ensureNote`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6843a0e6b75e018704004be738e794cd3e86a59a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->