### PR TITLE
Ensure DB schema before plugin queries

### DIFF
--- a/plugins/db/Cargo.toml
+++ b/plugins/db/Cargo.toml
@@ -24,6 +24,7 @@ sqlx = { workspace = true, features = ["runtime-tokio", "sqlite", "sqlite-unbund
 tauri = { workspace = true, features = ["test"] }
 tauri-specta = { workspace = true, features = ["derive", "typescript"] }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/plugins/db/src/lib.rs
+++ b/plugins/db/src/lib.rs
@@ -134,6 +134,22 @@ mod test {
         (dir, Arc::new(runtime::PluginDbRuntime::new(Arc::new(db))))
     }
 
+    async fn setup_unmigrated_runtime() -> (tempfile::TempDir, Arc<runtime::PluginDbRuntime>) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("app.db");
+        let db = hypr_db_core::Db::open(hypr_db_core::DbOpenOptions {
+            storage: hypr_db_core::DbStorage::Local(&db_path),
+            cloudsync_enabled: false,
+            journal_mode_wal: true,
+            foreign_keys: true,
+            max_connections: Some(4),
+        })
+        .await
+        .unwrap();
+
+        (dir, Arc::new(runtime::PluginDbRuntime::new(Arc::new(db))))
+    }
+
     #[tokio::test]
     async fn query_event_channel_sends_result_payload() {
         let (channel, events) = capture_channel();
@@ -186,6 +202,36 @@ mod test {
 
         let event = next_event(&events, 0).await.unwrap();
         assert_eq!(event, QueryEvent::Result(Vec::new()));
+    }
+
+    #[tokio::test]
+    async fn execute_proxy_applies_app_schema_before_run() {
+        let (_dir, runtime) = setup_unmigrated_runtime().await;
+
+        runtime
+            .execute_proxy(
+                "INSERT INTO templates (id, title) VALUES (?, ?)".to_string(),
+                vec![json!("template-1"), json!("Template 1")],
+                hypr_db_execute::ProxyQueryMethod::Run,
+            )
+            .await
+            .unwrap();
+
+        let rows = runtime
+            .execute(
+                "SELECT id, title FROM templates WHERE id = ?".to_string(),
+                vec![json!("template-1")],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            rows,
+            vec![json!({
+                "id": "template-1",
+                "title": "Template 1",
+            })]
+        );
     }
 
     #[tokio::test]

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -31,6 +31,8 @@ impl QueryEventSink for QueryEventChannel {
 }
 
 pub struct PluginDbRuntime {
+    db: std::sync::Arc<Db>,
+    schema_ready: tokio::sync::OnceCell<()>,
     executor: DbExecutor,
     live_query_runtime: LiveQueryRuntime<QueryEventChannel>,
 }
@@ -38,17 +40,29 @@ pub struct PluginDbRuntime {
 impl PluginDbRuntime {
     pub fn new(db: std::sync::Arc<Db>) -> Self {
         Self {
+            db: std::sync::Arc::clone(&db),
+            schema_ready: tokio::sync::OnceCell::new(),
             executor: DbExecutor::new(std::sync::Arc::clone(&db)),
             live_query_runtime: LiveQueryRuntime::new(db),
         }
+    }
+
+    async fn ensure_app_schema(&self) -> Result<()> {
+        self.schema_ready
+            .get_or_try_init(|| async {
+                hypr_db_migrate::migrate(self.db.as_ref(), hypr_db_app::schema()).await
+            })
+            .await?;
+        Ok(())
     }
 
     pub async fn execute(
         &self,
         sql: String,
         params: Vec<serde_json::Value>,
-    ) -> hypr_db_execute::Result<Vec<serde_json::Value>> {
-        self.executor.execute(sql, params).await
+    ) -> Result<Vec<serde_json::Value>> {
+        self.ensure_app_schema().await?;
+        Ok(self.executor.execute(sql, params).await?)
     }
 
     pub async fn execute_proxy(
@@ -56,8 +70,9 @@ impl PluginDbRuntime {
         sql: String,
         params: Vec<serde_json::Value>,
         method: ProxyQueryMethod,
-    ) -> hypr_db_execute::Result<ProxyQueryResult> {
-        self.executor.execute_proxy(sql, params, method).await
+    ) -> Result<ProxyQueryResult> {
+        self.ensure_app_schema().await?;
+        Ok(self.executor.execute_proxy(sql, params, method).await?)
     }
 
     pub async fn subscribe(
@@ -65,8 +80,9 @@ impl PluginDbRuntime {
         sql: String,
         params: Vec<serde_json::Value>,
         sink: QueryEventChannel,
-    ) -> hypr_db_reactive::Result<SubscriptionRegistration> {
-        self.live_query_runtime.subscribe(sql, params, sink).await
+    ) -> Result<SubscriptionRegistration> {
+        self.ensure_app_schema().await?;
+        Ok(self.live_query_runtime.subscribe(sql, params, sink).await?)
     }
 
     pub async fn unsubscribe(&self, subscription_id: &str) -> hypr_db_reactive::Result<()> {


### PR DESCRIPTION
Adds a one-shot app schema guard to the DB plugin runtime and covers template inserts from unmigrated databases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when migrations run relative to plugin SQL and legacy import; assumes migrate is safe to call concurrently via OnceCell.
> 
> **Overview**
> Plugin DB queries can run against a connection that was opened without running app migrations first. **`PluginDbRuntime`** now keeps the DB handle and a **`tokio::sync::OnceCell`**, and **`ensure_app_schema()`** runs **`hypr_db_migrate::migrate`** with **`hypr_db_app::schema()`** once before **`execute`**, **`execute_proxy`**, and **`subscribe`**.
> 
> Return types on those methods are unified to the plugin **`Result`** while still surfacing executor/reactive errors. A test opens an unmigrated temp DB and checks that **`execute_proxy`** can insert into **`templates`**; **`tokio`** gains the **`sync`** feature for **`OnceCell`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3248e0654f3a392889e83b14d386448296a60d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->