### PR TITLE
Hide upload actions during live meetings

### DIFF
--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -166,6 +166,26 @@ describe("OverflowButton", () => {
     ).toBeNull();
   });
 
+  it("hides upload actions while a meeting is in progress", () => {
+    useListenerMock.mockImplementation((selector) =>
+      selector({
+        getSessionMode: () => "active",
+      }),
+    );
+
+    render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Upload audio" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Upload transcript" }),
+    ).toBeNull();
+  });
+
   it("opens the floating panel while actively listening", () => {
     useConfigValueMock.mockReturnValue(true);
     useListenerMock.mockImplementation((selector) =>

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -57,6 +57,9 @@ export function OverflowButton({
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const floatingBarEnabled = useConfigValue("floating_bar_enabled");
   const settings = settingsStore.UI.useStore(settingsStore.STORE_ID);
+  const isMeetingInProgress =
+    sessionMode === "active" || sessionMode === "finalizing";
+  const showUploadActions = !currentNoteHasContent && !isMeetingInProgress;
   const canOpenFloatingPanel =
     allowListening && floatingBarEnabled && sessionMode === "active";
   const openExportModal = () => {
@@ -110,7 +113,7 @@ export function OverflowButton({
             {allowListening && (
               <Listening sessionId={sessionId} hasTranscript={hasTranscript} />
             )}
-            {!currentNoteHasContent && (
+            {showUploadActions && (
               <>
                 <DropdownMenuItem
                   onClick={handleUploadAudio}


### PR DESCRIPTION
Hide manual upload options while live capture is active or finalizing, with overflow menu coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI gating change in the overflow menu with no auth, data, or capture pipeline changes.
> 
> **Overview**
> **Upload audio** and **Upload transcript** in the session overflow menu no longer appear while live capture is **active** or **finalizing**, in addition to the existing rule that hides them when the current note already has content.
> 
> `OverflowButton` derives `showUploadActions` from session mode via `useListener` and gates the upload dropdown items on that flag. A unit test asserts both upload actions are absent when `getSessionMode` returns `"active"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6cca2ccb122f7b00b836738c781474a6b4a9606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->