### PR TITLE
Fix transcript tab context menu

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -8,7 +8,6 @@ import {
 } from "lucide-react";
 import { type ReactNode, useCallback, useRef } from "react";
 
-import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { Button } from "@hypr/ui/components/ui/button";
 import { Spinner } from "@hypr/ui/components/ui/spinner";
 import {
@@ -19,9 +18,9 @@ import {
 import { cn } from "@hypr/utils";
 
 import * as AudioPlayer from "~/audio-player";
-import { getEnhancerService } from "~/services/enhancer";
 import type { PastSessionNote } from "~/session/components/bottom-accessory/past-notes";
 import { Transcript } from "~/session/components/note-input/transcript";
+import { useRegenerateTranscript } from "~/session/components/note-input/transcript/actions";
 import {
   formatTranscriptExportSegments,
   useTranscriptExportSegments,
@@ -29,7 +28,6 @@ import {
 import { useTranscriptScreen } from "~/session/components/note-input/transcript/state";
 import { showTransientToast } from "~/sidebar/toast/transient";
 import { useListener } from "~/stt/contexts";
-import { isStoppedTranscriptionError, useRunBatch } from "~/stt/useRunBatch";
 
 export type PostSessionTab = "transcript" | "insights";
 
@@ -359,36 +357,6 @@ function TranscriptPanel({
       fillHeight={fillHeight}
     />
   );
-}
-
-function useRegenerateTranscript(sessionId: string) {
-  const runBatch = useRunBatch(sessionId);
-  const handleBatchFailed = useListener((state) => state.handleBatchFailed);
-
-  return useCallback(async () => {
-    const result = await fsSyncCommands.audioPath(sessionId);
-    if (result.status === "error") {
-      showTransientToast({
-        id: `transcript-regenerate-audio-missing-${sessionId}`,
-        description: "Recording not found. It may have been deleted.",
-        variant: "error",
-      });
-      return;
-    }
-
-    const audioPath = result.data;
-
-    try {
-      await runBatch(audioPath);
-      getEnhancerService()?.queueAutoEnhanceIfSummaryEmpty(sessionId);
-    } catch (error) {
-      if (isStoppedTranscriptionError(error)) {
-        return;
-      }
-      const msg = error instanceof Error ? error.message : String(error);
-      handleBatchFailed(sessionId, msg);
-    }
-  }, [handleBatchFailed, runBatch, sessionId]);
 }
 
 function BatchingTranscriptPanel({

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -3,10 +3,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EditorView } from "~/store/zustand/tabs/schema";
 
+type CapturedMenuItem =
+  | {
+      id: string;
+      text: string;
+      action: () => void;
+      disabled?: boolean;
+    }
+  | { separator: true };
+
 const hoisted = vi.hoisted(() => ({
   enhance: vi.fn(),
+  regenerateTranscript: vi.fn(),
+  deleteRecording: vi.fn(),
   activeTemplateTitle: "Customer Call",
+  audioExists: true,
+  isDeletingRecording: false,
+  transcriptExportRequest: {},
+  transcriptSegments: [{ speaker: "Speaker 1", text: "Hello transcript" }],
   isGenerating: false,
+  nativeContextMenus: [] as CapturedMenuItem[][],
   userTemplates: [] as Array<{
     id: string;
     title: string;
@@ -31,6 +47,14 @@ vi.mock("@hypr/ui/components/ui/spinner", () => ({
   Spinner: () => <span data-testid="tab-spinner" />,
 }));
 
+vi.mock("~/audio-player", () => ({
+  useAudioPlayer: () => ({
+    audioExists: hoisted.audioExists,
+    deleteRecording: hoisted.deleteRecording,
+    isDeletingRecording: hoisted.isDeletingRecording,
+  }),
+}));
+
 vi.mock("~/ai/hooks", () => ({
   useAITaskTask: () => ({
     isIdle: true,
@@ -52,8 +76,36 @@ vi.mock("~/services/enhancer", () => ({
   getEnhancerService: () => ({ enhance: hoisted.enhance }),
 }));
 
+vi.mock("~/session/components/note-input/transcript/actions", () => ({
+  useRegenerateTranscript: () => hoisted.regenerateTranscript,
+}));
+
+vi.mock("~/session/components/note-input/transcript/export-data", () => ({
+  buildTranscriptExportSegments: () =>
+    Promise.resolve(hoisted.transcriptSegments),
+  formatTranscriptExportSegments: (
+    segments: Array<{ speaker: string | null; text: string }>,
+  ) =>
+    segments
+      .map((segment) => `${segment.speaker ?? "Speaker"}: ${segment.text}`)
+      .join("\n\n"),
+}));
+
+vi.mock(
+  "~/session/components/note-input/transcript/render-request-hooks",
+  () => ({
+    useSessionTranscriptRenderData: () => ({
+      request: hoisted.transcriptExportRequest,
+      transcriptRows: [],
+    }),
+  }),
+);
+
 vi.mock("~/shared/hooks/useNativeContextMenu", () => ({
-  useNativeContextMenu: () => vi.fn(),
+  useNativeContextMenu: (items: CapturedMenuItem[]) => {
+    hoisted.nativeContextMenus.push(items);
+    return vi.fn();
+  },
 }));
 
 vi.mock("~/shared/ui/resource-list", () => ({
@@ -118,8 +170,17 @@ import { Header } from "./header";
 describe("Header", () => {
   beforeEach(() => {
     hoisted.enhance.mockReset();
+    hoisted.regenerateTranscript.mockReset();
+    hoisted.deleteRecording.mockReset();
     hoisted.activeTemplateTitle = "Customer Call";
+    hoisted.audioExists = true;
+    hoisted.isDeletingRecording = false;
+    hoisted.transcriptExportRequest = {};
+    hoisted.transcriptSegments = [
+      { speaker: "Speaker 1", text: "Hello transcript" },
+    ];
     hoisted.isGenerating = false;
+    hoisted.nativeContextMenus = [];
     hoisted.userTemplates = [];
   });
 
@@ -243,6 +304,60 @@ describe("Header", () => {
     });
   });
 
+  it("adds recording actions to the transcript tab context menu", () => {
+    const editorTabs: EditorView[] = [
+      { type: "enhanced", id: "note-1" },
+      { type: "raw" },
+      { type: "transcript" },
+    ];
+
+    render(
+      <Header
+        sessionId="session-1"
+        editorTabs={editorTabs}
+        currentTab={{ type: "transcript" }}
+        handleTabChange={vi.fn()}
+      />,
+    );
+
+    const menu = findContextMenu("copy-transcript-session-1");
+
+    expect(
+      menu.map((item) => ("text" in item ? item.text : "separator")),
+    ).toEqual(["Copy", "Regenerate", "Delete recording"]);
+    expect(menu.find(isMenuItem)?.disabled).toBe(false);
+    expect(
+      menu.find(
+        (item): item is Extract<CapturedMenuItem, { id: string }> =>
+          "id" in item && item.id === "delete-recording-session-1",
+      )?.disabled,
+    ).toBe(false);
+  });
+
+  it("omits transcript recording actions when recording is missing", () => {
+    hoisted.audioExists = false;
+    const editorTabs: EditorView[] = [
+      { type: "enhanced", id: "note-1" },
+      { type: "raw" },
+      { type: "transcript" },
+    ];
+
+    render(
+      <Header
+        sessionId="session-1"
+        editorTabs={editorTabs}
+        currentTab={{ type: "transcript" }}
+        handleTabChange={vi.fn()}
+      />,
+    );
+
+    const menu = findContextMenu("copy-transcript-session-1");
+
+    expect(
+      menu.map((item) => ("text" in item ? item.text : "separator")),
+    ).toEqual(["Copy"]);
+  });
+
   it("replaces the current enhanced note when changing templates", () => {
     hoisted.userTemplates = [
       {
@@ -308,3 +423,19 @@ describe("Header", () => {
     ).toBe("Customer Call");
   });
 });
+
+function findContextMenu(id: string) {
+  const menu = hoisted.nativeContextMenus.find((items) =>
+    items.some((item) => "id" in item && item.id === id),
+  );
+  if (!menu) {
+    throw new Error(`Context menu not found: ${id}`);
+  }
+  return menu;
+}
+
+function isMenuItem(
+  item: CapturedMenuItem,
+): item is Extract<CapturedMenuItem, { id: string }> {
+  return "id" in item;
+}

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -25,7 +25,14 @@ import { cn } from "@hypr/utils";
 
 import { useAITaskTask } from "~/ai/hooks";
 import { useLanguageModel, useLLMConnectionStatus } from "~/ai/hooks";
+import * as AudioPlayer from "~/audio-player";
 import { getEnhancerService } from "~/services/enhancer";
+import { useRegenerateTranscript } from "~/session/components/note-input/transcript/actions";
+import {
+  buildTranscriptExportSegments,
+  formatTranscriptExportSegments,
+} from "~/session/components/note-input/transcript/export-data";
+import { useSessionTranscriptRenderData } from "~/session/components/note-input/transcript/render-request-hooks";
 import { useHasTranscript } from "~/session/components/shared";
 import { shouldShowEmptySummaryConfigError } from "~/session/enhance-config";
 import { useEnsureDefaultSummary } from "~/session/hooks/useEnhancedNotes";
@@ -106,7 +113,7 @@ function IconHeaderTab({
 
 function iconHeaderTabClassName(isActive: boolean, className?: string) {
   return cn([
-    "flex shrink-0 items-center justify-center rounded-full transition-colors [&>svg]:shrink-0",
+    "flex shrink-0 items-center justify-center rounded-full transition-colors select-none [&>svg]:shrink-0",
     isActive
       ? ["bg-foreground/10 text-foreground -my-px h-[30px]"]
       : [
@@ -428,16 +435,91 @@ function HeaderTabEnhanced({
 function HeaderTabTranscript({
   isActive,
   onClick = () => {},
+  sessionId,
 }: {
   isActive: boolean;
   onClick?: () => void;
+  sessionId: string;
 }) {
+  const regenerate = useRegenerateTranscript(sessionId);
+  const { request: transcriptExportRequest } =
+    useSessionTranscriptRenderData(sessionId);
+  const { audioExists, deleteRecording, isDeletingRecording } =
+    AudioPlayer.useAudioPlayer();
+  const canCopyTranscript = Boolean(transcriptExportRequest);
+  const handleCopyTranscript = useCallback(async () => {
+    if (!transcriptExportRequest) {
+      return;
+    }
+
+    try {
+      const transcriptSegments = await buildTranscriptExportSegments(
+        transcriptExportRequest,
+      );
+      const transcriptText = formatTranscriptExportSegments(transcriptSegments);
+      if (!transcriptText) {
+        return;
+      }
+
+      await copyTextToClipboard(transcriptText, {
+        success: "Transcript copied to clipboard",
+        error: "Failed to copy transcript",
+      });
+    } catch (error) {
+      console.error("Failed to copy transcript", error);
+      sonnerToast.error("Failed to copy transcript");
+    }
+  }, [transcriptExportRequest]);
+  const handleDeleteRecording = useCallback(() => {
+    void deleteRecording();
+  }, [deleteRecording]);
+  const contextMenu = useMemo<MenuItemDef[]>(() => {
+    const items: MenuItemDef[] = [
+      {
+        id: `copy-transcript-${sessionId}`,
+        text: "Copy",
+        action: () => {
+          void handleCopyTranscript();
+        },
+        disabled: !canCopyTranscript,
+      },
+    ];
+
+    if (audioExists) {
+      items.push({
+        id: `regenerate-transcript-${sessionId}`,
+        text: "Regenerate",
+        action: () => {
+          void regenerate();
+        },
+      });
+      items.push({
+        id: `delete-recording-${sessionId}`,
+        text: "Delete recording",
+        action: handleDeleteRecording,
+        disabled: isDeletingRecording,
+      });
+    }
+
+    return items;
+  }, [
+    audioExists,
+    canCopyTranscript,
+    handleCopyTranscript,
+    handleDeleteRecording,
+    isDeletingRecording,
+    regenerate,
+    sessionId,
+  ]);
+  const showContextMenu = useNativeContextMenu(contextMenu);
+
   return (
     <IconHeaderTab
       isActive={isActive}
       label="Transcript"
       icon={<AudioLinesIcon className="size-4" />}
       onClick={onClick}
+      onContextMenu={showContextMenu}
     />
   );
 }
@@ -943,6 +1025,7 @@ export function Header({
                 return (
                   <HeaderTabTranscript
                     key={view.type}
+                    sessionId={sessionId}
                     isActive={currentTab.type === view.type}
                     onClick={() => handleTabChange(view)}
                   />

--- a/apps/desktop/src/session/components/note-input/transcript/actions.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/actions.ts
@@ -1,0 +1,38 @@
+import { useCallback } from "react";
+
+import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
+
+import { getEnhancerService } from "~/services/enhancer";
+import { showTransientToast } from "~/sidebar/toast/transient";
+import { useListener } from "~/stt/contexts";
+import { isStoppedTranscriptionError, useRunBatch } from "~/stt/useRunBatch";
+
+export function useRegenerateTranscript(sessionId: string) {
+  const runBatch = useRunBatch(sessionId);
+  const handleBatchFailed = useListener((state) => state.handleBatchFailed);
+
+  return useCallback(async () => {
+    const result = await fsSyncCommands.audioPath(sessionId);
+    if (result.status === "error") {
+      showTransientToast({
+        id: `transcript-regenerate-audio-missing-${sessionId}`,
+        description: "Recording not found. It may have been deleted.",
+        variant: "error",
+      });
+      return;
+    }
+
+    const audioPath = result.data;
+
+    try {
+      await runBatch(audioPath);
+      getEnhancerService()?.queueAutoEnhanceIfSummaryEmpty(sessionId);
+    } catch (error) {
+      if (isStoppedTranscriptionError(error)) {
+        return;
+      }
+      const msg = error instanceof Error ? error.message : String(error);
+      handleBatchFailed(sessionId, msg);
+    }
+  }, [handleBatchFailed, runBatch, sessionId]);
+}


### PR DESCRIPTION
Add a native Transcript tab menu with Copy plus recording-gated Regenerate and Delete recording actions.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5692
- <kbd>&nbsp;2&nbsp;</kbd> #5699
- <kbd>&nbsp;1&nbsp;</kbd> #5698 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop UI and a small hook extraction; delete/regenerate reuse existing audio-player and STT paths already used in the post-session transcript panel.
> 
> **Overview**
> Adds a **native context menu** on the session **Transcript** header tab (right-click), aligned with memo/summary tabs: **Copy** (built from transcript export data), plus **Regenerate** and **Delete recording** when a recording still exists. Copy is disabled when export data isn’t available; delete is disabled while a delete is in progress.
> 
> **`useRegenerateTranscript`** is moved out of `post-session.tsx` into `transcript/actions.ts` so the post-session panel and header tab share the same batch-transcription + auto-enhance behavior. Header tab styling picks up `select-none` on icon tabs.
> 
> Tests assert the transcript menu shows all three actions with audio, and only **Copy** when `audioExists` is false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 367348d9a0359b6bca76621ea07cf52c08576231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->