### PR TITLE
Fix empty memo title editor crash

### DIFF
--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -6,7 +6,6 @@ import {
   ProseMirrorDoc,
   reactKeys,
   useEditorEffect,
-  useEditorEventCallback,
 } from "@handlewithcare/react-prosemirror";
 import { dropCursor } from "prosemirror-dropcursor";
 import { gapCursor } from "prosemirror-gapcursor";
@@ -320,139 +319,133 @@ function EditorCommandsBridge({
 }: {
   commandsRef: React.RefObject<EditorCommands>;
 }) {
-  commandsRef.current.focus = useEditorEventCallback((view) => {
-    if (!view) return;
-    view.focus();
-  });
+  useEditorEffect(
+    (view) => {
+      if (!view) {
+        commandsRef.current = noopCommands;
+        return;
+      }
 
-  commandsRef.current.focusAtStart = useEditorEventCallback((view) => {
-    if (!view) return;
-    view.dispatch(
-      view.state.tr.setSelection(Selection.atStart(view.state.doc)),
-    );
-    view.focus();
-  });
-
-  commandsRef.current.focusAtPixelWidth = useEditorEventCallback(
-    (view, pixelWidth: number) => {
-      if (!view) return;
-
-      const blockStart = Selection.atStart(view.state.doc).from;
-      const firstTextNode = view.dom.querySelector(".ProseMirror > *");
-      if (firstTextNode) {
-        const editorStyle = window.getComputedStyle(firstTextNode);
-        const canvas = document.createElement("canvas");
-        const ctx = canvas.getContext("2d");
-        if (ctx) {
-          ctx.font = `${editorStyle.fontWeight} ${editorStyle.fontSize} ${editorStyle.fontFamily}`;
-          const firstBlock = view.state.doc.firstChild;
-          if (firstBlock && firstBlock.textContent) {
-            const text = firstBlock.textContent;
-            let charPos = 0;
-            for (let i = 0; i <= text.length; i++) {
-              const currentWidth = ctx.measureText(text.slice(0, i)).width;
-              if (currentWidth >= pixelWidth) {
-                charPos = i;
-                break;
+      commandsRef.current = {
+        focus: () => {
+          view.focus();
+        },
+        focusAtStart: () => {
+          view.dispatch(
+            view.state.tr.setSelection(Selection.atStart(view.state.doc)),
+          );
+          view.focus();
+        },
+        focusAtPixelWidth: (pixelWidth: number) => {
+          const blockStart = Selection.atStart(view.state.doc).from;
+          const firstTextNode = view.dom.querySelector(".ProseMirror > *");
+          if (firstTextNode) {
+            const editorStyle = window.getComputedStyle(firstTextNode);
+            const canvas = document.createElement("canvas");
+            const ctx = canvas.getContext("2d");
+            if (ctx) {
+              ctx.font = `${editorStyle.fontWeight} ${editorStyle.fontSize} ${editorStyle.fontFamily}`;
+              const firstBlock = view.state.doc.firstChild;
+              if (firstBlock && firstBlock.textContent) {
+                const text = firstBlock.textContent;
+                let charPos = 0;
+                for (let i = 0; i <= text.length; i++) {
+                  const currentWidth = ctx.measureText(text.slice(0, i)).width;
+                  if (currentWidth >= pixelWidth) {
+                    charPos = i;
+                    break;
+                  }
+                  charPos = i;
+                }
+                const targetPos = Math.min(
+                  blockStart + charPos,
+                  view.state.doc.content.size - 1,
+                );
+                view.dispatch(
+                  view.state.tr.setSelection(
+                    TextSelection.create(view.state.doc, targetPos),
+                  ),
+                );
+                view.focus();
+                return;
               }
-              charPos = i;
             }
-            const targetPos = Math.min(
-              blockStart + charPos,
-              view.state.doc.content.size - 1,
-            );
+          }
+
+          view.dispatch(
+            view.state.tr.setSelection(Selection.atStart(view.state.doc)),
+          );
+          view.focus();
+        },
+        insertAtStartAndFocus: (content: string) => {
+          if (!content) return;
+          const pos = Selection.atStart(view.state.doc).from;
+          const tr = view.state.tr.insertText(content, pos);
+          tr.setSelection(TextSelection.create(tr.doc, pos));
+          view.dispatch(tr);
+          view.focus();
+        },
+        replaceContent: (content: JSONContent) => {
+          if (content.type !== "doc") return;
+
+          try {
+            const nextDoc = PMNode.fromJSON(schema, content);
+            if (nextDoc.eq(view.state.doc)) {
+              return;
+            }
+
             view.dispatch(
-              view.state.tr.setSelection(
-                TextSelection.create(view.state.doc, targetPos),
+              view.state.tr.replaceWith(
+                0,
+                view.state.doc.content.size,
+                nextDoc.content,
               ),
             );
-            view.focus();
-            return;
+          } catch {
+            // invalid content
           }
-        }
-      }
+        },
+        setSearch: (query: string, caseSensitive: boolean) => {
+          const q = new SearchQuery({ search: query, caseSensitive });
+          const current = getSearchState(view.state);
+          if (current && current.query.eq(q)) return;
+          view.dispatch(setSearchState(view.state.tr, q));
+        },
+        replace: (params: SearchReplaceParams) => {
+          const query = new SearchQuery({
+            search: params.query,
+            replace: params.replacement,
+            caseSensitive: params.caseSensitive,
+            wholeWord: params.wholeWord,
+          });
 
-      view.dispatch(
-        view.state.tr.setSelection(Selection.atStart(view.state.doc)),
-      );
-      view.focus();
+          view.dispatch(setSearchState(view.state.tr, query));
+
+          if (params.all) {
+            searchReplaceAll(view.state, (tr) => view.dispatch(tr));
+          } else {
+            let result = query.findNext(view.state);
+            let idx = 0;
+            while (result && idx < params.matchIndex) {
+              result = query.findNext(view.state, result.to);
+              idx++;
+            }
+            if (!result) return;
+            view.dispatch(
+              view.state.tr.setSelection(
+                TextSelection.create(view.state.doc, result.from, result.to),
+              ),
+            );
+            searchReplaceCurrent(view.state, (tr) => view.dispatch(tr));
+          }
+        },
+      };
+
+      return () => {
+        commandsRef.current = noopCommands;
+      };
     },
-  );
-
-  commandsRef.current.insertAtStartAndFocus = useEditorEventCallback(
-    (view, content: string) => {
-      if (!view || !content) return;
-      const pos = Selection.atStart(view.state.doc).from;
-      const tr = view.state.tr.insertText(content, pos);
-      tr.setSelection(TextSelection.create(tr.doc, pos));
-      view.dispatch(tr);
-      view.focus();
-    },
-  );
-
-  commandsRef.current.replaceContent = useEditorEventCallback(
-    (view, content: JSONContent) => {
-      if (!view || content.type !== "doc") return;
-
-      try {
-        const nextDoc = PMNode.fromJSON(schema, content);
-        if (nextDoc.eq(view.state.doc)) {
-          return;
-        }
-
-        view.dispatch(
-          view.state.tr.replaceWith(
-            0,
-            view.state.doc.content.size,
-            nextDoc.content,
-          ),
-        );
-      } catch {
-        // invalid content
-      }
-    },
-  );
-
-  commandsRef.current.setSearch = useEditorEventCallback(
-    (view, query: string, caseSensitive: boolean) => {
-      if (!view) return;
-      const q = new SearchQuery({ search: query, caseSensitive });
-      const current = getSearchState(view.state);
-      if (current && current.query.eq(q)) return;
-      view.dispatch(setSearchState(view.state.tr, q));
-    },
-  );
-
-  commandsRef.current.replace = useEditorEventCallback(
-    (view, params: SearchReplaceParams) => {
-      if (!view) return;
-      const query = new SearchQuery({
-        search: params.query,
-        replace: params.replacement,
-        caseSensitive: params.caseSensitive,
-        wholeWord: params.wholeWord,
-      });
-
-      view.dispatch(setSearchState(view.state.tr, query));
-
-      if (params.all) {
-        searchReplaceAll(view.state, (tr) => view.dispatch(tr));
-      } else {
-        let result = query.findNext(view.state);
-        let idx = 0;
-        while (result && idx < params.matchIndex) {
-          result = query.findNext(view.state, result.to);
-          idx++;
-        }
-        if (!result) return;
-        view.dispatch(
-          view.state.tr.setSelection(
-            TextSelection.create(view.state.doc, result.from, result.to),
-          ),
-        );
-        searchReplaceCurrent(view.state, (tr) => view.dispatch(tr));
-      }
-    },
+    [commandsRef],
   );
 
   return null;

--- a/packages/editor/src/note/title-layout.test.ts
+++ b/packages/editor/src/note/title-layout.test.ts
@@ -5,6 +5,18 @@ import { schema } from "./schema";
 import { normalizeTitleHeadingDoc, titleHeadingPlugin } from "./title-layout";
 
 describe("normalizeTitleHeadingDoc", () => {
+  it("keeps a body paragraph after an empty title", () => {
+    const doc = schema.node("doc", null, [schema.node("paragraph")]);
+
+    expect(normalizeTitleHeadingDoc(doc).toJSON()).toEqual({
+      type: "doc",
+      content: [
+        { type: "heading", attrs: { level: 1 } },
+        { type: "paragraph" },
+      ],
+    });
+  });
+
   it("converts the first paragraph into a title heading", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [schema.text("Planning")]),
@@ -47,6 +59,30 @@ describe("normalizeTitleHeadingDoc", () => {
 });
 
 describe("titleHeadingPlugin", () => {
+  it("restores a body paragraph when only an empty title remains", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("heading", { level: 1 }, [schema.text("Planning")]),
+      schema.node("paragraph", null, [schema.text("Follow up")]),
+    ]);
+    const state = EditorState.create({
+      schema,
+      doc,
+      plugins: [titleHeadingPlugin()],
+    });
+
+    const result = state.applyTransaction(
+      state.tr.delete(1, state.doc.content.size),
+    );
+
+    expect(result.state.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        { type: "heading", attrs: { level: 1 } },
+        { type: "paragraph" },
+      ],
+    });
+  });
+
   it("restores the first block to a title heading after edits", () => {
     const doc = schema.node("doc", null, [
       schema.node("heading", { level: 1 }, [schema.text("Planning")]),

--- a/packages/editor/src/note/title-layout.ts
+++ b/packages/editor/src/note/title-layout.ts
@@ -8,20 +8,30 @@ const titleHeadingPluginKey = new PluginKey("titleHeading");
 export function normalizeTitleHeadingDoc(doc: PMNode) {
   const first = doc.firstChild;
   const heading = schema.nodes.heading;
+  const paragraph = schema.nodes.paragraph;
 
   if (!first) {
-    return schema.node("doc", null, [heading.create({ level: 1 })]);
+    return schema.node("doc", null, [
+      heading.create({ level: 1 }),
+      paragraph.create(),
+    ]);
   }
 
   if (first.type === heading && first.attrs.level === 1) {
+    if (doc.childCount === 1 && !first.textContent.trim()) {
+      return schema.node("doc", null, [first, paragraph.create()]);
+    }
     return doc;
   }
 
   const children: PMNode[] = [];
   doc.forEach((child) => children.push(child));
 
-  if (first.type === schema.nodes.paragraph || first.type === heading) {
+  if (first.type === paragraph || first.type === heading) {
     children[0] = heading.create({ level: 1 }, first.content, first.marks);
+    if (children.length === 1 && !children[0].textContent.trim()) {
+      children.push(paragraph.create());
+    }
   } else {
     children.unshift(heading.create({ level: 1 }));
   }
@@ -44,6 +54,12 @@ export function titleHeadingPlugin() {
       }
 
       if (first?.type === heading && first.attrs.level === 1) {
+        if (newState.doc.childCount === 1 && !first.textContent.trim()) {
+          return newState.tr.insert(
+            newState.doc.content.size,
+            newState.schema.nodes.paragraph.create(),
+          );
+        }
         return null;
       }
 


### PR DESCRIPTION
Keep empty title-heading docs with a body paragraph so memo tabs can render and focus. Add title-layout regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized note editor document shape and ref bridge lifecycle; behavior is covered by new unit tests with no auth or data-layer changes.
> 
> **Overview**
> Fixes memo tab crashes when the title is cleared by **always keeping a body paragraph** alongside an empty H1 title, in both `normalizeTitleHeadingDoc` and the `titleHeadingPlugin` append transaction (including after a full-document delete).
> 
> **`EditorCommandsBridge`** now wires imperative editor commands through **`useEditorEffect`** instead of multiple **`useEditorEventCallback`** assignments: it sets a full `commandsRef` object when the view mounts, resets to **`noopCommands`** when the view is missing or on cleanup.
> 
> Adds **`title-layout`** regression tests for empty-title normalization and plugin behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf0bb5a28ac2a5844fb7bd34ac54851ed14c49d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->