### PR TITLE
Fix floating bar drag behavior

### DIFF
--- a/plugins/windows/swift-lib/src/FloatingBarManager.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarManager.swift
@@ -28,7 +28,14 @@ final class FloatingBarManager {
 
       let panel = self.createPanel()
       let hostingView = NSHostingView(
-        rootView: FloatingBarView(model: self.model, settings: self.settingsModel))
+        rootView: FloatingBarView(
+          model: self.model,
+          settings: self.settingsModel,
+          panelOrigin: { [weak self] in self?.panel?.frame.origin },
+          movePanel: { [weak self] origin in
+            guard let self, let panel = self.panel else { return }
+            self.placement.moveByUserDrag(panel, to: origin)
+          }))
       hostingView.frame = NSRect(
         x: 0,
         y: 0,

--- a/plugins/windows/swift-lib/src/FloatingBarView.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 enum FloatingBarLayout {
@@ -35,9 +36,12 @@ enum FloatingBarLayout {
 struct FloatingBarView: View {
   @ObservedObject var model: FloatingBarViewModel
   @ObservedObject var settings: FloatingOverlaySettingsModel
+  let panelOrigin: () -> NSPoint?
+  let movePanel: (NSPoint) -> Void
   @State private var isBarHovered = false
   @State private var isBarsHovered = false
   @State private var suppressNextClick = false
+  @State private var dragStart: FloatingBarDragStart?
 
   var body: some View {
     VStack(spacing: FloatingBarLayout.hoverHandleGap) {
@@ -215,8 +219,26 @@ struct FloatingBarView: View {
     )
     .onChanged { _ in
       suppressNextClick = true
+
+      let mouseLocation = NSEvent.mouseLocation
+      let start =
+        dragStart
+        ?? panelOrigin().map {
+          FloatingBarDragStart(panelOrigin: $0, mouseLocation: mouseLocation)
+        }
+
+      guard let start else { return }
+      dragStart = start
+
+      movePanel(
+        NSPoint(
+          x: start.panelOrigin.x + mouseLocation.x - start.mouseLocation.x,
+          y: start.panelOrigin.y + mouseLocation.y - start.mouseLocation.y
+        )
+      )
     }
     .onEnded { _ in
+      dragStart = nil
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
         suppressNextClick = false
       }
@@ -241,6 +263,11 @@ struct FloatingBarView: View {
       LiveCaptionManager.shared.show()
     }
   }
+}
+
+private struct FloatingBarDragStart {
+  let panelOrigin: NSPoint
+  let mouseLocation: NSPoint
 }
 
 private struct FloatingBarHoverHandle: View {

--- a/plugins/windows/swift-lib/src/FloatingPanelPositionController.swift
+++ b/plugins/windows/swift-lib/src/FloatingPanelPositionController.swift
@@ -61,6 +61,13 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
     pinnedOrigin = nil
   }
 
+  func moveByUserDrag(_ panel: NSPanel, to origin: NSPoint) {
+    panel.setFrameOrigin(origin)
+    pinnedOrigin = panel.frame.origin
+    activeScreenId = panel.screen.flatMap { displayId(for: $0) }
+    programmaticOrigin = nil
+  }
+
   func preparePinnedFrameForReplacement(_ panel: NSPanel, size: NSSize) {
     guard pinnedOrigin != nil else { return }
 


### PR DESCRIPTION
Route native floating bar drag gestures through the position controller so moved panels stay pinned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized macOS overlay UI/positioning change with no auth, data, or network impact.
> 
> **Overview**
> **User drags on the native floating bar now move the panel explicitly and persist the new position** instead of depending only on AppKit window moves.
> 
> `FloatingBarView` extends the existing drag gesture (still used to suppress accidental clicks) to track a drag anchor from `NSEvent.mouseLocation` and the panel origin, then applies delta moves via injected `movePanel` callbacks. `FloatingBarManager` passes those closures into the SwiftUI root so each move calls `FloatingPanelPositionController.moveByUserDrag`, which sets the frame origin, updates `pinnedOrigin` and `activeScreenId`, and clears programmatic-move state so later `position()` calls respect the user-chosen spot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1190bbff60abc0bd6549ae8a04178a23cac669b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->