### PR TITLE
Add empty line on editor whitespace click

### DIFF
--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -91,6 +91,7 @@ import {
 } from "./linked-item-open-behavior";
 import { schema } from "./schema";
 import { normalizeTitleHeadingDoc, titleHeadingPlugin } from "./title-layout";
+import { trailingEmptyLineClickPlugin } from "./trailing-empty-line-click";
 
 export type { MentionConfig, FileHandlerConfig, PlaceholderFunction };
 export { schema };
@@ -552,6 +553,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         ...(enforceTitleHeading ? [titleHeadingPlugin()] : []),
         taskIdentityPlugin(),
         buildKeymap(onNavigateToTitle),
+        trailingEmptyLineClickPlugin(),
         history(),
         dropCursor(),
         gapCursor(),

--- a/packages/editor/src/note/trailing-empty-line-click.test.ts
+++ b/packages/editor/src/note/trailing-empty-line-click.test.ts
@@ -1,0 +1,111 @@
+import { EditorState, type Transaction } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+import { describe, expect, it, vi } from "vitest";
+
+import { schema } from "./schema";
+import { handleTrailingEmptyLineMouseDown } from "./trailing-empty-line-click";
+
+describe("handleTrailingEmptyLineMouseDown", () => {
+  it("adds an empty paragraph when clicking below the last filled line", () => {
+    const { view, getState } = createView([
+      schema.node("paragraph", null, [schema.text("Follow up")]),
+    ]);
+    const event = createMouseEvent({ target: view.dom, clientY: 40 });
+
+    const handled = handleTrailingEmptyLineMouseDown(view, event);
+
+    expect(handled).toBe(true);
+    expect(event.defaultPrevented).toBe(true);
+    expect(getState().doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Follow up" }],
+        },
+        { type: "paragraph" },
+      ],
+    });
+    expect(getState().selection.from).toBe(getState().doc.content.size - 1);
+    expect(view.focus).toHaveBeenCalled();
+  });
+
+  it("uses an existing trailing empty paragraph instead of adding another", () => {
+    const { view, getState } = createView([
+      schema.node("paragraph", null, [schema.text("Follow up")]),
+      schema.node("paragraph"),
+    ]);
+    const event = createMouseEvent({ target: view.dom, clientY: 40 });
+
+    const handled = handleTrailingEmptyLineMouseDown(view, event);
+
+    expect(handled).toBe(true);
+    expect(getState().doc.childCount).toBe(2);
+    expect(getState().selection.from).toBe(getState().doc.content.size - 1);
+  });
+
+  it("ignores clicks on document blocks", () => {
+    const { view, block, getState } = createView([
+      schema.node("paragraph", null, [schema.text("Follow up")]),
+    ]);
+    const event = createMouseEvent({ target: block, clientY: 10 });
+
+    const handled = handleTrailingEmptyLineMouseDown(view, event);
+
+    expect(handled).toBe(false);
+    expect(getState().doc.childCount).toBe(1);
+  });
+});
+
+function createView(children: Parameters<typeof schema.node>[2]) {
+  const block = document.createElement("p");
+  block.getBoundingClientRect = () =>
+    ({
+      bottom: 20,
+      height: 20,
+      left: 0,
+      right: 100,
+      top: 0,
+      width: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }) as DOMRect;
+
+  const dom = document.createElement("div");
+  dom.append(block);
+
+  let state = EditorState.create({
+    schema,
+    doc: schema.node("doc", null, children),
+  });
+
+  const view = {
+    dom,
+    get state() {
+      return state;
+    },
+    dispatch(transaction: Transaction) {
+      state = state.apply(transaction);
+    },
+    focus: vi.fn(),
+  } as Pick<EditorView, "dispatch" | "dom" | "focus" | "state"> as EditorView;
+
+  return { view, block, getState: () => state };
+}
+
+function createMouseEvent({
+  target,
+  clientY,
+}: {
+  target: EventTarget;
+  clientY: number;
+}) {
+  const event = new MouseEvent("mousedown", {
+    button: 0,
+    cancelable: true,
+    clientY,
+  });
+  Object.defineProperty(event, "target", { value: target });
+  return event;
+}

--- a/packages/editor/src/note/trailing-empty-line-click.ts
+++ b/packages/editor/src/note/trailing-empty-line-click.ts
@@ -1,0 +1,57 @@
+import { Plugin, PluginKey, Selection, TextSelection } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+
+const trailingEmptyLineClickPluginKey = new PluginKey("trailingEmptyLineClick");
+
+export function trailingEmptyLineClickPlugin() {
+  return new Plugin({
+    key: trailingEmptyLineClickPluginKey,
+    props: {
+      handleDOMEvents: {
+        mousedown(view, event) {
+          return handleTrailingEmptyLineMouseDown(view, event);
+        },
+      },
+    },
+  });
+}
+
+export function handleTrailingEmptyLineMouseDown(
+  view: EditorView,
+  event: MouseEvent,
+) {
+  if (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.target !== view.dom
+  ) {
+    return false;
+  }
+
+  const lastBlock = view.dom.lastElementChild;
+  if (lastBlock && event.clientY <= lastBlock.getBoundingClientRect().bottom) {
+    return false;
+  }
+
+  const paragraph = view.state.schema.nodes.paragraph;
+  if (!paragraph) {
+    return false;
+  }
+
+  event.preventDefault();
+
+  const { doc } = view.state;
+  const lastChild = doc.lastChild;
+  if (lastChild?.type === paragraph && !lastChild.textContent.trim()) {
+    view.dispatch(view.state.tr.setSelection(Selection.atEnd(doc)));
+    view.focus();
+    return true;
+  }
+
+  const insertPos = doc.content.size;
+  const tr = view.state.tr.insert(insertPos, paragraph.create());
+  tr.setSelection(TextSelection.create(tr.doc, insertPos + 1));
+  view.dispatch(tr.scrollIntoView());
+  view.focus();
+  return true;
+}


### PR DESCRIPTION
Adds a shared ProseMirror plugin that turns clicks below the last note line into a trailing empty paragraph and covers the behavior with focused tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized editor interaction and document structure change with tests; no auth, persistence, or API impact.
> 
> **Overview**
> **Note editor** now treats a primary click on empty space below the last line (mousedown on the editor root, below the last block’s bottom edge) like starting a new line: focus moves to the end of the document and the user can type immediately.
> 
> A new ProseMirror plugin wires `mousedown` to shared handler logic. If the document already ends with an empty paragraph, it only moves selection there; otherwise it inserts a new empty paragraph, scrolls into view, and focuses. Clicks on actual block content are left to default behavior.
> 
> The plugin is registered on the note editor plugin stack. Unit tests cover insert vs reuse trailing paragraph and ignoring block-targeted clicks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eca367c6d26724843bf4e0efdd257637be502f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->