### PR TITLE
Reduce template list top padding

### DIFF
--- a/apps/desktop/src/templates/template-sidebar.tsx
+++ b/apps/desktop/src/templates/template-sidebar.tsx
@@ -394,7 +394,7 @@ export function TemplatesSidebarContent({
         ) : (
           <>
             {hasResults && (
-              <div className="pt-3">
+              <div className="pt-1">
                 {combinedTemplates.map((item) =>
                   item.source === "user" ? (
                     <TemplateListItem
@@ -431,7 +431,7 @@ export function TemplatesSidebarContent({
             )}
 
             {isWebLoading && !hasResults && (
-              <div className="pt-3">
+              <div className="pt-1">
                 <div className="flex flex-col gap-1">
                   {[0, 1, 2, 3].map((index) => (
                     <div


### PR DESCRIPTION
Tighten the space above template sidebar list rows and loading placeholders.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Tailwind spacing tweak with no logic, data, or behavior changes.
> 
> **Overview**
> Reduces top padding above the template list in the templates sidebar from `pt-3` to `pt-1` for both the populated results list and the web-loading skeleton rows, so list content sits closer to the search bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39aff5d4b4b1c37d15fe402ba4a88442b1370942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->