### PR TITLE
Add chat follow-up queue

### DIFF
--- a/apps/desktop/src/chat/components/body/index.test.tsx
+++ b/apps/desktop/src/chat/components/body/index.test.tsx
@@ -55,8 +55,10 @@ describe("ChatBody", () => {
 
     expect(content?.className).toContain("px-3");
     expect(content?.className).not.toContain("min-h-full");
-    expect(scrollArea?.className).toContain("max-h-[min(16rem,35vh)]");
-    expect(root?.className).toContain("shrink-0");
+    expect(scrollArea?.className).toContain("max-h-[min(36rem,70vh)]");
+    expect(scrollArea?.className).toContain("flex-auto");
+    expect(root?.className).toContain("flex-auto");
+    expect(root?.className).not.toContain("shrink-0");
     expect(content?.className).not.toContain("px-2");
     expect(content?.className).not.toContain("pr-0");
   });

--- a/apps/desktop/src/chat/components/body/index.tsx
+++ b/apps/desktop/src/chat/components/body/index.tsx
@@ -51,7 +51,7 @@ export function ChatBody({
     <div
       className={cn([
         "relative flex min-h-0 flex-col",
-        isRightPanel ? "flex-1" : "shrink-0",
+        isRightPanel ? "flex-1" : "flex-auto",
       ])}
     >
       <div
@@ -60,7 +60,7 @@ export function ChatBody({
         onWheel={handleWheel}
         className={cn([
           "flex min-h-0 flex-col overflow-y-auto",
-          isRightPanel ? "flex-1" : "max-h-[min(16rem,35vh)] shrink-0",
+          isRightPanel ? "flex-1" : "max-h-[min(36rem,70vh)] flex-auto",
         ])}
       >
         <div

--- a/apps/desktop/src/chat/components/content.test.tsx
+++ b/apps/desktop/src/chat/components/content.test.tsx
@@ -83,11 +83,12 @@ describe("ChatContent", () => {
     cleanup();
   });
 
-  it("uses shrink-wrapped layout by default for floating chat", () => {
+  it("lets floating chat body shrink before the composer is clipped", () => {
     const container = renderContent();
 
-    expect(container?.className).toContain("shrink-0");
+    expect(container?.className).toContain("max-h-full");
     expect(container?.className).not.toContain("flex-1");
+    expect(container?.className).not.toContain("shrink-0");
   });
 
   it("fills available height in the right panel layout", () => {

--- a/apps/desktop/src/chat/components/content.test.tsx
+++ b/apps/desktop/src/chat/components/content.test.tsx
@@ -1,5 +1,11 @@
-import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ChatContent } from "./content";
 
@@ -12,7 +18,26 @@ vi.mock("./context-bar", () => ({
 }));
 
 vi.mock("./input", () => ({
-  ChatMessageInput: () => <div data-testid="chat-input" />,
+  ChatMessageInput: ({
+    onSendMessage,
+  }: {
+    onSendMessage: (
+      content: string,
+      parts: Array<{ type: "text"; text: string }>,
+    ) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="chat-input"
+      onClick={() =>
+        onSendMessage("Queued follow-up", [
+          { type: "text", text: "Queued follow-up" },
+        ])
+      }
+    >
+      Mock input
+    </button>
+  ),
 }));
 
 class FakeDataTransfer {
@@ -54,6 +79,10 @@ const renderContent = (onAddContextEntity = vi.fn()) => {
 };
 
 describe("ChatContent", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
   it("uses shrink-wrapped layout by default for floating chat", () => {
     const container = renderContent();
 
@@ -117,5 +146,170 @@ describe("ChatContent", () => {
     fireEvent.drop(container!, { dataTransfer });
 
     expect(onAddContextEntity).not.toHaveBeenCalled();
+  });
+
+  it("queues messages submitted while streaming", () => {
+    const handleSendMessage = vi.fn();
+    const sendMessage = vi.fn();
+
+    render(
+      <ChatContent
+        sessionId="active-session"
+        messages={[]}
+        sendMessage={sendMessage}
+        regenerate={vi.fn()}
+        stop={vi.fn()}
+        status="streaming"
+        model={{} as never}
+        handleSendMessage={handleSendMessage}
+        contextEntities={[]}
+        pendingRefs={[]}
+        isSystemPromptReady
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("chat-input"));
+
+    expect(screen.getByText("Queued follow-up")).toBeTruthy();
+    expect(handleSendMessage).not.toHaveBeenCalled();
+  });
+
+  it("removes queued messages before they are sent", () => {
+    const handleSendMessage = vi.fn();
+    const { rerender } = render(
+      <ChatContent
+        sessionId="active-session"
+        messages={[]}
+        sendMessage={vi.fn()}
+        regenerate={vi.fn()}
+        stop={vi.fn()}
+        status="streaming"
+        model={{} as never}
+        handleSendMessage={handleSendMessage}
+        contextEntities={[]}
+        pendingRefs={[]}
+        isSystemPromptReady
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("chat-input"));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Remove queued message: Queued follow-up",
+      }),
+    );
+
+    expect(screen.queryByText("Queued follow-up")).toBeNull();
+
+    rerender(
+      <ChatContent
+        sessionId="active-session"
+        messages={[]}
+        sendMessage={vi.fn()}
+        regenerate={vi.fn()}
+        stop={vi.fn()}
+        status="ready"
+        model={{} as never}
+        handleSendMessage={handleSendMessage}
+        contextEntities={[]}
+        pendingRefs={[]}
+        isSystemPromptReady
+      />,
+    );
+
+    expect(handleSendMessage).not.toHaveBeenCalled();
+  });
+
+  it("sends the next queued message when the chat becomes ready", async () => {
+    const handleSendMessage = vi.fn();
+    const sendMessage = vi.fn();
+    const { rerender } = render(
+      <ChatContent
+        sessionId="active-session"
+        messages={[]}
+        sendMessage={sendMessage}
+        regenerate={vi.fn()}
+        stop={vi.fn()}
+        status="streaming"
+        model={{} as never}
+        handleSendMessage={handleSendMessage}
+        contextEntities={[]}
+        pendingRefs={[
+          { kind: "session", key: "session:auto", sessionId: "s1" },
+        ]}
+        isSystemPromptReady
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("chat-input"));
+
+    rerender(
+      <ChatContent
+        sessionId="active-session"
+        messages={[]}
+        sendMessage={sendMessage}
+        regenerate={vi.fn()}
+        stop={vi.fn()}
+        status="ready"
+        model={{} as never}
+        handleSendMessage={handleSendMessage}
+        contextEntities={[]}
+        pendingRefs={[]}
+        isSystemPromptReady
+      />,
+    );
+
+    await waitFor(() => {
+      expect(handleSendMessage).toHaveBeenCalledWith(
+        "Queued follow-up",
+        [{ type: "text", text: "Queued follow-up" }],
+        sendMessage,
+        [{ kind: "session", key: "session:auto", sessionId: "s1" }],
+      );
+    });
+  });
+
+  it("continues dequeueing if a send does not enter a busy state", async () => {
+    const handleSendMessage = vi.fn();
+    const sendMessage = vi.fn();
+    const { rerender } = render(
+      <ChatContent
+        sessionId="active-session"
+        messages={[]}
+        sendMessage={sendMessage}
+        regenerate={vi.fn()}
+        stop={vi.fn()}
+        status="streaming"
+        model={{} as never}
+        handleSendMessage={handleSendMessage}
+        contextEntities={[]}
+        pendingRefs={[]}
+        isSystemPromptReady
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("chat-input"));
+    fireEvent.click(screen.getByTestId("chat-input"));
+
+    rerender(
+      <ChatContent
+        sessionId="active-session"
+        messages={[]}
+        sendMessage={sendMessage}
+        regenerate={vi.fn()}
+        stop={vi.fn()}
+        status="ready"
+        model={{} as never}
+        handleSendMessage={handleSendMessage}
+        contextEntities={[]}
+        pendingRefs={[]}
+        isSystemPromptReady
+      />,
+    );
+
+    await waitFor(() => {
+      expect(handleSendMessage).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.queryByText("Queued follow-up")).toBeNull();
   });
 });

--- a/apps/desktop/src/chat/components/content.tsx
+++ b/apps/desktop/src/chat/components/content.tsx
@@ -1,4 +1,6 @@
 import type { ChatStatus } from "ai";
+import { CornerDownRightIcon, Trash2Icon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { ChatBody } from "./body";
 import { ContextBar } from "./context-bar";
@@ -12,6 +14,14 @@ import {
 } from "~/chat/context/session-drag";
 import type { DisplayEntity } from "~/chat/context/use-chat-context-pipeline";
 import type { HyprUIMessage } from "~/chat/types";
+import { id } from "~/shared/utils";
+
+type QueuedChatMessage = {
+  id: string;
+  content: string;
+  parts: HyprUIMessage["parts"];
+  contextRefs: ContextRef[];
+};
 
 export function ChatContent({
   layout = "floating",
@@ -60,8 +70,112 @@ export function ChatContent({
   const isModelConfigured = !!model;
   const isFloating = layout === "floating";
   const disabled = !isSystemPromptReady;
-  const mergeContextRefs = (contextRefs?: ContextRef[]) =>
-    contextRefs ? dedupeByKey([pendingRefs, contextRefs]) : pendingRefs;
+  const isBusy = status === "submitted" || status === "streaming";
+  const [queueState, setQueueState] = useState<{
+    sessionId: string;
+    messages: QueuedChatMessage[];
+  }>(() => ({ sessionId, messages: [] }));
+  const dequeueInFlightRef = useRef(false);
+  const queuedMessages =
+    queueState.sessionId === sessionId ? queueState.messages : [];
+  const mergeContextRefs = useCallback(
+    (contextRefs?: ContextRef[]) =>
+      contextRefs ? dedupeByKey([pendingRefs, contextRefs]) : pendingRefs,
+    [pendingRefs],
+  );
+  const setQueuedMessages = useCallback(
+    (
+      next:
+        | QueuedChatMessage[]
+        | ((messages: QueuedChatMessage[]) => QueuedChatMessage[]),
+    ) => {
+      setQueueState((prev) => {
+        const currentMessages =
+          prev.sessionId === sessionId ? prev.messages : [];
+        return {
+          sessionId,
+          messages: typeof next === "function" ? next(currentMessages) : next,
+        };
+      });
+    },
+    [sessionId],
+  );
+  const submitOrQueueMessage = useCallback(
+    (
+      content: string,
+      parts: HyprUIMessage["parts"],
+      contextRefs?: ContextRef[],
+    ) => {
+      const mergedContextRefs = mergeContextRefs(contextRefs);
+
+      if (isBusy) {
+        setQueuedMessages((messages) => [
+          ...messages,
+          {
+            id: id(),
+            content,
+            parts,
+            contextRefs: mergedContextRefs,
+          },
+        ]);
+        return;
+      }
+
+      handleSendMessage(content, parts, sendMessage, mergedContextRefs);
+    },
+    [
+      handleSendMessage,
+      isBusy,
+      mergeContextRefs,
+      sendMessage,
+      setQueuedMessages,
+    ],
+  );
+  const removeQueuedMessage = useCallback(
+    (queuedMessageId: string) => {
+      setQueuedMessages((messages) =>
+        messages.filter((message) => message.id !== queuedMessageId),
+      );
+    },
+    [setQueuedMessages],
+  );
+
+  useEffect(() => {
+    if (isBusy) {
+      dequeueInFlightRef.current = false;
+      return;
+    }
+
+    if (
+      status !== "ready" ||
+      queuedMessages.length === 0 ||
+      dequeueInFlightRef.current
+    ) {
+      return;
+    }
+
+    const [nextMessage] = queuedMessages;
+    dequeueInFlightRef.current = true;
+    setQueuedMessages((messages) => messages.slice(1));
+    try {
+      handleSendMessage(
+        nextMessage.content,
+        nextMessage.parts,
+        sendMessage,
+        nextMessage.contextRefs,
+      );
+    } finally {
+      dequeueInFlightRef.current = false;
+    }
+  }, [
+    handleSendMessage,
+    isBusy,
+    queuedMessages,
+    sendMessage,
+    setQueuedMessages,
+    status,
+  ]);
+
   const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
     if (!onAddContextEntity || !hasSessionContextDragData(event.dataTransfer)) {
       return;
@@ -104,14 +218,7 @@ export function ChatContent({
           error={error}
           onReload={regenerate}
           isModelConfigured={isModelConfigured}
-          onSendMessage={(content, parts, contextRefs) => {
-            handleSendMessage(
-              content,
-              parts,
-              sendMessage,
-              mergeContextRefs(contextRefs),
-            );
-          }}
+          onSendMessage={submitOrQueueMessage}
         />
       )}
       {isModelConfigured && (
@@ -120,17 +227,14 @@ export function ChatContent({
             entities={contextEntities}
             onRemoveEntity={onRemoveContextEntity}
           />
+          <ChatQueue
+            messages={queuedMessages}
+            onRemoveMessage={removeQueuedMessage}
+          />
           <ChatMessageInput
             draftKey={sessionId}
             disabled={disabled}
-            onSendMessage={(content, parts, contextRefs) => {
-              handleSendMessage(
-                content,
-                parts,
-                sendMessage,
-                mergeContextRefs(contextRefs),
-              );
-            }}
+            onSendMessage={submitOrQueueMessage}
             onDraftContentChange={onDraftContentChange}
             onContextRefsChange={onDraftContextRefsChange}
             isStreaming={status === "streaming" || status === "submitted"}
@@ -138,6 +242,43 @@ export function ChatContent({
           />
         </>
       )}
+    </div>
+  );
+}
+
+function ChatQueue({
+  messages,
+  onRemoveMessage,
+}: {
+  messages: QueuedChatMessage[];
+  onRemoveMessage: (messageId: string) => void;
+}) {
+  if (messages.length === 0) {
+    return null;
+  }
+
+  return (
+    <div data-chat-queue className="shrink-0 px-3 pb-1.5">
+      <div className="mx-auto flex max-w-full flex-col gap-0.5">
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            data-chat-queue-item
+            className="group text-muted-foreground hover:bg-muted/55 grid min-h-7 grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors"
+          >
+            <CornerDownRightIcon className="size-3.5" />
+            <span className="truncate">{message.content}</span>
+            <button
+              type="button"
+              aria-label={`Remove queued message: ${message.content}`}
+              onClick={() => onRemoveMessage(message.id)}
+              className="hover:bg-accent/20 inline-flex size-6 items-center justify-center rounded-md opacity-65 transition-opacity group-hover:opacity-100"
+            >
+              <Trash2Icon className="size-3.5" />
+            </button>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/chat/components/content.tsx
+++ b/apps/desktop/src/chat/components/content.tsx
@@ -204,7 +204,7 @@ export function ChatContent({
     <div
       className={
         isFloating
-          ? "flex min-h-0 shrink-0 flex-col overflow-hidden"
+          ? "flex max-h-full min-h-0 flex-col overflow-hidden"
           : "flex min-h-0 flex-1 flex-col overflow-hidden"
       }
       data-chat-content

--- a/apps/desktop/src/chat/components/input/chat-input.css
+++ b/apps/desktop/src/chat/components/input/chat-input.css
@@ -13,6 +13,33 @@
   padding: 0 !important;
 }
 
+[data-chat-input-surface="floating"] .chat-input-editor.prosemirror-editor {
+  padding-right: 42px !important;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.22) transparent;
+}
+
+[data-chat-input-surface="floating"]
+  .chat-input-editor.prosemirror-editor::-webkit-scrollbar {
+  width: 6px;
+}
+
+[data-chat-input-surface="floating"]
+  .chat-input-editor.prosemirror-editor::-webkit-scrollbar-track {
+  background: transparent;
+  margin-bottom: 36px;
+}
+
+[data-chat-input-surface="floating"]
+  .chat-input-editor.prosemirror-editor::-webkit-scrollbar-thumb {
+  background: hsl(var(--muted-foreground) / 0.22);
+  border-radius: 999px;
+}
+
+[data-chat-input-surface="floating"]
+  .chat-input-editor.prosemirror-editor::-webkit-scrollbar-thumb:hover {
+  background: hsl(var(--muted-foreground) / 0.32);
+}
+
 [data-chat-input-surface="floating"]
   .chat-input-editor.prosemirror-editor
   .is-editor-empty:first-child::before,

--- a/apps/desktop/src/chat/components/input/hooks.ts
+++ b/apps/desktop/src/chat/components/input/hooks.ts
@@ -50,7 +50,6 @@ export function useSubmit({
   draftKey,
   editorRef,
   disabled,
-  isStreaming,
   onSendMessage,
   onDraftContentChange,
   onContextRefsChange,
@@ -72,7 +71,7 @@ export function useSubmit({
     const text = proseMirrorJsonToText(json).trim();
     const mentionRefs = extractContextRefsFromTiptapJson(json);
 
-    if (!text || disabled || isStreaming) {
+    if (!text || disabled) {
       return;
     }
 
@@ -86,7 +85,6 @@ export function useSubmit({
     draftKey,
     editorRef,
     disabled,
-    isStreaming,
     onSendMessage,
     onDraftContentChange,
     onContextRefsChange,

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -12,6 +12,7 @@ const { clearContentMock, editorState, shellState } = vi.hoisted(() => ({
   editorState: {
     json: undefined as unknown,
     onUpdate: undefined as undefined | ((json: unknown) => void),
+    onSubmit: undefined as undefined | (() => void),
   },
   shellState: {
     mode: "FloatingOpen" as
@@ -36,7 +37,8 @@ vi.mock("@hypr/editor/chat", async () => {
           pos: number;
         }) => string;
       }
-    >(function ChatEditor({ className, onUpdate, placeholder }, ref) {
+    >(function ChatEditor({ className, onSubmit, onUpdate, placeholder }, ref) {
+      editorState.onSubmit = onSubmit;
       editorState.onUpdate = onUpdate;
 
       React.useImperativeHandle(ref, () => ({
@@ -95,6 +97,7 @@ describe("ChatMessageInput", () => {
     cleanup();
     clearContentMock.mockClear();
     editorState.json = { type: "doc", content: [] };
+    editorState.onSubmit = undefined;
     editorState.onUpdate = undefined;
     shellState.mode = "FloatingOpen";
   });
@@ -184,6 +187,39 @@ describe("ChatMessageInput", () => {
 
     expect(onDraftContentChange).toHaveBeenCalledWith(true);
     expect(sendButton.disabled).toBe(true);
+  });
+
+  it("submits drafts while streaming so the caller can queue them", () => {
+    shellState.mode = "RightPanelOpen";
+    const onSendMessage = vi.fn();
+    render(
+      <ChatMessageInput
+        draftKey="chat-input-test"
+        isStreaming
+        onSendMessage={onSendMessage}
+      />,
+    );
+
+    editorState.json = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Follow up" }],
+        },
+      ],
+    };
+    act(() => {
+      editorState.onUpdate?.(editorState.json);
+      editorState.onSubmit?.();
+    });
+
+    expect(onSendMessage).toHaveBeenCalledWith(
+      "Follow up",
+      [{ type: "text", text: "Follow up" }],
+      [],
+    );
+    expect(clearContentMock).toHaveBeenCalled();
   });
 
   it("marks the send control for disabled surface styling before the draft has content", () => {

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -236,9 +236,13 @@ describe("ChatMessageInput", () => {
     expect(sendButton.disabled).toBe(true);
     expect(sendButton.className).toContain("chat-input-send");
     expect(sendButton.className).not.toContain("bg-primary");
+    expect(sendButton.className).toContain("rounded-full");
+    expect(sendButton.className).toContain("size-7");
+    expect(sendButton.textContent).toBe("");
+    expect(sendButton.querySelector("svg")).not.toBeNull();
   });
 
-  it("uses a white input surface while floating", () => {
+  it("uses a growable white input surface while floating", () => {
     render(
       <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
     );
@@ -249,17 +253,17 @@ describe("ChatMessageInput", () => {
 
     expect(editor.className).toContain("chat-input-editor");
     expect(editor.className).toContain("max-h-24");
+    expect(editor.className).toContain("min-h-5");
     expect(editor.className).toContain("overflow-y-auto");
     expect(editor.dataset.placeholder).toBe("Ask anything");
-    expect(messageInput?.className).toContain("h-full");
+    expect(messageInput?.className).toContain("min-h-[30px]");
     expect(messageInput?.className).not.toContain("min-h-10");
     expect(screen.queryByRole("button", { name: /send/i })).toBeNull();
     expect(surface?.getAttribute("data-chat-input-surface")).toBe("floating");
-    expect(surface?.className).toContain("h-10");
-    expect(surface?.className).toContain("min-h-10");
-    expect(surface?.className).toContain("max-h-10");
-    expect(surface?.className).toContain("rounded-full");
-    expect(surface?.className).toContain("py-0");
+    expect(surface?.className).toContain("min-h-[38px]");
+    expect(surface?.className).toContain("max-h-28");
+    expect(surface?.className).toContain("rounded-[19px]");
+    expect(surface?.className).toContain("py-[3px]");
     expect(surface?.className).toContain("bg-white");
     expect(surface?.className).toContain("text-card-foreground");
     expect(surface?.className).toContain("dark:bg-card");
@@ -268,6 +272,8 @@ describe("ChatMessageInput", () => {
     expect(surface?.className).toContain("shadow-none");
     expect(surface?.className).not.toContain("shadow-[");
     expect(surface?.className).not.toContain("inset_0_0_0_1px");
+    expect(surface?.className).not.toContain("h-10");
+    expect(surface?.className).not.toContain("max-h-10");
   });
 
   it("uses the light card input surface in the right panel", () => {

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -252,7 +252,7 @@ describe("ChatMessageInput", () => {
     const surface = messageInput?.parentElement;
 
     expect(editor.className).toContain("chat-input-editor");
-    expect(editor.className).toContain("max-h-24");
+    expect(editor.className).toContain("max-h-36");
     expect(editor.className).toContain("min-h-5");
     expect(editor.className).toContain("overflow-y-auto");
     expect(editor.dataset.placeholder).toBe("Ask anything");
@@ -261,7 +261,7 @@ describe("ChatMessageInput", () => {
     expect(screen.queryByRole("button", { name: /send/i })).toBeNull();
     expect(surface?.getAttribute("data-chat-input-surface")).toBe("floating");
     expect(surface?.className).toContain("min-h-[38px]");
-    expect(surface?.className).toContain("max-h-28");
+    expect(surface?.className).toContain("max-h-40");
     expect(surface?.className).toContain("rounded-[19px]");
     expect(surface?.className).toContain("py-[3px]");
     expect(surface?.className).toContain("bg-white");
@@ -274,6 +274,7 @@ describe("ChatMessageInput", () => {
     expect(surface?.className).not.toContain("inset_0_0_0_1px");
     expect(surface?.className).not.toContain("h-10");
     expect(surface?.className).not.toContain("max-h-10");
+    expect(surface?.className).not.toContain("max-h-28");
   });
 
   it("uses the light card input surface in the right panel", () => {

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -257,11 +257,15 @@ describe("ChatMessageInput", () => {
     expect(editor.className).toContain("overflow-y-auto");
     expect(editor.dataset.placeholder).toBe("Ask anything");
     expect(messageInput?.className).toContain("min-h-[30px]");
+    expect(messageInput?.className).toContain("items-center");
+    expect(messageInput?.className).not.toContain("items-end");
     expect(messageInput?.className).not.toContain("min-h-10");
     expect(screen.queryByRole("button", { name: /send/i })).toBeNull();
     expect(surface?.getAttribute("data-chat-input-surface")).toBe("floating");
     expect(surface?.className).toContain("min-h-[38px]");
     expect(surface?.className).toContain("max-h-40");
+    expect(surface?.className).toContain("items-center");
+    expect(surface?.className).not.toContain("items-end");
     expect(surface?.className).toContain("rounded-[19px]");
     expect(surface?.className).toContain("py-[3px]");
     expect(surface?.className).toContain("bg-white");

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -266,6 +266,9 @@ describe("ChatMessageInput", () => {
     expect(surface?.className).toContain("max-h-40");
     expect(surface?.className).toContain("items-center");
     expect(surface?.className).not.toContain("items-end");
+    expect(surface?.className).toContain("pr-[6px]");
+    expect(surface?.className).toContain("pl-4");
+    expect(surface?.className).not.toContain("px-4");
     expect(surface?.className).toContain("rounded-[19px]");
     expect(surface?.className).toContain("py-[3px]");
     expect(surface?.className).toContain("bg-white");
@@ -279,6 +282,42 @@ describe("ChatMessageInput", () => {
     expect(surface?.className).not.toContain("h-10");
     expect(surface?.className).not.toContain("max-h-10");
     expect(surface?.className).not.toContain("max-h-28");
+  });
+
+  it("anchors the floating send control to the bottom edge", () => {
+    render(
+      <ChatMessageInput draftKey="chat-input-test" onSendMessage={vi.fn()} />,
+    );
+
+    editorState.json = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello" }],
+        },
+      ],
+    };
+    act(() => {
+      editorState.onUpdate?.(editorState.json);
+    });
+
+    const sendButton = screen.getByRole<HTMLButtonElement>("button", {
+      name: /send/i,
+    });
+    const sendControl = sendButton.parentElement;
+    const messageInput = screen
+      .getByTestId("chat-editor")
+      .closest("[data-chat-message-input]");
+
+    expect(sendControl?.className).toContain("absolute");
+    expect(sendControl?.className).toContain("right-0");
+    expect(sendControl?.className).toContain("bottom-0.5");
+    expect(sendControl?.className).not.toContain("self-end");
+    expect(sendControl?.className).not.toContain("ml-3");
+    expect(messageInput?.className).toContain("items-center");
+    expect(messageInput?.className).toContain("relative");
+    expect(messageInput?.className).not.toContain("items-end");
   });
 
   it("uses the light card input surface in the right panel", () => {

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -84,7 +84,7 @@ export function ChatMessageInput({
               "chat-input-editor",
               "text-sm",
               isFloating
-                ? "max-h-24 min-h-5 w-full min-w-0 overflow-y-auto overscroll-contain"
+                ? "max-h-36 min-h-5 w-full min-w-0 overflow-y-auto overscroll-contain"
                 : "overflow-y-auto overscroll-contain",
               !isFloating && (isRightPanel ? "max-h-[40vh]" : "max-h-48"),
             ])}
@@ -163,7 +163,7 @@ function Container({
           "flex max-h-full border",
           isFloating
             ? [
-                "border-border/70 text-card-foreground max-h-28 min-h-[38px] flex-row items-end overflow-hidden rounded-[19px] bg-white px-4 py-[3px] text-sm shadow-none",
+                "border-border/70 text-card-foreground max-h-40 min-h-[38px] flex-row items-end overflow-hidden rounded-[19px] bg-white px-4 py-[3px] text-sm shadow-none",
                 "dark:bg-card dark:text-card-foreground",
               ]
             : [elevatedSurfaceClassName, "flex-col rounded-xl"],

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -52,7 +52,6 @@ export function ChatMessageInput({
     draftKey,
     editorRef,
     disabled,
-    isStreaming,
     onSendMessage,
     onDraftContentChange,
     onContextRefsChange,

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -1,6 +1,6 @@
 import "./chat-input.css";
 
-import { SquareIcon } from "lucide-react";
+import { ArrowUpIcon, SquareIcon } from "lucide-react";
 import { useRef } from "react";
 
 import { ChatEditor, type ChatEditorHandle } from "@hypr/editor/chat";
@@ -73,7 +73,7 @@ export function ChatMessageInput({
         data-chat-message-input
         className={cn([
           isFloating
-            ? "flex h-full min-h-0 w-full min-w-0 items-center"
+            ? "flex max-h-full min-h-[30px] w-full min-w-0 items-end"
             : "flex flex-col px-2 pt-3 pb-2",
         ])}
       >
@@ -84,7 +84,7 @@ export function ChatMessageInput({
               "chat-input-editor",
               "text-sm",
               isFloating
-                ? "max-h-24 w-full min-w-0 overflow-y-auto overscroll-contain"
+                ? "max-h-24 min-h-5 w-full min-w-0 overflow-y-auto overscroll-contain"
                 : "overflow-y-auto overscroll-contain",
               !isFloating && (isRightPanel ? "max-h-[40vh]" : "max-h-48"),
             ])}
@@ -115,11 +115,13 @@ export function ChatMessageInput({
               </Button>
             ) : (
               <button
+                type="button"
+                aria-label="Send message"
                 onClick={handleSubmit}
                 disabled={isSendDisabled}
                 className={cn([
                   "chat-input-send",
-                  "inline-flex h-7 items-center gap-1.5 rounded-lg border pr-1.5 pl-2.5 text-xs font-medium transition-all duration-100",
+                  "border-border text-muted-foreground/60 inline-flex size-7 shrink-0 items-center justify-center rounded-full border transition-all duration-100",
                   !isSendDisabled && [
                     "bg-primary text-primary-foreground border-stone-600",
                     "hover:bg-primary/90",
@@ -127,15 +129,7 @@ export function ChatMessageInput({
                   ],
                 ])}
               >
-                Send
-                <span
-                  className={cn([
-                    "chat-input-send-shortcut font-mono text-xs",
-                    !isSendDisabled && "text-stone-400",
-                  ])}
-                >
-                  ⌘ ↩
-                </span>
+                <ArrowUpIcon size={15} strokeWidth={2.25} />
               </button>
             )}
           </div>
@@ -169,7 +163,7 @@ function Container({
           "flex max-h-full border",
           isFloating
             ? [
-                "border-border/70 text-card-foreground h-10 max-h-10 min-h-10 flex-row items-center overflow-hidden rounded-full bg-white px-4 py-0 text-sm shadow-none",
+                "border-border/70 text-card-foreground max-h-28 min-h-[38px] flex-row items-end overflow-hidden rounded-[19px] bg-white px-4 py-[3px] text-sm shadow-none",
                 "dark:bg-card dark:text-card-foreground",
               ]
             : [elevatedSurfaceClassName, "flex-col rounded-xl"],

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -66,7 +66,6 @@ export function ChatMessageInput({
   return (
     <Container
       elevatedSurfaceClassName={elevatedSurfaceClassName}
-      hasFloatingDraftContent={hasContent}
       isFloating={isFloating}
       isRightPanel={isRightPanel}
     >
@@ -74,10 +73,7 @@ export function ChatMessageInput({
         data-chat-message-input
         className={cn([
           isFloating
-            ? [
-                "flex max-h-full min-h-[30px] w-full min-w-0",
-                hasContent ? "items-end" : "items-center",
-              ]
+            ? "relative flex max-h-full min-h-[30px] w-full min-w-0 items-center"
             : "flex flex-col px-2 pt-3 pb-2",
         ])}
       >
@@ -104,7 +100,9 @@ export function ChatMessageInput({
           <div
             className={cn([
               "flex shrink-0 items-center",
-              isFloating ? "ml-3" : "justify-between",
+              isFloating
+                ? "absolute right-0 bottom-0.5 z-10"
+                : "justify-between",
             ])}
           >
             <div />
@@ -146,13 +144,11 @@ export function ChatMessageInput({
 function Container({
   children,
   elevatedSurfaceClassName,
-  hasFloatingDraftContent,
   isFloating,
   isRightPanel,
 }: {
   children: React.ReactNode;
   elevatedSurfaceClassName: string;
-  hasFloatingDraftContent: boolean;
   isFloating: boolean;
   isRightPanel: boolean;
 }) {
@@ -169,8 +165,7 @@ function Container({
           "flex max-h-full border",
           isFloating
             ? [
-                "border-border/70 text-card-foreground max-h-40 min-h-[38px] flex-row overflow-hidden rounded-[19px] bg-white px-4 py-[3px] text-sm shadow-none",
-                hasFloatingDraftContent ? "items-end" : "items-center",
+                "border-border/70 text-card-foreground max-h-40 min-h-[38px] flex-row items-center overflow-hidden rounded-[19px] bg-white py-[3px] pr-[6px] pl-4 text-sm shadow-none",
                 "dark:bg-card dark:text-card-foreground",
               ]
             : [elevatedSurfaceClassName, "flex-col rounded-xl"],

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -66,6 +66,7 @@ export function ChatMessageInput({
   return (
     <Container
       elevatedSurfaceClassName={elevatedSurfaceClassName}
+      hasFloatingDraftContent={hasContent}
       isFloating={isFloating}
       isRightPanel={isRightPanel}
     >
@@ -73,7 +74,10 @@ export function ChatMessageInput({
         data-chat-message-input
         className={cn([
           isFloating
-            ? "flex max-h-full min-h-[30px] w-full min-w-0 items-end"
+            ? [
+                "flex max-h-full min-h-[30px] w-full min-w-0",
+                hasContent ? "items-end" : "items-center",
+              ]
             : "flex flex-col px-2 pt-3 pb-2",
         ])}
       >
@@ -142,11 +146,13 @@ export function ChatMessageInput({
 function Container({
   children,
   elevatedSurfaceClassName,
+  hasFloatingDraftContent,
   isFloating,
   isRightPanel,
 }: {
   children: React.ReactNode;
   elevatedSurfaceClassName: string;
+  hasFloatingDraftContent: boolean;
   isFloating: boolean;
   isRightPanel: boolean;
 }) {
@@ -163,7 +169,8 @@ function Container({
           "flex max-h-full border",
           isFloating
             ? [
-                "border-border/70 text-card-foreground max-h-40 min-h-[38px] flex-row items-end overflow-hidden rounded-[19px] bg-white px-4 py-[3px] text-sm shadow-none",
+                "border-border/70 text-card-foreground max-h-40 min-h-[38px] flex-row overflow-hidden rounded-[19px] bg-white px-4 py-[3px] text-sm shadow-none",
+                hasFloatingDraftContent ? "items-end" : "items-center",
                 "dark:bg-card dark:text-card-foreground",
               ]
             : [elevatedSurfaceClassName, "flex-col rounded-xl"],

--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -124,8 +124,12 @@ describe("PersistentChatPanel", () => {
       expect(floatingFrame?.className).toContain("justify-center");
       expect(floatingFrame?.className).toContain("px-3");
       expect(floatingFrame?.className).toContain("pb-2");
+      expect((floatingFrame as HTMLElement | null)?.style.paddingTop).toBe(
+        "46px",
+      );
+      expect(floatingFrame?.className).not.toContain("pt-4");
       expect(floatingFrame?.className).not.toContain("pb-3");
-      expect(panel?.style.width).toBe("calc(100% - 1.5rem)");
+      expect(panel?.style.width).toBe("100%");
       expect(panel?.style.minWidth).toBe("min(476px, 100%)");
       expect(panel?.style.maxWidth).toBe("648px");
       expect(panel?.style.height).toBe("");

--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -129,6 +129,7 @@ describe("PersistentChatPanel", () => {
       expect(panel?.style.minWidth).toBe("min(476px, 100%)");
       expect(panel?.style.maxWidth).toBe("648px");
       expect(panel?.style.height).toBe("");
+      expect(panel?.style.maxHeight).toBe("100%");
       expect(panel?.style.transformOrigin).toBe("bottom center");
       expect(panel?.className).toContain("rounded-[24px]");
       expect(panel?.dataset.chatPanelReveal).toBe("bottom-up");

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -19,6 +19,7 @@ const FLOATING_PANEL_DEFAULT_MAX_WIDTH =
 const FLOATING_PANEL_REVEAL_HEIGHT =
   FLOATING_CHAT_INPUT_HEIGHT + FLOATING_CHAT_SHELL_INSET;
 const FLOATING_PANEL_RADIUS = 24;
+const FLOATING_PANEL_TOP_CLEARANCE = 46;
 
 type FloatingContainerRect = {
   top: number;
@@ -152,7 +153,7 @@ export function PersistentChatPanel({
     clipPath: { duration: 0.32, ease: [0.22, 1, 0.36, 1] },
   };
   const panelStyle = {
-    width: "calc(100% - 1.5rem)",
+    width: "100%",
     minWidth: `min(${FLOATING_PANEL_MIN_WIDTH}px, 100%)`,
     maxWidth: `${FLOATING_PANEL_DEFAULT_MAX_WIDTH}px`,
     maxHeight: "100%",
@@ -183,8 +184,11 @@ export function PersistentChatPanel({
             data-chat-floating-frame
             className={cn([
               "pointer-events-auto relative flex h-full min-h-0",
-              "items-end justify-center px-3 pt-4 pb-2",
+              "items-end justify-center px-3 pb-2",
             ])}
+            style={{
+              paddingTop: FLOATING_PANEL_TOP_CLEARANCE,
+            }}
             onClick={(event) => {
               if (event.target === event.currentTarget) {
                 if (draftHasContent) {

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -155,7 +155,7 @@ export function PersistentChatPanel({
     width: "calc(100% - 1.5rem)",
     minWidth: `min(${FLOATING_PANEL_MIN_WIDTH}px, 100%)`,
     maxWidth: `${FLOATING_PANEL_DEFAULT_MAX_WIDTH}px`,
-    maxHeight: "calc(100% - 1rem)",
+    maxHeight: "100%",
     transformOrigin: "bottom center",
   };
 

--- a/apps/desktop/src/chat/surface.test.ts
+++ b/apps/desktop/src/chat/surface.test.ts
@@ -41,10 +41,10 @@ describe("chat surface tokens", () => {
 
   it("uses a neutral surface on the floating shell", () => {
     expect(chatFloatingPanelShellClassNames()).toContain(
-      "shadow-[0_18px_56px_rgba(0,0,0,0.22)]",
+      "shadow-[0_28px_72px_rgba(0,0,0,0.28)]",
     );
     expect(chatFloatingPanelShellClassNames()).toContain(
-      "dark:shadow-[0_18px_64px_rgba(0,0,0,0.6)]",
+      "dark:shadow-[0_32px_84px_rgba(0,0,0,0.68)]",
     );
     expect(chatFloatingPanelShellClassNames()).toContain("bg-[#f4f4f5]");
     expect(chatFloatingPanelShellClassNames()).toContain("rounded-[24px]");

--- a/apps/desktop/src/chat/surface.ts
+++ b/apps/desktop/src/chat/surface.ts
@@ -17,7 +17,7 @@ export function chatPanelBorderClassNames(): string {
 }
 
 export function chatFloatingPanelShellClassNames(): string {
-  return "bg-[#f4f4f5] text-card-foreground rounded-[24px] border border-border/70 shadow-[0_18px_56px_rgba(0,0,0,0.22)] dark:border-white/10 dark:bg-[#202020] dark:shadow-[0_18px_64px_rgba(0,0,0,0.6)]";
+  return "bg-[#f4f4f5] text-card-foreground rounded-[24px] border border-border/70 shadow-[0_28px_72px_rgba(0,0,0,0.28)] dark:border-white/10 dark:bg-[#202020] dark:shadow-[0_32px_84px_rgba(0,0,0,0.68)]";
 }
 
 export function chatElevatedSurfaceClassNames(): string {


### PR DESCRIPTION
Summary:
- Queue follow-up messages while chat is streaming and render removable queue rows above the composer.
- Tune floating chat sizing, shadow, composer alignment, and width to match the collapsed ask bar.
- Add focused tests for the chat queue and floating chat layout behavior.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5703 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5696
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when messages actually send during streaming and adds dequeue logic tied to chat status; behavior is covered by new tests but ordering/context merging could still surprise edge cases.
> 
> **Overview**
> Adds a **follow-up message queue** while chat is `submitted` or `streaming`: submits go through `submitOrQueueMessage` in `ChatContent`, queued rows render above the composer with remove actions, and a `useEffect` sends the next item when status returns to `ready` (including draining multiple items if sends stay non-busy). Queue state is keyed per `sessionId`.
> 
> The composer **no longer blocks send on streaming** in `useSubmit`; `ChatMessageInput` still clears the draft on submit so the parent can queue. **Floating chat layout** is retuned—taller message scroll area (`max-h-[min(36rem,70vh)]`, `flex-auto`), content shell uses `max-h-full` instead of `shrink-0`, panel is full width with top clearance and stronger shell shadow, and the floating ask bar grows vertically with a bottom-anchored circular arrow send control and editor scrollbar/padding tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb0742388490ed789b62d3f508500f5dfdac1e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->