### PR TITLE
Update desktop 1.1.0 changelog

### DIFF
--- a/packages/changelog/content/1.1.0.md
+++ b/packages/changelog/content/1.1.0.md
@@ -1,6 +1,6 @@
 ---
 date: "2026-06-24"
-summary: "Anarlog now adds Cartesia transcription, smarter chat context, better meeting controls, and a steadier editing experience."
+summary: "Anarlog now adds Cartesia transcription, live transcript overlay controls, smarter chat context, and steadier editing."
 ---
 
 ## Transcription
@@ -9,6 +9,8 @@ summary: "Anarlog now adds Cartesia transcription, smarter chat context, better 
 - Transcript speaker labels can now be reassigned from the transcript, either across matching speaker turns or for a single segment
 - Speaker corrections now carry through transcript rendering and exports more reliably
 - Live captions now use a native desktop surface for a cleaner, more reliable viewing experience
+- Live transcript overlay controls now let you show, hide, and tune the floating transcript during active meetings
+- Live caption visibility now behaves more predictably when captions are hidden, restored, or shown by default
 
 ## Notes and Summaries
 
@@ -31,6 +33,7 @@ summary: "Anarlog now adds Cartesia transcription, smarter chat context, better 
 
 - Cal.com meetings now include a join control directly in the meeting surface
 - Collapsed sidebars no longer show the upcoming meeting badge when that meeting note is already open
+- Floating meeting controls now drag more reliably around the screen
 - The left sidebar is now resizable and starts at a more comfortable default width
 - Notification close buttons now stay inside the notification panel and keep a round shape while hovering
 


### PR DESCRIPTION
Summary:
- Refresh the 1.1.0 changelog with live transcript overlay controls and floating meeting control fixes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown changelog only; no runtime or product logic changes.
> 
> **Overview**
> Updates the **1.1.0** changelog copy to document recently shipped desktop behavior.
> 
> The frontmatter **summary** now highlights live transcript overlay controls instead of generic “meeting controls” wording. Under **Transcription**, two bullets were added for overlay show/hide/tune controls and more predictable live caption visibility. Under **Meetings and Notifications**, a bullet was added for more reliable dragging of floating meeting controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2363b649885f8fbc751e76647020e97a0f41179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->