### PR TITLE
Repair templates database schema

### DIFF
--- a/crates/db-app/migrations/20260624000000_repair_templates.sql
+++ b/crates/db-app/migrations/20260624000000_repair_templates.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS templates (
+  id            TEXT PRIMARY KEY NOT NULL,
+  title         TEXT NOT NULL DEFAULT '',
+  description   TEXT NOT NULL DEFAULT '',
+  pinned        INTEGER NOT NULL DEFAULT 0,
+  pin_order     INTEGER,
+  category      TEXT,
+  targets_json  TEXT,
+  sections_json TEXT NOT NULL DEFAULT '[]',
+  created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+  updated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -32,6 +32,11 @@ pub const APP_MIGRATION_STEPS: &[hypr_db_migrate::MigrationStep] = &[
         scope: hypr_db_migrate::MigrationScope::Plain,
         sql: include_str!("../migrations/20260524000000_default_templates.sql"),
     },
+    hypr_db_migrate::MigrationStep {
+        id: "20260624000000_repair_templates",
+        scope: hypr_db_migrate::MigrationScope::Plain,
+        sql: include_str!("../migrations/20260624000000_repair_templates.sql"),
+    },
 ];
 
 pub fn schema() -> hypr_db_migrate::DbSchema {
@@ -116,6 +121,33 @@ mod tests {
             tables,
             vec!["_sqlx_migrations", "calendars", "events", "templates"]
         );
+    }
+
+    #[tokio::test]
+    async fn repair_migration_recreates_missing_templates_table() {
+        let db = Db::connect_memory_plain().await.unwrap();
+        hypr_db_migrate::migrate(
+            &db,
+            hypr_db_migrate::DbSchema {
+                steps: &APP_MIGRATION_STEPS[..3],
+                validate_cloudsync_table: cloudsync_alter_guard_required,
+            },
+        )
+        .await
+        .unwrap();
+
+        sqlx::query("DROP TABLE templates")
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        hypr_db_migrate::migrate(&db, schema()).await.unwrap();
+
+        let row_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM templates")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(row_count, 0);
     }
 
     #[test]

--- a/plugins/db/src/lib.rs
+++ b/plugins/db/src/lib.rs
@@ -45,6 +45,11 @@ pub fn init<R: tauri::Runtime>(
     tauri::plugin::Builder::new(PLUGIN_NAME)
         .invoke_handler(specta_builder.invoke_handler())
         .setup(move |app, _| {
+            hypr_tauri_utils::block_on(hypr_db_migrate::migrate(
+                db.as_ref(),
+                hypr_db_app::schema(),
+            ))?;
+
             let pool = db.pool().clone();
             let app_handle = app.app_handle().clone();
             hypr_tauri_utils::spawn("import legacy tinybase json", async move {
@@ -232,6 +237,30 @@ mod test {
                 "title": "Template 1",
             })]
         );
+    }
+
+    #[tokio::test]
+    async fn open_memory_app_db_subscribe_sees_app_schema() {
+        let db = runtime::open_app_db(None).await.unwrap();
+        let runtime = runtime::PluginDbRuntime::new(Arc::new(db));
+        let (channel, events) = capture_channel();
+
+        let registration = runtime
+            .subscribe(
+                "SELECT id, title FROM templates ORDER BY id".to_string(),
+                vec![],
+                runtime::QueryEventChannel::new(channel),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            registration.analysis,
+            hypr_db_reactive::DependencyAnalysis::Reactive { .. }
+        ));
+
+        let event = next_event(&events, 0).await.unwrap();
+        assert!(matches!(event, QueryEvent::Result(rows) if !rows.is_empty()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Ensure the DB plugin installs app schema before subscriptions and add an append-only templates table repair migration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup DB migration ordering and ships a schema repair path; low blast radius but affects every app launch and local SQLite state.
> 
> **Overview**
> Adds an append-only **`20260624000000_repair_templates`** migration that runs `CREATE TABLE IF NOT EXISTS templates` with the same column layout as the original templates migration, so databases that lost the table can be fixed without re-running earlier steps.
> 
> The **DB Tauri plugin** now **blocks on `hypr_db_app::schema()` migration during `setup`**, before legacy import and reactive subscriptions, so the app schema (including `templates`) is present when clients subscribe.
> 
> New tests cover dropping `templates` and re-migrating to an empty table, and that **`open_app_db` + subscribe** returns reactive results against seeded template rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d448a7d2d56852205affc286910a64ac9a7b5acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->