### PR TITLE
Stabilize live caption opacity

### DIFF
--- a/plugins/windows/swift-lib/src/FloatingOverlaySettingsModel.swift
+++ b/plugins/windows/swift-lib/src/FloatingOverlaySettingsModel.swift
@@ -47,6 +47,10 @@ final class FloatingOverlaySettingsModel: ObservableObject {
 
   func apply(liveCaptionState state: LiveCaptionStatePayload) -> Bool {
     applyLiveCaptionOpacity(state.opacity)
+    return applyLiveCaptionLayout(state)
+  }
+
+  func applyLiveCaptionLayout(_ state: LiveCaptionStatePayload) -> Bool {
     applyLiveCaptionWidth(state.width)
     applyLiveCaptionLineCount(state.lineCount)
     let positionChanged = applyLiveCaptionPosition(state.position)

--- a/plugins/windows/swift-lib/src/LiveCaptionManager.swift
+++ b/plugins/windows/swift-lib/src/LiveCaptionManager.swift
@@ -85,7 +85,12 @@ final class LiveCaptionManager {
   func update(state: LiveCaptionStatePayload) {
     runOnMain { [weak self] in
       guard let self else { return }
-      let placementChanged = self.settingsModel.apply(liveCaptionState: state)
+      let placementChanged: Bool
+      if self.panel == nil {
+        placementChanged = self.settingsModel.apply(liveCaptionState: state)
+      } else {
+        placementChanged = self.settingsModel.applyLiveCaptionLayout(state)
+      }
       if state.minimized {
         self.hidePanel(clearText: false)
         return


### PR DESCRIPTION
Keep live caption text updates from reapplying stale opacity after local changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to Windows floating overlay settings sync with no auth or data handling impact.
> 
> **Overview**
> Frequent live caption **text** updates from Rust no longer reapply **opacity** when the caption panel is already on screen, so a locally adjusted opacity is not overwritten by stale values in the payload.
> 
> `FloatingOverlaySettingsModel` now exposes **`applyLiveCaptionLayout`**, which updates width, line count, position, and minimized only. **`apply(liveCaptionState:)`** still applies opacity plus layout (used when the panel is hidden). **`LiveCaptionManager.update`** calls the full apply path only when `panel == nil`; otherwise it applies layout alone while still updating caption text and resizing/repositioning as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88441aedc8861944e56db0592b930ee45f4c6dd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->