### PR TITLE
Adjust timeline top chip spacing

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -197,8 +197,12 @@ describe("TimelineView", () => {
     expect(getSidebarActionTabsOrNull()).toBeNull();
     expect(calendarButton.className).toContain("rounded-full");
     expect(
+      container.querySelector("[data-sidebar-timeline-top-chip-stack]")
+        ?.className,
+    ).toContain("top-10");
+    expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).toContain("h-20");
+    ).toContain("h-18");
 
     fireEvent.click(calendarButton);
 
@@ -286,6 +290,10 @@ describe("TimelineView", () => {
     });
 
     expect(getSidebarActionTabsOrNull()).toBeNull();
+    expect(
+      container.querySelector("[data-sidebar-timeline-top-chip-stack]")
+        ?.className,
+    ).toContain("top-4");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
     ).toContain("h-10");

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -151,12 +151,12 @@ export function TimelineView({
   const hasReservedTopChromeChip = showOpenCalendarChip;
   const topSpacerClassName = topChromeInset
     ? hasReservedTopChromeChip
-      ? "h-20"
+      ? "h-18"
       : "h-8"
     : "h-10";
   const bucketHeaderTopClassName = topChromeInset
     ? hasReservedTopChromeChip
-      ? "top-20"
+      ? "top-18"
       : "top-8"
     : "top-0";
   const showTopChromeFade = topChromeInset && !isScrolledToTop;
@@ -457,7 +457,7 @@ export function TimelineView({
           className={cn([
             "pointer-events-none absolute inset-x-0 top-0 z-[15]",
             hasReservedTopChromeChip
-              ? "bg-background h-20"
+              ? "bg-background h-18"
               : "from-background via-background/95 to-background/0 h-16 bg-linear-to-b from-60% via-85%",
           ])}
         />
@@ -465,9 +465,10 @@ export function TimelineView({
 
       {(showOpenCalendarChip || showUpcomingMeetingChip || showTopNowChip) && (
         <div
+          data-sidebar-timeline-top-chip-stack
           className={cn([
             "absolute left-1/2 z-20 flex -translate-x-1/2 transform flex-col items-center gap-2",
-            topChromeInset ? "top-8" : "top-2",
+            topChromeInset ? "top-10" : "top-4",
           ])}
         >
           {showOpenCalendarChip && (


### PR DESCRIPTION
Move timeline chips lower and tighten the open calendar spacer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only Tailwind class changes in the timeline sidebar with no logic or data impact.
> 
> **Overview**
> Tweaks **sidebar timeline top chrome** layout so calendar / meeting / “Now” chips sit lower while the reserved scroll area when the **Open calendar** chip is visible is slightly shorter.
> 
> When `topChromeInset` is on and the open-calendar chip reserves space, top spacer, sticky bucket headers, and the solid top fade move from **`h-20` / `top-20`** to **`h-18` / `top-18`**. The floating chip stack shifts from **`top-8` → `top-10`** (inset) and **`top-2` → `top-4`** (no inset). A **`data-sidebar-timeline-top-chip-stack`** hook was added on the chip container; tests assert the new positions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c076d56b24c3da9ed24ec71ce3ae3a648129e052. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->