### PR TITLE
Repair missing app schema tables

### DIFF
--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -46,6 +46,75 @@ pub fn schema() -> hypr_db_migrate::DbSchema {
     }
 }
 
+#[derive(Debug)]
+pub enum AppSchemaError {
+    Migrate(hypr_db_migrate::MigrateError),
+    Sqlx(sqlx::Error),
+}
+
+impl std::fmt::Display for AppSchemaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Migrate(error) => write!(f, "{error}"),
+            Self::Sqlx(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for AppSchemaError {}
+
+impl From<hypr_db_migrate::MigrateError> for AppSchemaError {
+    fn from(error: hypr_db_migrate::MigrateError) -> Self {
+        Self::Migrate(error)
+    }
+}
+
+impl From<sqlx::Error> for AppSchemaError {
+    fn from(error: sqlx::Error) -> Self {
+        Self::Sqlx(error)
+    }
+}
+
+pub async fn prepare_schema(db: &hypr_db_core::Db) -> Result<(), AppSchemaError> {
+    let templates_missing_before_migration = !templates_table_exists(db.pool()).await?;
+    hypr_db_migrate::migrate(db, schema()).await?;
+    repair_missing_core_tables(db.pool(), templates_missing_before_migration).await?;
+    Ok(())
+}
+
+async fn templates_table_exists(pool: &sqlx::SqlitePool) -> Result<bool, sqlx::Error> {
+    sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1
+            FROM sqlite_master
+            WHERE type = 'table' AND name = 'templates'
+        )",
+    )
+    .fetch_one(pool)
+    .await
+}
+
+async fn repair_missing_core_tables(
+    pool: &sqlx::SqlitePool,
+    templates_missing_before_migration: bool,
+) -> Result<(), sqlx::Error> {
+    if !templates_table_exists(pool).await? {
+        sqlx::query(include_str!("../migrations/20260413020000_templates.sql"))
+            .execute(pool)
+            .await?;
+    }
+
+    if templates_missing_before_migration {
+        sqlx::query(include_str!(
+            "../migrations/20260524000000_default_templates.sql"
+        ))
+        .execute(pool)
+        .await?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -62,7 +131,7 @@ mod tests {
         })
         .await
         .unwrap();
-        hypr_db_migrate::migrate(&db, schema()).await.unwrap();
+        prepare_schema(&db).await.unwrap();
         db
     }
 
@@ -148,6 +217,51 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(row_count, 0);
+    }
+
+    #[tokio::test]
+    async fn prepare_schema_recreates_templates_after_repair_migration_was_already_applied() {
+        let db = test_db().await;
+
+        sqlx::query("DROP TABLE templates")
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        prepare_schema(&db).await.unwrap();
+
+        let row_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM templates")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert!(row_count > 0);
+    }
+
+    #[tokio::test]
+    async fn prepare_schema_seeds_templates_when_repair_migration_creates_missing_table() {
+        let db = Db::connect_memory_plain().await.unwrap();
+        hypr_db_migrate::migrate(
+            &db,
+            hypr_db_migrate::DbSchema {
+                steps: &APP_MIGRATION_STEPS[..3],
+                validate_cloudsync_table: cloudsync_alter_guard_required,
+            },
+        )
+        .await
+        .unwrap();
+
+        sqlx::query("DROP TABLE templates")
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        prepare_schema(&db).await.unwrap();
+
+        let row_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM templates")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert!(row_count > 0);
     }
 
     #[test]

