### PR TITLE
Keep note and chat panels readable

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -201,6 +201,21 @@ describe("ClassicMainBody", () => {
     expect(sidebarChrome?.style.width).toBe("24%");
   });
 
+  it("keeps the note content panel at least 500px wide", () => {
+    mocks.currentTab = {
+      active: true,
+      id: "session-1",
+      pinned: false,
+      slotId: "slot-session",
+      type: "sessions",
+    };
+
+    render(<ClassicMainBody />);
+
+    const panels = screen.getAllByTestId("panel");
+    expect(panels[1]?.dataset.minWidth).toBe("500");
+  });
+
   it("keeps the collapsed layout free of the sidebar resize handle", () => {
     mocks.leftsidebar.expanded = false;
 

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -36,6 +36,7 @@ import { useClassicMainTabsShortcuts } from "./useTabsShortcuts";
 
 import { useShell } from "~/contexts/shell";
 import { GlobalLiveTranscriptAccessory } from "~/session/components/bottom-accessory/global-live";
+import { NOTE_SURFACE_MIN_WIDTH_PX } from "~/shared/main/layout-widths";
 import { useOpenNoteDialog } from "~/shared/open-note-dialog";
 import { useNewNote } from "~/shared/useNewNote";
 import { useSidebarUpcomingMeetingStatus } from "~/sidebar/timeline/upcoming-meeting";
@@ -72,6 +73,7 @@ export function ClassicMainBody() {
 
   const isOnboarding = currentTab?.type === "onboarding";
   const isChangelog = currentTab?.type === "changelog";
+  const isSessionTab = currentTab?.type === "sessions";
   const hasCustomSidebar = hasCustomSidebarTab(currentTab);
   const hasLeftSurfaceCustomSidebar =
     hasLeftSurfaceCustomSidebarTab(currentTab);
@@ -217,6 +219,9 @@ export function ClassicMainBody() {
           id="classic-main-content"
           order={2}
           className="min-h-0 flex-1 overflow-hidden"
+          style={{
+            minWidth: isSessionTab ? NOTE_SURFACE_MIN_WIDTH_PX : undefined,
+          }}
         >
           <div
             className="h-full min-h-0 min-w-0 flex-1 overflow-auto"

--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -6,9 +6,27 @@ const mocks = vi.hoisted(() => ({
     | "FloatingClosed"
     | "FloatingOpen"
     | "RightPanelOpen",
+  currentTab: { type: "empty" } as { type: string } | null,
+  leftSidebarExpanded: true,
   persistentChatPanel: vi.fn(),
   sendEvent: vi.fn(),
   sessionProps: { sessionId: "chat-session-1" },
+  setLeftSidebarExpanded: vi.fn(),
+  windowExpandWidth: vi.fn(() => Promise.resolve({ status: "ok", data: null })),
+  windowRestoreWidth: vi.fn(() =>
+    Promise.resolve({ status: "ok", data: null }),
+  ),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  isTauri: () => true,
+}));
+
+vi.mock("@hypr/plugin-windows", () => ({
+  commands: {
+    windowExpandWidth: mocks.windowExpandWidth,
+    windowRestoreWidth: mocks.windowRestoreWidth,
+  },
 }));
 
 vi.mock("@hypr/ui/components/ui/resizable", () => ({
@@ -60,7 +78,17 @@ vi.mock("~/contexts/shell", () => ({
       mode: mocks.chatMode,
       sendEvent: mocks.sendEvent,
     },
+    leftsidebar: {
+      expanded: mocks.leftSidebarExpanded,
+      setExpanded: mocks.setLeftSidebarExpanded,
+    },
   }),
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: (
+    selector: (state: { currentTab: typeof mocks.currentTab }) => unknown,
+  ) => selector({ currentTab: mocks.currentTab }),
 }));
 
 vi.mock("~/chat/components/chat-panel", () => ({
@@ -105,12 +133,21 @@ vi.mock("~/chat/components/persistent-chat", () => ({
 
 import { MainChatPanels } from "./chat-panels";
 
+let restorePanelWidths: (() => void) | null = null;
+
 describe("MainChatPanels", () => {
   beforeEach(() => {
     cleanup();
+    restorePanelWidths?.();
+    restorePanelWidths = null;
     mocks.chatMode = "FloatingClosed";
+    mocks.currentTab = { type: "empty" };
+    mocks.leftSidebarExpanded = true;
     mocks.persistentChatPanel.mockClear();
     mocks.sendEvent.mockClear();
+    mocks.setLeftSidebarExpanded.mockClear();
+    mocks.windowExpandWidth.mockClear();
+    mocks.windowRestoreWidth.mockClear();
   });
 
   it("renders the main content and persistent floating chat host", () => {
@@ -165,4 +202,188 @@ describe("MainChatPanels", () => {
     expect(rightPanel?.className).not.toContain("ml-2");
     expect(rightPanel?.className).not.toContain("mr-1");
   });
+
+  it("reserves enough main-body width for a 500px note surface beside the sidebar", () => {
+    mocks.currentTab = { type: "sessions" };
+    mocks.leftSidebarExpanded = true;
+
+    render(
+      <MainChatPanels>
+        <div data-testid="main-content" />
+      </MainChatPanels>,
+    );
+
+    expect(screen.getAllByTestId("panel")[0]?.dataset.minWidth).toBe("700");
+  });
+
+  it("expands left when opening the sidebar would make a note surface narrower than 500px", () => {
+    mocks.currentTab = { type: "sessions" };
+    mocks.leftSidebarExpanded = true;
+    mockPanelWidths({
+      bodyPanelWidth: 640,
+      leftSidebarWidth: 200,
+    });
+
+    render(
+      <MainChatPanels>
+        <div data-left-sidebar-chrome />
+        <div data-chat-floating-anchor>
+          <div data-session-surface />
+        </div>
+      </MainChatPanels>,
+    );
+
+    expect(mocks.windowExpandWidth).toHaveBeenCalledWith(60, null, false, true);
+  });
+
+  it("expands right when docked chat would make a note surface narrower than 500px", () => {
+    mocks.chatMode = "RightPanelOpen";
+    mocks.currentTab = { type: "sessions" };
+    mocks.leftSidebarExpanded = false;
+    mockPanelWidths({
+      bodyPanelWidth: 460,
+      leftSidebarWidth: 0,
+      rightPanelWidth: 120,
+    });
+
+    render(
+      <MainChatPanels>
+        <div data-chat-floating-anchor>
+          <div data-session-surface />
+        </div>
+      </MainChatPanels>,
+    );
+
+    expect(mocks.windowExpandWidth).toHaveBeenCalledWith(
+      240,
+      null,
+      false,
+      false,
+    );
+  });
+
+  it("expands right when docked chat renders narrower than 320px", () => {
+    mocks.chatMode = "RightPanelOpen";
+    mocks.currentTab = { type: "sessions" };
+    mocks.leftSidebarExpanded = true;
+    mockPanelWidths({
+      bodyPanelWidth: 700,
+      leftSidebarWidth: 200,
+      rightPanelWidth: 120,
+    });
+
+    render(
+      <MainChatPanels>
+        <div data-left-sidebar-chrome />
+        <div data-chat-floating-anchor>
+          <div data-session-surface />
+        </div>
+      </MainChatPanels>,
+    );
+
+    expect(mocks.windowExpandWidth).toHaveBeenCalledWith(
+      200,
+      null,
+      false,
+      false,
+    );
+  });
+
+  it("restores window width expansions after the side panels close", () => {
+    mocks.chatMode = "RightPanelOpen";
+    mocks.currentTab = { type: "sessions" };
+    mocks.leftSidebarExpanded = false;
+    mockPanelWidths({
+      bodyPanelWidth: 460,
+      leftSidebarWidth: 0,
+      rightPanelWidth: 320,
+    });
+
+    const renderPanels = () => (
+      <MainChatPanels>
+        <div data-chat-floating-anchor>
+          <div data-session-surface />
+        </div>
+      </MainChatPanels>
+    );
+    const { rerender } = render(renderPanels());
+
+    expect(mocks.windowExpandWidth).toHaveBeenCalledWith(
+      40,
+      null,
+      false,
+      false,
+    );
+
+    mocks.chatMode = "FloatingClosed";
+    rerender(renderPanels());
+
+    expect(mocks.windowRestoreWidth).toHaveBeenCalledTimes(1);
+  });
+
+  it("collapses the left sidebar when a window resize would make the note surface narrower than 500px", () => {
+    mocks.currentTab = { type: "sessions" };
+    mocks.leftSidebarExpanded = true;
+    const panelWidths = {
+      bodyPanelWidth: 720,
+      leftSidebarWidth: 200,
+    };
+    mockPanelWidths(panelWidths);
+
+    render(
+      <MainChatPanels>
+        <div data-left-sidebar-chrome />
+        <div data-chat-floating-anchor>
+          <div data-session-surface />
+        </div>
+      </MainChatPanels>,
+    );
+
+    expect(mocks.setLeftSidebarExpanded).not.toHaveBeenCalled();
+
+    panelWidths.bodyPanelWidth = 690;
+    fireEvent.resize(window);
+
+    expect(mocks.setLeftSidebarExpanded).toHaveBeenCalledWith(false);
+  });
 });
+
+function mockPanelWidths(widths: {
+  bodyPanelWidth: number;
+  leftSidebarWidth: number;
+  rightPanelWidth?: number;
+}) {
+  restorePanelWidths?.();
+  const spy = vi
+    .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+    .mockImplementation(function getBoundingClientRectMock(this: HTMLElement) {
+      if (this.hasAttribute("data-main-body-panel-container")) {
+        return rectWithWidth(widths.bodyPanelWidth);
+      }
+
+      if (this.hasAttribute("data-left-sidebar-chrome")) {
+        return rectWithWidth(widths.leftSidebarWidth);
+      }
+
+      if (this.hasAttribute("data-chat-right-panel")) {
+        return rectWithWidth(widths.rightPanelWidth ?? 0);
+      }
+
+      return rectWithWidth(0);
+    });
+  restorePanelWidths = () => spy.mockRestore();
+}
+
+function rectWithWidth(width: number) {
+  return {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: width,
+    top: 0,
+    width,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  };
+}

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -1,21 +1,44 @@
-import { useRef } from "react";
+import { isTauri } from "@tauri-apps/api/core";
+import { useCallback, useLayoutEffect, useRef } from "react";
 
+import { commands as windowsCommands } from "@hypr/plugin-windows";
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from "@hypr/ui/components/ui/resizable";
 
+import { NOTE_SURFACE_MIN_WIDTH_PX } from "./layout-widths";
+
 import { ChatPanelFrame, ChatSessionHost } from "~/chat/components/chat-panel";
 import { PersistentChatPanel } from "~/chat/components/persistent-chat";
 import { useShell } from "~/contexts/shell";
+import { type Tab, useTabs } from "~/store/zustand/tabs";
 
 const RIGHT_CHAT_PANEL_MIN_WIDTH_PX = 320;
+const LEFT_SIDEBAR_MIN_WIDTH_PX = 200;
 
 export function MainChatPanels({ children }: { children: React.ReactNode }) {
-  const { chat } = useShell();
+  const { chat, leftsidebar } = useShell();
+  const currentTab = useTabs((state) => state.currentTab);
   const bodyPanelContainerRef = useRef<HTMLDivElement>(null);
   const isRightPanelOpen = chat.mode === "RightPanelOpen";
+  const isSessionTab = currentTab?.type === "sessions";
+  const collapseLeftSidebar = useCallback(() => {
+    leftsidebar.setExpanded(false);
+  }, [leftsidebar.setExpanded]);
+  const bodyMinWidth = getMainBodyMinWidth({
+    currentTab,
+    leftSidebarExpanded: leftsidebar.expanded,
+  });
+
+  useNoteSurfaceWindowWidthGuard({
+    bodyPanelContainerRef,
+    enabled: isSessionTab,
+    leftPanelOpen: leftsidebar.expanded,
+    collapseLeftPanel: collapseLeftSidebar,
+    rightPanelOpen: isRightPanelOpen,
+  });
 
   return (
     <ChatSessionHost>
@@ -26,9 +49,13 @@ export function MainChatPanels({ children }: { children: React.ReactNode }) {
             direction="horizontal"
             className="flex min-h-0 flex-1 overflow-hidden"
           >
-            <ResizablePanel className="min-h-0 flex-1 overflow-hidden">
+            <ResizablePanel
+              className="min-h-0 flex-1 overflow-hidden"
+              style={{ minWidth: bodyMinWidth }}
+            >
               <div
                 ref={bodyPanelContainerRef}
+                data-main-body-panel-container
                 className="h-full min-h-0 min-w-0 flex-1 overflow-hidden"
               >
                 {children}
@@ -67,4 +94,257 @@ export function MainChatPanels({ children }: { children: React.ReactNode }) {
       )}
     </ChatSessionHost>
   );
+}
+
+function getMainBodyMinWidth({
+  currentTab,
+  leftSidebarExpanded,
+}: {
+  currentTab: Tab | null;
+  leftSidebarExpanded: boolean;
+}) {
+  if (currentTab?.type !== "sessions") {
+    return undefined;
+  }
+
+  return (
+    NOTE_SURFACE_MIN_WIDTH_PX +
+    (leftSidebarExpanded ? LEFT_SIDEBAR_MIN_WIDTH_PX : 0)
+  );
+}
+
+function useNoteSurfaceWindowWidthGuard({
+  bodyPanelContainerRef,
+  collapseLeftPanel,
+  enabled,
+  leftPanelOpen,
+  rightPanelOpen,
+}: {
+  bodyPanelContainerRef: React.RefObject<HTMLDivElement | null>;
+  collapseLeftPanel: () => void;
+  enabled: boolean;
+  leftPanelOpen: boolean;
+  rightPanelOpen: boolean;
+}) {
+  const expansionCountRef = useRef(0);
+  const lastVisibleBodyWidthRef = useRef<number | null>(null);
+  const previousStateRef = useRef({
+    enabled: false,
+    leftPanelOpen: false,
+    rightPanelOpen: false,
+  });
+
+  const restoreWidthExpansions = useCallback(() => {
+    const restoreCount = expansionCountRef.current;
+    expansionCountRef.current = 0;
+
+    for (let i = 0; i < restoreCount; i += 1) {
+      void windowsCommands.windowRestoreWidth();
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    const previousState = previousStateRef.current;
+    const hasOpenPanel = enabled && (leftPanelOpen || rightPanelOpen);
+
+    if (!hasOpenPanel) {
+      previousStateRef.current = { enabled, leftPanelOpen, rightPanelOpen };
+      restoreWidthExpansions();
+      return;
+    }
+
+    const leftPanelJustOpened =
+      leftPanelOpen && (!previousState.enabled || !previousState.leftPanelOpen);
+    const rightPanelJustOpened =
+      rightPanelOpen &&
+      (!previousState.enabled || !previousState.rightPanelOpen);
+
+    previousStateRef.current = { enabled, leftPanelOpen, rightPanelOpen };
+
+    if (!leftPanelJustOpened && !rightPanelJustOpened) {
+      return;
+    }
+
+    if (!isTauri()) {
+      return;
+    }
+
+    const bodyPanel = bodyPanelContainerRef.current;
+    if (!bodyPanel) {
+      return;
+    }
+
+    const bodyWidth = getVisibleBodyWidth(bodyPanel);
+    if (bodyWidth <= 0) {
+      return;
+    }
+
+    const leftSidebarWidth = getLeftSidebarWidth(bodyPanel, leftPanelOpen);
+    const rightPanelWidth = getRightPanelWidth(bodyPanel, rightPanelOpen);
+    const requiredBodyWidth = NOTE_SURFACE_MIN_WIDTH_PX + leftSidebarWidth;
+    const requiredTotalWidth =
+      requiredBodyWidth + (rightPanelOpen ? RIGHT_CHAT_PANEL_MIN_WIDTH_PX : 0);
+    const visibleTotalWidth = bodyWidth + rightPanelWidth;
+    const widthDeficit = Math.ceil(
+      Math.max(
+        requiredBodyWidth - bodyWidth,
+        requiredTotalWidth - visibleTotalWidth,
+        rightPanelOpen ? RIGHT_CHAT_PANEL_MIN_WIDTH_PX - rightPanelWidth : 0,
+      ),
+    );
+
+    if (widthDeficit <= 0) {
+      return;
+    }
+
+    const expandLeft = leftPanelJustOpened && !rightPanelJustOpened;
+
+    expansionCountRef.current += 1;
+    void windowsCommands.windowExpandWidth(
+      widthDeficit,
+      null,
+      false,
+      expandLeft,
+    );
+  }, [
+    bodyPanelContainerRef,
+    enabled,
+    leftPanelOpen,
+    restoreWidthExpansions,
+    rightPanelOpen,
+  ]);
+
+  useLayoutEffect(() => {
+    lastVisibleBodyWidthRef.current = null;
+
+    if (!enabled || !leftPanelOpen) {
+      return;
+    }
+
+    const bodyPanel = bodyPanelContainerRef.current;
+    if (!bodyPanel) {
+      return;
+    }
+
+    const handleResize = () => {
+      collapseLeftPanelIfNoteSurfaceWouldShrink({
+        bodyPanel,
+        collapseLeftPanel,
+        lastVisibleBodyWidthRef,
+      });
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(handleResize)
+        : null;
+    resizeObserver?.observe(bodyPanel);
+
+    const shell = bodyPanel.closest<HTMLElement>(
+      "[data-testid='main-app-shell']",
+    );
+    if (shell) {
+      resizeObserver?.observe(shell);
+    }
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      resizeObserver?.disconnect();
+    };
+  }, [
+    bodyPanelContainerRef,
+    collapseLeftPanel,
+    enabled,
+    leftPanelOpen,
+    rightPanelOpen,
+  ]);
+
+  useLayoutEffect(() => restoreWidthExpansions, [restoreWidthExpansions]);
+}
+
+function collapseLeftPanelIfNoteSurfaceWouldShrink({
+  bodyPanel,
+  collapseLeftPanel,
+  lastVisibleBodyWidthRef,
+}: {
+  bodyPanel: HTMLElement;
+  collapseLeftPanel: () => void;
+  lastVisibleBodyWidthRef: React.MutableRefObject<number | null>;
+}) {
+  const visibleBodyWidth = getVisibleBodyWidth(bodyPanel);
+  if (visibleBodyWidth <= 0) {
+    return;
+  }
+
+  const lastVisibleBodyWidth = lastVisibleBodyWidthRef.current;
+  lastVisibleBodyWidthRef.current = visibleBodyWidth;
+
+  if (
+    lastVisibleBodyWidth === null ||
+    visibleBodyWidth >= lastVisibleBodyWidth
+  ) {
+    return;
+  }
+
+  const leftSidebarWidth = getLeftSidebarWidth(bodyPanel, true);
+  const noteSurfaceWidth = visibleBodyWidth - leftSidebarWidth;
+
+  if (noteSurfaceWidth < NOTE_SURFACE_MIN_WIDTH_PX) {
+    collapseLeftPanel();
+  }
+}
+
+function getVisibleBodyWidth(bodyPanel: HTMLElement) {
+  const bodyWidth = bodyPanel.getBoundingClientRect().width;
+  const shell = bodyPanel.closest<HTMLElement>(
+    "[data-testid='main-app-shell']",
+  );
+  if (!shell) {
+    return bodyWidth;
+  }
+
+  const shellWidth = shell.getBoundingClientRect().width;
+  if (shellWidth <= 0) {
+    return bodyWidth;
+  }
+
+  const rightPanel = shell.querySelector<HTMLElement>(
+    "[data-chat-right-panel]",
+  );
+  const rightPanelWidth = rightPanel?.getBoundingClientRect().width ?? 0;
+  const visibleShellBodyWidth = Math.max(0, shellWidth - rightPanelWidth);
+
+  if (bodyWidth <= 0) {
+    return visibleShellBodyWidth;
+  }
+
+  return Math.min(bodyWidth, visibleShellBodyWidth);
+}
+
+function getRightPanelWidth(bodyPanel: HTMLElement, rightPanelOpen: boolean) {
+  if (!rightPanelOpen) {
+    return 0;
+  }
+
+  const rightPanel = bodyPanel.ownerDocument.querySelector<HTMLElement>(
+    "[data-chat-right-panel]",
+  );
+
+  return rightPanel?.getBoundingClientRect().width ?? 0;
+}
+
+function getLeftSidebarWidth(bodyPanel: HTMLElement, leftPanelOpen: boolean) {
+  if (!leftPanelOpen) {
+    return 0;
+  }
+
+  const leftSidebarChrome = bodyPanel.querySelector<HTMLElement>(
+    "[data-left-sidebar-chrome]",
+  );
+  const measuredWidth = leftSidebarChrome?.getBoundingClientRect().width ?? 0;
+
+  return measuredWidth > 0 ? measuredWidth : LEFT_SIDEBAR_MIN_WIDTH_PX;
 }

--- a/apps/desktop/src/shared/main/layout-widths.ts
+++ b/apps/desktop/src/shared/main/layout-widths.ts
@@ -1,0 +1,1 @@
+export const NOTE_SURFACE_MIN_WIDTH_PX = 500;


### PR DESCRIPTION
Set 500px note and 320px chat minimums, expand when side panels open, and collapse the sidebar when resizing squeezes notes.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5707 
- <kbd>&nbsp;1&nbsp;</kbd> #5706 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop window sizing and automatic sidebar collapse on resize; behavior is Tauri-specific and could surprise users or interact oddly with manual window management.
> 
> **Overview**
> Introduces a shared **500px** minimum for the note surface on session tabs and wires layout so side panels do not squeeze notes or docked chat below usable widths.
> 
> **Classic main body** applies that minimum on the content `ResizablePanel` when the current tab is a session. **Main chat panels** raise the main-body `minWidth` to **700px** (500 + 200px sidebar) when the left sidebar is open on a session tab, and run a Tauri **window width guard**: on sidebar or right-panel chat open, it calls `windowExpandWidth` (left or right) if layout would violate the 500px note or **320px** chat minimums; expansions are reversed with `windowRestoreWidth` when those panels close. If the user shrinks the window while the sidebar is open, the guard **auto-collapses** the left sidebar when the note area would drop under 500px.
> 
> Tests cover panel `minWidth` values and expand/restore/collapse behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 988ae0093361ef70aa7f790d22c0b0cdf6cbd745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->