### PR TITLE
Use sans font in template sections

### DIFF
--- a/apps/desktop/src/templates/sections-editor.tsx
+++ b/apps/desktop/src/templates/sections-editor.tsx
@@ -300,7 +300,7 @@ function SectionItem({
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
           className={cn([
-            "min-h-[100px] w-full resize-y rounded-xl border p-3 font-mono text-sm transition-colors",
+            "min-h-[100px] w-full resize-y rounded-xl border p-3 text-sm transition-colors",
             "focus-visible:outline-hidden",
             disabled
               ? "bg-muted"


### PR DESCRIPTION
Remove the monospace class from template section textareas.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS class removal in a desktop UI editor with no logic, data, or security impact.
> 
> **Overview**
> Template section **description** textareas in the sections editor no longer use monospace (`font-mono`); they inherit the app’s default **sans** typography via `text-sm` only.
> 
> This is a visual-only tweak for editing Jinja2 template content—behavior, placeholders, and focus/disabled styling are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e23bdb24732363a13f2d87f5986da4fe0445df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->