### PR TITLE
Match memo editor title styling

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
@@ -93,6 +93,8 @@ describe("EnhancedEditor", () => {
 
     const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
 
+    expect(props?.className).toContain("session-note-editor");
+    expect(props?.className).toContain("enhanced-summary-editor");
     expect(props?.syncContentWhenFocused).toBe(false);
     expect(props?.handleChange).not.toBe(hoisted.persistContent);
     expect(props?.taskSource).toEqual({ type: "enhanced_note", id: "note-1" });

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -105,7 +105,7 @@ export const EnhancedEditor = forwardRef<
       <div className="h-full">
         <NoteEditor
           ref={ref}
-          className="enhanced-summary-editor"
+          className="session-note-editor enhanced-summary-editor"
           key={editorKey}
           initialContent={initialContent}
           handleChange={persistChanges ? handleChange : undefined}

--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -1,0 +1,111 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RawEditor } from "./raw";
+
+const hoisted = vi.hoisted(() => ({
+  rawMd: JSON.stringify({ type: "doc", content: [] }),
+  sessionTitle: "Weekly sync",
+  persistChange: vi.fn(),
+  noteEditorProps: [] as Record<string, unknown>[],
+}));
+
+vi.mock("@hypr/editor/markdown", () => ({
+  parseJsonContent: (value: string) => JSON.parse(value),
+}));
+
+vi.mock("@hypr/editor/note", () => ({
+  NoteEditor: (props: Record<string, unknown>) => {
+    hoisted.noteEditorProps.push(props);
+
+    return <div>Note editor</div>;
+  },
+}));
+
+vi.mock("@hypr/plugin-analytics", () => ({
+  commands: {
+    event: vi.fn(),
+  },
+}));
+
+vi.mock("~/editor-bridge/app-link-view", () => ({
+  AppLinkView: () => null,
+}));
+
+vi.mock("~/editor-bridge/mention-config", () => ({
+  useMentionConfig: () => ({ users: [] }),
+}));
+
+vi.mock("~/editor-bridge/open-editor-link", () => ({
+  openEditorLink: vi.fn(),
+}));
+
+vi.mock("~/editor-bridge/session-mention-drop", () => ({
+  sessionMentionDropConfig: { read: () => null },
+}));
+
+vi.mock("~/editor-bridge/session-view", () => ({
+  SessionNodeView: () => null,
+}));
+
+vi.mock("~/session/components/shared", () => ({
+  hasStoredNoteContent: (value: unknown) => Boolean(value),
+}));
+
+vi.mock("~/session/raw-editor-sync", () => ({
+  emitRawEditorSync: vi.fn(),
+}));
+
+vi.mock("~/shared/hooks/useFileUpload", () => ({
+  useFileUpload: () => vi.fn(),
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useCell: (table: string, _row: string, cell: string) => {
+      if (table === "sessions" && cell === "raw_md") {
+        return hoisted.rawMd;
+      }
+
+      if (table === "sessions" && cell === "title") {
+        return hoisted.sessionTitle;
+      }
+
+      return undefined;
+    },
+    useSetPartialRowCallback: () => hoisted.persistChange,
+  },
+}));
+
+describe("RawEditor", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    hoisted.noteEditorProps = [];
+    hoisted.rawMd = JSON.stringify({ type: "doc", content: [] });
+    hoisted.sessionTitle = "Weekly sync";
+    hoisted.persistChange = vi.fn();
+  });
+
+  it("uses the shared session note editor styling", () => {
+    render(<RawEditor sessionId="session-1" className="custom-editor-class" />);
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+
+    expect(props?.className).toContain("session-note-editor");
+    expect(props?.className).toContain("custom-editor-class");
+    expect(props?.initialContent).toMatchObject({
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Weekly sync" }],
+        },
+      ],
+    });
+  });
+});

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -8,6 +8,7 @@ import {
   type NoteEditorRef,
 } from "@hypr/editor/note";
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
+import { cn } from "@hypr/utils";
 
 import { AppLinkView } from "~/editor-bridge/app-link-view";
 import { useMentionConfig } from "~/editor-bridge/mention-config";
@@ -129,7 +130,7 @@ export const RawEditor = forwardRef<
     return (
       <NoteEditor
         ref={ref}
-        className={className}
+        className={cn(["session-note-editor", className])}
         key={`session-${sessionId}-raw`}
         initialContent={initialContent}
         handleChange={handleChange}

--- a/packages/editor/src/styles/prosemirror/nodes/heading.css
+++ b/packages/editor/src/styles/prosemirror/nodes/heading.css
@@ -46,6 +46,7 @@
   }
 }
 
+.prosemirror-editor.session-note-editor,
 .prosemirror-editor.enhanced-summary-editor {
   h1,
   h2,
@@ -74,6 +75,7 @@
   margin-bottom: 1rem;
 }
 
