### PR TITLE
Animate left sidebar transitions

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -1,4 +1,10 @@
-import { act, cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -13,6 +19,7 @@ const mocks = vi.hoisted(() => ({
     toggleExpanded: vi.fn(),
   },
   onPanelLayout: null as null | ((sizes: number[]) => void),
+  onResizeDragging: null as null | ((isDragging: boolean) => void),
 }));
 
 vi.mock("@hypr/ui/components/ui/resizable", () => ({
@@ -70,17 +77,27 @@ vi.mock("@hypr/ui/components/ui/resizable", () => ({
       data-panel-id={id}
       data-max-size={maxSize}
       data-min-size={minSize}
+      data-flex-grow={style?.flexGrow}
       data-max-width={style?.maxWidth}
       data-min-width={style?.minWidth}
       data-order={order}
+      data-transition={style?.transition}
       data-testid="panel"
     >
       {children}
     </div>
   ),
-  ResizableHandle: ({ className }: { className?: string }) => (
-    <div data-class-name={className} data-testid="resize-handle" />
-  ),
+  ResizableHandle: ({
+    className,
+    onDragging,
+  }: {
+    className?: string;
+    onDragging?: (isDragging: boolean) => void;
+  }) => {
+    mocks.onResizeDragging = onDragging ?? null;
+
+    return <div data-class-name={className} data-testid="resize-handle" />;
+  },
 }));
 
 vi.mock("~/contexts/shell", () => ({
@@ -97,8 +114,9 @@ vi.mock("~/store/zustand/tabs", () => ({
 }));
 
 vi.mock("./shell-sidebar", () => ({
-  ClassicMainSidebar: () =>
-    mocks.leftsidebar.expanded && mocks.currentTab?.type !== "onboarding" ? (
+  ClassicMainSidebar: ({ forceMount = false }: { forceMount?: boolean }) =>
+    (forceMount || mocks.leftsidebar.expanded) &&
+    mocks.currentTab?.type !== "onboarding" ? (
       <aside data-testid="classic-main-sidebar" />
     ) : null,
 }));
@@ -156,6 +174,7 @@ describe("ClassicMainBody", () => {
     mocks.leftsidebar.expanded = true;
     mocks.leftsidebar.toggleExpanded.mockClear();
     mocks.onPanelLayout = null;
+    mocks.onResizeDragging = null;
   });
 
   it("wraps the expanded left sidebar in a persistent resizable panel", () => {
@@ -172,6 +191,9 @@ describe("ClassicMainBody", () => {
     expect(screen.getByTestId("resize-handle").dataset.className).toContain(
       "after:w-2",
     );
+    expect(screen.getByTestId("resize-handle").dataset.className).toContain(
+      "w-1",
+    );
 
     const panels = screen.getAllByTestId("panel");
     expect(panels).toHaveLength(2);
@@ -180,15 +202,22 @@ describe("ClassicMainBody", () => {
     expect(panels[0]?.dataset.defaultSize).toBe("12.5");
     expect(panels[0]?.dataset.minSize).toBe("12.5");
     expect(panels[0]?.dataset.maxSize).toBe("22.5");
+    expect(panels[0]?.dataset.flexGrow).toBe("12.5");
     expect(panels[0]?.dataset.minWidth).toBe("200");
     expect(panels[0]?.dataset.maxWidth).toBe("360");
+    expect(panels[0]?.dataset.transition).toContain("flex-grow");
     expect(panels[1]?.dataset.panelId).toBe("classic-main-content");
     expect(panels[1]?.dataset.order).toBe("2");
 
+    const sidebarContent = document.querySelector<HTMLElement>(
+      "[data-left-sidebar-panel-content]",
+    );
     const sidebarChrome = document.querySelector<HTMLElement>(
       "[data-left-sidebar-chrome]",
     );
 
+    expect(sidebarContent?.className).toContain("translate-x-0");
+    expect(sidebarContent?.getAttribute("aria-hidden")).toBe("false");
     expect(sidebarChrome?.style.width).toBe("12.5%");
     expect(sidebarChrome?.style.minWidth).toBe("200px");
     expect(sidebarChrome?.style.maxWidth).toBe("360px");
@@ -216,14 +245,53 @@ describe("ClassicMainBody", () => {
     expect(panels[1]?.dataset.minWidth).toBe("500");
   });
 
-  it("keeps the collapsed layout free of the sidebar resize handle", () => {
+  it("collapses the sidebar panel without unmounting the animated shell", () => {
     mocks.leftsidebar.expanded = false;
 
     render(<ClassicMainBody />);
 
-    expect(screen.queryByTestId("classic-main-sidebar")).toBeNull();
-    expect(screen.queryByTestId("resize-handle")).toBeNull();
-    expect(screen.getAllByTestId("panel")).toHaveLength(1);
+    const resizeHandle = screen.getByTestId("resize-handle");
+
+    expect(resizeHandle.dataset.className).toContain("pointer-events-none");
+    expect(resizeHandle.dataset.className).toContain("w-0");
+    expect(screen.getByTestId("classic-main-sidebar")).toBeTruthy();
+
+    const panels = screen.getAllByTestId("panel");
+    expect(panels).toHaveLength(2);
+    expect(panels[0]?.dataset.panelId).toBe("classic-main-sidebar-left");
+    expect(panels[0]?.dataset.flexGrow).toBe("0");
+    expect(panels[0]?.dataset.minWidth).toBe("0");
+    expect(panels[0]?.dataset.maxWidth).toBe("0");
+    expect(panels[0]?.dataset.transition).toContain("flex-grow");
+
+    const sidebarContent = document.querySelector<HTMLElement>(
+      "[data-left-sidebar-panel-content]",
+    );
+    expect(sidebarContent?.className).toContain("-translate-x-3");
+    expect(sidebarContent?.className).toContain("opacity-0");
+    expect(sidebarContent?.getAttribute("aria-hidden")).toBe("true");
+    expect(sidebarContent?.hasAttribute("inert")).toBe(true);
+  });
+
+  it("restores sidebar transitions when a resize is interrupted by collapse", () => {
+    const { rerender } = render(<ClassicMainBody />);
+
+    act(() => {
+      mocks.onResizeDragging?.(true);
+    });
+
+    expect(screen.getAllByTestId("panel")[0]?.dataset.transition).toBe(
+      undefined,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide sidebar" }));
+    mocks.leftsidebar.expanded = false;
+    rerender(<ClassicMainBody />);
+
+    expect(screen.getAllByTestId("panel")[0]?.dataset.transition).toContain(
+      "flex-grow",
+    );
+    expect(mocks.leftsidebar.toggleExpanded).toHaveBeenCalledTimes(1);
   });
 
   it("does not reserve a sidebar panel during onboarding", () => {

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -79,7 +79,8 @@ export function ClassicMainBody() {
     hasLeftSurfaceCustomSidebarTab(currentTab);
   const showSidebarTimelineChrome = !hasCustomSidebar && !isOnboarding;
   const showSidebarTimeline = showSidebarTimelineChrome && leftsidebar.expanded;
-  const showLeftSidebarPanel = leftsidebar.expanded && !isOnboarding;
+  const mountLeftSidebarPanel = !isOnboarding;
+  const showLeftSidebarPanel = mountLeftSidebarPanel && leftsidebar.expanded;
   const showLeftSurfaceChromeBack = hasLeftSurfaceCustomSidebar;
   const enableMainAreaTopDrag =
     showSidebarTimelineChrome || hasLeftSurfaceCustomSidebar;
@@ -93,6 +94,7 @@ export function ClassicMainBody() {
   const mainAreaTopDrag = useMainAreaTopWindowDrag(enableMainAreaTopDrag);
   const update = useDesktopUpdateControl();
   const upcomingMeetingStatus = useSidebarUpcomingMeetingStatus();
+  const [leftSidebarResizing, setLeftSidebarResizing] = useState(false);
   const hasUpcomingMeetingBadge = upcomingMeetingStatus
     ? currentTab?.type !== "sessions" ||
       upcomingMeetingStatus.itemKey !== `session-${currentTab.id}`
@@ -115,6 +117,13 @@ export function ClassicMainBody() {
     },
     [showLeftSidebarPanel],
   );
+  const handleLeftSidebarResizeDragging = useCallback((isDragging: boolean) => {
+    setLeftSidebarResizing(isDragging);
+  }, []);
+  const handleToggleLeftSidebar = useCallback(() => {
+    setLeftSidebarResizing(false);
+    leftsidebar.toggleExpanded();
+  }, [leftsidebar.toggleExpanded]);
   const leftSidebarChromeStyle = useMemo(
     () =>
       ({
@@ -123,6 +132,23 @@ export function ClassicMainBody() {
         maxWidth: LEFT_SIDEBAR_MAX_WIDTH_PX,
       }) satisfies CSSProperties,
     [leftSidebarPanelSize],
+  );
+  const leftSidebarPanelStyle = useMemo(
+    () =>
+      ({
+        flexGrow: leftsidebar.expanded ? leftSidebarPanelSize : 0,
+        maxWidth: leftsidebar.expanded ? LEFT_SIDEBAR_MAX_WIDTH_PX : 0,
+        minWidth: leftsidebar.expanded ? LEFT_SIDEBAR_MIN_WIDTH_PX : 0,
+        transition:
+          leftSidebarResizing && leftsidebar.expanded
+            ? undefined
+            : [
+                "flex-grow 180ms ease-out",
+                "max-width 180ms ease-out",
+                "min-width 180ms ease-out",
+              ].join(", "),
+      }) satisfies CSSProperties,
+    [leftSidebarPanelSize, leftSidebarResizing, leftsidebar.expanded],
   );
 
   return (
@@ -146,7 +172,7 @@ export function ClassicMainBody() {
               sidebarExpanded={leftsidebar.expanded}
               onNewNote={createNewNote}
               onSearch={handleOpenNoteDialog}
-              onToggleSidebar={leftsidebar.toggleExpanded}
+              onToggleSidebar={handleToggleLeftSidebar}
               hasUpcomingMeeting={hasUpcomingMeetingBadge}
               update={update}
             />
@@ -188,13 +214,13 @@ export function ClassicMainBody() {
         </div>
       ) : null}
       <ResizablePanelGroup
-        autoSaveId={showLeftSidebarPanel ? "classic-main-sidebar" : undefined}
+        autoSaveId={mountLeftSidebarPanel ? "classic-main-sidebar" : undefined}
         dir="ltr"
         direction="horizontal"
         className="min-h-0 flex-1 overflow-hidden"
         onLayout={handlePanelLayout}
       >
-        {showLeftSidebarPanel ? (
+        {mountLeftSidebarPanel ? (
           <>
             <ResizablePanel
               id="classic-main-sidebar-left"
@@ -202,19 +228,37 @@ export function ClassicMainBody() {
               defaultSize={leftSidebarPanelConstraints.defaultSize}
               minSize={leftSidebarPanelConstraints.minSize}
               maxSize={leftSidebarPanelConstraints.maxSize}
-              className="min-h-0 overflow-hidden"
-              style={{
-                minWidth: LEFT_SIDEBAR_MIN_WIDTH_PX,
-                maxWidth: LEFT_SIDEBAR_MAX_WIDTH_PX,
-              }}
+              className={cn([
+                "min-h-0 overflow-hidden",
+                !leftsidebar.expanded && "pointer-events-none",
+              ])}
+              style={leftSidebarPanelStyle}
             >
-              <ClassicMainSidebar />
+              <div
+                data-left-sidebar-panel-content
+                aria-hidden={!leftsidebar.expanded}
+                inert={!leftsidebar.expanded ? true : undefined}
+                className={cn([
+                  "h-full w-full transition-[opacity,transform] duration-200 ease-out",
+                  leftsidebar.expanded
+                    ? "translate-x-0 opacity-100"
+                    : "-translate-x-3 opacity-0",
+                ])}
+              >
+                <ClassicMainSidebar forceMount />
+              </div>
             </ResizablePanel>
-            <ResizableHandle className="z-10 w-1 !bg-transparent after:w-2" />
+            <ResizableHandle
+              className={cn([
+                "z-10 !bg-transparent after:w-2",
+                showLeftSidebarPanel
+                  ? "w-1"
+                  : "pointer-events-none w-0 after:w-0",
+              ])}
+              onDragging={handleLeftSidebarResizeDragging}
+            />
           </>
-        ) : (
-          <ClassicMainSidebar />
-        )}
+        ) : null}
         <ResizablePanel
           id="classic-main-content"
           order={2}

--- a/apps/desktop/src/main/shell-sidebar.tsx
+++ b/apps/desktop/src/main/shell-sidebar.tsx
@@ -6,7 +6,11 @@ import {
 } from "~/sidebar/use-custom-sidebar";
 import { useTabs } from "~/store/zustand/tabs";
 
-export function ClassicMainSidebar() {
+export function ClassicMainSidebar({
+  forceMount = false,
+}: {
+  forceMount?: boolean;
+} = {}) {
   const { leftsidebar } = useShell();
   const currentTab = useTabs((state) => state.currentTab);
   const isOnboarding = currentTab?.type === "onboarding";
@@ -15,7 +19,7 @@ export function ClassicMainSidebar() {
 
   useCustomSidebarEffect(hasCustomSidebar, leftsidebar);
 
-  if (!leftsidebar.expanded || isOnboarding) {
+  if ((!leftsidebar.expanded && !forceMount) || isOnboarding) {
     return null;
   }
 

--- a/apps/desktop/src/shared/main/shell-sidebar.test.tsx
+++ b/apps/desktop/src/shared/main/shell-sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
@@ -37,6 +37,7 @@ import { ClassicMainSidebar } from "~/main/shell-sidebar";
 
 describe("ClassicMainSidebar", () => {
   beforeEach(() => {
+    cleanup();
     mockCurrentTab = { type: "empty" };
     mockLeftSidebar.expanded = false;
     setExpanded.mockClear();
@@ -77,6 +78,14 @@ describe("ClassicMainSidebar", () => {
     mockLeftSidebar.expanded = true;
 
     render(<ClassicMainSidebar />);
+
+    expect(screen.getByTestId("left-sidebar")).toBeTruthy();
+  });
+
+  it("can keep the sidebar mounted while the shell animates closed", () => {
+    mockLeftSidebar.expanded = false;
+
+    render(<ClassicMainSidebar forceMount />);
 
     expect(screen.getByTestId("left-sidebar")).toBeTruthy();
   });


### PR DESCRIPTION
Keep the left sidebar panel mounted while collapsed so open and close states slide smoothly without flicker.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5707 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5706 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop shell layout and animation only; accessibility attributes added for collapsed state with no auth or data-path changes.
> 
> **Overview**
> The classic main layout **keeps the left sidebar resizable panel mounted** when collapsed (except during onboarding), instead of removing the panel and handle from the tree. Collapse is driven by **animated `flex-grow` / min-max width** on the panel plus **opacity and slide** on a wrapper around the sidebar content.
> 
> **Resize behavior:** `onDragging` tracks active resize and **turns off panel transitions** while dragging; toggling the sidebar clears that state so collapse still animates if resize was interrupted. The resize handle is **non-interactive and zero-width** when collapsed; the panel uses `pointer-events-none`, and collapsed content is **`aria-hidden` / `inert`**.
> 
> `ClassicMainSidebar` gains optional **`forceMount`** so the timeline sidebar can stay in the DOM during the close animation. Tests cover expanded/collapsed panel styles, transition restore after interrupted resize, and `forceMount`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bea3ff52c9dd03b384c1aac9ffe6f3c7c67b1a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->