### PR TITLE
Add note header left padding

### DIFF
--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -962,7 +962,7 @@ export function Header({
   )?.id;
 
   return (
-    <div data-tauri-drag-region className="flex flex-col">
+    <div data-tauri-drag-region className="flex flex-col pl-1">
       <div
         data-tauri-drag-region
         className="flex items-center justify-between gap-2"


### PR DESCRIPTION
Adds a small left inset to the session note header so the tab control has more breathing room.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class on layout chrome; no logic, data, or security impact.
> 
> **Overview**
> Adds **`pl-1`** to the outer session note header container in `header.tsx` so the rounded tab strip (Memos / Summary / Transcript) sits slightly inset from the left edge of the drag region.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a107b541e0bb087030fd571f81e24eff41482c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->