### PR TITLE
Remove speaker selector footer padding

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -531,7 +531,7 @@ function ParticipantList({
           )}
         </div>
       </AppFloatingPanel>
-      <div className="flex items-center gap-3 px-2 pt-1 pb-3">
+      <div className="flex items-center gap-3 pt-1 pb-3 pl-2">
         <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-2">
           <Checkbox
             checked={applyToAllMatching}


### PR DESCRIPTION
Remove horizontal padding from the speaker selector footer controls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on layout only; no logic or data paths affected.
> 
> **Overview**
> Adjusts the **speaker assign** popover footer (the row with “Apply to all” and **Confirm**) so it no longer uses symmetric horizontal padding.
> 
> The footer container class changes from `px-2` to `pl-2`, dropping right padding while keeping a small left inset for the checkbox row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52dcab5d2e78e413921386f51f3517de0fb464a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->