### PR TITLE
Fix left sidebar resize direction

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -20,12 +20,14 @@ vi.mock("@hypr/ui/components/ui/resizable", () => ({
     autoSaveId,
     children,
     className,
+    dir,
     direction,
     onLayout,
   }: {
     autoSaveId?: string;
     children: React.ReactNode;
     className?: string;
+    dir?: string;
     direction: string;
     onLayout?: (sizes: number[]) => void;
   }) => {
@@ -35,6 +37,7 @@ vi.mock("@hypr/ui/components/ui/resizable", () => ({
       <div
         data-auto-save-id={autoSaveId}
         data-class-name={className}
+        data-dir={dir}
         data-direction={direction}
         data-testid="panel-group"
       >
@@ -46,24 +49,30 @@ vi.mock("@hypr/ui/components/ui/resizable", () => ({
     children,
     className,
     defaultSize,
+    id,
     maxSize,
     minSize,
+    order,
     style,
   }: {
     children: React.ReactNode;
     className?: string;
     defaultSize?: number;
+    id?: string;
     maxSize?: number;
     minSize?: number;
+    order?: number;
     style?: React.CSSProperties;
   }) => (
     <div
       data-class-name={className}
       data-default-size={defaultSize}
+      data-panel-id={id}
       data-max-size={maxSize}
       data-min-size={minSize}
       data-max-width={style?.maxWidth}
       data-min-width={style?.minWidth}
+      data-order={order}
       data-testid="panel"
     >
       {children}
@@ -155,6 +164,7 @@ describe("ClassicMainBody", () => {
     expect(screen.getByTestId("panel-group").dataset.direction).toBe(
       "horizontal",
     );
+    expect(screen.getByTestId("panel-group").dataset.dir).toBe("ltr");
     expect(screen.getByTestId("panel-group").dataset.autoSaveId).toBe(
       "classic-main-sidebar",
     );
@@ -165,11 +175,15 @@ describe("ClassicMainBody", () => {
 
     const panels = screen.getAllByTestId("panel");
     expect(panels).toHaveLength(2);
+    expect(panels[0]?.dataset.panelId).toBe("classic-main-sidebar-left");
+    expect(panels[0]?.dataset.order).toBe("1");
     expect(panels[0]?.dataset.defaultSize).toBe("12.5");
     expect(panels[0]?.dataset.minSize).toBe("12.5");
     expect(panels[0]?.dataset.maxSize).toBe("22.5");
     expect(panels[0]?.dataset.minWidth).toBe("200");
     expect(panels[0]?.dataset.maxWidth).toBe("360");
+    expect(panels[1]?.dataset.panelId).toBe("classic-main-content");
+    expect(panels[1]?.dataset.order).toBe("2");
 
     const sidebarChrome = document.querySelector<HTMLElement>(
       "[data-left-sidebar-chrome]",

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -187,6 +187,7 @@ export function ClassicMainBody() {
       ) : null}
       <ResizablePanelGroup
         autoSaveId={showLeftSidebarPanel ? "classic-main-sidebar" : undefined}
+        dir="ltr"
         direction="horizontal"
         className="min-h-0 flex-1 overflow-hidden"
         onLayout={handlePanelLayout}
@@ -194,6 +195,8 @@ export function ClassicMainBody() {
         {showLeftSidebarPanel ? (
           <>
             <ResizablePanel
+              id="classic-main-sidebar-left"
+              order={1}
               defaultSize={leftSidebarPanelConstraints.defaultSize}
               minSize={leftSidebarPanelConstraints.minSize}
               maxSize={leftSidebarPanelConstraints.maxSize}
@@ -210,7 +213,11 @@ export function ClassicMainBody() {
         ) : (
           <ClassicMainSidebar />
         )}
-        <ResizablePanel className="min-h-0 flex-1 overflow-hidden">
+        <ResizablePanel
+          id="classic-main-content"
+          order={2}
+          className="min-h-0 flex-1 overflow-hidden"
+        >
           <div
             className="h-full min-h-0 min-w-0 flex-1 overflow-auto"
             onClickCapture={mainAreaTopDrag.onClickCapture}


### PR DESCRIPTION
Force the left sidebar split to use LTR resize math and stable panel IDs so dragging the handle grows and shrinks in the expected direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI layout change to the desktop main body resizable panels with matching test updates; no auth, data, or security impact.
> 
> **Overview**
> Fixes inverted or inconsistent drag behavior on the classic main **left sidebar** split by forcing the horizontal `ResizablePanelGroup` to use **`dir="ltr"`** so resize math matches left-to-right dragging.
> 
> Assigns **stable panel identity** on the sidebar and main content panels (`id` and `order`) so layout persistence (`autoSaveId`) and panel ordering stay consistent when the sidebar is expanded.
> 
> Tests are updated to assert `dir`, panel ids, and order on the mocked resizable components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d2b7c2f59be7fad61e6bf7b40537e6bef5043da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->