### PR TITLE
Replace summary templates in place

### DIFF
--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -27,7 +27,12 @@ function createTables(data?: {
   transcripts?: Record<string, { session_id: string; words: string }>;
   enhanced_notes?: Record<
     string,
-    { session_id: string; template_id?: string; content?: string }
+    {
+      session_id: string;
+      template_id?: string;
+      content?: string;
+      title?: string;
+    }
   >;
   sessions?: Record<string, { title: string }>;
 }): Tables {
@@ -52,7 +57,15 @@ function createMockStore(tables: Tables) {
       if (!tables[table]) tables[table] = {};
       tables[table][rowId] = row;
     }),
-    setPartialRow: vi.fn(),
+    setPartialRow: vi.fn(
+      (table: string, rowId: string, partial: Record<string, any>) => {
+        if (!tables[table]) tables[table] = {};
+        tables[table][rowId] = {
+          ...(tables[table][rowId] ?? {}),
+          ...partial,
+        };
+      },
+    ),
   } as any;
 }
 
@@ -256,6 +269,59 @@ describe("EnhancerService", () => {
       const result = service.enhance("session-1");
       expect(result).toEqual({ type: "started", noteId: "note-1" });
       expect(aiTaskStore.getState().generate).toHaveBeenCalled();
+    });
+
+    it("replaces the target note instead of creating a template-specific tab", () => {
+      const tables = createTables({
+        enhanced_notes: {
+          "note-1": {
+            session_id: "session-1",
+            template_id: "template-1",
+            title: "Customer Call",
+            content: "Generated summary",
+          },
+        },
+      });
+      const store = createMockStore(tables);
+      const generate = vi.fn().mockResolvedValue(undefined);
+      const aiTaskStore = createMockAITaskStore();
+      aiTaskStore.getState.mockReturnValue({
+        generate,
+        getState: vi.fn().mockReturnValue({ status: "success" }),
+      });
+      const deps = createDeps({
+        mainStore: store,
+        indexes: createMockIndexes(tables),
+        aiTaskStore,
+      });
+      const service = new EnhancerService(deps);
+
+      const result = service.enhance("session-1", {
+        templateId: "template-2",
+        targetNoteId: "note-1",
+        templateTitle: "Decision Log",
+      });
+
+      expect(result).toEqual({ type: "started", noteId: "note-1" });
+      expect(store.setRow).not.toHaveBeenCalled();
+      expect(store.setPartialRow).toHaveBeenCalledWith(
+        "enhanced_notes",
+        "note-1",
+        {
+          content: "",
+          title: "Decision Log",
+          template_id: "template-2",
+        },
+      );
+      expect(generate).toHaveBeenCalledWith("note-1-enhance", {
+        model: expect.anything(),
+        taskType: "enhance",
+        args: {
+          sessionId: "session-1",
+          enhancedNoteId: "note-1",
+          templateId: "template-2",
+        },
+      });
     });
   });
 

--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -23,6 +23,8 @@ type QueueEmptySummaryResult =
 type EnhanceOpts = {
   isAuto?: boolean;
   templateId?: string;
+  targetNoteId?: string;
+  templateTitle?: string;
 };
 
 type EnhancerEvent =
