### PR TITLE
Left align session tabs

### DIFF
--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -182,7 +182,6 @@ function TabContentNoteInner({
           sessionId={tab.id}
           currentView={currentView}
           standaloneWindow={standaloneWindow}
-          centerTitle
           title={
             <NoteInputHeader
               sessionId={tab.id}


### PR DESCRIPTION
Remove the centered header-slot option from the session note tabs so the tab group starts from the left edge of its available header area.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single prop removal affecting session header layout only; no logic, data, or API changes.
> 
> **Overview**
> **Left-aligns** the session note tab strip in the header by no longer passing `centerTitle` to `OuterHeader` in the session tab view.
> 
> Previously the `NoteInputHeader` tab group was centered in the header title slot (`justify-center`); it now follows `OuterHeader`’s default layout so tabs start from the left edge of the reserved header area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4c9a3f9b1ee33fdc14ee2161bba9695e48e3bec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->