### PR TITLE
Stop generating insights when panel opens

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -33,7 +33,6 @@ const hoisted = vi.hoisted(() => ({
     isGenerating: boolean;
   }>,
   batch: {} as Record<string, { error: string | null }>,
-  generateMissingPastNotes: vi.fn(),
   regenerateInsights: vi.fn(),
 }));
 
@@ -63,7 +62,6 @@ vi.mock("./past-notes", () => ({
     hasPastNotes: hoisted.pastNotes.length > 0,
     isGenerating: false,
     canGenerate: true,
-    generateMissing: hoisted.generateMissingPastNotes,
     regenerate: vi.fn(),
     regenerateAll: hoisted.regenerateInsights,
   }),
@@ -107,7 +105,6 @@ describe("useSessionBottomAccessory", () => {
     hoisted.live.liveTranscriptionActive = true;
     hoisted.pastNotes = [];
     hoisted.batch = {};
-    hoisted.generateMissingPastNotes.mockClear();
     hoisted.regenerateInsights.mockClear();
     useShellMock.mockReturnValue({
       chat: {
@@ -221,7 +218,7 @@ describe("useSessionBottomAccessory", () => {
       handle.props.onSelect("insights");
     });
 
-    expect(hoisted.generateMissingPastNotes).toHaveBeenCalledTimes(1);
+    expect(hoisted.regenerateInsights).not.toHaveBeenCalled();
     expect(result.current.bottomAccessoryState).toEqual({
       mode: "transcript_only",
       expanded: true,
@@ -259,7 +256,7 @@ describe("useSessionBottomAccessory", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Expand Insights" }));
 
-    expect(hoisted.generateMissingPastNotes).toHaveBeenCalledTimes(1);
+    expect(hoisted.regenerateInsights).not.toHaveBeenCalled();
     expect(result.current.bottomAccessoryState).toEqual({
       mode: "transcript_only",
       expanded: true,

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -54,7 +54,6 @@ export function useSessionBottomAccessory({
     enabled: shouldLoadPastNotes,
   });
   const hasPastNotes = pastNotes.hasPastNotes;
-  const generateMissingPastNotes = pastNotes.generateMissing;
   const activePostSessionTab: PostSessionTab = hasPastNotes
     ? (postSessionTab ?? "insights")
     : "transcript";
@@ -66,17 +65,12 @@ export function useSessionBottomAccessory({
     (!shouldDeferToGlobalLiveAccessory && isInactive && hasPastNotes);
   const selectPostSessionTab = useCallback(
     (tab: PostSessionTab) => {
-      const shouldExpand = activePostSessionTab !== tab || !isExpanded;
-      if (tab === "insights" && shouldExpand) {
-        generateMissingPastNotes();
-      }
-
       setPostSessionTab(tab);
       setIsExpanded((expanded) =>
         activePostSessionTab === tab ? !expanded : true,
       );
     },
-    [activePostSessionTab, generateMissingPastNotes, isExpanded],
+    [activePostSessionTab],
   );
 
   useHotkeys(

--- a/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
+++ b/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
@@ -43,7 +43,6 @@ export type PastSessionNotesResult = {
   hasPastNotes: boolean;
   isGenerating: boolean;
   canGenerate: boolean;
-  generateMissing: () => void;
   regenerate: (sessionId: string) => void;
   regenerateAll: () => void;
 };
@@ -157,19 +156,6 @@ export function usePastSessionNotes(
     [built.notes, generatingIds, mutation.isPending],
   );
 
-  const generateMissing = useCallback(() => {
-    if (
-      !enabled ||
-      !model ||
-      built.missing.length === 0 ||
-      mutation.isPending
-    ) {
-      return;
-    }
-
-    mutation.mutate(built.missing);
-  }, [built.missing, enabled, model, mutation]);
-
   const regenerate = useCallback(
     (targetSessionId: string) => {
       if (!enabled || !model || mutation.isPending) {
@@ -206,7 +192,6 @@ export function usePastSessionNotes(
     hasPastNotes: notes.length > 0,
     isGenerating: mutation.isPending,
     canGenerate: enabled && Boolean(model),
-    generateMissing,
     regenerate,
     regenerateAll,
   };


### PR DESCRIPTION
Remove the automatic missing-insights generation trigger from the bottom accessory and keep regeneration explicit from the panel action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-only UX change in desktop session UI; no auth or data-model changes, though users may see empty insights until they explicitly regenerate.
> 
> **Overview**
> **Stops automatic LLM generation** for missing past-session key facts when users expand or switch to the Insights tab in the session bottom accessory.
> 
> Previously, `selectPostSessionTab` called `pastNotes.generateMissing()` whenever the insights panel expanded. That path is removed from `index.tsx`, and **`generateMissing` is deleted** from `usePastSessionNotes` and its public type—only **`regenerate`** (per session) and **`regenerateAll`** (panel action via `onRegenerateInsights`) remain.
> 
> Tests now assert that opening/expanding Insights does **not** trigger bulk regeneration (`regenerateInsights` is not called).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 596268867c7040385d5a169fca6b42899453b32c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->