### PR TITLE
Hide insights tab divider

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -196,7 +196,7 @@ function PostSessionTabButton({
       onClick={() => onSelect(tab)}
       className={cn([
         "border-border relative flex h-5 items-center justify-center gap-1 border-t px-3",
-        "after:pointer-events-none after:absolute after:right-px after:-bottom-px after:left-px after:h-0.5 after:bg-inherit after:content-['']",
+        "after:pointer-events-none after:absolute after:right-px after:-bottom-0.5 after:left-px after:h-1 after:bg-inherit after:content-['']",
         "text-[10px] font-medium transition-colors",
         isActive && isExpanded
           ? "bg-card text-foreground"


### PR DESCRIPTION
Extend the bottom accessory tab mask so the Insights panel border does not show through in detached note windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class tweak on a tab button; no logic, data, or auth changes.
> 
> **Overview**
> Adjusts the **Insights** bottom-accessory tab button (`PostSessionTabButton`) so its `::after` mask sits lower and is taller (`after:-bottom-0.5`, `after:h-1` instead of `after:-bottom-px`, `after:h-0.5`).
> 
> That widens the painted strip under the tab handle so the panel border no longer shows through in detached note windows, matching the PR goal of hiding the tab divider bleed-through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a75c3f284c24b1973b4a63af01ca57d67ee8f79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->