### PR TITLE
Fit summary FAB to content

### DIFF
--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -1,4 +1,4 @@
-import { SparklesIcon } from "lucide-react";
+import { RefreshCwIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import type { CSSProperties } from "react";
 import { useCallback } from "react";
@@ -161,10 +161,10 @@ function GenerateSummaryButton({
   return (
     <FloatingButton
       onClick={handleGenerateSummary}
-      className="w-[164px] justify-start gap-2 px-4"
+      className="w-fit gap-2 px-4 whitespace-nowrap"
     >
       <span className="flex items-center gap-1.5">
-        <SparklesIcon className="size-3.5" /> Generate summary
+        <RefreshCwIcon className="size-3.5" /> Generate summary
       </span>
     </FloatingButton>
   );


### PR DESCRIPTION
Use a refresh icon for the generate summary FAB and let the pill width size from its content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic FAB styling and icon only; generate-summary behavior is unchanged.
> 
> **Overview**
> Updates the session **Generate summary** floating action button so the pill sizes to its label instead of a fixed **164px** width, and swaps the **Sparkles** icon for **RefreshCw**.
> 
> The button `className` changes from `w-[164px] justify-start` to `w-fit` with `whitespace-nowrap` so the layout stays compact and doesn’t wrap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba5f2282c9d8e6c6f36a27a1590af45790aef22a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->