### PR TITLE
Set default sidebar width

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -134,6 +134,10 @@ import { ClassicMainBody } from "./body";
 describe("ClassicMainBody", () => {
   beforeEach(() => {
     cleanup();
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1600,
+    });
     mocks.currentTab = {
       active: true,
       pinned: false,
@@ -161,9 +165,9 @@ describe("ClassicMainBody", () => {
 
     const panels = screen.getAllByTestId("panel");
     expect(panels).toHaveLength(2);
-    expect(panels[0]?.dataset.defaultSize).toBe("20");
-    expect(panels[0]?.dataset.minSize).toBe("12");
-    expect(panels[0]?.dataset.maxSize).toBe("32");
+    expect(panels[0]?.dataset.defaultSize).toBe("12.5");
+    expect(panels[0]?.dataset.minSize).toBe("12.5");
+    expect(panels[0]?.dataset.maxSize).toBe("22.5");
     expect(panels[0]?.dataset.minWidth).toBe("200");
     expect(panels[0]?.dataset.maxWidth).toBe("360");
 
@@ -171,7 +175,7 @@ describe("ClassicMainBody", () => {
       "[data-left-sidebar-chrome]",
     );
 
-    expect(sidebarChrome?.style.width).toBe("20%");
+    expect(sidebarChrome?.style.width).toBe("12.5%");
     expect(sidebarChrome?.style.minWidth).toBe("200px");
     expect(sidebarChrome?.style.maxWidth).toBe("360px");
     expect(sidebarChrome?.className).not.toContain("w-[200px]");

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -47,11 +47,10 @@ import { type Tab, uniqueIdfromTab, useTabs } from "~/store/zustand/tabs";
 
 const MAIN_AREA_TOP_DRAG_HEIGHT_PX = 48;
 const MAIN_AREA_WINDOW_DRAG_THRESHOLD_PX = 5;
-const LEFT_SIDEBAR_DEFAULT_SIZE = 20;
-const LEFT_SIDEBAR_MIN_SIZE = 12;
-const LEFT_SIDEBAR_MAX_SIZE = 32;
+const LEFT_SIDEBAR_DEFAULT_WIDTH_PX = 200;
 const LEFT_SIDEBAR_MIN_WIDTH_PX = 200;
 const LEFT_SIDEBAR_MAX_WIDTH_PX = 360;
+const LEFT_SIDEBAR_FALLBACK_CONTAINER_WIDTH_PX = 1000;
 
 type MainAreaWindowDragStart = {
   pointerId: number;
@@ -64,8 +63,11 @@ export function ClassicMainBody() {
   const { leftsidebar } = useShell();
   const currentTab = useTabs((state) => state.currentTab);
   const { runEscapeShortcut } = useClassicMainTabsShortcuts();
+  const [leftSidebarPanelConstraints] = useState(
+    createLeftSidebarPanelConstraints,
+  );
   const [leftSidebarPanelSize, setLeftSidebarPanelSize] = useState(
-    LEFT_SIDEBAR_DEFAULT_SIZE,
+    leftSidebarPanelConstraints.defaultSize,
   );
 
   const isOnboarding = currentTab?.type === "onboarding";
@@ -192,9 +194,9 @@ export function ClassicMainBody() {
         {showLeftSidebarPanel ? (
           <>
             <ResizablePanel
-              defaultSize={LEFT_SIDEBAR_DEFAULT_SIZE}
-              minSize={LEFT_SIDEBAR_MIN_SIZE}
-              maxSize={LEFT_SIDEBAR_MAX_SIZE}
+              defaultSize={leftSidebarPanelConstraints.defaultSize}
+              minSize={leftSidebarPanelConstraints.minSize}
+              maxSize={leftSidebarPanelConstraints.maxSize}
               className="min-h-0 overflow-hidden"
               style={{
                 minWidth: LEFT_SIDEBAR_MIN_WIDTH_PX,
@@ -233,6 +235,45 @@ export function ClassicMainBody() {
       </ResizablePanelGroup>
     </div>
   );
+}
+
+function createLeftSidebarPanelConstraints() {
+  const containerWidthPx = Math.max(
+    getInitialMainAreaWidthPx(),
+    LEFT_SIDEBAR_DEFAULT_WIDTH_PX,
+  );
+  const minSize = percentageFromPixels(
+    LEFT_SIDEBAR_MIN_WIDTH_PX,
+    containerWidthPx,
+  );
+
+  return {
+    defaultSize: percentageFromPixels(
+      LEFT_SIDEBAR_DEFAULT_WIDTH_PX,
+      containerWidthPx,
+    ),
+    minSize,
+    maxSize: Math.max(
+      minSize,
+      percentageFromPixels(LEFT_SIDEBAR_MAX_WIDTH_PX, containerWidthPx),
+    ),
+  };
+}
+
+function getInitialMainAreaWidthPx() {
+  if (typeof window === "undefined") {
+    return LEFT_SIDEBAR_FALLBACK_CONTAINER_WIDTH_PX;
+  }
+
+  return (
+    window.innerWidth ||
+    document.documentElement.clientWidth ||
+    LEFT_SIDEBAR_FALLBACK_CONTAINER_WIDTH_PX
+  );
+}
+
+function percentageFromPixels(widthPx: number, containerWidthPx: number) {
+  return Math.min((widthPx / containerWidthPx) * 100, 100);
 }
 
 function useMainAreaTopWindowDrag(enabled: boolean) {


### PR DESCRIPTION
Derive the clean-state sidebar panel percentage from a 200px target and update coverage for wider windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only change in the desktop main shell; pixel min/max bounds are preserved and behavior is covered by updated unit tests.
> 
> **Overview**
> The classic main left sidebar no longer uses fixed **20% / 12% / 32%** resizable panel sizes. **Default, min, and max** panel percentages are now computed once at mount from **200px** (default/min) and **360px** (max), using `window.innerWidth` (with a **1000px** fallback when `window` is unavailable).
> 
> `ClassicMainBody` initializes panel constraints via `createLeftSidebarPanelConstraints` and wires those values into `ResizablePanel` and the initial sidebar chrome width. **200px / 360px** min/max width styles on the panel are unchanged.
> 
> Tests set **`window.innerWidth` to 1600** and expect **12.5%** default/min and **22.5%** max instead of the old percentage constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee6e7ac619577198209a0551596aa44922f83ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->