### PR TITLE
Show chat context as input chips

### DIFF
--- a/apps/desktop/src/chat/components/body/empty.test.tsx
+++ b/apps/desktop/src/chat/components/body/empty.test.tsx
@@ -37,7 +37,12 @@ describe("ChatBodyEmpty", () => {
     });
 
     expect(actionItem.className).toContain("w-full");
+    expect(actionItem.className).toContain("grid");
+    expect(actionItem.className).toContain("grid-cols-[1.5rem_minmax(0,1fr)]");
+    expect(actionItem.className).toContain("gap-x-1.5");
+    expect(actionItem.className).toContain("hover:bg-muted/55");
     expect(actionItem.className).toContain("text-left");
+    expect(actionItem.firstElementChild?.className).toContain("size-6");
     expect(followUp.className).toContain("w-full");
     expect(decisions.className).toContain("w-full");
 

--- a/apps/desktop/src/chat/components/body/empty.tsx
+++ b/apps/desktop/src/chat/components/body/empty.tsx
@@ -104,29 +104,31 @@ export function ChatBodyEmpty({
     <div className="flex justify-start pb-1">
       <div className="flex w-full flex-col">
         {hasContext && (
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-0.5">
             {SUGGESTIONS.map(({ label, icon: Icon, prompt }) => (
               <button
                 key={label}
                 onClick={() => handleSuggestionClick(prompt)}
                 className={cn([
-                  "group flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm",
+                  "group grid w-full grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-x-1.5 rounded-lg py-2 pr-3 pl-0 text-left text-sm",
                   isDarkAppearance
-                    ? "text-primary-foreground/85 hover:bg-primary-foreground/7"
-                    : "text-muted-foreground hover:bg-card",
+                    ? "text-primary-foreground/85 hover:bg-primary-foreground/10"
+                    : "text-muted-foreground hover:bg-muted/55",
                   "transition-colors",
                 ])}
               >
-                <Icon
-                  size={15}
-                  className={cn([
-                    "shrink-0 transition-colors",
-                    isDarkAppearance
-                      ? "text-primary-foreground/55 group-hover:text-primary-foreground/80"
-                      : "text-muted-foreground/75 group-hover:text-foreground",
-                  ])}
-                />
-                <span>{label}</span>
+                <span className="flex size-6 items-center justify-center">
+                  <Icon
+                    size={16}
+                    className={cn([
+                      "shrink-0 transition-colors",
+                      isDarkAppearance
+                        ? "text-primary-foreground/55 group-hover:text-primary-foreground/80"
+                        : "text-muted-foreground/75 group-hover:text-foreground",
+                    ])}
+                  />
+                </span>
+                <span className="min-w-0 truncate">{label}</span>
               </button>
             ))}
           </div>

--- a/apps/desktop/src/chat/components/content.tsx
+++ b/apps/desktop/src/chat/components/content.tsx
@@ -119,12 +119,10 @@ export function ChatContent({
           <ContextBar
             entities={contextEntities}
             onRemoveEntity={onRemoveContextEntity}
-            onAddEntity={onAddContextEntity}
           />
           <ChatMessageInput
             draftKey={sessionId}
             disabled={disabled}
-            hasContextBar={contextEntities.length > 0}
             onSendMessage={(content, parts, contextRefs) => {
               handleSendMessage(
                 content,

--- a/apps/desktop/src/chat/components/context-bar.test.tsx
+++ b/apps/desktop/src/chat/components/context-bar.test.tsx
@@ -1,38 +1,9 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { openNewMock, searchMock, shellState, storeState } = vi.hoisted(() => ({
+const { openNewMock } = vi.hoisted(() => ({
   openNewMock: vi.fn(),
-  searchMock: vi.fn(),
-  shellState: {
-    mode: "FloatingOpen" as
-      | "FloatingClosed"
-      | "FloatingOpen"
-      | "RightPanelOpen",
-  },
-  storeState: {
-    rows: {} as Record<string, Record<string, unknown>>,
-    sessionIds: [] as string[],
-  },
-}));
-
-vi.mock("@hypr/ui/components/ui/popover", () => ({
-  AppFloatingPanel: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  PopoverContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
 vi.mock("@hypr/ui/components/ui/tooltip", () => ({
@@ -43,42 +14,6 @@ vi.mock("@hypr/ui/components/ui/tooltip", () => ({
   TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
-vi.mock("~/contexts/shell", () => ({
-  useShell: () => ({
-    chat: {
-      mode: shellState.mode,
-    },
-  }),
-}));
-
-vi.mock("~/chat/hooks/use-chat-appearance", () => ({
-  useChatAppearance: () => ({
-    isDarkAppearance: true,
-    toolbarSurface: "dark",
-    panelClassName: "bg-primary text-primary-foreground",
-    panelBorderClassName: "border-primary/80",
-    elevatedSurfaceClassName: "bg-accent text-accent-foreground border-border",
-    inputEditorClassName: "text-accent-foreground",
-  }),
-}));
-
-vi.mock("~/search/contexts/engine", () => ({
-  useSearchEngine: () => ({
-    search: searchMock,
-  }),
-}));
-
-vi.mock("~/store/tinybase/store/main", () => ({
-  STORE_ID: "main",
-  UI: {
-    useRowIds: () => storeState.sessionIds,
-    useStore: () => ({
-      getRow: (_table: string, rowId: string) => storeState.rows[rowId] ?? {},
-      hasRow: (_table: string, rowId: string) => rowId in storeState.rows,
-    }),
-  },
-}));
-
 vi.mock("~/store/zustand/tabs", () => ({
   useTabs: <T,>(selector: (state: { openNew: typeof openNewMock }) => T) =>
     selector({ openNew: openNewMock }),
@@ -86,17 +21,41 @@ vi.mock("~/store/zustand/tabs", () => ({
 
 import { ContextBar } from "./context-bar";
 
-function renderContextBar() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
+describe("ContextBar", () => {
+  beforeEach(() => {
+    cleanup();
+    openNewMock.mockClear();
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof ResizeObserver;
   });
 
-  return render(
-    <QueryClientProvider client={queryClient}>
+  it("renders context as chips without an add session control", () => {
+    render(
+      <ContextBar
+        entities={[
+          {
+            kind: "session",
+            key: "session:auto:current",
+            source: "auto-current",
+            sessionId: "current",
+            title: "Current Note",
+            date: "2026-04-01T00:00:00.000Z",
+            pending: true,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText("Current Note").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByText("Search sessions...")).toBeNull();
+  });
+
+  it("centers the squircle chip strip above the input surface", () => {
+    const { container } = render(
       <ContextBar
         entities={[
           {
@@ -109,115 +68,235 @@ function renderContextBar() {
             pending: false,
           },
         ]}
-        onAddEntity={vi.fn()}
-      />
-    </QueryClientProvider>,
-  );
-}
-
-describe("ContextBar session picker", () => {
-  beforeEach(() => {
-    cleanup();
-    openNewMock.mockClear();
-    searchMock.mockReset();
-    shellState.mode = "FloatingOpen";
-    storeState.rows = {};
-    storeState.sessionIds = [];
-    globalThis.ResizeObserver = class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    } as typeof ResizeObserver;
-  });
-
-  it("shows recent sessions from TinyBase and skips malformed blank rows", () => {
-    storeState.sessionIds = ["blank", "old", "new"];
-    storeState.rows = {
-      blank: {
-        title: "",
-        created_at: "",
-      },
-      old: {
-        title: "Old Note",
-        created_at: "2024-01-01T00:00:00.000Z",
-      },
-      new: {
-        title: "New Note",
-        created_at: "2026-04-14T00:00:00.000Z",
-      },
-    };
-
-    renderContextBar();
-
-    const newNote = screen.getByText("New Note");
-    const oldNote = screen.getByText("Old Note");
-
-    expect(
-      newNote.compareDocumentPosition(oldNote) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(screen.queryByText("Untitled")).toBeNull();
-    expect(screen.queryByText(/1970/)).toBeNull();
-    expect(searchMock).not.toHaveBeenCalled();
-  });
-
-  it("hydrates search hits from TinyBase before rendering", async () => {
-    storeState.sessionIds = ["session-1"];
-    storeState.rows = {
-      "session-1": {
-        title: "Hydrated Note",
-        created_at: "2026-02-02T00:00:00.000Z",
-      },
-    };
-    searchMock.mockResolvedValue([
-      {
-        score: 1,
-        document: {
-          id: "session-1",
-          type: "session",
-          title: "",
-          content: "",
-          created_at: 0,
-        },
-      },
-    ]);
-
-    renderContextBar();
-
-    fireEvent.change(screen.getByPlaceholderText("Search sessions..."), {
-      target: { value: "hydrated" },
-    });
-
-    await waitFor(() => {
-      expect(searchMock).toHaveBeenCalledWith("hydrated", {
-        created_at: undefined,
-      });
-    });
-
-    expect(await screen.findByText("Hydrated Note")).toBeTruthy();
-    expect(screen.queryByText(/1970/)).toBeNull();
-  });
-
-  it("uses balanced context bar horizontal margin in the right panel", () => {
-    shellState.mode = "RightPanelOpen";
-
-    renderContextBar();
+      />,
+    );
 
     const outer = document.querySelector("[data-chat-context-bar]");
+    const chipList = container.querySelector("[data-chat-context-chip-list]");
+    const chipRow = chipList?.parentElement;
+    const chip = container.querySelector("[data-chat-context-chip]");
 
-    expect(outer?.className).toContain("mx-3");
-    expect(outer?.className).not.toContain("mx-5");
-    expect(outer?.className).not.toContain("mx-2");
-    expect(outer?.className).not.toContain("mr-0");
+    expect(outer?.className).toContain("px-3");
+    expect(outer?.className).toContain("pb-1.5");
+    expect(outer?.className).not.toContain("border");
+    expect(outer?.className).not.toContain("rounded-t-xl");
+    expect(chipRow?.className).toContain("justify-center");
+    expect(chip?.className).toContain("rounded-[10px]");
   });
 
-  it("uses an elevated surface that contrasts with the dark chat panel", () => {
-    renderContextBar();
+  it("shows four chips and expands hidden chips from the overflow control", () => {
+    const { container } = render(
+      <ContextBar
+        entities={[
+          {
+            kind: "session",
+            key: "session:manual:first",
+            source: "manual",
+            sessionId: "first",
+            title: "First Note",
+            date: "2026-04-01T00:00:00.000Z",
+            pending: true,
+          },
+          {
+            kind: "session",
+            key: "session:manual:second",
+            source: "manual",
+            sessionId: "second",
+            title: "Second Note",
+            date: "2026-04-02T00:00:00.000Z",
+            pending: true,
+          },
+          {
+            kind: "session",
+            key: "session:manual:third",
+            source: "manual",
+            sessionId: "third",
+            title: "Third Note",
+            date: "2026-04-03T00:00:00.000Z",
+            pending: true,
+          },
+          {
+            kind: "session",
+            key: "session:manual:fourth",
+            source: "manual",
+            sessionId: "fourth",
+            title: "Fourth Note",
+            date: "2026-04-04T00:00:00.000Z",
+            pending: true,
+          },
+          {
+            kind: "session",
+            key: "session:manual:fifth",
+            source: "manual",
+            sessionId: "fifth",
+            title: "Fifth Note",
+            date: "2026-04-05T00:00:00.000Z",
+            pending: true,
+          },
+          {
+            kind: "session",
+            key: "session:manual:sixth",
+            source: "manual",
+            sessionId: "sixth",
+            title: "Sixth Note",
+            date: "2026-04-06T00:00:00.000Z",
+            pending: true,
+          },
+        ]}
+      />,
+    );
 
-    const outer = document.querySelector("[data-chat-context-bar]");
+    const chipList = container.querySelector("[data-chat-context-chip-list]");
 
-    expect(outer?.className).toContain("bg-accent");
-    expect(outer?.className).toContain("text-accent-foreground");
-    expect(outer?.className).not.toContain("bg-card");
+    expect(chipList?.className).toContain("overflow-hidden");
+    expect(chipList?.className).not.toContain("flex-wrap");
+    expect(container.querySelectorAll("[data-chat-context-chip]")).toHaveLength(
+      4,
+    );
+    expect(screen.queryByText("Fifth Note")).toBeNull();
+    expect(screen.queryByText("Sixth Note")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "+2 more",
+      }),
+    );
+
+    expect(screen.getAllByText("Fifth Note").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Sixth Note").length).toBeGreaterThan(0);
+    expect(container.querySelectorAll("[data-chat-context-chip]")).toHaveLength(
+      6,
+    );
+    expect(chipList?.className).toContain("flex-wrap");
+    expect(screen.queryByText("+2 more")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Collapse context chips",
+      }),
+    );
+
+    expect(container.querySelectorAll("[data-chat-context-chip]")).toHaveLength(
+      4,
+    );
+    expect(screen.getByText("+2 more")).not.toBeNull();
+    expect(chipList?.className).toContain("overflow-hidden");
+  });
+
+  it("wraps four-or-fewer chips instead of clipping them", () => {
+    const { container } = render(
+      <ContextBar
+        entities={[
+          {
+            kind: "session",
+            key: "session:manual:first",
+            source: "manual",
+            sessionId: "first",
+            title: "First Note",
+            date: "2026-04-01T00:00:00.000Z",
+            pending: true,
+          },
+          {
+            kind: "session",
+            key: "session:manual:second",
+            source: "manual",
+            sessionId: "second",
+            title: "Second Note",
+            date: "2026-04-02T00:00:00.000Z",
+            pending: true,
+          },
+          {
+            kind: "session",
+            key: "session:manual:third",
+            source: "manual",
+            sessionId: "third",
+            title: "Third Note",
+            date: "2026-04-03T00:00:00.000Z",
+            pending: true,
+          },
+          {
+            kind: "session",
+            key: "session:manual:fourth",
+            source: "manual",
+            sessionId: "fourth",
+            title: "Fourth Note",
+            date: "2026-04-04T00:00:00.000Z",
+            pending: true,
+          },
+        ]}
+      />,
+    );
+
+    const chipList = container.querySelector("[data-chat-context-chip-list]");
+    const chip = container.querySelector("[data-chat-context-chip]");
+
+    expect(chipList?.className).toContain("flex-wrap");
+    expect(chipList?.className).not.toContain("overflow-hidden");
+    expect(chip?.className).toContain("shrink-0");
+    expect(screen.queryByRole("button", { name: /more/ })).toBeNull();
+  });
+
+  it("opens a session chip when clicked", () => {
+    render(
+      <ContextBar
+        entities={[
+          {
+            kind: "session",
+            key: "session:auto:current",
+            source: "auto-current",
+            sessionId: "current",
+            title: "Current Note",
+            date: "2026-04-01T00:00:00.000Z",
+            pending: false,
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByText("Current Note")[0]);
+
+    expect(openNewMock).toHaveBeenCalledWith({
+      type: "sessions",
+      id: "current",
+    });
+  });
+
+  it("removes manual context chips", () => {
+    const onRemoveEntity = vi.fn();
+    const { container } = render(
+      <ContextBar
+        entities={[
+          {
+            kind: "session",
+            key: "session:manual:current",
+            source: "manual",
+            sessionId: "current",
+            title: "Current Note",
+            date: "2026-04-01T00:00:00.000Z",
+            removable: true,
+            pending: true,
+          },
+        ]}
+        onRemoveEntity={onRemoveEntity}
+      />,
+    );
+
+    const chip = container.querySelector("[data-chat-context-chip]");
+    const iconSlot = chip?.firstElementChild;
+    const contextIcon = iconSlot?.querySelector("svg");
+    const removeButton = screen.getByRole("button", {
+      name: "Remove Current Note",
+    });
+
+    expect(iconSlot?.className).toContain("size-4");
+    expect(iconSlot?.contains(removeButton)).toBe(true);
+    expect(contextIcon?.className.baseVal).toContain("group-hover:opacity-0");
+    expect(removeButton.className).toContain("group-hover:opacity-100");
+    expect(removeButton.className).toContain("group-hover:pointer-events-auto");
+
+    fireEvent.click(removeButton);
+
+    expect(onRemoveEntity).toHaveBeenCalledWith("session:manual:current");
+    expect(openNewMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/chat/components/context-bar.tsx
+++ b/apps/desktop/src/chat/components/context-bar.tsx
@@ -1,126 +1,18 @@
-import { useQuery } from "@tanstack/react-query";
-import { ChevronDownIcon, PlusIcon, XIcon } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { ChevronUpIcon, XIcon } from "lucide-react";
+import { useMemo, useState } from "react";
 
-import {
-  AppFloatingPanel,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@hypr/ui/components/ui/popover";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@hypr/ui/components/ui/tooltip";
-import { cn, safeParseDate } from "@hypr/utils";
+import { cn } from "@hypr/utils";
 
-import type { ContextRef } from "~/chat/context/entities";
 import { type ContextChipProps, renderChip } from "~/chat/context/registry";
 import type { DisplayEntity } from "~/chat/context/use-chat-context-pipeline";
-import { useChatAppearance } from "~/chat/hooks/use-chat-appearance";
-import { useSearchEngine } from "~/search/contexts/engine";
-import { getSessionEvent } from "~/session/utils";
-import * as main from "~/store/tinybase/store/main";
 import { useTabs } from "~/store/zustand/tabs";
 
-const MAX_SESSION_PICKER_RESULTS = 8;
-
-type SessionPickerItem = {
-  id: string;
-  title: string;
-  dateLabel: string | null;
-  timestamp: number | null;
-};
-
-type MainStore = ReturnType<typeof main.UI.useStore>;
-
-function getSessionTimestamp(row: {
-  created_at?: unknown;
-  event_json?: unknown;
-}): number | null {
-  const event =
-    typeof row.event_json === "string"
-      ? getSessionEvent({ event_json: row.event_json })
-      : null;
-  const date = safeParseDate(event?.started_at ?? row.created_at);
-  return date ? date.getTime() : null;
-}
-
-function toSessionPickerItem(
-  store: MainStore,
-  sessionId: string,
-): SessionPickerItem | null {
-  if (!store?.hasRow("sessions", sessionId)) {
-    return null;
-  }
-
-  const row = store.getRow("sessions", sessionId);
-  const title = typeof row.title === "string" ? row.title.trim() : "";
-  const timestamp = getSessionTimestamp(row);
-
-  if (!title && timestamp === null) {
-    return null;
-  }
-
-  return {
-    id: sessionId,
-    title: title || "Untitled",
-    timestamp,
-    dateLabel: timestamp ? new Date(timestamp).toLocaleDateString() : null,
-  };
-}
-
-function sortByNewestSession(
-  a: SessionPickerItem,
-  b: SessionPickerItem,
-): number {
-  const aTime = a.timestamp ?? Number.NEGATIVE_INFINITY;
-  const bTime = b.timestamp ?? Number.NEGATIVE_INFINITY;
-  if (aTime === bTime) {
-    return a.title.localeCompare(b.title);
-  }
-  return bTime - aTime;
-}
-
-function useOverflow(
-  ref: React.RefObject<HTMLDivElement | null>,
-  deps: unknown[],
-) {
-  const [hasOverflow, setHasOverflow] = useState(false);
-  const [hiddenCount, setHiddenCount] = useState(0);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-
-    const check = () => {
-      const overflows = el.scrollHeight > el.clientHeight;
-      setHasOverflow(overflows);
-
-      if (overflows) {
-        const cutoff = el.getBoundingClientRect().bottom;
-        let hidden = 0;
-        for (const child of el.children) {
-          if ((child as HTMLElement).getBoundingClientRect().top >= cutoff) {
-            hidden++;
-          }
-        }
-        setHiddenCount(hidden);
-      } else {
-        setHiddenCount(0);
-      }
-    };
-
-    const observer = new ResizeObserver(check);
-    observer.observe(el);
-    check();
-    return () => observer.disconnect();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, deps);
-
-  return { hasOverflow, hiddenCount };
-}
+const COLLAPSED_CONTEXT_CHIP_LIMIT = 4;
 
 function ContextChip({
   chip,
@@ -159,32 +51,40 @@ function ContextChip({
     <Tooltip>
       <TooltipTrigger asChild>
         <span
+          data-chat-context-chip
           onClick={handleClick}
           className={cn([
-            "group max-w-48 min-w-0 rounded-md px-1.5 py-0.5 text-xs",
+            "group border-border/60 inline-flex h-7 max-w-56 min-w-0 shrink-0 items-center gap-1.5 rounded-[10px] border px-2.5 text-xs leading-4 shadow-xs",
             pending
-              ? "bg-muted/5 text-muted-foreground"
-              : "bg-card text-muted-foreground shadow-xs",
-            "inline-flex shrink items-center gap-1",
+              ? "bg-card/60 text-muted-foreground"
+              : "bg-card/90 text-muted-foreground",
             isClickable
               ? "hover:bg-accent/20 cursor-pointer"
               : "cursor-default",
           ])}
         >
-          {Icon && <Icon className="text-muted-foreground size-3 shrink-0" />}
+          <span className="relative flex size-4 shrink-0 items-center justify-center">
+            <Icon
+              className={cn([
+                "text-muted-foreground size-3.5 shrink-0 transition-opacity",
+                chip.removable && onRemove ? "group-hover:opacity-0" : "",
+              ])}
+            />
+            {chip.removable && onRemove && (
+              <button
+                type="button"
+                aria-label={`Remove ${chip.label}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRemove(chip.key);
+                }}
+                className="hover:bg-accent/30 hover:text-foreground pointer-events-none absolute inset-0 flex items-center justify-center rounded-[5px] opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100"
+              >
+                <XIcon className="size-3" />
+              </button>
+            )}
+          </span>
           <span className="truncate">{chip.label}</span>
-          {chip.removable && onRemove && (
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                onRemove(chip.key);
-              }}
-              className="hover:bg-accent/20 ml-0.5 hidden items-center justify-center rounded-sm group-hover:inline-flex"
-            >
-              <XIcon className="size-2.5" />
-            </button>
-          )}
         </span>
       </TooltipTrigger>
       <TooltipContent side="top" className="z-110">
@@ -201,26 +101,23 @@ function ChipList({
   chips: Array<{ chip: ContextChipProps; pending: boolean }>;
   onRemove?: (key: string) => void;
 }) {
-  const ref = useRef<HTMLDivElement>(null);
-  const [expanded, setExpanded] = useState(false);
-  const { hasOverflow, hiddenCount } = useOverflow(ref, [chips]);
-
-  useEffect(() => {
-    setExpanded(false);
-  }, [chips.length]);
-
-  const showToggle = hasOverflow || expanded;
+  const [isExpanded, setIsExpanded] = useState(false);
+  const hiddenCount = Math.max(0, chips.length - COLLAPSED_CONTEXT_CHIP_LIMIT);
+  const visibleChips = isExpanded
+    ? chips
+    : chips.slice(0, COLLAPSED_CONTEXT_CHIP_LIMIT);
+  const canExpand = hiddenCount > 0;
 
   return (
-    <div className="flex items-start gap-1.5">
+    <div className="flex w-full min-w-0 items-center justify-center gap-1.5">
       <div
-        ref={ref}
+        data-chat-context-chip-list
         className={cn([
-          "flex min-w-0 flex-1 flex-wrap items-center gap-1.5",
-          !expanded && "max-h-[22px] overflow-hidden",
+          "flex max-w-full min-w-0 items-center justify-center gap-1.5",
+          canExpand && !isExpanded ? "overflow-hidden" : "flex-wrap",
         ])}
       >
-        {chips.map(({ chip, pending }) => (
+        {visibleChips.map(({ chip, pending }) => (
           <ContextChip
             key={chip.key}
             chip={chip}
@@ -230,130 +127,33 @@ function ChipList({
         ))}
       </div>
 
-      {showToggle && (
+      {canExpand && (
         <button
           type="button"
-          onClick={() => setExpanded((v) => !v)}
-          className="bg-muted/10 text-muted-foreground hover:bg-accent/20 hover:text-muted-foreground inline-flex shrink-0 items-center gap-0.5 rounded-md px-1 py-0.5 text-xs transition-colors"
+          data-chat-context-overflow-chip
+          aria-expanded={isExpanded}
+          aria-label={isExpanded ? "Collapse context chips" : undefined}
+          onClick={() => setIsExpanded((value) => !value)}
+          className="bg-card/70 border-border/60 text-muted-foreground hover:bg-accent/20 hover:text-muted-foreground inline-flex h-7 shrink-0 items-center gap-0.5 rounded-[10px] border px-1.5 text-xs shadow-xs transition-colors"
         >
-          {!expanded && hiddenCount > 0 && <span>+{hiddenCount}</span>}
-          <ChevronDownIcon
-            className={cn(["size-3.5", expanded && "rotate-180"])}
-          />
+          {isExpanded ? (
+            <ChevronUpIcon aria-hidden="true" className="size-3" />
+          ) : (
+            `+${hiddenCount} more`
+          )}
         </button>
       )}
     </div>
   );
 }
 
-function SessionPicker({
-  onSelect,
-  onClose,
-}: {
-  onSelect: (sessionId: string) => void;
-  onClose: () => void;
-}) {
-  const [query, setQuery] = useState("");
-  const normalizedQuery = query.trim();
-  const { search } = useSearchEngine();
-  const store = main.UI.useStore(main.STORE_ID);
-  const sessionIds = main.UI.useRowIds("sessions", main.STORE_ID);
-
-  const searchResults = useQuery({
-    queryKey: ["chat-session-picker", normalizedQuery],
-    enabled: normalizedQuery.length > 0,
-    queryFn: () => search(normalizedQuery, { created_at: undefined }),
-  });
-
-  const recentSessions = useMemo(() => {
-    return sessionIds
-      .map((sessionId) => toSessionPickerItem(store, sessionId))
-      .filter((item): item is SessionPickerItem => item !== null)
-      .sort(sortByNewestSession)
-      .slice(0, MAX_SESSION_PICKER_RESULTS);
-  }, [sessionIds, store]);
-
-  const matchingSessions = useMemo(() => {
-    return (searchResults.data ?? [])
-      .filter((hit) => hit.document.type === "session")
-      .map((hit) => toSessionPickerItem(store, hit.document.id))
-      .filter((item): item is SessionPickerItem => item !== null)
-      .slice(0, MAX_SESSION_PICKER_RESULTS);
-  }, [searchResults.data, store]);
-
-  const results = normalizedQuery ? matchingSessions : recentSessions;
-
-  return (
-    <div className="flex flex-col gap-2">
-      <input
-        autoFocus
-        type="text"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        placeholder="Search sessions..."
-        className="border-border bg-card focus:border-border w-full rounded-md border px-2.5 py-1.5 text-xs outline-none"
-      />
-      <div className="flex max-h-48 flex-col gap-0.5 overflow-y-auto">
-        {results.map((result) => (
-          <button
-            key={result.id}
-            type="button"
-            onClick={() => {
-              onSelect(result.id);
-              onClose();
-            }}
-            className="hover:bg-accent flex flex-col items-start rounded-md px-2 py-1.5 text-left transition-colors"
-          >
-            <span className="text-muted-foreground w-full truncate text-xs font-medium">
-              {result.title || "Untitled"}
-            </span>
-            <span className="text-muted-foreground text-[10px]">
-              {result.dateLabel ?? "Unknown date"}
-            </span>
-          </button>
-        ))}
-        {results.length === 0 && (
-          <span className="text-muted-foreground px-2 py-1.5 text-xs">
-            {searchResults.isFetching ? "Searching..." : "No sessions found"}
-          </span>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function AddSessionButton({ onAdd }: { onAdd: (sessionId: string) => void }) {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className="bg-muted/10 text-muted-foreground hover:bg-accent/20 hover:text-muted-foreground inline-flex shrink-0 items-center justify-center rounded-md p-0.5 transition-colors"
-        >
-          <PlusIcon className="size-3.5" />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent variant="app" side="top" align="start" className="w-64">
-        <AppFloatingPanel className="p-3">
-          <SessionPicker onSelect={onAdd} onClose={() => setOpen(false)} />
-        </AppFloatingPanel>
-      </PopoverContent>
-    </Popover>
-  );
-}
-
 export function ContextBar({
   entities,
   onRemoveEntity,
-  onAddEntity,
 }: {
   entities: DisplayEntity[];
   onRemoveEntity?: (key: string) => void;
-  onAddEntity?: (ref: ContextRef) => void;
 }) {
-  const { elevatedSurfaceClassName } = useChatAppearance();
   const chips = useMemo(
     () =>
       entities
@@ -373,32 +173,8 @@ export function ContextBar({
   }
 
   return (
-    <div
-      data-chat-context-bar
-      className={cn([
-        "border-border shrink-0 rounded-t-xl border-t border-r border-l",
-        elevatedSurfaceClassName,
-        "mx-3",
-      ])}
-    >
-      <div className="flex items-start gap-1.5 px-2 py-2">
-        <div className="min-w-0 flex-1">
-          <ChipList chips={chips} onRemove={onRemoveEntity} />
-        </div>
-
-        {onAddEntity && (
-          <AddSessionButton
-            onAdd={(sessionId) => {
-              onAddEntity({
-                kind: "session",
-                key: `session:manual:${sessionId}`,
-                source: "manual",
-                sessionId,
-              });
-            }}
-          />
-        )}
-      </div>
+    <div data-chat-context-bar className={cn(["shrink-0 px-3 pb-1.5"])}>
+      <ChipList chips={chips} onRemove={onRemoveEntity} />
     </div>
   );
 }

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -19,7 +19,6 @@ export function ChatMessageInput({
   draftKey,
   onSendMessage,
   disabled: disabledProp,
-  hasContextBar,
   isStreaming,
   onStop,
   onDraftContentChange,
@@ -32,7 +31,6 @@ export function ChatMessageInput({
     contextRefs?: ContextRef[],
   ) => void;
   disabled?: boolean | { disabled: boolean; message?: string };
-  hasContextBar?: boolean;
   isStreaming?: boolean;
   onStop?: () => void;
   onDraftContentChange?: (hasDraftContent: boolean) => void;
@@ -69,7 +67,6 @@ export function ChatMessageInput({
   return (
     <Container
       elevatedSurfaceClassName={elevatedSurfaceClassName}
-      hasContextBar={hasContextBar}
       isFloating={isFloating}
       isRightPanel={isRightPanel}
     >
@@ -152,13 +149,11 @@ export function ChatMessageInput({
 function Container({
   children,
   elevatedSurfaceClassName,
-  hasContextBar,
   isFloating,
   isRightPanel,
 }: {
   children: React.ReactNode;
   elevatedSurfaceClassName: string;
-  hasContextBar?: boolean;
   isFloating: boolean;
   isRightPanel: boolean;
 }) {
@@ -179,7 +174,6 @@ function Container({
                 "dark:bg-card dark:text-card-foreground",
               ]
             : [elevatedSurfaceClassName, "flex-col rounded-xl"],
-          hasContextBar && !isFloating && "rounded-t-none border-t-0",
         ])}
       >
         {children}

--- a/apps/desktop/src/chat/components/toolbar-controls.test.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.test.tsx
@@ -15,14 +15,42 @@ vi.mock("@hypr/ui/components/ui/button", () => ({
 }));
 
 vi.mock("@hypr/ui/components/ui/dropdown-menu", () => ({
-  AppFloatingPanel: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
+  AppFloatingPanel: ({
+    children,
+    className,
+  }: {
+    children: ReactNode;
+    className?: string;
+  }) => (
+    <div className={className} data-testid="chat-history-panel">
+      {children}
+    </div>
   ),
   DropdownMenu: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
-  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
+  DropdownMenuContent: ({
+    avoidCollisions,
+    children,
+    className,
+    side,
+    sideOffset,
+  }: {
+    avoidCollisions?: boolean;
+    children: ReactNode;
+    className?: string;
+    side?: string;
+    sideOffset?: number;
+  }) => (
+    <div
+      className={className}
+      data-avoid-collisions={String(avoidCollisions)}
+      data-side={side}
+      data-side-offset={sideOffset}
+      data-testid="chat-history-menu"
+    >
+      {children}
+    </div>
   ),
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
     <>{children}</>
@@ -61,7 +89,7 @@ describe("ChatToolbarControls", () => {
     expect(historyButton.className).toContain("h-8");
     expect(historyButton.className).toContain("w-auto");
     expect(historyButton.className).toContain("gap-1.5");
-    expect(historyButton.className).toContain("hover:bg-primary-foreground/7");
+    expect(historyButton.className).toContain("hover:bg-primary-foreground/14");
     expect(screen.queryByText("Ask Anarlog AI anything")).toBeNull();
   });
 
@@ -85,8 +113,32 @@ describe("ChatToolbarControls", () => {
     expect(historyButton.className).toContain("w-auto");
     expect(historyButton.className).toContain("gap-1.5");
     expect(historyButton.className).toContain("text-muted-foreground");
+    expect(historyButton.className).toContain("hover:bg-muted/80");
     expect(historyButton.textContent).toBe("");
     expect(screen.queryByText("Ask Anarlog AI anything")).toBeNull();
+  });
+
+  it("keeps the history menu below the trigger and scrolls inside the panel", () => {
+    render(
+      <ChatToolbarControls
+        currentChatGroupId={undefined}
+        onNewChat={vi.fn()}
+        onOpenRightPanel={vi.fn()}
+        onSelectChat={vi.fn()}
+        surface="light"
+      />,
+    );
+
+    const menu = screen.getByTestId("chat-history-menu");
+    const panel = screen.getByTestId("chat-history-panel");
+
+    expect(menu.dataset.side).toBe("bottom");
+    expect(menu.dataset.sideOffset).toBe("4");
+    expect(menu.dataset.avoidCollisions).toBe("false");
+    expect(menu.className).toContain("w-72");
+    expect(menu.className).toContain("max-w-[calc(100vw-2rem)]");
+    expect(panel.className).toContain("max-h-80");
+    expect(panel.className).toContain("overflow-y-auto");
   });
 
   it("renders dark toolbar action buttons as circles without tooltips", () => {
@@ -107,11 +159,13 @@ describe("ChatToolbarControls", () => {
     });
 
     expect(newChatButton.className).toContain("rounded-full");
-    expect(newChatButton.className).toContain("hover:!bg-primary-foreground/7");
+    expect(newChatButton.className).toContain(
+      "hover:!bg-primary-foreground/14",
+    );
     expect(newChatButton.getAttribute("title")).toBeNull();
     expect(rightPanelButton.className).toContain("rounded-full");
     expect(rightPanelButton.className).toContain(
-      "hover:!bg-primary-foreground/7",
+      "hover:!bg-primary-foreground/14",
     );
     expect(rightPanelButton.getAttribute("title")).toBeNull();
     expect(screen.queryByRole("button", { name: "Close chat" })).toBeNull();
@@ -142,6 +196,7 @@ describe("ChatToolbarControls", () => {
 
     expect(actions?.className).toContain("gap-0");
     expect(actions?.className).not.toContain("gap-1");
+    expect(rightPanelButton.className).toContain("hover:!bg-muted/80");
     expect(onOpenRightPanel).toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
     expect(screen.queryByRole("button", { name: "Close chat" })).toBeNull();
@@ -178,10 +233,10 @@ describe("ChatToolbarControls", () => {
     expect(screen.queryByText("Ask Anarlog AI anything")).toBeNull();
     const floatButton = screen.getByRole("button", { name: "Float chat" });
     const closeButton = screen.getByRole("button", { name: "Close chat" });
-    expect(floatButton.className).not.toContain("bg-muted");
-    expect(floatButton.className).not.toContain("text-foreground");
+    expect(floatButton.className).toContain("hover:!bg-muted/80");
+    expect(floatButton.className).toContain("hover:!text-foreground");
     expect(floatButton.className).not.toContain("mr-1");
-    expect(closeButton.className).not.toContain("bg-muted");
+    expect(closeButton.className).toContain("hover:!bg-muted/80");
     expect(
       screen.queryByRole("button", { name: "Open in right panel" }),
     ).toBeNull();

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -61,7 +61,9 @@ export function ChatToolbarControls({
           icon={<Plus size={16} />}
           label="New chat"
           onClick={onNewChat}
-          className={isDark ? darkToolbarButtonClassName : undefined}
+          className={
+            isDark ? darkToolbarButtonClassName : lightToolbarButtonClassName
+          }
         />
         {isRightPanel ? (
           <>
@@ -69,13 +71,21 @@ export function ChatToolbarControls({
               icon={<PictureInPicture2 size={16} />}
               label="Float chat"
               onClick={onOpenFloating ?? (() => {})}
-              className={isDark ? darkToolbarButtonClassName : undefined}
+              className={
+                isDark
+                  ? darkToolbarButtonClassName
+                  : lightToolbarButtonClassName
+              }
             />
             <ChatActionButton
               icon={<X size={16} />}
               label="Close chat"
               onClick={onClose ?? (() => {})}
-              className={isDark ? darkToolbarButtonClassName : undefined}
+              className={
+                isDark
+                  ? darkToolbarButtonClassName
+                  : lightToolbarButtonClassName
+              }
             />
           </>
         ) : (
@@ -84,7 +94,11 @@ export function ChatToolbarControls({
               icon={<PanelRight size={16} />}
               label="Open in right panel"
               onClick={onOpenRightPanel ?? (() => {})}
-              className={isDark ? darkToolbarButtonClassName : undefined}
+              className={
+                isDark
+                  ? darkToolbarButtonClassName
+                  : lightToolbarButtonClassName
+              }
             />
           </>
         )}
@@ -94,7 +108,10 @@ export function ChatToolbarControls({
 }
 
 const darkToolbarButtonClassName =
-  "size-8 bg-transparent text-primary-foreground/60 hover:!bg-primary-foreground/7 hover:!text-primary-foreground focus-visible:!bg-primary-foreground/7 focus-visible:!text-primary-foreground active:!bg-primary-foreground/10";
+  "size-8 bg-transparent text-primary-foreground/60 hover:!bg-primary-foreground/14 hover:!text-primary-foreground focus-visible:!bg-primary-foreground/14 focus-visible:!text-primary-foreground active:!bg-primary-foreground/18";
+
+const lightToolbarButtonClassName =
+  "size-8 bg-transparent text-muted-foreground hover:!bg-muted/80 hover:!text-foreground focus-visible:!bg-muted/80 focus-visible:!text-foreground active:!bg-muted";
 
 function ChatActionButton({
   className,
@@ -149,10 +166,10 @@ function ChatGroups({
           variant="ghost"
           size="sm"
           className={cn([
-            "group -ml-2 h-8 w-auto shrink-0 gap-1.5 rounded-full px-2.5 py-0",
+            "group -ml-2 h-8 w-auto shrink-0 gap-1.5 rounded-full px-2.5 py-0 transition-colors",
             isDark
-              ? "text-primary-foreground/70 hover:bg-primary-foreground/7 hover:text-primary-foreground data-[state=open]:bg-primary-foreground/7"
-              : "text-muted-foreground hover:bg-accent hover:text-foreground data-[state=open]:bg-accent",
+              ? "text-primary-foreground/70 hover:bg-primary-foreground/14 hover:text-primary-foreground data-[state=open]:bg-primary-foreground/14 data-[state=open]:text-primary-foreground"
+              : "text-muted-foreground hover:bg-muted/80 hover:text-foreground data-[state=open]:bg-muted/80 data-[state=open]:text-foreground",
           ])}
         >
           <History
@@ -173,10 +190,12 @@ function ChatGroups({
       <DropdownMenuContent
         variant="app"
         align="start"
-        sideOffset={0}
-        className="w-72"
+        side="bottom"
+        sideOffset={4}
+        avoidCollisions={false}
+        className="w-72 max-w-[calc(100vw-2rem)]"
       >
-        <AppFloatingPanel className="flex flex-col gap-0.5 p-1.5">
+        <AppFloatingPanel className="max-h-80 overflow-y-auto p-1.5">
           <div className="px-2 py-1.5">
             <h4 className="text-muted-foreground text-[10px] font-semibold tracking-wider uppercase">
               Recent Chats


### PR DESCRIPTION
Remove the context add button and render context chips as a standalone strip above the chat input.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop chat UI and styling only; context can still be added via drag-drop and other existing paths in `ChatContent`. No auth or data-layer changes.
> 
> **Overview**
> Reworks chat context so **session/context entities appear as a centered chip strip above the input**, not as part of a bordered bar attached to the composer.
> 
> **Context bar:** Removes the **add session** control and the entire session search/recent picker (TinyBase + search engine). Chips are restyled as bordered squircles with hover-to-remove on manual entries, click-to-open for sessions/people/orgs, and a **4-chip collapse** with a `+N more` / collapse control instead of resize-based overflow. The bar is a lightweight `px-3 pb-1.5` strip with no elevated panel or shared top border with the input.
> 
> **Composer layout:** Drops `hasContextBar` / `onAddContextEntity` wiring from `ChatContent` → `ContextBar` / `ChatMessageInput`, so the input keeps a full `rounded-xl` surface instead of `rounded-t-none` when context is present.
> 
> **Related UI polish:** Empty-state suggestion rows use a grid icon + label layout and updated hover colors; toolbar buttons and chat history dropdown get stronger hover states, fixed bottom placement, and a scrollable history panel. Tests are updated to match the new chip and toolbar behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cabf49b10ff8b79894a1cf07936595c9ed3a63ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5703
- <kbd>&nbsp;1&nbsp;</kbd> #5696 👈 
<!-- GitButler Footer Boundary Bottom -->