+.prosemirror-editor.session-note-editor.note-title-editor > h1:first-child,
 .prosemirror-editor.enhanced-summary-editor.note-title-editor > h1:first-child {
   font-size: 1.5rem;
   line-height: 1.875rem;

--- a/packages/tiptap/src/styles/base.css
+++ b/packages/tiptap/src/styles/base.css
@@ -1,15 +1,17 @@
-.tiptap-root {
+.tiptap-root,
+.prosemirror-editor-root {
   height: 100%;
   display: flex;
   flex-direction: column;
 }
 
-.tiptap-root .tiptap {
+.tiptap-root .tiptap,
+.prosemirror-editor-root .prosemirror-editor {
   flex: 1 1 auto;
   min-height: 100%;
 }
 
-.tiptap {
+:is(.tiptap, .prosemirror-editor) {
   font-variant-ligatures: common-ligatures contextual;
   font-feature-settings: "liga" 1, "calt" 1;
   word-break: break-word;
@@ -55,7 +57,7 @@
     outline: none;
   }
 
-  .tiptap-image {
+  :is(.tiptap-image, .prosemirror-image) {
     max-width: 100%;
     height: auto;
     display: block;

--- a/packages/tiptap/src/styles/base.css
+++ b/packages/tiptap/src/styles/base.css
@@ -1,0 +1,66 @@
+.tiptap-root {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.tiptap-root .tiptap {
+  flex: 1 1 auto;
+  min-height: 100%;
+}
+
+.tiptap {
+  font-variant-ligatures: common-ligatures contextual;
+  font-feature-settings: "liga" 1, "calt" 1;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+  hyphens: auto;
+  padding-bottom: 24px;
+  caret-color: #374151;
+  min-height: 100%;
+
+  :first-child {
+    margin-top: 0;
+  }
+
+  /* focus states */
+  &:focus {
+    outline: none;
+    box-shadow: none;
+  }
+
+  p {
+    margin-bottom: 0.25rem;
+    text-wrap: wrap;
+    line-height: 20px;
+  }
+
+  .node-image {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    overflow: visible;
+  }
+
+  > .node-image:first-child {
+    padding-top: 0;
+  }
+
+  > .node-image:last-child {
+    padding-bottom: 0;
+  }
+
+  .node-image.ProseMirror-selectednode,
+  .node-session.ProseMirror-selectednode {
+    outline: none;
+  }
+
+  .tiptap-image {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-user-drag: none;
+  }
+}

--- a/packages/tiptap/src/styles/nodes/search.css
+++ b/packages/tiptap/src/styles/nodes/search.css
@@ -1,0 +1,7 @@
+.ProseMirror .ProseMirror-search-match {
+  background-color: #fef08a;
+}
+
+.ProseMirror .ProseMirror-active-search-match {
+  background-color: #fb923c;
+}

--- a/packages/tiptap/src/styles/nodes/table.css
+++ b/packages/tiptap/src/styles/nodes/table.css
@@ -1,0 +1,72 @@
+.ProseMirror .tiptap-table {
+  border-collapse: collapse;
+  margin: 1rem 0;
+  overflow: hidden;
+  table-layout: fixed;
+  width: 100%;
+}
+
+.ProseMirror table {
+  border-collapse: collapse;
+  margin: 1rem 0;
+  overflow: hidden;
+  table-layout: fixed;
+  width: 100%;
+}
+
+.ProseMirror td,
+.ProseMirror th {
+  border: 1px solid #d1d5db;
+  box-sizing: border-box;
+  min-width: 1em;
+  padding: 0.5rem 0.75rem;
+  position: relative;
+  vertical-align: top;
+}
+
+.ProseMirror th {
+  background-color: #f3f4f6;
+  font-weight: 600;
+  text-align: left;
+}
+
+.ProseMirror .selectedCell:after {
+  background: rgba(59, 130, 246, 0.1);
+  content: "";
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  pointer-events: none;
+  position: absolute;
+  z-index: 2;
+}
+
+.ProseMirror .column-resize-handle {
+  background-color: #3b82f6;
+  bottom: -2px;
+  pointer-events: none;
+  position: absolute;
+  right: -2px;
+  top: 0;
+  width: 4px;
+}
+
+.ProseMirror.resize-cursor {
+  cursor: col-resize;
+}
+
+.ProseMirror th p,
+.ProseMirror td p {
+  margin: 0;
+}
+
+.ProseMirror th > *:first-child,
+.ProseMirror td > *:first-child {
+  margin-top: 0;
+}
+
+.ProseMirror th > *:last-child,
+.ProseMirror td > *:last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Share compact session note editor styles between memo and summary editors and add focused raw editor coverage.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5688 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5686 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual/className and CSS-only changes with unit test coverage; no auth, data, or persistence logic changes.
> 
> **Overview**
> Introduces a shared **`session-note-editor`** class on the raw (memo) and enhanced summary **`NoteEditor`** instances so both pick up the same compact heading and title-line typography.
> 
> **`heading.css`** now treats **`.session-note-editor`** like **`.enhanced-summary-editor`** (smaller headings) and applies the same first-line **`note-title-editor`** h1 sizing when both classes are present. **`RawEditor`** merges the shared class with any caller **`className`** via **`cn`**.
> 
> Adds **`raw.test.tsx`** and extends the enhanced editor test to assert the combined class names and title-as-first-line content. Also adds TipTap package styles (**`base.css`**, search match highlights, table layout) for editor parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f16c6c50c1b36bc98fd0fe34c1df803839162ed1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->