### PR TITLE
Smooth floating chat open animation

### DIFF
--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -131,7 +131,8 @@ describe("PersistentChatPanel", () => {
       expect(panel?.style.height).toBe("");
       expect(panel?.style.transformOrigin).toBe("bottom center");
       expect(panel?.className).toContain("rounded-[28px]");
-      expect(panel?.dataset.chatPanelReveal).toBe("bottom-up");
+      expect(panel?.className).toContain("will-change-[clip-path,transform]");
+      expect(panel?.dataset.chatPanelReveal).toBe("input-slot-bottom-up");
     });
   });
 

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -18,6 +18,7 @@ const FLOATING_PANEL_DEFAULT_MAX_WIDTH =
 const FLOATING_PANEL_REVEAL_HEIGHT =
   FLOATING_CHAT_INPUT_HEIGHT + FLOATING_CHAT_SHELL_INSET;
 const FLOATING_PANEL_RADIUS = 28;
+const FLOATING_PANEL_INPUT_CLIP = `inset(calc(100% - ${FLOATING_PANEL_REVEAL_HEIGHT}px) ${FLOATING_CHAT_SHELL_INSET}px ${FLOATING_CHAT_SHELL_INSET}px ${FLOATING_CHAT_SHELL_INSET}px round 9999px)`;
 
 type FloatingContainerRect = {
   top: number;
@@ -128,27 +129,23 @@ export function PersistentChatPanel({
     initial: {
       y: 0,
       opacity: 1,
-      scale: 1,
-      clipPath: `inset(calc(100% - ${FLOATING_PANEL_REVEAL_HEIGHT}px) 0 0 0 round ${FLOATING_PANEL_RADIUS}px)`,
+      clipPath: FLOATING_PANEL_INPUT_CLIP,
     },
     animate: {
       y: 0,
       opacity: 1,
-      scale: 1,
       clipPath: `inset(0 0 0 0 round ${FLOATING_PANEL_RADIUS}px)`,
     },
     exit: {
-      y: 8,
+      y: 6,
       opacity: 0,
-      scale: 0.99,
-      clipPath: `inset(calc(100% - ${FLOATING_PANEL_REVEAL_HEIGHT}px) 0 0 0 round ${FLOATING_PANEL_RADIUS}px)`,
+      clipPath: FLOATING_PANEL_INPUT_CLIP,
     },
   };
   const panelTransition = {
     opacity: { duration: 0.18, ease: [0.22, 1, 0.36, 1] },
-    scale: { duration: 0.2, ease: [0.22, 1, 0.36, 1] },
-    y: { duration: 0.22, ease: [0.22, 1, 0.36, 1] },
-    clipPath: { duration: 0.32, ease: [0.22, 1, 0.36, 1] },
+    y: { duration: 0.24, ease: [0.22, 1, 0.36, 1] },
+    clipPath: { duration: 0.44, ease: [0.16, 1, 0.3, 1] },
   };
   const panelStyle = {
     width: "calc(100% - 1.5rem)",
@@ -173,7 +170,7 @@ export function PersistentChatPanel({
                 }
               : { display: "none" }
           }
-          initial={{ opacity: 0 }}
+          initial={{ opacity: 1 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.2 }}
@@ -196,10 +193,11 @@ export function PersistentChatPanel({
           >
             <motion.div
               data-chat-panel
-              data-chat-panel-reveal="bottom-up"
+              data-chat-panel-reveal="input-slot-bottom-up"
               data-chat-size="floating"
               className={cn([
                 "relative flex min-h-0 flex-col overflow-hidden",
+                "will-change-[clip-path,transform]",
                 chatFloatingPanelShellClassNames(),
               ])}
               style={panelStyle}

--- a/apps/desktop/src/shared/chat-cta.test.tsx
+++ b/apps/desktop/src/shared/chat-cta.test.tsx
@@ -120,7 +120,7 @@ describe("ChatCTA", () => {
     expect(hoverZone?.className).toContain("pb-0");
   });
 
-  it("hides while the floating chat is open", () => {
+  it("keeps an inert expanded handoff surface while the floating chat is open", () => {
     mocks.chatMode = "FloatingOpen";
 
     render(<ChatCTA />);
@@ -128,6 +128,14 @@ describe("ChatCTA", () => {
     expect(
       screen.queryByRole("button", { name: "Ask Anarlog anything" }),
     ).toBeNull();
+    const surface = document.querySelector("[data-chat-cta-surface]");
+
+    expect(surface?.className).toContain("h-10");
+    expect(surface?.className).toContain("border-border/70");
+    expect(surface?.className).toContain("bg-[#f4f4f5]");
+    expect(surface?.className).toContain(
+      "[clip-path:inset(0_0_0_0_round_9999px)]",
+    );
   });
 
   it("hides while the right panel chat is open", () => {

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -10,14 +10,59 @@ export function ChatCTA({
   ariaLabel?: string;
 }) {
   const { chat } = useShell();
-  const isChatOpen = chat.mode !== "FloatingClosed";
+  const isFloatingOpen = chat.mode === "FloatingOpen";
 
   const handleClick = () => {
     chat.sendEvent({ type: "OPEN" });
   };
 
-  if (isChatOpen) {
+  if (chat.mode === "RightPanelOpen") {
     return null;
+  }
+
+  const surface = (
+    <span
+      data-chat-cta-surface
+      aria-hidden="true"
+      className={cn([
+        "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-[min(640px,calc(100cqw_-_2rem))] -translate-x-1/2 items-center overflow-hidden rounded-full border border-transparent bg-black dark:bg-white",
+        "[clip-path:inset(0_calc(50%_-_3rem)_0_calc(50%_-_3rem)_round_9999px)]",
+        "origin-bottom px-0 text-sm shadow-[0_8px_22px_rgba(0,0,0,0.2)] transition-[clip-path,height,padding,background-color,border-color,box-shadow] duration-200 ease-out dark:shadow-[0_8px_24px_rgba(0,0,0,0.45)]",
+        "group-hover/anarlog-chat-cta:border-border/70 group-focus-visible/anarlog-chat-cta:border-border/70 group-hover/anarlog-chat-cta:bg-[#f4f4f5] group-focus-visible/anarlog-chat-cta:bg-[#f4f4f5] dark:group-hover/anarlog-chat-cta:bg-[#202020] dark:group-focus-visible/anarlog-chat-cta:bg-[#202020]",
+        "group-hover/anarlog-chat-cta:h-10 group-hover/anarlog-chat-cta:px-4 group-hover/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
+        "group-focus-visible/anarlog-chat-cta:h-10 group-focus-visible/anarlog-chat-cta:px-4 group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
+        "group-focus-visible/anarlog-chat-cta:ring-ring group-focus-visible/anarlog-chat-cta:ring-2 group-focus-visible/anarlog-chat-cta:ring-offset-2",
+        isFloatingOpen && [
+          "border-border/70 h-10 px-4 [clip-path:inset(0_0_0_0_round_9999px)]",
+          "bg-[#f4f4f5] dark:bg-[#202020]",
+        ],
+      ])}
+    >
+      <span
+        aria-hidden="true"
+        className={cn([
+          "max-w-0 min-w-0 flex-1 truncate text-left opacity-0",
+          "group-focus-within/anarlog-chat-cta:text-muted-foreground group-hover/anarlog-chat-cta:text-muted-foreground text-white/55",
+          "transition-[max-width,opacity] duration-200 ease-out",
+          "group-hover/anarlog-chat-cta:max-w-full group-hover/anarlog-chat-cta:opacity-100",
+          "group-focus-within/anarlog-chat-cta:max-w-full group-focus-within/anarlog-chat-cta:opacity-100",
+          isFloatingOpen && "text-muted-foreground max-w-full opacity-100",
+        ])}
+      >
+        {label}
+      </span>
+    </span>
+  );
+
+  if (isFloatingOpen) {
+    return (
+      <div
+        aria-hidden="true"
+        className="group/anarlog-chat-cta pointer-events-none relative h-10 w-40 max-w-full"
+      >
+        {surface}
+      </div>
+    );
   }
 
   return (
@@ -27,32 +72,7 @@ export function ChatCTA({
       onClick={handleClick}
       className="group/anarlog-chat-cta relative h-10 w-40 max-w-full cursor-text focus-visible:outline-none"
     >
-      <span
-        data-chat-cta-surface
-        aria-hidden="true"
-        className={cn([
-          "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-[min(640px,calc(100cqw_-_2rem))] -translate-x-1/2 items-center overflow-hidden rounded-full border border-transparent bg-black dark:bg-white",
-          "[clip-path:inset(0_calc(50%_-_3rem)_0_calc(50%_-_3rem)_round_9999px)]",
-          "origin-bottom px-0 text-sm shadow-[0_8px_22px_rgba(0,0,0,0.2)] transition-[clip-path,height,padding,background-color,border-color,box-shadow] duration-200 ease-out dark:shadow-[0_8px_24px_rgba(0,0,0,0.45)]",
-          "group-hover/anarlog-chat-cta:border-border/70 group-focus-visible/anarlog-chat-cta:border-border/70 group-hover/anarlog-chat-cta:bg-[#f4f4f5] group-focus-visible/anarlog-chat-cta:bg-[#f4f4f5] dark:group-hover/anarlog-chat-cta:bg-[#202020] dark:group-focus-visible/anarlog-chat-cta:bg-[#202020]",
-          "group-hover/anarlog-chat-cta:h-10 group-hover/anarlog-chat-cta:px-4 group-hover/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
-          "group-focus-visible/anarlog-chat-cta:h-10 group-focus-visible/anarlog-chat-cta:px-4 group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
-          "group-focus-visible/anarlog-chat-cta:ring-ring group-focus-visible/anarlog-chat-cta:ring-2 group-focus-visible/anarlog-chat-cta:ring-offset-2",
-        ])}
-      >
-        <span
-          aria-hidden="true"
-          className={cn([
-            "max-w-0 min-w-0 flex-1 truncate text-left opacity-0",
-            "group-focus-within/anarlog-chat-cta:text-muted-foreground group-hover/anarlog-chat-cta:text-muted-foreground text-white/55",
-            "transition-[max-width,opacity] duration-200 ease-out",
-            "group-hover/anarlog-chat-cta:max-w-full group-hover/anarlog-chat-cta:opacity-100",
-            "group-focus-within/anarlog-chat-cta:max-w-full group-focus-within/anarlog-chat-cta:opacity-100",
-          ])}
-        >
-          {label}
-        </span>
-      </span>
+      {surface}
     </button>
   );
 }


### PR DESCRIPTION
Keep the ask bar as an inert handoff surface and reveal the floating panel from the input slot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop UI and animation-only changes with no auth, data, or API impact; minor a11y shift (no button while floating open, aria-hidden handoff div).
> 
> **Overview**
> Improves the **floating chat open/close** motion so the panel grows from the bottom **input slot** (horizontal insets + pill clip) instead of a generic bottom-up reveal with scale. Motion drops **scale**, tunes **clip-path** and **y** timing, adds **`will-change-[clip-path,transform]`**, and renames the reveal marker to **`input-slot-bottom-up`**. The fixed overlay no longer fades in on mount (**opacity stays 1**).
> 
> **`ChatCTA`** now keeps an **inert, expanded ask-bar surface** while floating chat is open (pointer-events-none, same styling as hover) so it can visually hand off to the panel; it still **fully hides** when the right-panel chat is open. Tests cover the new reveal mode and the floating-open handoff surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c64a33e091dfe994280e4a8713700e127fef3cd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->