--- a/crates/db-cli/src/runtime.rs
+++ b/crates/db-cli/src/runtime.rs
@@ -33,7 +33,7 @@ pub async fn run(args: Args) -> Result<()> {
         .await
         .map_err(|e| Error::operation_failed("open database", e.to_string()))?;
 
-    hypr_db_migrate::migrate(&db, hypr_db_app::schema())
+    hypr_db_app::prepare_schema(&db)
         .await
         .map_err(|e| Error::operation_failed("migrate database", e.to_string()))?;
 
@@ -214,9 +214,7 @@ mod tests {
         let db = hypr_db_core::Db::connect_local_plain(&db_path)
             .await
             .unwrap();
-        hypr_db_migrate::migrate(&db, hypr_db_app::schema())
-            .await
-            .unwrap();
+        hypr_db_app::prepare_schema(&db).await.unwrap();
         hypr_db_app::upsert_template(
             db.pool(),
             hypr_db_app::UpsertTemplate {

--- a/crates/mobile-bridge/src/db.rs
+++ b/crates/mobile-bridge/src/db.rs
@@ -17,7 +17,7 @@ pub(crate) async fn open_app_db(
     })
     .await?;
 
-    hypr_db_migrate::migrate(&db, hypr_db_app::schema()).await?;
+    hypr_db_app::prepare_schema(&db).await?;
 
     Ok(db)
 }

--- a/crates/mobile-bridge/src/error.rs
+++ b/crates/mobile-bridge/src/error.rs
@@ -69,4 +69,6 @@ pub(crate) enum OpenAppDbError {
     Open(#[from] hypr_db_core::DbOpenError),
     #[error(transparent)]
     Migrate(#[from] hypr_db_migrate::MigrateError),
+    #[error(transparent)]
+    AppSchema(#[from] hypr_db_app::AppSchemaError),
 }

--- a/plugins/db/src/error.rs
+++ b/plugins/db/src/error.rs
@@ -9,6 +9,8 @@ pub enum Error {
     #[error(transparent)]
     Migrate(#[from] hypr_db_migrate::MigrateError),
     #[error(transparent)]
+    AppSchema(#[from] hypr_db_app::AppSchemaError),
+    #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error(transparent)]
     Sqlx(#[from] sqlx::Error),

--- a/plugins/db/src/import/calendars.rs
+++ b/plugins/db/src/import/calendars.rs
@@ -101,9 +101,7 @@ mod tests {
 
     async fn test_db() -> Db {
         let db = Db::connect_memory_plain().await.unwrap();
-        hypr_db_migrate::migrate(&db, hypr_db_app::schema())
-            .await
-            .unwrap();
+        hypr_db_app::prepare_schema(&db).await.unwrap();
         db
     }
 

--- a/plugins/db/src/import/events.rs
+++ b/plugins/db/src/import/events.rs
@@ -110,9 +110,7 @@ mod tests {
 
     async fn test_db() -> Db {
         let db = Db::connect_memory_plain().await.unwrap();
-        hypr_db_migrate::migrate(&db, hypr_db_app::schema())
-            .await
-            .unwrap();
+        hypr_db_app::prepare_schema(&db).await.unwrap();
         db
     }
 

--- a/plugins/db/src/import/templates.rs
+++ b/plugins/db/src/import/templates.rs
@@ -200,9 +200,7 @@ mod tests {
 
     async fn test_db() -> Db {
         let db = Db::connect_memory_plain().await.unwrap();
-        hypr_db_migrate::migrate(&db, hypr_db_app::schema())
-            .await
-            .unwrap();
+        hypr_db_app::prepare_schema(&db).await.unwrap();
         db
     }
 

--- a/plugins/db/src/lib.rs
+++ b/plugins/db/src/lib.rs
@@ -45,10 +45,7 @@ pub fn init<R: tauri::Runtime>(
     tauri::plugin::Builder::new(PLUGIN_NAME)
         .invoke_handler(specta_builder.invoke_handler())
         .setup(move |app, _| {
-            hypr_tauri_utils::block_on(hypr_db_migrate::migrate(
-                db.as_ref(),
-                hypr_db_app::schema(),
-            ))?;
+            hypr_tauri_utils::block_on(hypr_db_app::prepare_schema(db.as_ref()))?;
 
             let pool = db.pool().clone();
             let app_handle = app.app_handle().clone();
@@ -132,9 +129,7 @@ mod test {
         })
         .await
         .unwrap();
-        hypr_db_migrate::migrate(&db, hypr_db_app::schema())
-            .await
-            .unwrap();
+        hypr_db_app::prepare_schema(&db).await.unwrap();
 
         (dir, Arc::new(runtime::PluginDbRuntime::new(Arc::new(db))))
     }

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -49,9 +49,7 @@ impl PluginDbRuntime {
 
     async fn ensure_app_schema(&self) -> Result<()> {
         self.schema_ready
-            .get_or_try_init(|| async {
-                hypr_db_migrate::migrate(self.db.as_ref(), hypr_db_app::schema()).await
-            })
+            .get_or_try_init(|| async { hypr_db_app::prepare_schema(self.db.as_ref()).await })
             .await?;
         Ok(())
     }
@@ -105,7 +103,7 @@ pub async fn open_app_db(db_path: Option<&Path>) -> Result<Db> {
     })
     .await?;
 
-    hypr_db_migrate::migrate(&db, hypr_db_app::schema()).await?;
+    hypr_db_app::prepare_schema(&db).await?;
 
     Ok(db)
 }


### PR DESCRIPTION
Route app database startup through a shared schema preparation path that repairs a missing templates table after migrations and keeps desktop, mobile, CLI, and plugin tests aligned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local SQLite migration/repair on every app open; incorrect repair logic could affect existing user DBs or duplicate seeds, though seeding is gated on pre-migration missing table.
> 
> **Overview**
> Introduces **`hypr_db_app::prepare_schema`** as the single app DB startup path: run migrations, then **repair** if `templates` is still missing (re-apply the templates DDL), and **seed default templates** when the table was absent before migration so repair-only runs still get data.
> 
> **Desktop (Tauri db plugin), mobile bridge, and db-cli** now call `prepare_schema` instead of `hypr_db_migrate::migrate` directly; **`AppSchemaError`** wraps migrate/sqlx failures and is plumbed through plugin and mobile open errors.
> 
> Adds tests for dropping `templates` after migrations and verifying `prepare_schema` recreates and seeds rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f752ddf06dc78ccce5e95eab0fd99232e239f726. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->