### PR TITLE
Add chat FAB shadows

### DIFF
--- a/apps/desktop/src/chat/surface.test.ts
+++ b/apps/desktop/src/chat/surface.test.ts
@@ -41,10 +41,10 @@ describe("chat surface tokens", () => {
 
   it("uses a neutral surface on the floating shell", () => {
     expect(chatFloatingPanelShellClassNames()).toContain(
-      "shadow-[0_28px_72px_rgba(0,0,0,0.28)]",
+      "shadow-[0_32px_84px_rgba(0,0,0,0.32)]",
     );
     expect(chatFloatingPanelShellClassNames()).toContain(
-      "dark:shadow-[0_32px_84px_rgba(0,0,0,0.68)]",
+      "dark:shadow-[0_36px_96px_rgba(0,0,0,0.72)]",
     );
     expect(chatFloatingPanelShellClassNames()).toContain("bg-[#f4f4f5]");
     expect(chatFloatingPanelShellClassNames()).toContain("rounded-[24px]");

--- a/apps/desktop/src/chat/surface.ts
+++ b/apps/desktop/src/chat/surface.ts
@@ -17,7 +17,7 @@ export function chatPanelBorderClassNames(): string {
 }
 
 export function chatFloatingPanelShellClassNames(): string {
-  return "bg-[#f4f4f5] text-card-foreground rounded-[24px] border border-border/70 shadow-[0_28px_72px_rgba(0,0,0,0.28)] dark:border-white/10 dark:bg-[#202020] dark:shadow-[0_32px_84px_rgba(0,0,0,0.68)]";
+  return "bg-[#f4f4f5] text-card-foreground rounded-[24px] border border-border/70 shadow-[0_32px_84px_rgba(0,0,0,0.32)] dark:border-white/10 dark:bg-[#202020] dark:shadow-[0_36px_96px_rgba(0,0,0,0.72)]";
 }
 
 export function chatElevatedSurfaceClassNames(): string {

--- a/apps/desktop/src/shared/chat-cta.test.tsx
+++ b/apps/desktop/src/shared/chat-cta.test.tsx
@@ -66,9 +66,17 @@ describe("ChatCTA", () => {
     expect(surface?.className).toContain("rounded-full");
     expect(surface?.className).toContain("bg-black");
     expect(surface?.className).toContain("dark:bg-white");
-    expect(surface?.className).toContain("shadow-[0_8px_22px_rgba(0,0,0,0.2)]");
     expect(surface?.className).toContain(
-      "dark:shadow-[0_8px_24px_rgba(0,0,0,0.45)]",
+      "shadow-[0_10px_26px_rgba(0,0,0,0.22)]",
+    );
+    expect(surface?.className).toContain(
+      "dark:shadow-[0_10px_30px_rgba(0,0,0,0.5)]",
+    );
+    expect(surface?.className).toContain(
+      "group-hover/anarlog-chat-cta:shadow-[0_16px_42px_rgba(0,0,0,0.26)]",
+    );
+    expect(surface?.className).toContain(
+      "dark:group-hover/anarlog-chat-cta:shadow-[0_18px_52px_rgba(0,0,0,0.64)]",
     );
     expect(surface?.className).toContain("border");
     expect(surface?.className).toContain("border-transparent");

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -33,8 +33,9 @@ export function ChatCTA({
         className={cn([
           "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-[min(640px,calc(100cqw_-_2rem))] -translate-x-1/2 items-center overflow-hidden rounded-full border border-transparent bg-black dark:bg-white",
           "[clip-path:inset(0_calc(50%_-_3rem)_0_calc(50%_-_3rem)_round_9999px)]",
-          "origin-bottom px-0 text-sm shadow-[0_8px_22px_rgba(0,0,0,0.2)] transition-[clip-path,height,padding,background-color,border-color,box-shadow] duration-200 ease-out dark:shadow-[0_8px_24px_rgba(0,0,0,0.45)]",
+          "origin-bottom px-0 text-sm shadow-[0_10px_26px_rgba(0,0,0,0.22)] transition-[clip-path,height,padding,background-color,border-color,box-shadow] duration-200 ease-out dark:shadow-[0_10px_30px_rgba(0,0,0,0.5)]",
           "group-hover/anarlog-chat-cta:border-border/70 group-focus-visible/anarlog-chat-cta:border-border/70 group-hover/anarlog-chat-cta:bg-[#f4f4f5] group-focus-visible/anarlog-chat-cta:bg-[#f4f4f5] dark:group-hover/anarlog-chat-cta:bg-[#202020] dark:group-focus-visible/anarlog-chat-cta:bg-[#202020]",
+          "group-hover/anarlog-chat-cta:shadow-[0_16px_42px_rgba(0,0,0,0.26)] group-focus-visible/anarlog-chat-cta:shadow-[0_16px_42px_rgba(0,0,0,0.26)] dark:group-hover/anarlog-chat-cta:shadow-[0_18px_52px_rgba(0,0,0,0.64)] dark:group-focus-visible/anarlog-chat-cta:shadow-[0_18px_52px_rgba(0,0,0,0.64)]",
           "group-hover/anarlog-chat-cta:h-10 group-hover/anarlog-chat-cta:px-4 group-hover/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
           "group-focus-visible/anarlog-chat-cta:h-10 group-focus-visible/anarlog-chat-cta:px-4 group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
           "group-focus-visible/anarlog-chat-cta:ring-ring group-focus-visible/anarlog-chat-cta:ring-2 group-focus-visible/anarlog-chat-cta:ring-offset-2",


### PR DESCRIPTION
Strengthen collapsed, hover, and expanded floating chat shadows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only shadow token changes with no logic, data, or auth impact.
> 
> **Overview**
> **Stronger drop shadows** on the desktop floating chat UI so collapsed, hover, and open states read more clearly against the app chrome.
> 
> `chatFloatingPanelShellClassNames` bumps light/dark shell shadows (larger blur/offset and slightly higher opacity). The **chat CTA** pill gets deeper default shadows and **new hover/focus-visible shadow classes** so the handle lifts further when expanded. Matching expectations were updated in `surface.test.ts` and `chat-cta.test.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28db823703d67ba887e06ba6a134b8ed1f92ddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->