### PR TITLE
Fix transcript bottom clearance

### DIFF
--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -193,9 +193,10 @@ export const NoteInput = forwardRef<
             onScroll={onScroll}
             className={cn([
               "h-full px-3",
-              "scroll-fade-y overflow-auto",
               "pt-2",
-              "pb-6",
+              currentTab.type === "transcript"
+                ? "overflow-hidden pb-0"
+                : "scroll-fade-y overflow-auto pb-6",
             ])}
           >
             {currentTab.type === "enhanced" && (

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -100,7 +100,9 @@ export function TranscriptViewer({
         data-transcript-container
         className={cn([
           "flex h-full flex-col gap-8 overflow-x-hidden overflow-y-auto",
-          "scrollbar-hide scroll-pb-32 pb-16",
+          "scrollbar-hide",
+          "scroll-pb-[calc(8rem+env(safe-area-inset-bottom))]",
+          "pb-[calc(4rem+env(safe-area-inset-bottom))]",
         ])}
       >
         {transcriptIds.map((transcriptId, index) => (


### PR DESCRIPTION
Remove the outer fade scroller from the transcript tab and keep bottom safe-area padding on the transcript scroller.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized layout/CSS changes for the transcript tab with no auth, data, or business-logic impact.
> 
> **Overview**
> Fixes transcript content being clipped or sitting under the bottom chrome by **splitting scroll behavior by tab** and **padding the inner transcript scroller for safe areas**.
> 
> On the **transcript** tab, the outer `NoteInput` wrapper no longer uses `scroll-fade-y` / `overflow-auto`; it is `overflow-hidden` with no bottom padding so only the transcript viewer scrolls. **Enhanced/raw** tabs keep the previous fade scroller and `pb-6`.
> 
> The transcript container’s bottom spacing now uses `calc(... + env(safe-area-inset-bottom))` for scroll padding and content padding instead of fixed `scroll-pb-32` / `pb-16`, so the last lines clear the home indicator and related UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f85a4a7c893c5cb6f25e4d080df6a2f32971cdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->