### PR TITLE
Persist selected transcription languages

### DIFF
--- a/apps/desktop/src/store/tinybase/persister/settings/persister.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/settings/persister.test.ts
@@ -455,7 +455,7 @@ describe("settingsPersister roundtrip", () => {
     expect(result.notification).toEqual({ event: false });
   });
 
-  test("storeValuesToSettings clears language values matching OS locale defaults", () => {
+  test("storeValuesToSettings preserves language values matching OS locale defaults", () => {
     const [tables, values] = settingsToContent({
       language: {
         ai_language: "pl",
@@ -474,7 +474,10 @@ describe("settingsPersister roundtrip", () => {
       { ai_language: "pl", spoken_languages: ["pl", "en"] },
     );
 
-    expect(result.language).toEqual({});
+    expect(result.language).toEqual({
+      ai_language: "pl",
+      spoken_languages: ["pl", "en"],
+    });
   });
 
   test("storeValuesToSettings preserves explicitly cleared spoken languages", () => {
@@ -497,6 +500,7 @@ describe("settingsPersister roundtrip", () => {
     );
 
     expect(result.language).toEqual({
+      ai_language: "ko",
       spoken_languages: [],
     });
   });
@@ -526,7 +530,7 @@ describe("settingsPersister roundtrip", () => {
     });
   });
 
-  test("storeValuesToSettings clears language values matching OS locale defaults by prefix", () => {
+  test("storeValuesToSettings preserves language values matching OS locale defaults by prefix", () => {
     const [tables, values] = settingsToContent({
       language: {
         ai_language: "ko",
@@ -545,7 +549,10 @@ describe("settingsPersister roundtrip", () => {
       { ai_language: "ko-KR", spoken_languages: ["ko-KR", "en-US"] },
     );
 
-    expect(result.language).toEqual({});
+    expect(result.language).toEqual({
+      ai_language: "ko",
+      spoken_languages: ["ko", "en"],
+    });
   });
 
   test("language section takes precedence over general section", () => {

--- a/apps/desktop/src/store/tinybase/persister/settings/transform.ts
+++ b/apps/desktop/src/store/tinybase/persister/settings/transform.ts
@@ -153,12 +153,6 @@ export type LanguageDefaults = {
   spoken_languages?: string[];
 };
 
-function languagePrefixMatch(a: string, b: string): boolean {
-  if (a === b) return true;
-  const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a];
-  return longer.startsWith(shorter + "-");
-}
-
 export function storeValuesToSettings(
   values: Record<string, unknown>,
   languageDefaults?: LanguageDefaults,
@@ -185,27 +179,6 @@ export function storeValuesToSettings(
 
       if (!isClearedSpokenLanguages) {
         continue;
-      }
-    }
-    if (languageDefaults) {
-      if (
-        key === "ai_language" &&
-        languageDefaults.ai_language &&
-        languagePrefixMatch(value as string, languageDefaults.ai_language)
-      ) {
-        continue;
-      }
-      if (key === "spoken_languages" && languageDefaults.spoken_languages) {
-        try {
-          const storeArr = JSON.parse(value as string) as string[];
-          const defaultArr = languageDefaults.spoken_languages;
-          if (
-            storeArr.length === defaultArr.length &&
-            storeArr.every((v, i) => languagePrefixMatch(v, defaultArr[i]))
-          ) {
-            continue;
-          }
-        } catch {}
       }
     }
     setByPath(result, config.path, fromStoreValue(key, value));

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -243,6 +243,36 @@ describe("useRunBatch", () => {
     expect(saveMock).toHaveBeenCalledTimes(1);
     expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
   });
+
+  test("passes selected transcription languages to batch transcription", async () => {
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "hyprnote",
+        model: "soniqo-parakeet-batch",
+        baseUrl: "soniqo://local",
+        apiKey: "",
+      },
+    });
+    useConfigValueMock.mockImplementation((key) =>
+      key === "ai_language" ? "de" : ["en"],
+    );
+    startTranscriptionMock.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await act(async () => {
+      await result.current("/tmp/session.wav");
+    });
+
+    expect(startTranscriptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "soniqo",
+        model: "soniqo-parakeet-batch",
+        languages: ["de", "en"],
+      }),
+      expect.any(Object),
+    );
+  });
 });
 
 describe("getSessionSpeakerCount", () => {

--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -133,19 +133,22 @@ pub(super) async fn run_soniqo_batch(
             .languages
             .first()
             .map(hypr_language::Language::bcp47_code);
+        let language_hint = soniqo_language_hint(language.as_deref());
         let language_label = language.as_deref().unwrap_or("auto").to_string();
+        let language_hint_label = language_hint.as_deref().unwrap_or("auto").to_string();
         let started_at = Instant::now();
 
         tracing::info!(
             hyprnote.stt.provider.name = "soniqo",
             hyprnote.stt.model = %model,
             hyprnote.stt.language = %language_label,
+            hyprnote.stt.language_hint = %language_hint_label,
             file.extension = %file_extension,
             "soniqo_batch_start"
         );
 
         let transcribed = tokio::task::spawn_blocking(move || {
-            transcribe_soniqo_file(model, &file_path, language.as_deref())
+            transcribe_soniqo_file(model, &file_path, language_hint.as_deref())
         })
         .await
         .map_err(|e| {
@@ -218,7 +221,7 @@ fn transcribe_soniqo_file(
         "soniqo_audio_file_loaded"
     );
 
-    if channel_count <= 1 {
+    if channel_count <= 1 && !uses_resilient_soniqo_chunking(model) {
         tracing::info!(
             hyprnote.stt.provider.name = "soniqo",
             hyprnote.stt.model = %model,
@@ -252,13 +255,68 @@ fn transcribe_soniqo_file(
         "soniqo_channels_prepared"
     );
 
-    channel_samples
-        .into_iter()
-        .enumerate()
-        .map(|(channel_index, samples)| {
+    collect_soniqo_channel_transcripts(channel_samples.into_iter().enumerate().map(
+        |(channel_index, samples)| {
             transcribe_soniqo_channel(model, channel_index, &samples, language)
-        })
-        .collect()
+        },
+    ))
+}
+
+fn soniqo_language_hint(language: Option<&str>) -> Option<String> {
+    let language = language?.trim();
+    if language.is_empty() {
+        return None;
+    }
+
+    language
+        .split(['-', '_'])
+        .next()
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_lowercase())
+}
+
+fn uses_resilient_soniqo_chunking(model: hypr_transcribe_soniqo::SoniqoModel) -> bool {
+    matches!(model, hypr_transcribe_soniqo::SoniqoModel::ParakeetBatch)
+}
+
+fn collect_soniqo_channel_transcripts<I>(
+    transcripts: I,
+) -> std::result::Result<Vec<hypr_transcribe_soniqo::FileTranscript>, String>
+where
+    I: IntoIterator<Item = std::result::Result<hypr_transcribe_soniqo::FileTranscript, String>>,
+{
+    let mut output = Vec::new();
+    let mut successful_channels = 0usize;
+    let mut failed_channels = 0usize;
+
+    for transcript in transcripts {
+        match transcript {
+            Ok(transcript) => {
+                successful_channels += 1;
+                output.push(transcript);
+            }
+            Err(error) => {
+                failed_channels += 1;
+                tracing::warn!(
+                    hyprnote.stt.provider.name = "soniqo",
+                    error = %error,
+                    "soniqo_channel_transcription_failed"
+                );
+                output.push(hypr_transcribe_soniqo::FileTranscript {
+                    text: String::new(),
+                    duration_seconds: 0.05,
+                });
+            }
+        }
+    }
+
+    if successful_channels == 0 && failed_channels > 0 {
+        return Err(format!(
+            "Soniqo failed to transcribe all {failed_channels} audio channel(s)."
+        ));
+    }
+
+    Ok(output)
 }
 
 fn transcribe_soniqo_channel(
@@ -282,6 +340,8 @@ fn transcribe_soniqo_channel(
     );
 
     let mut texts = Vec::new();
+    let mut successful_chunks = 0usize;
+    let mut failed_chunks = 0usize;
 
     for (chunk_index, chunk) in chunks.into_iter().enumerate() {
         let chunk_duration_ms =
@@ -299,9 +359,14 @@ fn transcribe_soniqo_channel(
             "soniqo_chunk_native_inference_start"
         );
 
-        let text = transcribe_soniqo_samples(model, &chunk.samples, language)
-            .map_err(|e| {
-                tracing::error!(
+        let text = match transcribe_soniqo_samples(model, &chunk.samples, language) {
+            Ok(transcript) => {
+                successful_chunks += 1;
+                transcript.text
+            }
+            Err(e) => {
+                failed_chunks += 1;
+                tracing::warn!(
                     hyprnote.stt.provider.name = "soniqo",
                     hyprnote.stt.model = %model,
                     channel.index = channel_index,
@@ -310,9 +375,9 @@ fn transcribe_soniqo_channel(
                     error = %e,
                     "soniqo_chunk_native_inference_failed"
                 );
-                e
-            })?
-            .text;
+                continue;
+            }
+        };
 
         tracing::info!(
             hyprnote.stt.provider.name = "soniqo",
@@ -328,6 +393,23 @@ fn transcribe_soniqo_channel(
         if !text.is_empty() {
             texts.push(text.to_string());
         }
+    }
+
+    if successful_chunks == 0 && failed_chunks > 0 {
+        return Err(format!(
+            "Soniqo failed to transcribe all {failed_chunks} chunk(s) for channel {channel_index}."
+        ));
+    }
+
+    if failed_chunks > 0 {
+        tracing::warn!(
+            hyprnote.stt.provider.name = "soniqo",
+            hyprnote.stt.model = %model,
+            channel.index = channel_index,
+            chunk.success_count = successful_chunks,
+            chunk.failed_count = failed_chunks,
+            "soniqo_channel_completed_with_chunk_failures"
+        );
     }
 
     Ok(hypr_transcribe_soniqo::FileTranscript {
@@ -489,5 +571,74 @@ mod tests {
 
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].samples.len(), oversized);
+    }
+
+    #[test]
+    fn soniqo_language_hint_uses_base_language_code() {
+        assert_eq!(soniqo_language_hint(Some("de-DE")).as_deref(), Some("de"));
+        assert_eq!(soniqo_language_hint(Some("en_US")).as_deref(), Some("en"));
+        assert_eq!(soniqo_language_hint(Some(" fr ")).as_deref(), Some("fr"));
+        assert_eq!(soniqo_language_hint(Some("")).as_deref(), None);
+        assert_eq!(soniqo_language_hint(None).as_deref(), None);
+    }
+
+    #[test]
+    fn parakeet_batch_uses_resilient_chunking() {
+        assert!(uses_resilient_soniqo_chunking(
+            hypr_transcribe_soniqo::SoniqoModel::ParakeetBatch
+        ));
+        assert!(!uses_resilient_soniqo_chunking(
+            hypr_transcribe_soniqo::SoniqoModel::Omnilingual
+        ));
+    }
+
+    #[test]
+    fn collect_soniqo_channel_transcripts_keeps_channel_slots() {
+        let transcripts = collect_soniqo_channel_transcripts([
+            Ok(hypr_transcribe_soniqo::FileTranscript {
+                text: "hello".to_string(),
+                duration_seconds: 1.0,
+            }),
+            Err("native chunk failed".to_string()),
+        ])
+        .unwrap();
+
+        assert_eq!(transcripts.len(), 2);
+        assert_eq!(transcripts[0].text, "hello");
+        assert_eq!(transcripts[1].text, "");
+    }
+
+    #[test]
+    fn collect_soniqo_channel_transcripts_preserves_later_channel_index() {
+        let transcripts = collect_soniqo_channel_transcripts([
+            Err("first failed".to_string()),
+            Ok(hypr_transcribe_soniqo::FileTranscript {
+                text: "system audio".to_string(),
+                duration_seconds: 1.0,
+            }),
+        ])
+        .unwrap();
+
+        let response = hypr_transcribe_soniqo::batch_response_from_channels(
+            hypr_transcribe_soniqo::SoniqoModel::ParakeetBatch,
+            transcripts,
+        );
+        let alternative = &response.results.channels[1].alternatives[0];
+
+        assert_eq!(response.results.channels.len(), 2);
+        assert_eq!(response.results.channels[0].alternatives[0].transcript, "");
+        assert_eq!(alternative.transcript, "system audio");
+        assert_eq!(alternative.words[0].channel, 1);
+    }
+
+    #[test]
+    fn collect_soniqo_channel_transcripts_errors_when_all_channels_fail() {
+        let error = collect_soniqo_channel_transcripts([
+            Err("first failed".to_string()),
+            Err("second failed".to_string()),
+        ])
+        .unwrap_err();
+
+        assert_eq!(error, "Soniqo failed to transcribe all 2 audio channel(s).");
     }
 }


### PR DESCRIPTION
Keep language settings in settings.json even when they match OS defaults and cover German Soniqo batch language hints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes settings persistence semantics and Soniqo batch failure/partial-success behavior, which can affect saved user config and transcript quality for multi-channel or chunked German/local STT runs.
> 
> **Overview**
> Language choices now stay in `settings.json` when they match the OS locale (including region-prefix matches like `ko` vs `ko-KR`). `storeValuesToSettings` no longer strips `ai_language` / `spoken_languages` against OS defaults; explicitly clearing spoken languages to `[]` is still written through.
> 
> Soniqo batch transcription passes a **base language hint** (e.g. `de` from `de-DE`) into native inference, with logging for the hint. **Parakeet batch** always uses the chunked multi-path (resilient chunking) even for mono audio, and tolerates partial failures: failed channels become empty transcript slots (preserving channel indices), failed chunks are skipped with warnings, and the run only errors if every channel or every chunk on a channel fails.
> 
> A desktop test asserts batch runs forward `ai_language` and `spoken_languages` (e.g. `["de","en"]`) into `startTranscription`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa8f9d5a13bc3adf55b92499b05106f7eb0a3d46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->