### PR TITLE
Fix transcript hover clipping

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SegmentHeader } from "./segment-header";
+
+import type { Segment } from "~/stt/live-segment";
+
+const { useStoreMock } = vi.hoisted(() => ({
+  useStoreMock: vi.fn(),
+}));
+
+vi.mock("./speaker-assign", () => ({
+  SpeakerAssignPopover: ({ label }: { label: string }) => (
+    <button type="button">{label}</button>
+  ),
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useStore: useStoreMock,
+  },
+}));
+
+beforeEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  useStoreMock.mockReturnValue(undefined);
+});
+
+describe("SegmentHeader", () => {
+  it("keeps the speaker label and timestamp visible", () => {
+    render(
+      <SegmentHeader
+        transcriptId="transcript-1"
+        segment={
+          {
+            id: "segment-1",
+            key: {
+              channel: "RemoteParty",
+              speaker_index: 2,
+              speaker_human_id: null,
+            },
+            start_ms: 12_000,
+            end_ms: 18_000,
+            text: "hello world",
+            words: [
+              {
+                id: "word-1",
+                text: "hello",
+                start_ms: 12_000,
+                end_ms: 13_000,
+                channel: "RemoteParty",
+                is_final: true,
+              },
+              {
+                id: "word-2",
+                text: "world",
+                start_ms: 17_000,
+                end_ms: 18_000,
+                channel: "RemoteParty",
+                is_final: true,
+              },
+            ],
+          } as Segment
+        }
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Speaker 3" })).toBeTruthy();
+    expect(screen.getByText("00:12 - 00:18")).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
@@ -26,7 +26,7 @@ export function SegmentHeader({
     "bg-card sticky top-0 z-20",
     "-mx-3 px-3 py-1",
     "text-xs font-light",
-    "flex items-center justify-between",
+    "flex items-center gap-3",
     "[--segment-color:var(--segment-color-light)]",
     "dark:[--segment-color:var(--segment-color-dark)]",
   ]);
@@ -39,7 +39,9 @@ export function SegmentHeader({
         color="var(--segment-color)"
         label={label}
       />
-      <span className="text-muted-foreground font-mono">{timestamp}</span>
+      <span className="text-muted-foreground ml-auto shrink-0 tabular-nums">
+        {timestamp}
+      </span>
     </div>
   );
 }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
@@ -224,10 +224,16 @@ describe("SpeakerAssignPopover", () => {
 
     const trigger = screen.getByRole("button", { name: "Speaker 2" });
     expect(trigger.className).toContain("rounded-full");
-    expect(trigger.className).toContain("px-2");
-    expect(trigger.className).toContain("-ml-2");
+    expect(trigger.className).toContain("pr-2");
+    expect(trigger.className).toContain("hover:underline");
+    expect(trigger.className).toContain("focus-visible:underline");
+    expect(trigger.className).not.toContain("hover:bg-accent");
+    expect(trigger.className.split(/\s+/)).not.toContain("underline");
+    expect(trigger.className).not.toContain("px-2");
+    expect(trigger.className).not.toContain("-ml-2");
 
     fireEvent.click(trigger);
+    expect(trigger.className.split(/\s+/)).toContain("underline");
     fireEvent.click(screen.getByRole("button", { name: "Alice" }));
     expect(cells.get("speaker_hints")).toBe(JSON.stringify([]));
 

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -74,8 +74,9 @@ export function SpeakerAssignPopover({
         <button
           type="button"
           className={cn([
-            "-my-0.5 -ml-2 cursor-pointer rounded-full px-2 py-0.5",
-            "hover:bg-accent transition-colors",
+            "-my-0.5 cursor-pointer rounded-full py-0.5 pr-2",
+            "underline-offset-2 hover:underline focus-visible:underline",
+            open ? "underline" : null,
             className,
           ])}
           style={{ color }}


### PR DESCRIPTION
Offset the transcript wrapper so speaker hover backgrounds render fully without shifting the text column.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only styling and test updates in the transcript renderer; no data or assignment logic changes.
> 
> **Overview**
> Addresses transcript speaker hover clipping by **replacing the accent background hover** on the speaker assign trigger with **underline on hover, focus, and when the popover is open**, and dropping the negative left margin / symmetric horizontal padding that extended the hit area into the gutter.
> 
> **Segment header** layout shifts from `justify-between` to a `gap-3` row with the timestamp **right-aligned via `ml-auto`**, using `tabular-nums` instead of `font-mono`.
> 
> Adds **`segment-header.test.tsx`** to assert speaker label and time range stay visible; updates **`speaker-assign.test.ts`** expectations for the new trigger classes and open-state underline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f7fecb0a4aabf155e9fcd9b72c5da9a176604ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->