@@ -255,12 +257,21 @@ export class EnhancerService {
     if (!model) return { type: "no_model" };
 
     const templateId = opts?.templateId || getSelectedTemplateId();
-    const enhancedNoteId = this.ensureNote(sessionId, templateId);
+    const targetNoteId = opts?.targetNoteId
+      ? this.getSessionEnhancedNoteId(sessionId, opts.targetNoteId)
+      : undefined;
+    const enhancedNoteId =
+      targetNoteId ?? this.ensureNote(sessionId, templateId);
     const enhanceTaskId = createTaskId(enhancedNoteId, "enhance");
     const existingTask = aiTaskStore.getState().getState(enhanceTaskId);
     if (existingTask?.status === "generating") {
       return { type: "already_active", noteId: enhancedNoteId };
     }
+
+    if (targetNoteId) {
+      this.replaceNoteTemplate(targetNoteId, templateId, opts?.templateTitle);
+    }
+
     if (
       existingTask?.status === "success" &&
       this.hasEnhancedNoteContent(enhancedNoteId)
@@ -298,6 +309,19 @@ export class EnhancerService {
       INDEXES.enhancedNotesBySession,
       sessionId,
     );
+  }
+
+  private getSessionEnhancedNoteId(
+    sessionId: string,
+    enhancedNoteId: string,
+  ): string | undefined {
+    const noteSessionId = this.deps.mainStore.getCell(
+      "enhanced_notes",
+      enhancedNoteId,
+      "session_id",
+    );
+
+    return noteSessionId === sessionId ? enhancedNoteId : undefined;
   }
 
   ensureNote(sessionId: string, templateId?: string): string {
@@ -356,6 +380,25 @@ export class EnhancerService {
     return hasSummaryContent(
       this.deps.mainStore.getCell("enhanced_notes", enhancedNoteId, "content"),
     );
+  }
+
+  private replaceNoteTemplate(
+    enhancedNoteId: string,
+    templateId: string | undefined,
+    templateTitle: string | undefined,
+  ) {
+    const normalizedTemplateId = templateId || undefined;
+    const title = templateTitle?.trim() || "Summary";
+
+    this.deps.mainStore.setPartialRow("enhanced_notes", enhancedNoteId, {
+      content: "",
+      title,
+      template_id: normalizedTemplateId,
+    });
+
+    if (normalizedTemplateId && !templateTitle?.trim()) {
+      void this.hydrateTemplateTitle(enhancedNoteId, normalizedTemplateId);
+    }
   }
 
   private async hydrateTemplateTitle(

--- a/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
@@ -27,6 +27,10 @@ vi.mock("@hypr/ui/components/ui/spinner", () => ({
   Spinner: () => <span data-testid="spinner" />,
 }));
 
+vi.mock("streamdown", () => ({
+  Streamdown: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+
 vi.mock("~/ai/hooks", () => ({
   useAITaskTask: () => ({
     status: hoisted.task?.status ?? "idle",
@@ -109,7 +113,26 @@ describe("Enhanced", () => {
     expect(screen.queryByTestId("spinner")).toBeNull();
   });
 
-  it("renders a generating summary through the editor preview", () => {
+  it("shows a generating status before streamed text arrives", () => {
+    hoisted.task = {
+      status: "generating",
+      error: undefined,
+      streamedText: "",
+      currentStep: undefined,
+      isGenerating: true,
+    };
+
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.queryByText("Enhanced editor")).toBeNull();
+    expect(screen.getByRole("status")).not.toBeNull();
+    expect(screen.getByText("Analyzing structure...")).not.toBeNull();
+    expect(
+      screen.getByText("Tip: The Anarlog team loves our users!"),
+    ).not.toBeNull();
+  });
+
+  it("renders streamed summary in the generating view", () => {
     hoisted.task = {
       status: "generating",
       error: undefined,
@@ -120,7 +143,7 @@ describe("Enhanced", () => {
 
     render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
 
-    expect(screen.getByText("Enhanced editor")).not.toBeNull();
+    expect(screen.queryByText("Enhanced editor")).toBeNull();
     expect(screen.getByText("Streaming summary")).not.toBeNull();
     expect(screen.queryByRole("status")).toBeNull();
   });

--- a/apps/desktop/src/session/components/note-input/enhanced/index.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.tsx
@@ -1,12 +1,12 @@
 import type { EditorView } from "prosemirror-view";
-import { forwardRef, useMemo } from "react";
+import { forwardRef } from "react";
 
-import { md2json } from "@hypr/editor/markdown";
 import type { NoteEditorRef } from "@hypr/editor/note";
 
 import { ConfigError } from "./config-error";
 import { EnhancedEditor } from "./editor";
 import { EnhanceError } from "./enhance-error";
+import { StreamingView } from "./streaming";
 
 import { useAITaskTask } from "~/ai/hooks";
 import { useLLMConnectionStatus } from "~/ai/hooks";
@@ -36,16 +36,12 @@ export const Enhanced = forwardRef<
   ) => {
     const taskId = createTaskId(enhancedNoteId, "enhance");
     const llmStatus = useLLMConnectionStatus();
-    const { status, error, streamedText } = useAITaskTask(taskId, "enhance");
+    const { status, error } = useAITaskTask(taskId, "enhance");
     const content = main.UI.useCell(
       "enhanced_notes",
       enhancedNoteId,
       "content",
       main.STORE_ID,
-    );
-    const streamingPreviewContent = useMemo(
-      () => (status === "generating" ? md2json(streamedText) : undefined),
-      [status, streamedText],
     );
 
     const hasContent = typeof content === "string" && content.trim().length > 0;
@@ -66,12 +62,15 @@ export const Enhanced = forwardRef<
       );
     }
 
+    if (status === "generating") {
+      return <StreamingView enhancedNoteId={enhancedNoteId} />;
+    }
+
     return (
       <EnhancedEditor
         ref={ref}
         sessionId={sessionId}
         enhancedNoteId={enhancedNoteId}
-        contentOverride={streamingPreviewContent}
         onNavigateToTitle={onNavigateToTitle}
         onViewReady={onViewReady}
         onViewDisposed={onViewDisposed}

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -5,6 +5,8 @@ import type { EditorView } from "~/store/zustand/tabs/schema";
 
 const hoisted = vi.hoisted(() => ({
   enhance: vi.fn(),
+  activeTemplateTitle: "Customer Call",
+  isGenerating: false,
   userTemplates: [] as Array<{
     id: string;
     title: string;
@@ -25,10 +27,14 @@ vi.mock("@hypr/plugin-analytics", () => ({
   },
 }));
 
+vi.mock("@hypr/ui/components/ui/spinner", () => ({
+  Spinner: () => <span data-testid="tab-spinner" />,
+}));
+
 vi.mock("~/ai/hooks", () => ({
   useAITaskTask: () => ({
     isIdle: true,
-    isGenerating: false,
+    isGenerating: hoisted.isGenerating,
     isError: false,
     error: null,
     start: vi.fn(),
@@ -103,7 +109,7 @@ vi.mock("~/templates", () => ({
   parseWebTemplates: () => [],
   useCreateTemplate: () => vi.fn(),
   useTemplateCreatorName: () => "You",
-  useUserTemplate: () => ({ data: { title: "Summary" } }),
+  useUserTemplate: () => ({ data: { title: hoisted.activeTemplateTitle } }),
   useUserTemplates: () => hoisted.userTemplates,
 }));
 
@@ -117,6 +123,8 @@ import { Header } from "./header";
 describe("Header", () => {
   beforeEach(() => {
     hoisted.enhance.mockReset();
+    hoisted.activeTemplateTitle = "Customer Call";
+    hoisted.isGenerating = false;
     hoisted.userTemplates = [];
   });
 
@@ -141,7 +149,7 @@ describe("Header", () => {
       />,
     );
 
-    const summaryTab = screen.getByRole("button", { name: "Summary" });
+    const summaryTab = screen.getByRole("button", { name: "Customer Call" });
     const memoTab = screen.getByRole("button", { name: "Memos" });
     const transcriptTab = screen.getByRole("button", { name: "Transcript" });
 
@@ -151,10 +159,16 @@ describe("Header", () => {
     ).toBe("false");
     expect(summaryTab.getAttribute("aria-current")).toBeNull();
     expect(memoTab.getAttribute("aria-current")).toBe("page");
+    expect(memoTab.textContent).toBe("Memos");
+    expect(memoTab.className).toContain("h-[30px]");
+    expect(memoTab.className).toContain("-my-px");
+    expect(summaryTab.className).toContain("h-7");
+    expect(summaryTab.querySelector("svg")).not.toBeNull();
+    expect(summaryTab.querySelectorAll("svg")).toHaveLength(1);
     expect(summaryTab.textContent).toBe("");
     expect(transcriptTab.textContent).toBe("");
     expect(summaryTab.getAttribute("title")).toBe(
-      "Summary was used to generate this summary.",
+      "Customer Call was used to generate this summary.",
     );
 
     fireEvent.click(summaryTab);
@@ -173,7 +187,13 @@ describe("Header", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Summary" }));
+    const activeSummaryTab = screen.getByRole("button", {
+      name: "Customer Call",
+    });
+    expect(activeSummaryTab.textContent).toBe("Customer Call");
+    expect(activeSummaryTab.querySelectorAll("svg")).toHaveLength(2);
+
+    fireEvent.click(activeSummaryTab);
 
     expect(screen.getByPlaceholderText("Search templates...")).not.toBeNull();
 
@@ -188,7 +208,7 @@ describe("Header", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Summary" }));
+    fireEvent.click(screen.getByRole("button", { name: "Customer Call" }));
 
     expect(handleTabChange).toHaveBeenNthCalledWith(2, { type: "raw" });
     expect(handleTabChange).toHaveBeenNthCalledWith(3, {
@@ -215,7 +235,11 @@ describe("Header", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Memos" }));
-    fireEvent.click(screen.getByRole("button", { name: "Summary" }));
+    expect(screen.getByRole("button", { name: "Transcript" }).textContent).toBe(
+      "Transcript",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Customer Call" }));
 
     expect(handleTabChange).toHaveBeenNthCalledWith(1, { type: "raw" });
     expect(handleTabChange).toHaveBeenNthCalledWith(2, {
@@ -224,7 +248,7 @@ describe("Header", () => {
     });
   });
 
-  it("selects the enhanced note returned by the enhancer when changing templates", () => {
+  it("replaces the current enhanced note when changing templates", () => {
     hoisted.userTemplates = [
       {
         id: "template-2",
@@ -236,7 +260,7 @@ describe("Header", () => {
     ];
     hoisted.enhance.mockReturnValue({
       type: "started",
-      noteId: "note-2",
+      noteId: "note-1",
     });
     const editorTabs: EditorView[] = [
       { type: "enhanced", id: "note-1" },
@@ -253,15 +277,39 @@ describe("Header", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Summary" }));
+    fireEvent.click(screen.getByRole("button", { name: "Customer Call" }));
     fireEvent.click(screen.getByRole("button", { name: /Decision Log/ }));
 
     expect(hoisted.enhance).toHaveBeenCalledWith("session-1", {
       templateId: "template-2",
+      targetNoteId: "note-1",
+      templateTitle: "Decision Log",
     });
     expect(handleTabChange).toHaveBeenCalledWith({
       type: "enhanced",
-      id: "note-2",
+      id: "note-1",
     });
+  });
+
+  it("shows a spinner in the active enhanced tab while generating", () => {
+    hoisted.isGenerating = true;
+    const editorTabs: EditorView[] = [
+      { type: "enhanced", id: "note-1" },
+      { type: "raw" },
+    ];
+
+    render(
+      <Header
+        sessionId="session-1"
+        editorTabs={editorTabs}
+        currentTab={{ type: "enhanced", id: "note-1" }}
+        handleTabChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("tab-spinner")).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Customer Call" }).textContent,
+    ).toBe("Customer Call");
   });
 });

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -20,6 +20,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@hypr/ui/components/ui/popover";
+import { Spinner } from "@hypr/ui/components/ui/spinner";
 import { sonnerToast } from "@hypr/ui/components/ui/toast";
 import { cn } from "@hypr/utils";
 
@@ -99,19 +100,26 @@ function IconHeaderTab({
       onClick={onClick}
       onContextMenu={onContextMenu}
       title={title}
-      className={iconHeaderTabClassName(isActive, "min-w-10 px-2")}
+      className={iconHeaderTabClassName(
+        isActive,
+        cn(["min-w-10 px-2", isActive ? "max-w-40 gap-1.5" : null]),
+      )}
     >
       {icon}
+      {isActive && (
+        <span className="min-w-0 truncate text-xs font-medium">{label}</span>
+      )}
     </button>
   );
 }
 
 function iconHeaderTabClassName(isActive: boolean, className?: string) {
   return cn([
-    "flex h-7 shrink-0 items-center justify-center rounded-full transition-colors",
+    "flex shrink-0 items-center justify-center rounded-full transition-colors [&>svg]:shrink-0",
     isActive
-      ? ["bg-foreground/10 text-foreground -my-0.5 h-8"]
+      ? ["bg-foreground/10 text-foreground -my-px h-[30px]"]
       : [
+          "h-7",
           "text-muted-foreground/70",
           "hover:bg-background/60 hover:text-foreground",
         ],
@@ -128,9 +136,13 @@ function getEnhancedNoteTitle({
   templateTitle: string | null;
   templateId: string | undefined;
 }) {
+  if (templateTitle) {
+    return templateTitle;
+  }
+
   const title = typeof rawTitle === "string" ? rawTitle.trim() : "";
   if (!title) {
-    return templateTitle || "Summary";
+    return "Summary";
   }
 
   const isGeneratedTitle =
@@ -139,8 +151,8 @@ function getEnhancedNoteTitle({
     UUID_TITLE_RE.test(title) ||
     ISO_TITLE_RE.test(title);
 
-  if (isGeneratedTitle && templateTitle) {
-    return templateTitle;
+  if (isGeneratedTitle) {
+    return "Summary";
   }
 
   return title;
@@ -185,6 +197,12 @@ async function copyTextToClipboard(
     return false;
   }
 }
+
+type TemplateSelection = {
+  templateId: string;
+  title: string;
+};
+
 function HeaderTabRaw({
   isActive,
   onClick = () => {},
@@ -288,13 +306,15 @@ function HeaderTabEnhanced({
     void onRegenerate(null);
   }, [onRegenerate]);
   const handleSelectTemplate = useCallback(
-    (selectedTemplateId: string) => {
+    (selection: TemplateSelection) => {
       if (isGenerating) {
         return;
       }
 
       const result = getEnhancerService()?.enhance(sessionId, {
-        templateId: selectedTemplateId,
+        templateId: selection.templateId,
+        targetNoteId: enhancedNoteId,
+        templateTitle: selection.title,
       });
 
       if (
@@ -304,7 +324,7 @@ function HeaderTabEnhanced({
         onSelectNote?.(result.noteId);
       }
     },
-    [isGenerating, onSelectNote, sessionId],
+    [enhancedNoteId, isGenerating, onSelectNote, sessionId],
   );
   const contextMenu = useMemo<MenuItemDef[]>(() => {
     const items: MenuItemDef[] = [
@@ -368,7 +388,7 @@ function HeaderTabEnhanced({
       className={iconHeaderTabClassName(
         true,
         cn([
-          "min-w-[62px] gap-2 pr-1.5 pl-2",
+          "max-w-56 min-w-[62px] gap-1.5 pr-1.5 pl-2",
           isGenerating ? "cursor-not-allowed opacity-70" : "cursor-pointer",
           isError
             ? [
@@ -379,7 +399,12 @@ function HeaderTabEnhanced({
         ]),
       )}
     >
-      <SparklesIcon className="size-4" />
+      {isGenerating ? (
+        <Spinner size={16} className="shrink-0" />
+      ) : (
+        <SparklesIcon className="size-4" />
+      )}
+      <span className="min-w-0 truncate text-xs font-medium">{tabTitle}</span>
       <ChevronDownIcon className="size-3.5" />
     </button>
   );
@@ -399,13 +424,13 @@ function HeaderTabEnhanced({
       onClick={onClick}
       onContextMenu={showContextMenu}
       title={templateTooltip}
-      className={iconHeaderTabClassName(
-        false,
-        "min-w-[62px] gap-2 pr-1.5 pl-2",
-      )}
+      className={iconHeaderTabClassName(false, "min-w-10 px-2")}
     >
-      <SparklesIcon className="size-4" />
-      <ChevronDownIcon className="size-3.5" />
+      {isGenerating ? (
+        <Spinner size={16} className="shrink-0" />
+      ) : (
+        <SparklesIcon className="size-4" />
+      )}
     </button>
   );
 }
@@ -461,7 +486,7 @@ function TemplatePickerPopover({
   trigger,
 }: {
   sessionId: string;
-  onSelectTemplate: (templateId: string) => void;
+  onSelectTemplate: (selection: TemplateSelection) => void;
   trigger: React.ReactNode;
 }) {
   const [open, setOpen] = useState(false);
@@ -499,12 +524,12 @@ function TemplatePickerPopover({
   const openTemplatesTab = useOpenTemplatesTab();
 
   const handleUseTemplate = useCallback(
-    (templateId: string) => {
+    (selection: TemplateSelection) => {
       setOpen(false);
       setSearch("");
       resultRefs.current = [];
 
-      onSelectTemplate(templateId);
+      onSelectTemplate(selection);
     },
     [onSelectTemplate],
   );
@@ -530,7 +555,10 @@ function TemplatePickerPopover({
         return;
       }
 
-      handleUseTemplate(templateId);
+      handleUseTemplate({
+        templateId,
+        title: template.title || "Untitled",
+      });
     },
     [createTemplate, handleUseTemplate],
   );
@@ -670,7 +698,11 @@ function TemplatePickerPopover({
         creatorName,
       }),
       tags: getTemplateTags(template),
-      onClick: () => handleUseTemplate(template.id),
+      onClick: () =>
+        handleUseTemplate({
+          templateId: template.id,
+          title: template.title || "Untitled",
+        }),
     }));
 
     const suggestedSlugs = new Set(
@@ -741,7 +773,11 @@ function TemplatePickerPopover({
               creatorName,
             }),
             tags: getTemplateTags(template),
-            onClick: () => handleUseTemplate(template.id),
+            onClick: () =>
+              handleUseTemplate({
+                templateId: template.id,
+                title: template.title || "Untitled",
+              }),
           })),
           emptyMessage: "No favorite templates yet",
         },
@@ -800,7 +836,11 @@ function TemplatePickerPopover({
                   creatorName,
                 }),
                 tags: getTemplateTags(template),
-                onClick: () => handleUseTemplate(template.id),
+                onClick: () =>
+                  handleUseTemplate({
+                    templateId: template.id,
+                    title: template.title || "Untitled",
+                  }),
               })),
             },
           ]


### PR DESCRIPTION
Regenerate selected templates in the current summary tab and show spinner/status feedback while generation runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core enhance/note persistence and tab behavior; wrong `targetNoteId` handling could clear or mis-label notes, but session validation and tests reduce that risk.
> 
> **Overview**
> **Template changes now regenerate the current summary tab** instead of opening a separate note per template. `EnhancerService.enhance` accepts `targetNoteId` and `templateTitle`, validates the note belongs to the session, and **partially updates** that row (clears content, sets template + title) before starting generation.
> 
> The note header passes those options from the template picker (including title), keeps the user on the same tab, and shows a **spinner** on the active summary tab while enhance runs. Inactive summary tabs stay icon-only; active tabs show the template title and updated styling.
> 
> While a summary is generating, the enhanced note area uses a dedicated **`StreamingView`** (status text until tokens arrive, then streamed markdown) instead of previewing stream text inside the ProseMirror editor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27ffc2ea51f69933d1310a19cd6bda2f60192297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->