### PR TITLE
Set floating chat modal min width

### DIFF
--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -126,7 +126,7 @@ describe("PersistentChatPanel", () => {
       expect(floatingFrame?.className).toContain("pb-2");
       expect(floatingFrame?.className).not.toContain("pb-3");
       expect(panel?.style.width).toBe("calc(100% - 1.5rem)");
-      expect(panel?.style.minWidth).toBe("min(368px, calc(100% - 1.5rem))");
+      expect(panel?.style.minWidth).toBe("min(476px, 100%)");
       expect(panel?.style.maxWidth).toBe("648px");
       expect(panel?.style.height).toBe("");
       expect(panel?.style.transformOrigin).toBe("bottom center");

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -13,6 +13,7 @@ import { useShell } from "~/contexts/shell";
 const FLOATING_CHAT_INPUT_MAX_WIDTH = 640;
 const FLOATING_CHAT_INPUT_HEIGHT = 40;
 const FLOATING_CHAT_SHELL_INSET = 4;
+const FLOATING_PANEL_MIN_WIDTH = 476;
 const FLOATING_PANEL_DEFAULT_MAX_WIDTH =
   FLOATING_CHAT_INPUT_MAX_WIDTH + FLOATING_CHAT_SHELL_INSET * 2;
 const FLOATING_PANEL_REVEAL_HEIGHT =
@@ -152,7 +153,7 @@ export function PersistentChatPanel({
   };
   const panelStyle = {
     width: "calc(100% - 1.5rem)",
-    minWidth: "min(368px, calc(100% - 1.5rem))",
+    minWidth: `min(${FLOATING_PANEL_MIN_WIDTH}px, 100%)`,
     maxWidth: `${FLOATING_PANEL_DEFAULT_MAX_WIDTH}px`,
     maxHeight: "calc(100% - 1rem)",
     transformOrigin: "bottom center",


### PR DESCRIPTION
Raise the responsive floating chat modal width floor to 476px and update the pinned geometry test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only width constraint change with no auth, data, or API impact.
> 
> **Overview**
> Raises the **responsive floor** for the floating chat panel from **368px** to **476px** so the modal stays wider on typical viewports.
> 
> The min width is now driven by a `FLOATING_PANEL_MIN_WIDTH` constant and applied as `min(476px, 100%)` instead of `min(368px, calc(100% - 1.5rem))`. The persistent chat geometry test was updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 765c10b371101e8180fe9921b19d7e026860e54c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->