### PR TITLE
Show concise summary-based insights

### DIFF
--- a/apps/desktop/src/devtools-panel/recurring-notes.ts
+++ b/apps/desktop/src/devtools-panel/recurring-notes.ts
@@ -1,4 +1,5 @@
 import type {
+  EnhancedNoteStorage,
   HumanStorage,
   MappingSessionParticipantStorage,
   SessionEvent,
@@ -199,6 +200,15 @@ function upsertSession({
     title: MEETING_TITLE,
     raw_md: rawMd,
   } satisfies SessionStorage);
+
+  store.setRow("enhanced_notes", `${sessionId}:summary`, {
+    user_id: ownerUserId,
+    session_id: sessionId,
+    content: rawMd,
+    template_id: "",
+    position: 0,
+    title: "Summary",
+  } satisfies EnhancedNoteStorage);
 
   for (const participant of PARTICIPANTS) {
     store.setRow(

--- a/apps/desktop/src/session/components/bottom-accessory/past-note-key-facts.system.md.jinja
+++ b/apps/desktop/src/session/components/bottom-accessory/past-note-key-facts.system.md.jinja
@@ -1,4 +1,4 @@
-You extract reusable insights from prior meeting notes.
+You extract reusable insights from prior meeting summaries.
 
 Return facts that will help someone prepare for the next meeting with the same people.
 
@@ -6,6 +6,7 @@ Rules:
 
 - Capture concrete decisions, commitments, blockers, preferences, constraints, open questions, names, dates, numbers, and follow-ups.
 - Prefer facts that clarify what has been discussed with the participants before.
+- Use only the provided summaries.
 - Omit generic meeting-summary language.
 - Do not mention that these are notes or that you are summarizing.
 - Keep each fact short and standalone.

--- a/apps/desktop/src/session/components/bottom-accessory/past-note-key-facts.user.md.jinja
+++ b/apps/desktop/src/session/components/bottom-accessory/past-note-key-facts.user.md.jinja
@@ -1,9 +1,9 @@
-# Prior Meeting
+# Prior Meeting Summary
 
 Title: {{ session.title }}
 Date: {{ session.date_label }}
 Participants: {{ session.participant_names | join(", ") }}
 
-# Notes
+# Summary
 
-{{ notes }}
+{{ summaries }}

--- a/apps/desktop/src/session/components/bottom-accessory/past-note-regenerate.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/past-note-regenerate.test.tsx
@@ -234,7 +234,7 @@ describe("insights regeneration", () => {
           title: "Weekly Product Sync",
           created_at: "2026-05-28T10:00:00.000Z",
           event_json: "",
-          raw_md: "Alex committed to send pricing by Friday.",
+          raw_md: "Raw note text should not feed insights.",
         },
       },
       mapping_session_participant: {
@@ -249,6 +249,13 @@ describe("insights regeneration", () => {
           human_id: "alex",
           user_id: "self",
           source: "auto",
+        },
+      },
+      enhanced_notes: {
+        previous_summary: {
+          session_id: "previous",
+          content: "Alex committed to send pricing by Friday.",
+          position: 0,
         },
       },
     });
@@ -285,7 +292,7 @@ describe("insights regeneration", () => {
           title: "Weekly Product Sync",
           created_at: "2026-05-28T10:00:00.000Z",
           event_json: "",
-          raw_md: "Alex committed to send pricing by Friday.",
+          raw_md: "Raw note text should not feed insights.",
         },
       },
       mapping_session_participant: {
@@ -300,6 +307,13 @@ describe("insights regeneration", () => {
           human_id: "alex",
           user_id: "self",
           source: "auto",
+        },
+      },
+      enhanced_notes: {
+        previous_summary: {
+          session_id: "previous",
+          content: "Alex committed to send pricing by Friday.",
+          position: 0,
         },
       },
     });

--- a/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
+++ b/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
@@ -396,7 +396,7 @@ async function generatePastSessionKeyFacts({
       date_label: request.dateLabel,
       participant_names: request.participantNames,
     },
-    notes: request.sourceText,
+    summaries: request.sourceText,
   });
 
   const result = await generateText({
@@ -466,7 +466,7 @@ function getSessionKeyFactsSource(
   store: MainStore,
   sessionId: string,
 ): string | null {
-  const enhancedNotes: Array<{ content: string; position: number }> = [];
+  const summaries: Array<{ content: string; position: number }> = [];
 
   store.forEachRow("enhanced_notes", (noteId, _forEachCell) => {
     const note = store.getRow("enhanced_notes", noteId);
@@ -474,23 +474,17 @@ function getSessionKeyFactsSource(
       return;
     }
 
-    enhancedNotes.push({
+    summaries.push({
       content: note.content,
       position: typeof note.position === "number" ? note.position : 0,
     });
   });
 
-  enhancedNotes.sort((a, b) => a.position - b.position);
-  const enhancedText = cleanSourceText(
-    enhancedNotes.map((note) => extractPlainText(note.content)).join("\n\n"),
+  summaries.sort((a, b) => a.position - b.position);
+  const summaryText = cleanSourceText(
+    summaries.map((note) => extractPlainText(note.content)).join("\n\n"),
   );
-  if (enhancedText) {
-    return truncateAtWord(enhancedText, MAX_SOURCE_LENGTH);
-  }
-
-  const rawMd = store.getCell("sessions", sessionId, "raw_md");
-  const rawText = cleanSourceText(extractPlainText(rawMd));
-  return rawText ? truncateAtWord(rawText, MAX_SOURCE_LENGTH) : null;
+  return summaryText ? truncateAtWord(summaryText, MAX_SOURCE_LENGTH) : null;
 }
 
 function cleanSourceText(text: string): string {

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -184,9 +184,10 @@ describe("PostSessionAccessory", () => {
       />,
     );
 
-    expect(screen.getByText("Insights")).toBeTruthy();
-    expect(screen.getByText("Alex")).toBeTruthy();
-    expect(screen.getByText("Jamie")).toBeTruthy();
+    expect(screen.queryByText("Insights")).toBeNull();
+    expect(screen.queryByText("With")).toBeNull();
+    expect(screen.queryByText("Alex")).toBeNull();
+    expect(screen.queryByText("Jamie")).toBeNull();
     expect(screen.queryByText("Weekly Product Sync")).toBeNull();
     expect(screen.queryByText("May 28, 2026")).toBeNull();
     const factsList = screen.getByRole("list");
@@ -203,6 +204,56 @@ describe("PostSessionAccessory", () => {
     expect(screen.getByText("Confirm keyboard behavior.")).toBeTruthy();
     expect(screen.queryByText("Do not show this fourth fact.")).toBeNull();
     expect(screen.queryByTestId("transcript")).toBeNull();
+  });
+
+  it("shows generation progress when opened without saved insights", () => {
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        isTranscriptExpanded
+        activeTab="insights"
+        pastNotes={[
+          {
+            sessionId: "session-0",
+            title: "Weekly Product Sync",
+            dateLabel: "May 28, 2026",
+            participantNames: ["Alex"],
+            summary: null,
+            isGenerating: true,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Generating insights...")).toBeTruthy();
+    expect(
+      screen.queryByText("Insights will be generated when this tab opens."),
+    ).toBeNull();
+    expect(screen.queryByText("With")).toBeNull();
+    expect(screen.queryByText("Alex")).toBeNull();
+  });
+
+  it("does not show generation progress for empty insights after generation stops", () => {
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        isTranscriptExpanded
+        activeTab="insights"
+        pastNotes={[
+          {
+            sessionId: "session-0",
+            title: "Weekly Product Sync",
+            dateLabel: "May 28, 2026",
+            participantNames: ["Alex"],
+            summary: null,
+            isGenerating: false,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("No insights yet.")).toBeTruthy();
+    expect(screen.queryByText("Generating insights...")).toBeNull();
   });
 
   it("builds descending past notes from recurring and same-title sessions", () => {
@@ -230,7 +281,7 @@ describe("PostSessionAccessory", () => {
           title: "Weekly Product Sync",
           created_at: "2026-05-27T10:00:00.000Z",
           event_json: "",
-          raw_md: "Confirmed notification copy and reviewed follow-ups.",
+          raw_md: "Raw note text should not feed insights.",
         },
         older: {
           title: "Older Product Sync",
@@ -332,6 +383,11 @@ describe("PostSessionAccessory", () => {
             "Aligned on transcript panel behavior. Past notes should stay short and scannable.",
           position: 0,
         },
+        same_title_summary: {
+          session_id: "same_title",
+          content: "Confirmed notification copy and reviewed follow-ups.",
+          position: 0,
+        },
       },
     });
 
@@ -358,6 +414,10 @@ describe("PostSessionAccessory", () => {
     expect(result.missing.map((request) => request.sessionId)).toEqual([
       "previous",
       "same_title",
+    ]);
+    expect(result.requests.map((request) => request.sourceText)).toEqual([
+      "Aligned on transcript panel behavior. Past notes should stay short and scannable.",
+      "Confirmed notification copy and reviewed follow-ups.",
     ]);
   });
 
@@ -424,7 +484,7 @@ describe("PostSessionAccessory", () => {
           title: "Weekly Product Sync",
           created_at: "2026-05-28T10:00:00.000Z",
           event_json: "",
-          raw_md: "Alex committed to send pricing by Friday.",
+          raw_md: "Raw note text should not feed insights.",
         },
       },
       mapping_session_participant: {
@@ -439,6 +499,13 @@ describe("PostSessionAccessory", () => {
           human_id: "alex",
           user_id: "self",
           source: "auto",
+        },
+      },
+      enhanced_notes: {
+        previous_summary: {
+          session_id: "previous",
+          content: "Alex committed to send pricing by Friday.",
+          position: 0,
         },
       },
     });

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -105,7 +105,6 @@ function InsightsPanel({
   onRegenerateInsights?: () => void;
   fillHeight: boolean;
 }) {
-  const participantNames = getCompiledParticipantNames(notes);
   const insightFacts = getCompiledInsightFacts(notes);
   const isGenerating = notes.some((note) => note.isGenerating);
   const isRegenerateDisabled =
@@ -114,63 +113,50 @@ function InsightsPanel({
 
   return (
     <TranscriptCard fillHeight={fillHeight}>
-      <div className="flex shrink-0 items-center justify-between px-3 py-1.5">
-        <span className="text-muted-foreground text-xs font-medium">
-          Insights
-        </span>
-        {onRegenerateInsights ? (
-          <RegenerateInsightsButton
-            isDisabled={isRegenerateDisabled}
-            isGenerating={isGenerating}
-            onClick={onRegenerateInsights}
-          />
-        ) : null}
-      </div>
-
       <div
         className={cn([
-          "min-h-0 overflow-y-auto px-4 pb-4",
-          fillHeight ? "flex-1" : "max-h-[300px]",
+          "relative min-h-0",
+          fillHeight && "flex flex-1 flex-col",
         ])}
       >
-        <div className="flex min-w-0 flex-col gap-3 pt-2">
-          {participantNames.length > 0 ? (
-            <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-              <span className="text-muted-foreground mr-0.5 text-[11px] font-medium">
-                With
-              </span>
-              {participantNames.map((participantName) => (
-                <span
-                  key={participantName}
-                  className="border-border bg-accent/35 text-muted-foreground max-w-full truncate rounded-full border px-2 py-0.5 text-[11px] leading-4"
-                >
-                  {participantName}
-                </span>
-              ))}
-            </div>
-          ) : null}
+        {onRegenerateInsights ? (
+          <div className="absolute top-2 right-3 z-10">
+            <RegenerateInsightsButton
+              isDisabled={isRegenerateDisabled}
+              isGenerating={isGenerating}
+              onClick={onRegenerateInsights}
+            />
+          </div>
+        ) : null}
 
-          {insightFacts.length > 0 ? (
-            <ul className="text-muted-foreground min-w-0 list-disc space-y-1.5 pr-1 pl-5 text-xs leading-5">
-              {insightFacts.map((fact) => (
-                <li key={fact.key} className="min-w-0 break-words">
-                  {fact.text}
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="text-muted-foreground text-xs leading-5">
-              {isGenerating
-                ? "Generating insights..."
-                : "Insights will be generated when this tab opens."}
-            </p>
-          )}
+        <div
+          className={cn([
+            "min-h-0 overflow-y-auto py-3 pl-4",
+            onRegenerateInsights ? "pr-10" : "pr-4",
+            fillHeight ? "flex-1" : "max-h-[300px]",
+          ])}
+        >
+          <div className="flex min-w-0 flex-col gap-2">
+            {insightFacts.length > 0 ? (
+              <ul className="text-muted-foreground min-w-0 list-disc space-y-1.5 pr-1 pl-5 text-xs leading-5">
+                {insightFacts.map((fact) => (
+                  <li key={fact.key} className="min-w-0 break-words">
+                    {fact.text}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-muted-foreground text-xs leading-5">
+                {isGenerating ? "Generating insights..." : "No insights yet."}
+              </p>
+            )}
 
-          {insightFacts.length > 0 && isGenerating ? (
-            <p className="text-muted-foreground text-xs leading-5">
-              Updating insights...
-            </p>
-          ) : null}
+            {insightFacts.length > 0 && isGenerating ? (
+              <p className="text-muted-foreground text-xs leading-5">
+                Updating insights...
+              </p>
+            ) : null}
+          </div>
         </div>
       </div>
     </TranscriptCard>
@@ -188,26 +174,6 @@ function splitKeyFacts(content: string): string[] {
     )
     .filter(Boolean)
     .slice(0, 3);
-}
-
-function getCompiledParticipantNames(notes: PastSessionNote[]): string[] {
-  const seen = new Set<string>();
-  const names: string[] = [];
-
-  for (const note of notes) {
-    for (const participantName of note.participantNames ?? []) {
-      const text = participantName.trim();
-      const key = text.toLowerCase();
-      if (!text || seen.has(key)) {
-        continue;
-      }
-
-      seen.add(key);
-      names.push(text);
-    }
-  }
-
-  return names.sort((a, b) => a.localeCompare(b));
 }
 
 function getCompiledInsightFacts(


### PR DESCRIPTION
Render only insight bullets in the bottom panel, source related-meeting facts from enhanced summaries, and show generation progress for empty insights.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Sessions without enhanced summaries will no longer contribute to past insights until summaries exist, which may reduce coverage for older data; changes are localized to post-session UI and insight generation.
> 
> **Overview**
> **Related-meeting insights** are now built from **`enhanced_notes` summaries only**—`sessions.raw_md` is no longer a fallback—so LLM key-fact generation and caching hash off summary text. Prompt templates were updated to refer to **summaries** instead of raw notes.
> 
> The **insights tab** is simplified to a **bullet list** of compiled facts: the **Insights** heading, **With** participant chips, and per-meeting titles/dates are removed. **Regenerate** floats in the corner. Empty UI shows **Generating insights...** while work is in flight and **No insights yet.** when generation finishes with nothing to show (replacing the passive “when this tab opens” copy).
> 
> Devtools recurring-note seed data now writes matching **`enhanced_notes`** rows so local Past Notes inspection still has summary sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3aba54733f34e2a1c661971c33e74bdbd108cff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->