### PR TITLE
Match note header side padding

### DIFF
--- a/apps/desktop/src/session/components/session-surface.tsx
+++ b/apps/desktop/src/session/components/session-surface.tsx
@@ -33,7 +33,7 @@ export function SessionSurface({
     >
       <div data-session-surface className="flex h-full flex-col">
         {header ? (
-          <div data-tauri-drag-region className="pr-1 pl-3">
+          <div data-tauri-drag-region className="px-1">
             {header}
           </div>
         ) : null}


### PR DESCRIPTION
Reduce the note view header left padding to match the right inset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic padding tweak on the desktop session header wrapper only; no logic or data changes.
> 
> **Overview**
> Updates **`SessionSurface`** so the drag-region wrapper around the session header uses **`px-1`** instead of **`pr-1 pl-3`**, giving equal left and right inset for note views (e.g. **`OuterHeader`** / **`NoteInputHeader`**).
> 
> No behavior or layout changes beyond that header gutter alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97f9a381f3aae350ce6ead92371bf629ffee3524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->