### PR TITLE
Add note window action to session overflow

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -82,6 +82,7 @@ export function OuterHeader({
         <HeaderMeetingControl sessionId={sessionId} sessionMode={sessionMode} />
         <OverflowButton
           allowListening={!standaloneWindow}
+          standaloneWindow={standaloneWindow}
           sessionId={sessionId}
           currentView={currentView}
         />

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -13,6 +13,7 @@ const {
   useHasTranscriptMock,
   useListenerMock,
   useConfigValueMock,
+  windowShowMock,
 } = vi.hoisted(() => ({
   uploadAudioMock: vi.fn(),
   uploadTranscriptMock: vi.fn(),
@@ -20,6 +21,7 @@ const {
   useHasTranscriptMock: vi.fn(),
   useListenerMock: vi.fn(),
   useConfigValueMock: vi.fn(),
+  windowShowMock: vi.fn(() => Promise.resolve({ status: "ok", data: null })),
 }));
 
 vi.mock("@hypr/ui/components/ui/button", () => ({
@@ -73,6 +75,12 @@ vi.mock("./misc", () => ({
 
 vi.mock("~/meeting-float/host", () => ({
   openFloatingMeetingPanel: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-windows", () => ({
+  commands: {
+    windowShow: windowShowMock,
+  },
 }));
 
 vi.mock("~/session/components/shared", () => ({
@@ -181,6 +189,36 @@ describe("OverflowButton", () => {
       sessionId: "session-1",
       enabled: true,
     });
+  });
+
+  it("opens the current note in a standalone window", () => {
+    render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open in New Window" }));
+
+    expect(windowShowMock).toHaveBeenCalledWith({
+      type: "note",
+      value: "session-1",
+    });
+  });
+
+  it("hides the standalone window action in standalone windows", () => {
+    render(
+      <OverflowButton
+        standaloneWindow
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Open in New Window" }),
+    ).toBeNull();
   });
 
   it("hides listening actions when listening is disabled", () => {

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -4,6 +4,7 @@ import {
   FileTextIcon,
   MoreHorizontalIcon,
   PictureInPicture2Icon,
+  SquareArrowOutUpRightIcon,
 } from "lucide-react";
 import { useState } from "react";
 
@@ -27,6 +28,7 @@ import {
   useCurrentNoteHasContent,
   useHasTranscript,
 } from "~/session/components/shared";
+import { openStandaloneNoteWindow } from "~/session/window";
 import { useConfigValue } from "~/shared/config";
 import * as settingsStore from "~/store/tinybase/store/settings";
 import type { EditorView } from "~/store/zustand/tabs/schema";
@@ -35,10 +37,12 @@ import { useUploadFile } from "~/stt/useUploadFile";
 
 export function OverflowButton({
   allowListening = true,
+  standaloneWindow = false,
   sessionId,
   currentView,
 }: {
   allowListening?: boolean;
+  standaloneWindow?: boolean;
   sessionId: string;
   currentView: EditorView;
 }) {
@@ -74,6 +78,10 @@ export function OverflowButton({
       enabled: floatingBarEnabled,
       store: settings,
     });
+  };
+  const handleOpenStandaloneWindow = () => {
+    setOpen(false);
+    void openStandaloneNoteWindow(sessionId);
   };
 
   return (
@@ -130,6 +138,15 @@ export function OverflowButton({
               </DropdownMenuItem>
             )}
             <DropdownMenuSeparator />
+            {!standaloneWindow && (
+              <DropdownMenuItem
+                onClick={handleOpenStandaloneWindow}
+                className="cursor-pointer"
+              >
+                <SquareArrowOutUpRightIcon />
+                <span>Open in New Window</span>
+              </DropdownMenuItem>
+            )}
             <ShowInFinder sessionId={sessionId} />
             <DeleteNote sessionId={sessionId} />
           </AppFloatingPanel>

--- a/apps/desktop/src/session/window.ts
+++ b/apps/desktop/src/session/window.ts
@@ -1,0 +1,12 @@
+import { commands as windowsCommands } from "@hypr/plugin-windows";
+
+export async function openStandaloneNoteWindow(sessionId: string) {
+  const result = await windowsCommands.windowShow({
+    type: "note",
+    value: sessionId,
+  });
+
+  if (result.status === "error") {
+    console.error("Failed to open note window:", result.error);
+  }
+}

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -9,7 +9,6 @@ import {
 
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
-import { commands as windowsCommands } from "@hypr/plugin-windows";
 import { DancingSticks } from "@hypr/ui/components/ui/dancing-sticks";
 import { Spinner } from "@hypr/ui/components/ui/spinner";
 import { cn, format, getYear, safeParseDate, TZDate } from "@hypr/utils";
@@ -25,6 +24,7 @@ import {
 import { writeSessionContextDragData } from "~/chat/context/session-drag";
 import { useIsSessionEnhancing } from "~/session/hooks/useEnhancedNotes";
 import { getSessionEvent } from "~/session/utils";
+import { openStandaloneNoteWindow } from "~/session/window";
 import type { MenuItemDef } from "~/shared/hooks/useNativeContextMenu";
 import { InteractiveButton } from "~/shared/ui/interactive-button";
 import { useIgnoredEvents } from "~/store/tinybase/hooks";
@@ -613,17 +613,6 @@ const SessionItem = memo(
     );
   },
 );
-
-async function openStandaloneNoteWindow(sessionId: string) {
-  const result = await windowsCommands.windowShow({
-    type: "note",
-    value: sessionId,
-  });
-
-  if (result.status === "error") {
-    console.error("Failed to open note window:", result.error);
-  }
-}
 
 function formatDisplayTime(
   timestamp: string | null | undefined,


### PR DESCRIPTION
Add a shared standalone note window helper and expose it in the session header overflow menu with regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI addition and a thin refactor around an existing `windowShow` path; no auth, data, or core session logic changes.
> 
> **Overview**
> Adds **Open in New Window** to the session header overflow menu so users can pop the current note into a standalone Tauri window from the main session view.
> 
> Standalone note opening is centralized in `openStandaloneNoteWindow` in `session/window.ts` (shared with the sidebar timeline, which no longer duplicates the `windowShow` call). The overflow passes through `standaloneWindow` from the outer header and **hides** this action when the user is already in a standalone note window.
> 
> Regression tests cover invoking `windowShow` with `{ type: "note", value: sessionId }` and the hidden-menu behavior when `standaloneWindow` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99a334e7606df1169fc72b8e5be4b55002c650bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->