### PR TITLE
Generate summary titles before note content

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
@@ -145,6 +145,7 @@ describe("Enhanced", () => {
 
     expect(screen.queryByText("Enhanced editor")).toBeNull();
     expect(screen.getByText("Streaming summary")).not.toBeNull();
+    expect(screen.getByTestId("summary-title-space")).not.toBeNull();
     expect(screen.queryByRole("status")).toBeNull();
   });
 

--- a/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
@@ -7,6 +7,16 @@ import { streamdownComponents } from "../../streamdown";
 import { useAITaskTask } from "~/ai/hooks";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 
+function SummaryTitleSpace() {
+  return (
+    <div
+      aria-hidden="true"
+      data-testid="summary-title-space"
+      className="pointer-events-none mb-4 h-[1.875rem]"
+    />
+  );
+}
+
 export function StreamingView({ enhancedNoteId }: { enhancedNoteId: string }) {
   const taskId = createTaskId(enhancedNoteId, "enhance");
   const { streamedText, isGenerating } = useAITaskTask(taskId, "enhance");
@@ -33,6 +43,7 @@ export function StreamingView({ enhancedNoteId }: { enhancedNoteId: string }) {
   return (
     <div className="pb-2">
       <div className="flex flex-col gap-1">
+        <SummaryTitleSpace />
         <Streamdown
           components={streamdownComponents}
           className={cn(["flex flex-col"])}

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
@@ -52,6 +52,7 @@ function createParams(
     transformedArgs: createTransformedArgs(),
     store,
     settingsStore: {} as EnhanceSuccessParams["settingsStore"],
+    signal: new AbortController().signal,
     startTask: vi.fn().mockResolvedValue(undefined),
     getTaskState: vi.fn().mockReturnValue(undefined),
     ...overrides,
@@ -147,8 +148,195 @@ describe("enhanceSuccess.onSuccess", () => {
     expect(startTask).toHaveBeenCalledWith("session-1-title", {
       model: params.model,
       taskType: "title",
-      args: { sessionId: "session-1" },
+      args: {
+        sessionId: "session-1",
+        enhancedNote: "# Summary\n\n- Point",
+        skipPersist: true,
+      },
+      onComplete: expect.any(Function),
     });
+  });
+
+  it("waits for the generated title before persisting summary content", async () => {
+    let sessionTitle = "";
+    const store = {
+      setPartialRow: vi.fn((table, row, value) => {
+        if (table === "sessions" && row === "session-1") {
+          sessionTitle = value.title;
+        }
+      }),
+      getCell: vi.fn((table, _row, cell) => {
+        if (table === "sessions" && cell === "title") return sessionTitle;
+        return "";
+      }),
+      getValue: vi.fn().mockReturnValue("user-1"),
+      setRow: vi.fn(),
+      forEachRow: vi.fn(),
+    } as unknown as EnhanceSuccessParams["store"];
+    const startTask = vi.fn().mockImplementation(async (_taskId, config) => {
+      config.onComplete?.("Positive Performance Feedback");
+    });
+    const params = createParams({ store, startTask });
+
+    await enhanceSuccess.onSuccess?.(params);
+
+    const enhancedCallIndex = (
+      store.setPartialRow as ReturnType<typeof vi.fn>
+    ).mock.calls.findIndex(
+      ([table, row]) => table === "enhanced_notes" && row === "note-1",
+    );
+    expect(enhancedCallIndex).toBeGreaterThan(-1);
+    expect(startTask.mock.invocationCallOrder[0]).toBeLessThan(
+      (store.setPartialRow as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[enhancedCallIndex],
+    );
+
+    const persisted = (store.setPartialRow as ReturnType<typeof vi.fn>).mock
+      .calls[enhancedCallIndex][2].content;
+    expect(json2md(JSON.parse(persisted)).trim()).toBe(
+      "# Positive Performance Feedback\n\n# Summary\n\n- Point",
+    );
+
+    expect(store.setPartialRow).toHaveBeenCalledWith("sessions", "session-1", {
+      title: "Positive Performance Feedback",
+    });
+  });
+
+  it("does not persist a generated title when summary content fails to persist", async () => {
+    const store = {
+      setPartialRow: vi.fn((table) => {
+        if (table === "enhanced_notes") {
+          throw new Error("write failed");
+        }
+      }),
+      getCell: vi.fn().mockReturnValue(""),
+      getValue: vi.fn().mockReturnValue("user-1"),
+      setRow: vi.fn(),
+      forEachRow: vi.fn(),
+    } as unknown as EnhanceSuccessParams["store"];
+    const startTask = vi.fn().mockImplementation(async (_taskId, config) => {
+      config.onComplete?.("Positive Performance Feedback");
+    });
+    const params = createParams({ store, startTask });
+
+    await enhanceSuccess.onSuccess?.(params);
+
+    expect(store.setPartialRow).not.toHaveBeenCalledWith(
+      "sessions",
+      "session-1",
+      expect.objectContaining({
+        title: "Positive Performance Feedback",
+      }),
+    );
+  });
+
+  it("does not write placeholder generated titles into summary content", async () => {
+    const store = {
+      setPartialRow: vi.fn(),
+      getCell: vi.fn().mockReturnValue(""),
+      getValue: vi.fn().mockReturnValue("user-1"),
+      setRow: vi.fn(),
+      forEachRow: vi.fn(),
+    } as unknown as EnhanceSuccessParams["store"];
+    const startTask = vi.fn().mockImplementation(async (_taskId, config) => {
+      config.onComplete?.("<EMPTY>");
+    });
+    const params = createParams({ store, startTask });
+
+    await enhanceSuccess.onSuccess?.(params);
+
+    const persisted = (store.setPartialRow as ReturnType<typeof vi.fn>).mock
+      .calls[0][2].content;
+    expect(json2md(JSON.parse(persisted)).trim()).toBe("# Summary\n\n- Point");
+    expect(store.setPartialRow).not.toHaveBeenCalledWith(
+      "sessions",
+      "session-1",
+      expect.objectContaining({
+        title: "<EMPTY>",
+      }),
+    );
+  });
+
+  it("reuses a previous skipped title result when retrying summary persistence", async () => {
+    const store = {
+      setPartialRow: vi.fn(),
+      getCell: vi.fn().mockReturnValue(""),
+      getValue: vi.fn().mockReturnValue("user-1"),
+      setRow: vi.fn(),
+      forEachRow: vi.fn(),
+    } as unknown as EnhanceSuccessParams["store"];
+    const params = createParams({
+      store,
+      getTaskState: vi.fn().mockReturnValue({
+        taskType: "title",
+        status: "success",
+        streamedText: "Recovered Summary Title",
+        abortController: null,
+        currentStep: undefined,
+      }),
+    });
+
+    await enhanceSuccess.onSuccess?.(params);
+
+    expect(params.startTask).not.toHaveBeenCalled();
+    const persisted = (store.setPartialRow as ReturnType<typeof vi.fn>).mock
+      .calls[0][2].content;
+    expect(json2md(JSON.parse(persisted)).trim()).toBe(
+      "# Recovered Summary Title\n\n# Summary\n\n- Point",
+    );
+    expect(store.setPartialRow).toHaveBeenCalledWith("sessions", "session-1", {
+      title: "Recovered Summary Title",
+    });
+  });
+
+  it("does not use a generated title if live title editing starts while waiting", async () => {
+    const store = {
+      setPartialRow: vi.fn(),
+      getCell: vi.fn().mockReturnValue(""),
+      getValue: vi.fn().mockReturnValue("user-1"),
+      setRow: vi.fn(),
+      forEachRow: vi.fn(),
+    } as unknown as EnhanceSuccessParams["store"];
+    const startTask = vi.fn().mockImplementation(async (_taskId, config) => {
+      useLiveTitle.getState().setTitle("session-1", "Custom title");
+      config.onComplete?.("Generated Title");
+    });
+    const params = createParams({ store, startTask });
+
+    await enhanceSuccess.onSuccess?.(params);
+
+    const persisted = (store.setPartialRow as ReturnType<typeof vi.fn>).mock
+      .calls[0][2].content;
+    expect(json2md(JSON.parse(persisted)).trim()).toBe("# Summary\n\n- Point");
+    expect(store.setPartialRow).not.toHaveBeenCalledWith(
+      "sessions",
+      "session-1",
+      expect.objectContaining({ title: "Generated Title" }),
+    );
+  });
+
+  it("does not persist summary content when cancelled during title generation", async () => {
+    const abortController = new AbortController();
+    const store = {
+      setPartialRow: vi.fn(),
+      getCell: vi.fn().mockReturnValue(""),
+      getValue: vi.fn().mockReturnValue("user-1"),
+      setRow: vi.fn(),
+      forEachRow: vi.fn(),
+    } as unknown as EnhanceSuccessParams["store"];
+    const startTask = vi.fn().mockImplementation(async (_taskId, config) => {
+      abortController.abort();
+      config.onComplete?.("Generated Title");
+    });
+    const params = createParams({
+      store,
+      startTask,
+      signal: abortController.signal,
+    });
+
+    await enhanceSuccess.onSuccess?.(params);
+
+    expect(store.setPartialRow).not.toHaveBeenCalled();
   });
 
   it("does not start title generation when title already exists", async () => {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
@@ -6,11 +6,19 @@ import {
   extractEnhanceTagNames,
   upsertSessionTags,
 } from "./summary-tags";
+import {
+  getPersistableGeneratedTitle,
+  persistGeneratedTitle,
+} from "./title-success";
 
 import { ensureMarkdownFirstLineTitle } from "~/session/title-content";
 import { hasLiveSessionTitleDraft } from "~/store/zustand/live-title";
 
-const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = ({
+type EnhanceSuccessParams = Parameters<
+  NonNullable<TaskConfig<"enhance">["onSuccess"]>
+>[0];
+
+const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = async ({
   text,
   args,
   transformedArgs,
@@ -18,6 +26,7 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = ({
   store,
   startTask,
   getTaskState,
+  signal,
 }) => {
   if (!text) {
     return;
@@ -26,9 +35,79 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = ({
   const tagNames = extractEnhanceTagNames(text, transformedArgs);
   const textWithTags = appendTagLineToMarkdown(text, tagNames);
   const currentTitle = store.getCell("sessions", args.sessionId, "title");
-  const trimmedTitle =
+  let trimmedTitle =
     typeof currentTitle === "string" ? currentTitle.trim() : "";
-  const titledText = ensureMarkdownFirstLineTitle(textWithTags, trimmedTitle);
+  let generatedTitle = "";
+  let shouldPersistGeneratedTitle = false;
+
+  if (!trimmedTitle && !hasLiveSessionTitleDraft(args.sessionId)) {
+    const titleTaskId = createTaskId(args.sessionId, "title");
+    const titleTask = getTaskState(titleTaskId);
+
+    if (titleTask?.status === "success") {
+      generatedTitle = getPersistableGeneratedTitle(titleTask.streamedText);
+    } else if (titleTask?.status !== "generating") {
+      await startTask(titleTaskId, {
+        model,
+        taskType: "title",
+        args: {
+          sessionId: args.sessionId,
+          enhancedNote: textWithTags,
+          skipPersist: true,
+        },
+        onComplete: (title) => {
+          generatedTitle = getPersistableGeneratedTitle(title);
+        },
+      });
+    }
+
+    if (signal.aborted) {
+      return;
+    }
+
+    const updatedTitle = store.getCell("sessions", args.sessionId, "title");
+    trimmedTitle = typeof updatedTitle === "string" ? updatedTitle.trim() : "";
+    if (
+      !trimmedTitle &&
+      !hasLiveSessionTitleDraft(args.sessionId) &&
+      generatedTitle
+    ) {
+      trimmedTitle = generatedTitle;
+      shouldPersistGeneratedTitle = true;
+    }
+  }
+
+  const didPersist = persistEnhancedNoteContent({
+    text: textWithTags,
+    title: trimmedTitle,
+    args,
+    store,
+    tagNames,
+  });
+
+  if (didPersist && shouldPersistGeneratedTitle) {
+    persistGeneratedTitle({
+      text: generatedTitle,
+      args: { sessionId: args.sessionId },
+      store,
+    });
+  }
+};
+
+function persistEnhancedNoteContent({
+  text,
+  title,
+  args,
+  store,
+  tagNames,
+}: {
+  text: string;
+  title: string;
+  args: EnhanceSuccessParams["args"];
+  store: EnhanceSuccessParams["store"];
+  tagNames: string[];
+}): boolean {
+  const titledText = ensureMarkdownFirstLineTitle(text, title);
 
   try {
     const jsonContent = md2json(titledText);
@@ -36,27 +115,12 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = ({
       content: JSON.stringify(jsonContent),
     });
     upsertSessionTags(store, args.sessionId, tagNames);
+    return true;
   } catch (error) {
     console.error("Failed to convert markdown to JSON:", error);
-    return;
+    return false;
   }
-
-  if (trimmedTitle || hasLiveSessionTitleDraft(args.sessionId)) {
-    return;
-  }
-
-  const titleTaskId = createTaskId(args.sessionId, "title");
-  const titleTask = getTaskState(titleTaskId);
-  if (titleTask?.status === "generating" || titleTask?.status === "success") {
-    return;
-  }
-
-  void startTask(titleTaskId, {
-    model,
-    taskType: "title",
-    args: { sessionId: args.sessionId },
-  });
-};
+}
 
 export const enhanceSuccess: Pick<TaskConfig<"enhance">, "onSuccess"> = {
   onSuccess,

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/index.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/index.ts
@@ -24,7 +24,11 @@ export type TaskType = "enhance" | "title";
 
 export interface TaskArgsMap {
   enhance: { sessionId: string; enhancedNoteId: string; templateId?: string };
-  title: { sessionId: string };
+  title: {
+    sessionId: string;
+    enhancedNote?: string;
+    skipPersist?: boolean;
+  };
 }
 
 export interface TaskArgsMapTransformed {
@@ -66,6 +70,7 @@ export interface TaskConfig<T extends TaskType = TaskType> {
     transformedArgs: TaskArgsMapTransformed[T];
     store: MainStore;
     settingsStore: SettingsStore;
+    signal: AbortSignal;
     startTask: <K extends TaskType>(
       taskId: TaskId<K>,
       config: {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.test.ts
@@ -27,6 +27,7 @@ function createParams(
     transformedArgs: {} as TitleSuccessParams["transformedArgs"],
     store,
     settingsStore: {} as TitleSuccessParams["settingsStore"],
+    signal: new AbortController().signal,
     startTask: vi.fn().mockResolvedValue(undefined),
     getTaskState: vi.fn().mockReturnValue(undefined),
     ...overrides,

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.ts
@@ -10,12 +10,32 @@ const onSuccess: NonNullable<TaskConfig<"title">["onSuccess"]> = ({
   args,
   store,
 }) => {
+  if (args.skipPersist) {
+    return;
+  }
+
+  persistGeneratedTitle({
+    text,
+    args,
+    store,
+  });
+};
+
+export function persistGeneratedTitle({
+  text,
+  args,
+  store,
+}: {
+  text: string;
+  args: { sessionId: string };
+  store: Parameters<NonNullable<TaskConfig<"title">["onSuccess"]>>[0]["store"];
+}) {
   if (!text) {
     return;
   }
 
-  const trimmed = text.trim();
-  if (!trimmed || trimmed === "<EMPTY>") {
+  const trimmed = getPersistableGeneratedTitle(text);
+  if (!trimmed) {
     return;
   }
 
@@ -58,7 +78,12 @@ const onSuccess: NonNullable<TaskConfig<"title">["onSuccess"]> = ({
       ),
     });
   });
-};
+}
+
+export function getPersistableGeneratedTitle(text: string): string {
+  const trimmed = text.trim();
+  return trimmed && trimmed !== "<EMPTY>" ? trimmed : "";
+}
 
 export const titleSuccess: Pick<TaskConfig<"title">, "onSuccess"> = {
   onSuccess,

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-transform.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-transform.ts
@@ -13,7 +13,8 @@ async function transformArgs(
   store: MainStore,
   settingsStore: SettingsStore,
 ): Promise<TaskArgsMapTransformed["title"]> {
-  const enhancedNote = collectEnhancedNotesContent(store, args.sessionId);
+  const enhancedNote =
+    args.enhancedNote ?? collectEnhancedNotesContent(store, args.sessionId);
   const language = getLanguage(settingsStore);
   return { language, enhancedNote };
 }

--- a/apps/desktop/src/store/zustand/ai-task/tasks.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/tasks.test.ts
@@ -1,7 +1,122 @@
 import { APICallError } from "ai";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { extractUnderlyingError } from "./tasks";
+import { TASK_CONFIGS } from "./task-configs";
+import { createTasksSlice, extractUnderlyingError } from "./tasks";
+
+const originalEnhanceConfig = { ...TASK_CONFIGS.enhance };
+
+afterEach(() => {
+  Object.assign(TASK_CONFIGS.enhance, originalEnhanceConfig);
+});
+
+describe("createTasksSlice", () => {
+  it("keeps a task generating until onSuccess finishes", async () => {
+    let state: ReturnType<typeof createTasksSlice>;
+    const set = (updater: any) => {
+      state =
+        typeof updater === "function"
+          ? updater(state)
+          : { ...state, ...updater };
+    };
+    const get = () => state;
+    state = createTasksSlice(set, get, {
+      persistedStore: {} as any,
+      settingsStore: {} as any,
+    });
+
+    let resolveOnSuccess: () => void;
+    const onSuccessStarted = new Promise<void>((resolve) => {
+      TASK_CONFIGS.enhance.onSuccess = vi.fn(async () => {
+        resolve();
+        await new Promise<void>((innerResolve) => {
+          resolveOnSuccess = innerResolve;
+        });
+      });
+    });
+
+    TASK_CONFIGS.enhance.transformArgs = vi.fn(async () => ({}) as any);
+    TASK_CONFIGS.enhance.transforms = [];
+    TASK_CONFIGS.enhance.executeWorkflow = vi.fn(async function* () {
+      yield { type: "text-delta", text: "Generated summary" } as any;
+    });
+
+    const taskId = "session-1-enhance" as const;
+    const promise = state.generate(taskId, {
+      model: {} as any,
+      taskType: "enhance",
+      args: {
+        sessionId: "session-1",
+        enhancedNoteId: "note-1",
+      },
+    });
+
+    await onSuccessStarted;
+
+    expect(state.tasks[taskId]).toMatchObject({
+      status: "generating",
+      streamedText: "Generated summary",
+    });
+
+    resolveOnSuccess!();
+    await promise;
+
+    expect(state.tasks[taskId]).toMatchObject({
+      status: "success",
+      streamedText: "Generated summary",
+    });
+  });
+
+  it("does not mark a task successful when it is cancelled during onSuccess", async () => {
+    let state: ReturnType<typeof createTasksSlice>;
+    const set = (updater: any) => {
+      state =
+        typeof updater === "function"
+          ? updater(state)
+          : { ...state, ...updater };
+    };
+    const get = () => state;
+    state = createTasksSlice(set, get, {
+      persistedStore: {} as any,
+      settingsStore: {} as any,
+    });
+
+    let resolveOnSuccess: () => void;
+    const onSuccessStarted = new Promise<void>((resolve) => {
+      TASK_CONFIGS.enhance.onSuccess = vi.fn(async () => {
+        resolve();
+        await new Promise<void>((innerResolve) => {
+          resolveOnSuccess = innerResolve;
+        });
+      });
+    });
+
+    TASK_CONFIGS.enhance.transformArgs = vi.fn(async () => ({}) as any);
+    TASK_CONFIGS.enhance.transforms = [];
+    TASK_CONFIGS.enhance.executeWorkflow = vi.fn(async function* () {
+      yield { type: "text-delta", text: "Generated summary" } as any;
+    });
+
+    const taskId = "session-1-enhance" as const;
+    const promise = state.generate(taskId, {
+      model: {} as any,
+      taskType: "enhance",
+      args: {
+        sessionId: "session-1",
+        enhancedNoteId: "note-1",
+      },
+    });
+
+    await onSuccessStarted;
+    state.cancel(taskId);
+    resolveOnSuccess!();
+    await promise;
+
+    expect(state.tasks[taskId]).toMatchObject({
+      status: "idle",
+    });
+  });
+});
 
 describe("extractUnderlyingError", () => {
   it("normalizes exhausted provider overload retries", () => {

--- a/apps/desktop/src/store/zustand/ai-task/tasks.ts
+++ b/apps/desktop/src/store/zustand/ai-task/tasks.ts
@@ -206,6 +206,26 @@ export const createTasksSlice = <T extends TasksState & TasksActions>(
         }
       }
 
+      try {
+        await taskConfig.onSuccess?.({
+          taskId,
+          text: fullText,
+          model: config.model,
+          args: config.args,
+          transformedArgs: enrichedArgs,
+          store: deps.persistedStore,
+          settingsStore: deps.settingsStore,
+          signal: abortController.signal,
+          startTask: (nextTaskId, nextConfig) =>
+            get().generate(nextTaskId, nextConfig),
+          getTaskState: (nextTaskId) => getTaskState(get().tasks, nextTaskId),
+        });
+      } catch (error) {
+        console.error("Task post-success hook failed:", error);
+      }
+
+      checkAbort();
+
       set((state) =>
         mutate(state, (draft) => {
           draft.tasks[taskId] = {
@@ -218,23 +238,6 @@ export const createTasksSlice = <T extends TasksState & TasksActions>(
           };
         }),
       );
-
-      try {
-        await taskConfig.onSuccess?.({
-          taskId,
-          text: fullText,
-          model: config.model,
-          args: config.args,
-          transformedArgs: enrichedArgs,
-          store: deps.persistedStore,
-          settingsStore: deps.settingsStore,
-          startTask: (nextTaskId, nextConfig) =>
-            get().generate(nextTaskId, nextConfig),
-          getTaskState: (nextTaskId) => getTaskState(get().tasks, nextTaskId),
-        });
-      } catch (error) {
-        console.error("Task post-success hook failed:", error);
-      }
 
       try {
         config.onComplete?.(fullText);


### PR DESCRIPTION
Summary:
- wait for title generation before persisting untitled enhanced notes
- reserve title space while streamed summaries render to avoid completion layout shift

Verification:
- pnpm exec dprint fmt
- pnpm -F desktop typecheck
- pnpm test -- src/session/components/note-input/enhanced/index.test.tsx
- pnpm test -- src/store/zustand/ai-task/task-configs/enhance-success.test.ts src/store/zustand/ai-task/task-configs/title-success.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering of session/enhanced-note persistence and task lifecycle (async onSuccess, cancel), which can affect data consistency if edge cases are missed; coverage is strong in new tests.
> 
> **Overview**
> Untitled sessions now **wait for AI title generation** (or a cached title task result) before writing enhanced note content, so the first persisted markdown includes the heading up front instead of a follow-up backfill.
> 
> Title tasks started from enhance use **`skipPersist`** and optional inline **`enhancedNote`**; session titles are written only after summary persistence succeeds, with guards for **`<EMPTY>`**, live title edits, abort/cancel, and failed note writes. The task runner keeps enhance in **`generating`** until async **`onSuccess`** finishes and does not mark success if cancelled mid-hook (**`AbortSignal`** passed into hooks).
> 
> While summary text streams in the UI, a **reserved title spacer** reduces layout shift when the editor appears with a title line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e31325951060437eec2cee415c1b4bd437413fdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->