### PR TITLE
Allow explicit desktop release versions

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -13,6 +13,11 @@ on:
         description: "Publish to Crabnebula and create GitHub release (ignored for staging)"
         type: boolean
         default: true
+      version:
+        description: "Optional explicit version for stable releases"
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.channel }}
@@ -40,7 +45,9 @@ jobs:
       - uses: ./.github/actions/doxxer_install
       - id: version
         run: |
-          if [[ "${{ inputs.channel }}" == "staging" ]]; then
+          if [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+          elif [[ "${{ inputs.channel }}" == "staging" ]]; then
             VERSION=$(doxxer --config doxxer.desktop.toml next dev)
           elif [[ "${{ inputs.channel }}" == "stable" ]]; then
             VERSION=$(doxxer --config doxxer.desktop.toml next patch)
@@ -198,11 +205,23 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: desktop_v${{ needs.compute-version.outputs.version }}
-          tag_prefix: ""
+          fetch-depth: 0
+          fetch-tags: true
+      - run: |
+          git fetch --tags --force
+
+          TAG="desktop_v${{ needs.compute-version.outputs.version }}"
+          TARGET=$(git rev-parse HEAD)
+          EXISTING=$(git rev-parse -q --verify "refs/tags/$TAG" || true)
+
+          if [[ -n "$EXISTING" && -z "${{ inputs.version }}" ]]; then
+            echo "::error::Tag $TAG already exists"
+            exit 1
+          fi
+
+          git tag -f "$TAG" "$TARGET"
+          git push origin "refs/tags/$TAG" --force
 
   cn-publish:
     if: ${{ inputs.channel != 'staging' && inputs.publish }}


### PR DESCRIPTION
Summary:
- Add an optional desktop CD version input for explicit stable releases.
- Make release tag creation handle explicit-version reruns by updating the tag to the dispatched commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stable release tagging (including force-push) and version selection in CI; mistakes could mislabel builds or move an existing release tag.
> 
> **Overview**
> Adds an optional **`version`** input to the desktop CD workflow so stable releases can pin a specific semver instead of always using doxxer’s next patch.
> 
> **`compute-version`** now prefers that input when set; staging/stable doxxer behavior is unchanged otherwise.
> 
> **`create-tag`** no longer uses `github-tag-action`. It tags `desktop_v{version}` on the dispatch commit, fails if the tag already exists on auto-version runs, and **force-updates** the tag when an explicit version was provided so reruns can point the same release tag at a new commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d82e098f160f7bc93fbebb02786a246bccc16b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->