### PR TITLE
Match template header height

### DIFF
--- a/apps/desktop/src/audio-player/timeline-shell.tsx
+++ b/apps/desktop/src/audio-player/timeline-shell.tsx
@@ -11,11 +11,13 @@ export function TimelineMeta({ children }: { children: ReactNode }) {
 }
 
 export function TimelineShell({
+  contentClassName,
   leading,
   meta,
   main,
   onContextMenu,
 }: {
+  contentClassName?: string;
   leading: ReactNode;
   meta?: ReactNode;
   main: ReactNode;
@@ -30,6 +32,7 @@ export function TimelineShell({
         className={cn([
           "flex items-center gap-2 px-2 py-1",
           "w-full max-w-full",
+          contentClassName,
         ])}
       >
         {leading}

--- a/apps/desktop/src/audio-player/timeline.tsx
+++ b/apps/desktop/src/audio-player/timeline.tsx
@@ -11,7 +11,11 @@ import { useNativeContextMenu } from "~/shared/hooks/useNativeContextMenu";
 
 const PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
 
-export function Timeline() {
+export function Timeline({
+  contentClassName,
+}: {
+  contentClassName?: string;
+} = {}) {
   const { isPro } = useBillingAccess();
   const {
     registerContainer,
@@ -93,6 +97,7 @@ export function Timeline() {
 
   return (
     <TimelineShell
+      contentClassName={contentClassName}
       onContextMenu={showContextMenu}
       leading={
         <button

--- a/apps/desktop/src/session/bottom-accessory-visibility.test.ts
+++ b/apps/desktop/src/session/bottom-accessory-visibility.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldShowSessionBottomAccessory } from "./bottom-accessory-visibility";
+
+describe("shouldShowSessionBottomAccessory", () => {
+  it("keeps transcript-only insights reachable on the transcript tab", () => {
+    expect(
+      shouldShowSessionBottomAccessory({
+        currentView: { type: "transcript" },
+        bottomAccessoryState: {
+          mode: "transcript_only",
+          expanded: false,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves playback bottom controls on the transcript tab", () => {
+    expect(
+      shouldShowSessionBottomAccessory({
+        currentView: { type: "transcript" },
+        bottomAccessoryState: {
+          mode: "playback",
+          expanded: false,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps live bottom controls off the transcript tab", () => {
+    expect(
+      shouldShowSessionBottomAccessory({
+        currentView: { type: "transcript" },
+        bottomAccessoryState: {
+          mode: "live",
+          expanded: false,
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/session/bottom-accessory-visibility.ts
+++ b/apps/desktop/src/session/bottom-accessory-visibility.ts
@@ -1,0 +1,17 @@
+import type { BottomAccessoryState } from "./components/bottom-accessory";
+
+import type { EditorView } from "~/store/zustand/tabs/schema";
+
+export function shouldShowSessionBottomAccessory({
+  currentView,
+  bottomAccessoryState,
+}: {
+  currentView: EditorView;
+  bottomAccessoryState: BottomAccessoryState;
+}) {
+  return (
+    currentView.type !== "transcript" ||
+    bottomAccessoryState?.mode === "playback" ||
+    bottomAccessoryState?.mode === "transcript_only"
+  );
+}

--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -116,7 +116,7 @@ describe("useSessionBottomAccessory", () => {
     });
   });
 
-  it("shows collapsed playback chrome for inactive sessions with audio", () => {
+  it("does not show bottom playback chrome for inactive sessions with audio", () => {
     const { result } = renderHook(() =>
       useSessionBottomAccessory({
         sessionId: "session-1",
@@ -126,12 +126,9 @@ describe("useSessionBottomAccessory", () => {
       }),
     );
 
-    expect(result.current.bottomAccessoryState).toEqual({
-      mode: "playback",
-      expanded: false,
-    });
+    expect(result.current.bottomAccessoryState).toBeNull();
     expect(result.current.bottomAccessory).toBeNull();
-    expect(result.current.bottomBorderHandle).not.toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
     expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
   });
 
@@ -151,11 +148,8 @@ describe("useSessionBottomAccessory", () => {
       }),
     );
 
-    expect(result.current.bottomAccessoryState).toEqual({
-      mode: "playback",
-      expanded: false,
-    });
-    expect(result.current.bottomBorderHandle).not.toBeNull();
+    expect(result.current.bottomAccessoryState).toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
     expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
   });
 
@@ -175,11 +169,8 @@ describe("useSessionBottomAccessory", () => {
       }),
     );
 
-    expect(result.current.bottomAccessoryState).toEqual({
-      mode: "playback",
-      expanded: false,
-    });
-    expect(result.current.bottomBorderHandle).not.toBeNull();
+    expect(result.current.bottomAccessoryState).toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
     expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
   });
 
@@ -232,7 +223,7 @@ describe("useSessionBottomAccessory", () => {
 
     expect(hoisted.generateMissingPastNotes).toHaveBeenCalledTimes(1);
     expect(result.current.bottomAccessoryState).toEqual({
-      mode: "playback",
+      mode: "transcript_only",
       expanded: true,
     });
   });
@@ -331,7 +322,7 @@ describe("useSessionBottomAccessory", () => {
     ).not.toBeNull();
   });
 
-  it("waits for the audio URL before showing inactive playback", () => {
+  it("does not show inactive bottom playback when the audio URL becomes ready", () => {
     const { result, rerender } = renderHook(
       ({ audioUrlReady }: { audioUrlReady: boolean }) =>
         useSessionBottomAccessory({
@@ -353,11 +344,8 @@ describe("useSessionBottomAccessory", () => {
 
     rerender({ audioUrlReady: true });
 
-    expect(result.current.bottomAccessoryState).toEqual({
-      mode: "playback",
-      expanded: false,
-    });
-    expect(result.current.bottomBorderHandle).not.toBeNull();
+    expect(result.current.bottomAccessoryState).toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
   });
 
   it("hides the post-session handle while audio lookup is loading without insights", () => {
@@ -456,7 +444,7 @@ describe("useSessionBottomAccessory", () => {
       expanded: false,
     });
     expect(result.current.bottomAccessory).not.toBeNull();
-    expect(result.current.bottomBorderHandle).not.toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
   });
 
   it("keeps batch progress visible while batch transcription is running", () => {
@@ -474,10 +462,10 @@ describe("useSessionBottomAccessory", () => {
       expanded: false,
     });
     expect(result.current.bottomAccessory).not.toBeNull();
-    expect(result.current.bottomBorderHandle).not.toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
   });
 
-  it("keeps collapsed inactive playback when regeneration starts", () => {
+  it("shows batch progress when regeneration starts", () => {
     const { result, rerender } = renderHook(
       ({ sessionMode }: { sessionMode: string }) =>
         useSessionBottomAccessory({
@@ -493,11 +481,8 @@ describe("useSessionBottomAccessory", () => {
       },
     );
 
-    expect(result.current.bottomAccessoryState).toEqual({
-      mode: "playback",
-      expanded: false,
-    });
-    expect(result.current.bottomBorderHandle).not.toBeNull();
+    expect(result.current.bottomAccessoryState).toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
 
     rerender({ sessionMode: "running_batch" });
 
@@ -506,6 +491,7 @@ describe("useSessionBottomAccessory", () => {
       expanded: false,
     });
     expect(result.current.bottomAccessory).not.toBeNull();
+    expect(result.current.bottomBorderHandle).toBeNull();
   });
 
   it("uses panel chrome for the live handle", () => {

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -21,7 +21,6 @@ import { useShell } from "~/contexts/shell";
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
 import { useListener } from "~/stt/contexts";
 
-const BOTTOM_ACCESSORY_HANDLE_CLASS = "bg-card dark:bg-app-floating-chrome";
 const LIVE_ACCESSORY_HANDLE_CLASS = "bg-app-floating-panel";
 
 export type BottomAccessoryState = {
@@ -32,18 +31,13 @@ export type BottomAccessoryState = {
 export function useSessionBottomAccessory({
   sessionId,
   sessionMode,
-  audioExists,
-  audioUrlReady = audioExists,
-  hasTranscript,
-  suppressTranscriptPanel = false,
 }: {
   sessionId: string;
   sessionMode: string;
-  audioExists: boolean;
+  audioExists?: boolean;
   audioUrlReady?: boolean;
   isAudioLoading?: boolean;
-  hasTranscript: boolean;
-  suppressTranscriptPanel?: boolean;
+  hasTranscript?: boolean;
 }): {
   bottomAccessory: ReactNode;
   bottomBorderHandle: ReactNode;
@@ -56,13 +50,6 @@ export function useSessionBottomAccessory({
   const isLive = sessionMode === "active";
   const isInactive = sessionMode === "inactive";
   const isRunningBatch = sessionMode === "running_batch";
-  const canUsePlayback = audioUrlReady && (isInactive || isRunningBatch);
-  const batchError = useListener(
-    (state) => state.batch[sessionId]?.error ?? null,
-  );
-  const hasTranscriptError = Boolean(batchError);
-  const canShowTranscriptTab =
-    canUsePlayback || hasTranscript || hasTranscriptError || isRunningBatch;
   const live = useListener((state) => ({
     status: state.live.status,
     sessionId: state.live.sessionId,
@@ -84,12 +71,9 @@ export function useSessionBottomAccessory({
   });
   const hasPastNotes = pastNotes.hasPastNotes;
   const generateMissingPastNotes = pastNotes.generateMissing;
-  const activePostSessionTab: PostSessionTab =
-    hasPastNotes && !canShowTranscriptTab
-      ? "insights"
-      : hasPastNotes
-        ? (postSessionTab ?? "transcript")
-        : "transcript";
+  const activePostSessionTab: PostSessionTab = hasPastNotes
+    ? (postSessionTab ?? "insights")
+    : "transcript";
   const canExpandLiveTranscript = showLiveAccessory;
   const effectiveExpanded =
     isLive && !canExpandLiveTranscript ? false : isExpanded;
@@ -112,9 +96,7 @@ export function useSessionBottomAccessory({
 
   const showPostSession =
     isRunningBatch ||
-    (!shouldDeferToGlobalLiveAccessory &&
-      isInactive &&
-      (canUsePlayback || hasPastNotes));
+    (!shouldDeferToGlobalLiveAccessory && isInactive && hasPastNotes);
   const selectPostSessionTab = useCallback(
     (tab: PostSessionTab) => {
       const shouldExpand = activePostSessionTab !== tab || !isExpanded;
@@ -148,7 +130,7 @@ export function useSessionBottomAccessory({
     showLiveAccessory
       ? "live"
       : showPostSession
-        ? canUsePlayback || isRunningBatch
+        ? isRunningBatch
           ? "playback"
           : "transcript_only"
         : null;
@@ -181,17 +163,14 @@ export function useSessionBottomAccessory({
   }
 
   if (showPostSession) {
-    const hasAccessoryContent = isExpanded || isRunningBatch;
+    const hasAccessoryContent = isRunningBatch || (hasPastNotes && isExpanded);
     return {
       bottomAccessory: hasAccessoryContent ? (
         <PostSessionAccessory
           sessionId={sessionId}
-          hasAudio={canUsePlayback}
-          hasTranscript={hasTranscript}
           isTranscriptExpanded={isExpanded}
           activeTab={activePostSessionTab}
           pastNotes={pastNotes.notes}
-          suppressTranscriptPanel={suppressTranscriptPanel}
           onRegenerateInsights={
             pastNotes.canGenerate ? pastNotes.regenerateAll : undefined
           }
@@ -202,18 +181,10 @@ export function useSessionBottomAccessory({
         <PostSessionTabHandle
           isExpanded={isExpanded}
           activeTab={activePostSessionTab}
-          showTranscriptTab={isRunningBatch && canShowTranscriptTab}
+          showTranscriptTab={false}
           onSelect={selectPostSessionTab}
         />
-      ) : (
-        <ExpandToggle
-          isExpanded={isExpanded}
-          onToggle={() => setIsExpanded((v) => !v)}
-          label="Transcript"
-          showExpandedCloseIcon
-          collapsedClassName={BOTTOM_ACCESSORY_HANDLE_CLASS}
-        />
-      ),
+      ) : null,
       bottomAccessoryState,
     };
   }

--- a/apps/desktop/src/session/components/bottom-accessory/past-note-regenerate.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/past-note-regenerate.test.tsx
@@ -136,8 +136,6 @@ describe("insights regeneration", () => {
     render(
       <PostSessionAccessory
         sessionId="session-1"
-        hasAudio={false}
-        hasTranscript
         isTranscriptExpanded
         activeTab="insights"
         pastNotes={[
@@ -164,8 +162,6 @@ describe("insights regeneration", () => {
     render(
       <PostSessionAccessory
         sessionId="session-1"
-        hasAudio={false}
-        hasTranscript
         isTranscriptExpanded
         activeTab="insights"
         pastNotes={[
@@ -192,8 +188,6 @@ describe("insights regeneration", () => {
     render(
       <PostSessionAccessory
         sessionId="session-1"
-        hasAudio={false}
-        hasTranscript
         isTranscriptExpanded
         activeTab="insights"
         pastNotes={[

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -1,43 +1,12 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildPastSessionNotes } from "./past-notes";
 import { PostSessionAccessory } from "./post-session";
 
-const {
-  audioPathMock,
-  useTranscriptScreenMock,
-  useRunBatchMock,
-  useListenerMock,
-  useTranscriptExportSegmentsMock,
-  runBatchMock,
-  handleBatchFailedMock,
-  audioExistsMock,
-  writeTextMock,
-  showTransientToastMock,
-} = vi.hoisted(() => ({
-  audioPathMock: vi.fn(),
+const { useTranscriptScreenMock, useListenerMock } = vi.hoisted(() => ({
   useTranscriptScreenMock: vi.fn(),
-  useRunBatchMock: vi.fn(),
   useListenerMock: vi.fn(),
-  useTranscriptExportSegmentsMock: vi.fn(),
-  runBatchMock: vi.fn(),
-  handleBatchFailedMock: vi.fn(),
-  audioExistsMock: vi.fn(),
-  writeTextMock: vi.fn(),
-  showTransientToastMock: vi.fn(),
-}));
-
-vi.mock("@hypr/plugin-fs-sync", () => ({
-  commands: {
-    audioPath: audioPathMock,
-  },
 }));
 
 vi.mock("@hypr/ui/components/ui/button", () => ({
@@ -64,7 +33,6 @@ vi.mock("@hypr/ui/components/ui/tooltip", () => ({
 }));
 
 vi.mock("~/audio-player", () => ({
-  Timeline: () => <div data-testid="timeline" />,
   TimelineShell: ({
     children,
     leading,
@@ -86,29 +54,6 @@ vi.mock("~/audio-player", () => ({
   TimelineMeta: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  useAudioPlayer: () => ({
-    audioExists: audioExistsMock(),
-    deleteRecording: vi.fn(),
-    isDeletingRecording: false,
-  }),
-}));
-
-vi.mock("~/session/components/note-input/transcript", () => ({
-  Transcript: () => <div data-testid="transcript" />,
-}));
-
-vi.mock("~/sidebar/toast/transient", () => ({
-  showTransientToast: showTransientToastMock,
-}));
-
-vi.mock("~/session/components/note-input/transcript/export-data", () => ({
-  useTranscriptExportSegments: useTranscriptExportSegmentsMock,
-  formatTranscriptExportSegments: (
-    segments: Array<{ speaker: string | null; text: string }>,
-  ) =>
-    segments
-      .map((segment) => `${segment.speaker ?? "Speaker"}: ${segment.text}`)
-      .join("\n\n"),
 }));
 
 vi.mock("~/session/components/note-input/transcript/state", () => ({
@@ -128,224 +73,37 @@ vi.mock("~/stt/contexts", () => ({
   useListener: useListenerMock,
 }));
 
-vi.mock("~/stt/useRunBatch", () => ({
-  useRunBatch: useRunBatchMock,
-  isStoppedTranscriptionError: vi.fn(() => false),
-}));
-
 describe("PostSessionAccessory", () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: {
-        writeText: writeTextMock,
-      },
-    });
-
-    audioPathMock.mockResolvedValue({
-      status: "ok",
-      data: "/tmp/session.wav",
-    });
-    audioExistsMock.mockReturnValue(true);
-
     useTranscriptScreenMock.mockReturnValue({
       kind: "ready",
       transcriptIds: ["transcript-1"],
       liveSegments: [],
       currentActive: false,
     });
-    useTranscriptExportSegmentsMock.mockReturnValue({
-      data: [
-        { speaker: "Alex", text: "We should ship this." },
-        { speaker: null, text: "Agreed." },
-      ],
-      isLoading: false,
-    });
-
-    writeTextMock.mockResolvedValue(undefined);
-    runBatchMock.mockResolvedValue(undefined);
-    useRunBatchMock.mockReturnValue(runBatchMock);
 
     useListenerMock.mockImplementation((selector) =>
       selector({
-        handleBatchFailed: handleBatchFailedMock,
         stopTranscription: vi.fn(),
       }),
     );
   });
 
-  it("starts regeneration without local batch state bookkeeping", async () => {
-    render(
-      <PostSessionAccessory
-        sessionId="session-1"
-        hasAudio
-        hasTranscript
-        isTranscriptExpanded
-      />,
+  it("does not render a bottom transcript panel for ready transcripts", () => {
+    const { container } = render(
+      <PostSessionAccessory sessionId="session-1" isTranscriptExpanded />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Regenerate" }));
-
-    await waitFor(() => {
-      expect(audioPathMock).toHaveBeenCalledWith("session-1");
-      expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav");
-    });
-
-    expect(handleBatchFailedMock).not.toHaveBeenCalled();
-  });
-
-  it("hides ready transcript regeneration when the recording is missing", () => {
-    audioExistsMock.mockReturnValue(false);
-
-    render(
-      <PostSessionAccessory
-        sessionId="session-1"
-        hasAudio={false}
-        hasTranscript
-        isTranscriptExpanded
-      />,
-    );
-
+    expect(container.textContent).toBe("");
     expect(screen.queryByRole("button", { name: "Regenerate" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Copy transcript" }),
+    ).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Delete recording" }),
     ).toBeNull();
-  });
-
-  it("shows an error toast when regeneration cannot find the recording", async () => {
-    audioPathMock.mockResolvedValue({
-      status: "error",
-      error: "audio_path_not_found",
-    });
-
-    render(
-      <PostSessionAccessory
-        sessionId="session-1"
-        hasAudio
-        hasTranscript
-        isTranscriptExpanded
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Regenerate" }));
-
-    await waitFor(() => {
-      expect(showTransientToastMock).toHaveBeenCalledWith({
-        id: "transcript-regenerate-audio-missing-session-1",
-        description: "Recording not found. It may have been deleted.",
-        variant: "error",
-      });
-    });
-    expect(runBatchMock).not.toHaveBeenCalled();
-  });
-
-  it("copies transcript text from the expanded transcript panel", async () => {
-    render(
-      <PostSessionAccessory
-        sessionId="session-1"
-        hasAudio
-        hasTranscript
-        isTranscriptExpanded
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Copy transcript" }));
-
-    await waitFor(() => {
-      expect(writeTextMock).toHaveBeenCalledWith(
-        "Alex: We should ship this.\n\nSpeaker: Agreed.",
-      );
-    });
-    expect(showTransientToastMock).toHaveBeenCalledWith({
-      id: "transcript-copy-success",
-      description: "Transcript copied to clipboard",
-    });
-  });
-
-  it("uses dark-aware colors for the delete recording action", () => {
-    render(
-      <PostSessionAccessory
-        sessionId="session-1"
-        hasAudio
-        hasTranscript
-        isTranscriptExpanded
-      />,
-    );
-
-    const deleteButton = screen.getByRole("button", {
-      name: "Delete recording",
-    });
-
-    expect(deleteButton.className).toContain("dark:text-red-400");
-    expect(deleteButton.className).toContain("dark:hover:bg-red-950/50");
-    expect(deleteButton.className).toContain("dark:hover:text-red-300");
-  });
-
-  it("shows Regenerate button without upload or reserved height in empty panel", async () => {
-    useTranscriptScreenMock.mockReturnValue({
-      kind: "ready",
-      transcriptIds: [],
-      liveSegments: [],
-      currentActive: false,
-    });
-
-    render(
-      <PostSessionAccessory
-        sessionId="session-1"
-        hasAudio
-        hasTranscript={false}
-        isTranscriptExpanded
-        fillHeight
-      />,
-    );
-
-    const noTranscript = screen.getByText("No transcript yet");
-    const transcriptCard = noTranscript.parentElement?.parentElement;
-    const transcriptSlot = transcriptCard?.parentElement;
-    const accessoryRoot = transcriptSlot?.parentElement;
-    expect(transcriptCard?.className).not.toContain("min-h-[114px]");
-    expect(transcriptCard?.className).not.toContain("min-h-[96px]");
-    expect(transcriptSlot?.className).not.toContain("min-h-[114px]");
-    expect(transcriptSlot?.className).toContain("shrink-0");
-    expect(accessoryRoot?.className).not.toContain("h-full");
-    expect(screen.queryByRole("button", { name: "Upload audio" })).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: /Regenerate/ }));
-
-    await waitFor(() => {
-      expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav");
-    });
-  });
-
-  it("hides the audio timeline while the transcript panel is collapsed", () => {
-    render(
-      <PostSessionAccessory
-        sessionId="session-1"
-        hasAudio
-        hasTranscript
-        isTranscriptExpanded={false}
-      />,
-    );
-
-    expect(screen.queryByTestId("timeline")).toBeNull();
-    expect(screen.queryByTestId("transcript")).toBeNull();
-  });
-
-  it("keeps the audio timeline when suppressing the expanded transcript panel", () => {
-    render(
-      <PostSessionAccessory
-        sessionId="session-1"
-        hasAudio
-        hasTranscript
-        isTranscriptExpanded
-        suppressTranscriptPanel
-      />,
-    );
-
-    expect(screen.getByTestId("timeline")).toBeTruthy();
-    expect(screen.queryByTestId("transcript")).toBeNull();
   });
 
   it("keeps batch status visible while the transcript panel is collapsed", () => {
@@ -358,8 +116,6 @@ describe("PostSessionAccessory", () => {
     render(
       <PostSessionAccessory
         sessionId="session-1"
-        hasAudio
-        hasTranscript
         isTranscriptExpanded={false}
       />,
     );
@@ -382,8 +138,6 @@ describe("PostSessionAccessory", () => {
     render(
       <PostSessionAccessory
         sessionId="session-1"
-        hasAudio
-        hasTranscript
         isTranscriptExpanded={false}
       />,
     );
@@ -395,79 +149,25 @@ describe("PostSessionAccessory", () => {
     expect(screen.queryByText("25%")).toBeNull();
   });
 
-  it("keeps the audio timeline slot height stable when expanded", () => {
-    render(
-      <PostSessionAccessory
-        sessionId="session-1"
-        hasAudio
-        hasTranscript
-        isTranscriptExpanded
-        fillHeight
-      />,
-    );
-
-    const expandedSlotClassName =
-      screen.getByTestId("timeline").parentElement?.className;
-    expect(expandedSlotClassName).toContain("h-10");
-    expect(expandedSlotClassName).not.toContain("-mt-1.5");
-  });
-
-  it("lets expanded transcript content fill the resizable bottom panel", () => {
-    render(
-      <PostSessionAccessory
-        sessionId="session-1"
-        hasAudio
-        hasTranscript
-        isTranscriptExpanded
-        fillHeight
-      />,
-    );
-
-    const scrollArea = screen.getByTestId("transcript").parentElement;
-    expect(scrollArea?.className).toContain("flex-1");
-    expect(scrollArea?.className).not.toContain("h-[300px]");
-
-    const transcriptCard = scrollArea?.parentElement;
-    const transcriptSlot = transcriptCard?.parentElement;
-    expect(transcriptCard?.className).toContain("rounded-b-xl");
-    expect(transcriptCard?.className).toContain("border");
-    expect(transcriptCard?.className).toContain("h-full");
-    expect(transcriptCard?.className).toContain("min-h-[114px]");
-    expect(transcriptCard?.className).not.toContain("min-h-[96px]");
-    expect(transcriptSlot?.className).toContain("flex-1");
-    expect(transcriptSlot?.className).toContain("min-h-[114px]");
-  });
-
-  it("shows transcript skeletons with simple batch status in the body", () => {
+  it("shows compact batch status without transcript body skeletons", () => {
     useTranscriptScreenMock.mockReturnValue({
       kind: "running_batch",
       percentage: 0.25,
       phase: "transcribing",
     });
 
-    render(
-      <PostSessionAccessory
-        sessionId="session-1"
-        hasAudio
-        hasTranscript
-        isTranscriptExpanded
-      />,
-    );
+    render(<PostSessionAccessory sessionId="session-1" isTranscriptExpanded />);
 
-    expect(screen.getByText("Transcript")).toBeTruthy();
-    expect(screen.getAllByText("Transcribing...")).toHaveLength(2);
+    expect(screen.queryByText("Transcript")).toBeNull();
+    expect(screen.getByText("Transcribing...")).toBeTruthy();
     expect(screen.queryByText("25%")).toBeNull();
-    expect(screen.getAllByTestId("spinner")).toHaveLength(2);
-    expect(screen.getByTestId("transcript-skeleton")).toBeTruthy();
-    expect(screen.queryByTestId("transcript")).toBeNull();
+    expect(screen.getByTestId("spinner")).toBeTruthy();
   });
 
   it("renders compiled insights when the insights tab is active", () => {
     render(
       <PostSessionAccessory
         sessionId="session-1"
-        hasAudio={false}
-        hasTranscript
         isTranscriptExpanded
         activeTab="insights"
         pastNotes={[

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -1,12 +1,5 @@
-import {
-  CopyIcon,
-  Loader2Icon,
-  Pencil,
-  RefreshCw,
-  SquareIcon,
-  TrashIcon,
-} from "lucide-react";
-import { type ReactNode, useCallback, useRef } from "react";
+import { Loader2Icon, RefreshCw, SquareIcon } from "lucide-react";
+import { type ReactNode, useCallback } from "react";
 
 import { Button } from "@hypr/ui/components/ui/button";
 import { Spinner } from "@hypr/ui/components/ui/spinner";
@@ -19,14 +12,7 @@ import { cn } from "@hypr/utils";
 
 import * as AudioPlayer from "~/audio-player";
 import type { PastSessionNote } from "~/session/components/bottom-accessory/past-notes";
-import { Transcript } from "~/session/components/note-input/transcript";
-import { useRegenerateTranscript } from "~/session/components/note-input/transcript/actions";
-import {
-  formatTranscriptExportSegments,
-  useTranscriptExportSegments,
-} from "~/session/components/note-input/transcript/export-data";
 import { useTranscriptScreen } from "~/session/components/note-input/transcript/state";
-import { showTransientToast } from "~/sidebar/toast/transient";
 import { useListener } from "~/stt/contexts";
 
 export type PostSessionTab = "transcript" | "insights";
@@ -35,41 +21,30 @@ const MAX_COMPILED_INSIGHTS = 12;
 
 export function PostSessionAccessory({
   sessionId,
-  hasAudio,
-  hasTranscript,
   isTranscriptExpanded,
   activeTab = "transcript",
   pastNotes = [],
-  suppressTranscriptPanel = false,
   onRegenerateInsights,
   fillHeight = false,
 }: {
   sessionId: string;
-  hasAudio: boolean;
-  hasTranscript: boolean;
   isTranscriptExpanded: boolean;
   activeTab?: PostSessionTab;
   pastNotes?: PastSessionNote[];
-  suppressTranscriptPanel?: boolean;
   onRegenerateInsights?: () => void;
   fillHeight?: boolean;
 }) {
   const screen = useTranscriptScreen({ sessionId });
   const isBatching = screen.kind === "running_batch";
-  const effectiveActiveTab =
-    activeTab === "insights" && pastNotes.length > 0
-      ? "insights"
-      : "transcript";
+  const showInsightsPanel =
+    activeTab === "insights" && pastNotes.length > 0 && isTranscriptExpanded;
   const shouldFillExpandedPanel =
-    fillHeight &&
-    (effectiveActiveTab === "insights" || hasTranscript || isBatching);
+    fillHeight && (showInsightsPanel || isBatching);
   const timeline = isBatching ? (
     <BatchProgressTimeline sessionId={sessionId} screen={screen} />
-  ) : hasAudio && isTranscriptExpanded ? (
-    <AudioPlayer.Timeline />
   ) : null;
 
-  if (!isTranscriptExpanded && !timeline) {
+  if (!showInsightsPanel && !timeline) {
     return null;
   }
 
@@ -80,7 +55,7 @@ export function PostSessionAccessory({
         shouldFillExpandedPanel && "h-full overflow-hidden",
       ])}
     >
-      {isTranscriptExpanded && !suppressTranscriptPanel ? (
+      {showInsightsPanel ? (
         <div
           className={cn([
             shouldFillExpandedPanel
@@ -88,26 +63,15 @@ export function PostSessionAccessory({
               : "shrink-0",
           ])}
         >
-          {effectiveActiveTab === "insights" ? (
-            <InsightsPanel
-              notes={pastNotes}
-              onRegenerateInsights={onRegenerateInsights}
-              fillHeight={shouldFillExpandedPanel}
-            />
-          ) : (
-            <TranscriptPanel
-              sessionId={sessionId}
-              screen={screen}
-              hasAudio={hasAudio}
-              hasTranscript={hasTranscript}
-              isExpanded={isTranscriptExpanded}
-              fillHeight={shouldFillExpandedPanel}
-            />
-          )}
+          <InsightsPanel
+            notes={pastNotes}
+            onRegenerateInsights={onRegenerateInsights}
+            fillHeight={shouldFillExpandedPanel}
+          />
         </div>
       ) : null}
       {timeline ? (
-        <TimelineSlot flushTop={!isTranscriptExpanded}>{timeline}</TimelineSlot>
+        <TimelineSlot flushTop={!showInsightsPanel}>{timeline}</TimelineSlot>
       ) : null}
     </div>
   );
@@ -313,169 +277,6 @@ function RegenerateInsightsButton({
   );
 }
 
-function TranscriptPanel({
-  sessionId,
-  screen,
-  hasAudio,
-  hasTranscript,
-  isExpanded,
-  fillHeight,
-}: {
-  sessionId: string;
-  screen: ReturnType<typeof useTranscriptScreen>;
-  hasAudio: boolean;
-  hasTranscript: boolean;
-  isExpanded: boolean;
-  fillHeight: boolean;
-}) {
-  if (screen.kind === "running_batch") {
-    return (
-      <BatchingTranscriptPanel
-        sessionId={sessionId}
-        screen={screen}
-        isExpanded={isExpanded}
-        fillHeight={fillHeight}
-      />
-    );
-  }
-
-  if (hasTranscript) {
-    return (
-      <TranscriptReadyPanel
-        sessionId={sessionId}
-        isExpanded={isExpanded}
-        fillHeight={fillHeight}
-      />
-    );
-  }
-
-  return (
-    <TranscriptEmptyPanel
-      sessionId={sessionId}
-      hasAudio={hasAudio}
-      isExpanded={isExpanded}
-      fillHeight={fillHeight}
-    />
-  );
-}
-
-function BatchingTranscriptPanel({
-  sessionId,
-  screen,
-  isExpanded,
-  fillHeight,
-}: {
-  sessionId: string;
-  screen: {
-    kind: "running_batch";
-    percentage?: number;
-    phase?: "importing" | "transcribing";
-  };
-  isExpanded: boolean;
-  fillHeight: boolean;
-}) {
-  const stopTranscription = useListener((state) => state.stopTranscription);
-  const handleStop = useCallback(() => {
-    void stopTranscription(sessionId);
-  }, [sessionId, stopTranscription]);
-  const { phase } = screen;
-  const phaseLabel = getBatchPhaseLabel(phase);
-  const canStopTranscription = phase !== "importing";
-
-  if (!isExpanded) {
-    return null;
-  }
-
-  return (
-    <TranscriptCard fillHeight={fillHeight}>
-      <div className="flex shrink-0 items-center justify-between px-3 py-1.5">
-        <span className="text-muted-foreground text-xs font-medium">
-          Transcript
-        </span>
-        <div className="flex items-center gap-1 px-1 py-0.5">
-          <BatchStatusControl
-            onStop={canStopTranscription ? handleStop : undefined}
-            compact
-          />
-          <span className="text-muted-foreground text-[11px]">
-            {phaseLabel}
-          </span>
-        </div>
-      </div>
-
-      <BatchTranscriptSkeleton fillHeight={fillHeight} />
-    </TranscriptCard>
-  );
-}
-
-function BatchTranscriptSkeleton({ fillHeight }: { fillHeight: boolean }) {
-  const rows = [
-    {
-      speaker: "w-16",
-      time: "w-8",
-      lines: ["w-[74%]", "w-[54%]"],
-    },
-    {
-      speaker: "w-12",
-      time: "w-10",
-      lines: ["w-[62%]", "w-[82%]", "w-[38%]"],
-    },
-    {
-      speaker: "w-20",
-      time: "w-8",
-      lines: ["w-[70%]", "w-[48%]"],
-    },
-  ] as const;
-
-  return (
-    <div
-      aria-hidden
-      data-testid="transcript-skeleton"
-      className={cn([
-        "flex flex-col overflow-hidden px-6 py-4",
-        fillHeight
-          ? "min-h-0 flex-1 justify-center"
-          : "h-[178px] justify-start",
-      ])}
-    >
-      <div className="flex w-full max-w-[940px] flex-col gap-8">
-        {rows.map((row, index) => (
-          <div key={index} className="flex gap-4">
-            <div className="flex w-[72px] shrink-0 flex-col gap-3 pt-0.5">
-              <div
-                className={cn([
-                  "bg-accent/80 h-2.5 rounded-full",
-                  "animate-pulse",
-                  row.speaker,
-                ])}
-              />
-              <div
-                className={cn([
-                  "bg-muted h-1.5 rounded-full",
-                  "animate-pulse",
-                  row.time,
-                ])}
-              />
-            </div>
-            <div className="flex min-w-0 flex-1 flex-col gap-3 pt-0.5">
-              {row.lines.map((lineWidth, lineIndex) => (
-                <div
-                  key={lineIndex}
-                  className={cn([
-                    "bg-muted h-2.5 rounded-full",
-                    "animate-pulse",
-                    lineWidth,
-                  ])}
-                />
-              ))}
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
 function BatchProgressTimeline({
   sessionId,
   screen,
@@ -571,203 +372,6 @@ function BatchStatusControl({
         <p>Stop transcription</p>
       </TooltipContent>
     </Tooltip>
-  );
-}
-
-function TranscriptReadyPanel({
-  sessionId,
-  isExpanded,
-  fillHeight,
-}: {
-  sessionId: string;
-  isExpanded: boolean;
-  fillHeight: boolean;
-}) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const regenerate = useRegenerateTranscript(sessionId);
-  const { data: transcriptSegments, isLoading: isTranscriptLoading } =
-    useTranscriptExportSegments(sessionId);
-  const { audioExists, deleteRecording, isDeletingRecording } =
-    AudioPlayer.useAudioPlayer();
-  const transcriptText = formatTranscriptExportSegments(transcriptSegments);
-  const canCopyTranscript = transcriptText.length > 0 && !isTranscriptLoading;
-  const handleCopyTranscript = useCallback(() => {
-    if (!canCopyTranscript) {
-      return;
-    }
-
-    void copyTranscriptToClipboard(transcriptText);
-  }, [canCopyTranscript, transcriptText]);
-
-  if (!isExpanded) {
-    return null;
-  }
-
-  return (
-    <TranscriptCard fillHeight={fillHeight}>
-      <div className="flex shrink-0 items-center justify-between px-3 py-1.5">
-        <div className="flex items-center gap-1">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                disabled
-                className={cn([
-                  "flex items-center gap-1 rounded-full px-1.5 py-0.5",
-                  "text-muted-foreground/70 text-[11px] font-medium",
-                  "cursor-not-allowed",
-                ])}
-              >
-                <Pencil size={10} />
-                Edit
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <p>Coming soon</p>
-            </TooltipContent>
-          </Tooltip>
-          <button
-            type="button"
-            onClick={handleCopyTranscript}
-            disabled={!canCopyTranscript}
-            aria-label="Copy transcript"
-            className={cn([
-              "flex items-center gap-1 rounded-full px-1.5 py-0.5",
-              "text-muted-foreground text-[11px] font-medium",
-              "hover:bg-accent/60 hover:text-muted-foreground transition-colors",
-              "disabled:text-muted-foreground/70 disabled:cursor-not-allowed",
-              "disabled:hover:text-muted-foreground/70 disabled:hover:bg-transparent",
-            ])}
-          >
-            <CopyIcon size={10} />
-            {isTranscriptLoading ? "Loading..." : "Copy"}
-          </button>
-          {audioExists ? (
-            <button
-              type="button"
-              onClick={regenerate}
-              className={cn([
-                "flex items-center gap-1 rounded-full px-1.5 py-0.5",
-                "text-muted-foreground text-[11px] font-medium",
-                "hover:bg-accent/60 hover:text-muted-foreground transition-colors",
-              ])}
-            >
-              <RefreshCw size={10} />
-              Regenerate
-            </button>
-          ) : null}
-        </div>
-        {audioExists ? (
-          <button
-            type="button"
-            onClick={() => void deleteRecording()}
-            disabled={isDeletingRecording}
-            className={cn([
-              "flex items-center gap-1 rounded-full px-1.5 py-0.5",
-              "text-[11px] font-medium text-red-600 dark:text-red-400",
-              "transition-colors hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-950/50 dark:hover:text-red-300",
-              "disabled:cursor-not-allowed disabled:text-red-300 dark:disabled:text-red-500/60",
-            ])}
-          >
-            {isDeletingRecording ? (
-              <Loader2Icon size={10} className="animate-spin" />
-            ) : (
-              <TrashIcon size={10} />
-            )}
-            {isDeletingRecording ? "Deleting..." : "Delete recording"}
-          </button>
-        ) : null}
-      </div>
-
-      <TranscriptScrollArea fillHeight={fillHeight}>
-        <Transcript sessionId={sessionId} scrollRef={scrollRef} />
-      </TranscriptScrollArea>
-    </TranscriptCard>
-  );
-}
-
-async function copyTranscriptToClipboard(text: string) {
-  try {
-    await navigator.clipboard.writeText(text);
-    showTransientToast({
-      id: "transcript-copy-success",
-      description: "Transcript copied to clipboard",
-    });
-  } catch (error) {
-    console.error("Failed to copy transcript", error);
-    showTransientToast({
-      id: "transcript-copy-error",
-      description: "Failed to copy transcript",
-      variant: "error",
-    });
-  }
-}
-
-function TranscriptEmptyPanel({
-  sessionId,
-  hasAudio,
-  isExpanded,
-  fillHeight,
-}: {
-  sessionId: string;
-  hasAudio: boolean;
-  isExpanded: boolean;
-  fillHeight: boolean;
-}) {
-  const screen = useTranscriptScreen({ sessionId });
-  const regenerate = useRegenerateTranscript(sessionId);
-
-  const error = screen.kind === "empty" ? screen.error : null;
-
-  if (!isExpanded) {
-    return null;
-  }
-
-  return (
-    <TranscriptCard fillHeight={fillHeight} reserveMinHeight={false}>
-      <div className="flex min-h-0 flex-1 items-center justify-between px-4 py-3">
-        {error ? (
-          <span className="text-xs text-red-500">{error}</span>
-        ) : (
-          <span className="text-muted-foreground text-xs">
-            No transcript yet
-          </span>
-        )}
-
-        <div className="flex items-center gap-1.5">
-          {hasAudio && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-muted-foreground h-7 gap-1.5 text-xs"
-              onClick={regenerate}
-            >
-              <RefreshCw size={12} />
-              Regenerate
-            </Button>
-          )}
-        </div>
-      </div>
-    </TranscriptCard>
-  );
-}
-
-function TranscriptScrollArea({
-  children,
-  fillHeight,
-}: {
-  children: ReactNode;
-  fillHeight: boolean;
-}) {
-  return (
-    <div
-      className={cn([
-        "overflow-y-auto px-3",
-        fillHeight ? "min-h-0 flex-1" : "h-[300px]",
-      ])}
-    >
-      {children}
-    </div>
   );
 }
 

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef } from "react";
 
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 
+import { shouldShowSessionBottomAccessory } from "./bottom-accessory-visibility";
 import { useSessionBottomAccessory } from "./components/bottom-accessory";
 import { CaretPositionProvider } from "./components/caret-position-context";
 import { FloatingActionButton } from "./components/floating";
@@ -17,6 +18,7 @@ import { OuterHeader } from "./components/outer-header";
 import { SessionSurface } from "./components/session-surface";
 import { useCurrentNoteTab, useHasTranscript } from "./components/shared";
 import { useAutoEnhance } from "./hooks/useAutoEnhance";
+import { shouldShowSessionTopAudioPlayer } from "./top-audio-player";
 
 import * as AudioPlayer from "~/audio-player";
 import * as main from "~/store/tinybase/store/main";
@@ -100,7 +102,6 @@ export function TabContentNote({
             tab={tab}
             standaloneWindow={standaloneWindow}
             audioUrlReady={Boolean(audioUrl)}
-            isAudioUrlLoading={audioUrlQuery.isPending}
           />
         </AudioPlayer.Provider>
       </SearchProvider>
@@ -112,12 +113,10 @@ function TabContentNoteInner({
   tab,
   standaloneWindow,
   audioUrlReady,
-  isAudioUrlLoading,
 }: {
   tab: Extract<Tab, { type: "sessions" }>;
   standaloneWindow: boolean;
   audioUrlReady: boolean;
-  isAudioUrlLoading: boolean;
 }) {
   const noteInputRef = React.useRef<NoteInputHandle>(null);
 
@@ -138,12 +137,13 @@ function TabContentNoteInner({
     useSessionBottomAccessory({
       sessionId,
       sessionMode,
-      audioExists,
-      audioUrlReady,
-      isAudioLoading: isAudioUrlLoading,
-      hasTranscript,
-      suppressTranscriptPanel: currentView.type === "transcript",
     });
+  const showTopAudioPlayer = shouldShowSessionTopAudioPlayer({
+    audioExists,
+    audioUrlReady,
+    currentView,
+    sessionMode,
+  });
 
   const handleTabChange = React.useCallback(
     (view: typeof currentView) => {
@@ -169,9 +169,10 @@ function TabContentNoteInner({
     bottomAccessoryState?.expanded === true &&
     canResizeTranscriptSurface &&
     hasResizableTranscriptSurface;
-  const showBottomAccessory =
-    currentView.type !== "transcript" ||
-    bottomAccessoryState?.mode === "playback";
+  const showBottomAccessory = shouldShowSessionBottomAccessory({
+    currentView,
+    bottomAccessoryState,
+  });
   const showBottomTranscriptSurface =
     showBottomAccessory && currentView.type !== "transcript";
 
@@ -212,14 +213,28 @@ function TabContentNoteInner({
         />
       }
     >
-      <NoteInput
-        ref={noteInputRef}
-        tab={tab}
-        editorTabs={editorTabs}
-        currentTab={currentView}
-        handleTabChange={handleTabChange}
-        hideHeader
-      />
+      <div className="flex h-full min-h-0 flex-col">
+        {showTopAudioPlayer ? (
+          <div
+            data-session-top-audio-player
+            className="shrink-0 px-1 pt-1 pb-2"
+          >
+            <div className="border-border/70 bg-card/80 overflow-hidden rounded-[22px] border">
+              <AudioPlayer.Timeline contentClassName="py-1.5 pr-3 pl-1" />
+            </div>
+          </div>
+        ) : null}
+        <div className="min-h-0 flex-1">
+          <NoteInput
+            ref={noteInputRef}
+            tab={tab}
+            editorTabs={editorTabs}
+            currentTab={currentView}
+            handleTabChange={handleTabChange}
+            hideHeader
+          />
+        </div>
+      </div>
     </SessionSurface>
   );
 }

--- a/apps/desktop/src/session/top-audio-player.test.ts
+++ b/apps/desktop/src/session/top-audio-player.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldShowSessionTopAudioPlayer } from "./top-audio-player";
+
+describe("shouldShowSessionTopAudioPlayer", () => {
+  it("shows playback only on the transcript tab", () => {
+    expect(
+      shouldShowSessionTopAudioPlayer({
+        audioExists: true,
+        audioUrlReady: true,
+        currentView: { type: "transcript" },
+        sessionMode: "inactive",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldShowSessionTopAudioPlayer({
+        audioExists: true,
+        audioUrlReady: true,
+        currentView: { type: "enhanced", id: "summary-1" },
+        sessionMode: "inactive",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps playback hidden while recording or finalizing", () => {
+    expect(
+      shouldShowSessionTopAudioPlayer({
+        audioExists: true,
+        audioUrlReady: true,
+        currentView: { type: "transcript" },
+        sessionMode: "active",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldShowSessionTopAudioPlayer({
+        audioExists: true,
+        audioUrlReady: true,
+        currentView: { type: "transcript" },
+        sessionMode: "finalizing",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/session/top-audio-player.ts
+++ b/apps/desktop/src/session/top-audio-player.ts
@@ -1,0 +1,21 @@
+import type { EditorView } from "~/store/zustand/tabs/schema";
+
+export function shouldShowSessionTopAudioPlayer({
+  audioExists,
+  audioUrlReady,
+  currentView,
+  sessionMode,
+}: {
+  audioExists: boolean;
+  audioUrlReady: boolean;
+  currentView: EditorView;
+  sessionMode: string;
+}) {
+  return (
+    currentView.type === "transcript" &&
+    audioExists &&
+    audioUrlReady &&
+    sessionMode !== "active" &&
+    sessionMode !== "finalizing"
+  );
+}

--- a/apps/desktop/src/shared/ui/resource-list/preview-header.tsx
+++ b/apps/desktop/src/shared/ui/resource-list/preview-header.tsx
@@ -53,8 +53,8 @@ export function ResourcePreviewHeader({
   ) : null;
 
   return (
-    <div className="pt-1 pr-1 pb-4 pl-3">
-      <div className="flex items-center justify-between gap-3">
+    <div className="flex h-full flex-col">
+      <div className="flex h-12 items-center justify-between gap-3 pr-1 pl-3">
         <div className="min-w-0">
           <TemplateCategoryLabel category={category} />
         </div>
@@ -63,39 +63,42 @@ export function ResourcePreviewHeader({
           {actionButton}
         </div>
       </div>
-      <div className="mt-3 min-w-0 pr-5 pl-3">
-        <div className="flex min-w-0 items-baseline gap-2">
-          <h2 className="min-w-0 truncate text-lg font-semibold">
-            {title || "Untitled"}
-          </h2>
-          {titleMeta}
-        </div>
-        {description && (
-          <p className="text-muted-foreground mt-1 min-h-[24px] text-sm">
-            {description}
-          </p>
-        )}
-        {targets && targets.length > 0 && (
-          <div className="mt-2 flex min-h-6 flex-wrap items-center gap-1.5">
-            {targets.map((target, index) => (
-              <span
-                key={index}
-                className="bg-muted text-muted-foreground inline-flex h-6 items-center rounded-md px-2 py-0.5 text-xs"
-              >
-                {target}
-              </span>
-            ))}
+
+      <div className="scroll-fade-y min-h-0 flex-1 overflow-y-auto px-6 pt-3 pb-6">
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-baseline gap-2">
+            <h2 className="min-w-0 truncate text-lg font-semibold">
+              {title || "Untitled"}
+            </h2>
+            {titleMeta}
           </div>
-        )}
-        {footer === undefined ? (
-          <p className="text-muted-foreground mt-2 text-xs">
-            {getTemplateCreatorLabel({ isUserTemplate: false })}
-          </p>
-        ) : (
-          footer
-        )}
+          {description && (
+            <p className="text-muted-foreground mt-1 min-h-[24px] text-sm">
+              {description}
+            </p>
+          )}
+          {targets && targets.length > 0 && (
+            <div className="mt-2 flex min-h-6 flex-wrap items-center gap-1.5">
+              {targets.map((target, index) => (
+                <span
+                  key={index}
+                  className="bg-muted text-muted-foreground inline-flex h-6 items-center rounded-md px-2 py-0.5 text-xs"
+                >
+                  {target}
+                </span>
+              ))}
+            </div>
+          )}
+          {footer === undefined ? (
+            <p className="text-muted-foreground mt-2 text-xs">
+              {getTemplateCreatorLabel({ isUserTemplate: false })}
+            </p>
+          ) : (
+            footer
+          )}
+        </div>
+        {children}
       </div>
-      {children}
     </div>
   );
 }

--- a/apps/desktop/src/shared/ui/template-category-label.tsx
+++ b/apps/desktop/src/shared/ui/template-category-label.tsx
@@ -52,7 +52,7 @@ export function TemplateCategoryLabel({
   return (
     <span
       className={cn([
-        "text-muted-foreground flex items-center gap-1.5 font-mono text-xs",
+        "text-muted-foreground flex items-center gap-1.5 text-xs",
         className,
       ])}
     >

--- a/apps/desktop/src/templates/details.tsx
+++ b/apps/desktop/src/templates/details.tsx
@@ -175,17 +175,15 @@ function WebTemplatePreview({
             </DropdownMenu>
           </>
         }
-      />
-
-      <div className="relative flex-1 overflow-hidden">
-        <div className="scroll-fade-y h-full overflow-y-auto px-6 pb-6">
+      >
+        <div className="mt-6">
           <SectionsList
             disabled={true}
             items={template.sections ?? []}
             onChange={() => {}}
           />
         </div>
-      </div>
+      </ResourcePreviewHeader>
     </div>
   );
 }

--- a/apps/desktop/src/templates/template-form.tsx
+++ b/apps/desktop/src/templates/template-form.tsx
@@ -214,132 +214,133 @@ export function TemplateForm({
 
   return (
     <div className="flex h-full flex-1 flex-col">
-      <div className="pt-1 pr-1 pb-4 pl-3">
-        <div className="flex items-center justify-between gap-3">
-          <div className="min-w-0">
-            <TemplateCategoryLabel category={template.category} />
-          </div>
-          <div className="flex items-center gap-0">
-            <Button
-              type="button"
-              size="sm"
-              variant="ghost"
-              onClick={setSelectedTemplateId}
-              title={isDefault ? "Remove as default" : "Set as default"}
-              className={cn([
-                "text-muted-foreground shrink-0 hover:text-black",
-                isDefault ? "bg-muted hover:bg-accent text-black" : null,
-              ])}
-            >
-              {isDefault ? "Current default" : "Set as default"}
-            </Button>
-            <Button
-              type="button"
-              size="icon"
-              variant="ghost"
-              onClick={() => toggleTemplateFavorite(id)}
-              className={cn([
-                "text-muted-foreground hover:text-foreground",
-                template.pinned && "text-rose-500 hover:text-rose-600",
-              ])}
-              title={
-                template.pinned ? "Unfavorite template" : "Favorite template"
-              }
-              aria-label={
-                template.pinned ? "Unfavorite template" : "Favorite template"
-              }
-            >
-              <HeartIcon
-                className="size-4"
-                fill={template.pinned ? "currentColor" : "none"}
-              />
-            </Button>
-            <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="ghost"
-                  className={cn([
-                    "text-muted-foreground hover:text-foreground",
-                    actionsOpen && "bg-muted text-foreground hover:bg-accent",
-                  ])}
-                  aria-label="Template actions"
-                >
-                  <MoreHorizontalIcon className="size-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent variant="app" align="end">
-                <AppFloatingPanel className="overflow-hidden p-1">
-                  <DropdownMenuItem
-                    onClick={() => handleDuplicateTemplate(id)}
-                    className="cursor-pointer"
-                  >
-                    Duplicate
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => handleDeleteTemplate(id)}
-                    className="cursor-pointer text-red-600 focus:text-red-600"
-                  >
-                    Delete
-                  </DropdownMenuItem>
-                </AppFloatingPanel>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+      <div className="flex h-12 items-center justify-between gap-3 pr-1 pl-3">
+        <div className="min-w-0">
+          <TemplateCategoryLabel category={template.category} />
         </div>
-        <div className="mt-3 min-w-0 pr-5 pl-3">
-          <form.Field name="title">
-            {(field) => (
-              <div className="flex min-w-0 items-baseline gap-2">
-                <div className="relative max-w-full min-w-0">
-                  <span
-                    aria-hidden="true"
-                    className="invisible block px-0 py-0 text-lg font-semibold whitespace-pre md:text-lg"
-                  >
-                    {(field.state.value || " ") + " "}
-                  </span>
-                  <Input
-                    value={field.state.value}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    placeholder="Enter template title"
-                    className="absolute inset-0 h-auto w-full max-w-full min-w-0 border-0 px-0 py-0 text-lg font-semibold shadow-none focus-visible:ring-0 md:text-lg"
-                  />
-                </div>
-              </div>
-            )}
-          </form.Field>
-          <form.Field name="description">
-            {(field) => (
-              <Textarea
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                placeholder="Describe the template purpose..."
-                className="text-muted-foreground mt-1 min-h-[24px] resize-none border-0 px-0 py-0 text-sm shadow-none focus-visible:ring-0"
-                rows={1}
-              />
-            )}
-          </form.Field>
-          <form.Field name="targets">
-            {(field) => (
-              <TemplateTargetsInput
-                value={field.state.value}
-                onChange={field.handleChange}
-              />
-            )}
-          </form.Field>
+        <div className="flex items-center gap-0">
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={setSelectedTemplateId}
+            title={isDefault ? "Remove as default" : "Set as default"}
+            className={cn([
+              "text-muted-foreground shrink-0 hover:text-black",
+              isDefault ? "bg-muted hover:bg-accent text-black" : null,
+            ])}
+          >
+            {isDefault ? "Current default" : "Set as default"}
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            onClick={() => toggleTemplateFavorite(id)}
+            className={cn([
+              "text-muted-foreground hover:text-foreground",
+              template.pinned && "text-rose-500 hover:text-rose-600",
+            ])}
+            title={
+              template.pinned ? "Unfavorite template" : "Favorite template"
+            }
+            aria-label={
+              template.pinned ? "Unfavorite template" : "Favorite template"
+            }
+          >
+            <HeartIcon
+              className="size-4"
+              fill={template.pinned ? "currentColor" : "none"}
+            />
+          </Button>
+          <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className={cn([
+                  "text-muted-foreground hover:text-foreground",
+                  actionsOpen && "bg-muted text-foreground hover:bg-accent",
+                ])}
+                aria-label="Template actions"
+              >
+                <MoreHorizontalIcon className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent variant="app" align="end">
+              <AppFloatingPanel className="overflow-hidden p-1">
+                <DropdownMenuItem
+                  onClick={() => handleDuplicateTemplate(id)}
+                  className="cursor-pointer"
+                >
+                  Duplicate
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => handleDeleteTemplate(id)}
+                  className="cursor-pointer text-red-600 focus:text-red-600"
+                >
+                  Delete
+                </DropdownMenuItem>
+              </AppFloatingPanel>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
 
-      <div className="relative flex-1 overflow-hidden">
-        <div className="scroll-fade-y h-full overflow-y-auto px-6 pb-6">
+      <div className="relative min-h-0 flex-1 overflow-hidden">
+        <div className="scroll-fade-y h-full overflow-y-auto px-6 pt-3 pb-6">
+          <div className="min-w-0">
+            <form.Field name="title">
+              {(field) => (
+                <div className="flex min-w-0 items-baseline gap-2">
+                  <div className="relative max-w-full min-w-0">
+                    <span
+                      aria-hidden="true"
+                      className="invisible block px-0 py-0 text-lg font-semibold whitespace-pre md:text-lg"
+                    >
+                      {(field.state.value || " ") + " "}
+                    </span>
+                    <Input
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      placeholder="Enter template title"
+                      className="absolute inset-0 h-auto w-full max-w-full min-w-0 border-0 px-0 py-0 text-lg font-semibold shadow-none focus-visible:ring-0 md:text-lg"
+                    />
+                  </div>
+                </div>
+              )}
+            </form.Field>
+            <form.Field name="description">
+              {(field) => (
+                <Textarea
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  placeholder="Describe the template purpose..."
+                  className="text-muted-foreground mt-1 min-h-[24px] resize-none border-0 px-0 py-0 text-sm shadow-none focus-visible:ring-0"
+                  rows={1}
+                />
+              )}
+            </form.Field>
+            <form.Field name="targets">
+              {(field) => (
+                <TemplateTargetsInput
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                />
+              )}
+            </form.Field>
+          </div>
+
           <form.Field name="sections">
             {(field) => (
-              <SectionsList
-                disabled={false}
-                items={field.state.value}
-                onChange={(items) => field.handleChange(items)}
-              />
+              <div className="mt-6">
+                <SectionsList
+                  disabled={false}
+                  items={field.state.value}
+                  onChange={(items) => field.handleChange(items)}
+                />
+              </div>
             )}
           </form.Field>
         </div>


### PR DESCRIPTION
Set the template detail header rows to the same 48px height as the note header.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5692 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #5699
- <kbd>&nbsp;1&nbsp;</kbd> #5698
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout and styling-only changes in template preview/edit UI; no auth, data, or business-logic changes.
> 
> **Overview**
> Template detail views now use a **fixed 48px (`h-12`) top row** for the category label and action buttons, matching the note header height.
> 
> **`ResourcePreviewHeader`** is restructured into a full-height column: the toolbar stays pinned at the top; title, description, targets, footer, and **`children`** scroll together in a single `scroll-fade-y` region with updated padding.
> 
> **`TemplateForm`** and **web template preview** follow the same split—category/actions in the `h-12` row, editable or read-only metadata plus **`SectionsList`** in the scrollable body (sections nested under the header via **`children`** in the community preview).
> 
> **`TemplateCategoryLabel`** drops **`font-mono`** so category text styling matches the note header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8b4f613e1ef11b55296a9596e974083ae0ee49e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->