### PR TITLE
Hide transcribing bottom panel

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -1398,7 +1398,7 @@ msgstr "Search or type owner/repo"
 msgid "Search people"
 msgstr "Search people"
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr "Search templates..."
@@ -1416,7 +1416,7 @@ msgstr "Search..."
 msgid "Section actions"
 msgstr "Section actions"
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr "See all templates"
 
@@ -1474,7 +1474,7 @@ msgstr "Send email"
 msgid "Send message"
 msgstr "Send message"
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr "Session note tabs"
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr "Tip: The Anarlog team loves our users!"
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:899
+#: src/session/components/note-input/header.tsx:907
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:965
+#: src/session/components/note-input/header.tsx:973
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1002
+#: src/session/components/note-input/header.tsx:1012
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:545
+#: src/session/components/note-input/header.tsx:547
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/session/bottom-accessory-visibility.test.ts
+++ b/apps/desktop/src/session/bottom-accessory-visibility.test.ts
@@ -39,7 +39,7 @@ describe("shouldShowSessionBottomAccessory", () => {
     ).toBe(false);
   });
 
-  it("hides batch transcription status on the transcript tab", () => {
+  it("keeps batch transcription stop controls on the transcript tab", () => {
     expect(
       shouldShowSessionBottomAccessory({
         currentView: { type: "transcript" },
@@ -49,10 +49,10 @@ describe("shouldShowSessionBottomAccessory", () => {
           expanded: false,
         },
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  it("hides batch transcription status outside the transcript tab", () => {
+  it("keeps batch transcription stop controls outside the transcript tab", () => {
     expect(
       shouldShowSessionBottomAccessory({
         currentView: { type: "raw" },
@@ -61,6 +61,16 @@ describe("shouldShowSessionBottomAccessory", () => {
           mode: "playback",
           expanded: false,
         },
+      }),
+    ).toBe(true);
+  });
+
+  it("hides batch transcription status without accessory state", () => {
+    expect(
+      shouldShowSessionBottomAccessory({
+        currentView: { type: "raw" },
+        sessionMode: "running_batch",
+        bottomAccessoryState: null,
       }),
     ).toBe(false);
   });

--- a/apps/desktop/src/session/bottom-accessory-visibility.test.ts
+++ b/apps/desktop/src/session/bottom-accessory-visibility.test.ts
@@ -51,4 +51,17 @@ describe("shouldShowSessionBottomAccessory", () => {
       }),
     ).toBe(false);
   });
+
+  it("hides batch transcription status outside the transcript tab", () => {
+    expect(
+      shouldShowSessionBottomAccessory({
+        currentView: { type: "raw" },
+        sessionMode: "running_batch",
+        bottomAccessoryState: {
+          mode: "playback",
+          expanded: false,
+        },
+      }),
+    ).toBe(false);
+  });
 });

--- a/apps/desktop/src/session/bottom-accessory-visibility.test.ts
+++ b/apps/desktop/src/session/bottom-accessory-visibility.test.ts
@@ -7,6 +7,7 @@ describe("shouldShowSessionBottomAccessory", () => {
     expect(
       shouldShowSessionBottomAccessory({
         currentView: { type: "transcript" },
+        sessionMode: "inactive",
         bottomAccessoryState: {
           mode: "transcript_only",
           expanded: false,
@@ -19,6 +20,7 @@ describe("shouldShowSessionBottomAccessory", () => {
     expect(
       shouldShowSessionBottomAccessory({
         currentView: { type: "transcript" },
+        sessionMode: "inactive",
         bottomAccessoryState: {
           mode: "playback",
           expanded: false,
@@ -31,7 +33,21 @@ describe("shouldShowSessionBottomAccessory", () => {
     expect(
       shouldShowSessionBottomAccessory({
         currentView: { type: "transcript" },
+        sessionMode: "inactive",
         bottomAccessoryState: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("hides batch transcription status on the transcript tab", () => {
+    expect(
+      shouldShowSessionBottomAccessory({
+        currentView: { type: "transcript" },
+        sessionMode: "running_batch",
+        bottomAccessoryState: {
+          mode: "playback",
+          expanded: false,
+        },
       }),
     ).toBe(false);
   });

--- a/apps/desktop/src/session/bottom-accessory-visibility.ts
+++ b/apps/desktop/src/session/bottom-accessory-visibility.ts
@@ -5,10 +5,16 @@ import type { EditorView } from "~/store/zustand/tabs/schema";
 export function shouldShowSessionBottomAccessory({
   currentView,
   bottomAccessoryState,
+  sessionMode,
 }: {
   currentView: EditorView;
   bottomAccessoryState: BottomAccessoryState;
+  sessionMode: string;
 }) {
+  if (currentView.type === "transcript" && sessionMode === "running_batch") {
+    return false;
+  }
+
   return (
     currentView.type !== "transcript" ||
     bottomAccessoryState?.mode === "playback" ||

--- a/apps/desktop/src/session/bottom-accessory-visibility.ts
+++ b/apps/desktop/src/session/bottom-accessory-visibility.ts
@@ -11,7 +11,7 @@ export function shouldShowSessionBottomAccessory({
   bottomAccessoryState: BottomAccessoryState;
   sessionMode: string;
 }) {
-  if (currentView.type === "transcript" && sessionMode === "running_batch") {
+  if (sessionMode === "running_batch") {
     return false;
   }
 

--- a/apps/desktop/src/session/bottom-accessory-visibility.ts
+++ b/apps/desktop/src/session/bottom-accessory-visibility.ts
@@ -12,7 +12,7 @@ export function shouldShowSessionBottomAccessory({
   sessionMode: string;
 }) {
   if (sessionMode === "running_batch") {
-    return false;
+    return bottomAccessoryState?.mode === "playback";
   }
 
   return (

--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -36,6 +36,50 @@ const hoisted = vi.hoisted(() => ({
   regenerateInsights: vi.fn(),
 }));
 
+const lingui = vi.hoisted(() => {
+  type LinguiDescriptor = {
+    message?: string;
+    values?: Record<string, unknown>;
+  };
+  const isDescriptor = (value: unknown): value is LinguiDescriptor =>
+    Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  const t = (
+    input: TemplateStringsArray | LinguiDescriptor | string,
+    ...values: unknown[]
+  ) => {
+    if (typeof input === "string") {
+      return input;
+    }
+
+    if (isDescriptor(input)) {
+      let message = input.message ?? "";
+      const replacements =
+        input.values ??
+        values.find(
+          (value): value is Record<string, unknown> =>
+            Boolean(value) &&
+            typeof value === "object" &&
+            !Array.isArray(value),
+        );
+
+      if (replacements) {
+        for (const [key, value] of Object.entries(replacements)) {
+          message = message.split(`{${key}}`).join(String(value));
+        }
+      }
+
+      return message;
+    }
+
+    return Array.from(input).reduce(
+      (text, part, index) => `${text}${part}${values[index] ?? ""}`,
+      "",
+    );
+  };
+
+  return { t };
+});
+
 vi.mock("react-hotkeys-hook", () => ({
   useHotkeys: (
     keys: string,
@@ -46,6 +90,20 @@ vi.mock("react-hotkeys-hook", () => ({
   ) => {
     hoisted.hotkeys.set(keys, { handler, options });
   },
+}));
+
+vi.mock("@lingui/react/macro", () => ({
+  useLingui: () => ({
+    _: lingui.t,
+    t: lingui.t,
+  }),
+}));
+
+vi.mock("@lingui/react", () => ({
+  useLingui: () => ({
+    _: lingui.t,
+    t: lingui.t,
+  }),
 }));
 
 vi.mock("./during-session", () => ({
@@ -423,7 +481,7 @@ describe("useSessionBottomAccessory", () => {
     expect(result.current.bottomBorderHandle).toBeNull();
   });
 
-  it("keeps batch progress visible while another session is live", () => {
+  it("hides batch progress from the bottom accessory while another session is live", () => {
     hoisted.live.status = "active";
     hoisted.live.sessionId = "live-session";
 
@@ -436,15 +494,12 @@ describe("useSessionBottomAccessory", () => {
       }),
     );
 
-    expect(result.current.bottomAccessoryState).toEqual({
-      mode: "playback",
-      expanded: false,
-    });
-    expect(result.current.bottomAccessory).not.toBeNull();
+    expect(result.current.bottomAccessoryState).toBeNull();
+    expect(result.current.bottomAccessory).toBeNull();
     expect(result.current.bottomBorderHandle).toBeNull();
   });
 
-  it("keeps batch progress visible while batch transcription is running", () => {
+  it("hides the bottom accessory while batch transcription is running", () => {
     const { result } = renderHook(() =>
       useSessionBottomAccessory({
         sessionId: "session-1",
@@ -454,15 +509,12 @@ describe("useSessionBottomAccessory", () => {
       }),
     );
 
-    expect(result.current.bottomAccessoryState).toEqual({
-      mode: "playback",
-      expanded: false,
-    });
-    expect(result.current.bottomAccessory).not.toBeNull();
+    expect(result.current.bottomAccessoryState).toBeNull();
+    expect(result.current.bottomAccessory).toBeNull();
     expect(result.current.bottomBorderHandle).toBeNull();
   });
 
-  it("shows batch progress when regeneration starts", () => {
+  it("keeps the bottom accessory hidden when regeneration starts", () => {
     const { result, rerender } = renderHook(
       ({ sessionMode }: { sessionMode: string }) =>
         useSessionBottomAccessory({
@@ -483,11 +535,8 @@ describe("useSessionBottomAccessory", () => {
 
     rerender({ sessionMode: "running_batch" });
 
-    expect(result.current.bottomAccessoryState).toEqual({
-      mode: "playback",
-      expanded: false,
-    });
-    expect(result.current.bottomAccessory).not.toBeNull();
+    expect(result.current.bottomAccessoryState).toBeNull();
+    expect(result.current.bottomAccessory).toBeNull();
     expect(result.current.bottomBorderHandle).toBeNull();
   });
 

--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -499,7 +499,7 @@ describe("useSessionBottomAccessory", () => {
     expect(result.current.bottomBorderHandle).toBeNull();
   });
 
-  it("hides the bottom accessory while batch transcription is running", () => {
+  it("keeps batch stop control available while batch transcription is running", () => {
     const { result } = renderHook(() =>
       useSessionBottomAccessory({
         sessionId: "session-1",
@@ -509,12 +509,15 @@ describe("useSessionBottomAccessory", () => {
       }),
     );
 
-    expect(result.current.bottomAccessoryState).toBeNull();
-    expect(result.current.bottomAccessory).toBeNull();
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "playback",
+      expanded: false,
+    });
+    expect(isValidElement(result.current.bottomAccessory)).toBe(true);
     expect(result.current.bottomBorderHandle).toBeNull();
   });
 
-  it("keeps the bottom accessory hidden when regeneration starts", () => {
+  it("shows batch progress when regeneration starts", () => {
     const { result, rerender } = renderHook(
       ({ sessionMode }: { sessionMode: string }) =>
         useSessionBottomAccessory({
@@ -535,8 +538,11 @@ describe("useSessionBottomAccessory", () => {
 
     rerender({ sessionMode: "running_batch" });
 
-    expect(result.current.bottomAccessoryState).toBeNull();
-    expect(result.current.bottomAccessory).toBeNull();
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "playback",
+      expanded: false,
+    });
+    expect(isValidElement(result.current.bottomAccessory)).toBe(true);
     expect(result.current.bottomBorderHandle).toBeNull();
   });
 

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -60,11 +60,10 @@ export function useSessionBottomAccessory({
   const isChatVisible =
     chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
 
+  const showBatchProgress = isRunningBatch && !shouldDeferToGlobalLiveAccessory;
   const showPostSession =
-    !isRunningBatch &&
-    !shouldDeferToGlobalLiveAccessory &&
-    isInactive &&
-    hasPastNotes;
+    showBatchProgress ||
+    (!shouldDeferToGlobalLiveAccessory && isInactive && hasPastNotes);
   const selectPostSessionTab = useCallback(
     (tab: PostSessionTab) => {
       setPostSessionTab(tab);

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -49,8 +49,7 @@ export function useSessionBottomAccessory({
     live.sessionId !== null &&
     live.sessionId !== sessionId &&
     shouldShowLiveTranscriptAccessory(live);
-  const shouldLoadPastNotes =
-    (isInactive || isRunningBatch) && !shouldDeferToGlobalLiveAccessory;
+  const shouldLoadPastNotes = isInactive && !shouldDeferToGlobalLiveAccessory;
   const pastNotes = usePastSessionNotes(sessionId, {
     enabled: shouldLoadPastNotes,
   });
@@ -62,8 +61,10 @@ export function useSessionBottomAccessory({
     chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
 
   const showPostSession =
-    isRunningBatch ||
-    (!shouldDeferToGlobalLiveAccessory && isInactive && hasPastNotes);
+    !isRunningBatch &&
+    !shouldDeferToGlobalLiveAccessory &&
+    isInactive &&
+    hasPastNotes;
   const selectPostSessionTab = useCallback(
     (tab: PostSessionTab) => {
       setPostSessionTab(tab);

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -223,7 +223,9 @@ describe("Header", () => {
     expect(memoTab.className).toContain("h-[26px]");
     expect(memoTab.className).not.toContain("-my-px");
     expect(memoTab.className).toContain("bg-white");
+    expect(memoTab.className).toContain("text-foreground");
     expect(memoTab.className).toContain("shadow-xs");
+    expect(memoTab.className).toContain("dark:text-primary");
     expect(memoTab.className).toContain("dark:bg-white");
     expect(summaryTab.className).toContain("h-[26px]");
     expect(summaryTab.className).toContain("dark:hover:bg-white/8");
@@ -255,6 +257,8 @@ describe("Header", () => {
       name: "Customer Call",
     });
     expect(activeSummaryTab.textContent).toBe("Customer Call");
+    expect(activeSummaryTab.className).toContain("text-foreground");
+    expect(activeSummaryTab.className).toContain("dark:text-primary");
     expect(activeSummaryTab.querySelectorAll("svg")).toHaveLength(2);
 
     fireEvent.click(activeSummaryTab);

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -32,6 +32,64 @@ const hoisted = vi.hoisted(() => ({
   }>,
 }));
 
+const lingui = vi.hoisted(() => {
+  type LinguiDescriptor = {
+    message?: string;
+    values?: Record<string, unknown>;
+  };
+  const isDescriptor = (value: unknown): value is LinguiDescriptor =>
+    Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  const t = (
+    input: TemplateStringsArray | LinguiDescriptor | string,
+    ...values: unknown[]
+  ) => {
+    if (typeof input === "string") {
+      return input;
+    }
+
+    if (isDescriptor(input)) {
+      let message = input.message ?? "";
+      const replacements =
+        input.values ??
+        values.find(
+          (value): value is Record<string, unknown> =>
+            Boolean(value) &&
+            typeof value === "object" &&
+            !Array.isArray(value),
+        );
+
+      if (replacements) {
+        for (const [key, value] of Object.entries(replacements)) {
+          message = message.split(`{${key}}`).join(String(value));
+        }
+      }
+
+      return message;
+    }
+
+    return Array.from(input).reduce(
+      (text, part, index) => `${text}${part}${values[index] ?? ""}`,
+      "",
+    );
+  };
+
+  return { t };
+});
+
+vi.mock("@lingui/react/macro", () => ({
+  useLingui: () => ({
+    _: lingui.t,
+    t: lingui.t,
+  }),
+}));
+
+vi.mock("@lingui/react", () => ({
+  useLingui: () => ({
+    _: lingui.t,
+    t: lingui.t,
+  }),
+}));
+
 vi.mock("@hypr/editor/markdown", () => ({
   json2md: () => "",
   parseJsonContent: () => ({}),
@@ -231,6 +289,7 @@ describe("Header", () => {
     expect(summaryTab.className).toContain("dark:hover:bg-white/8");
     expect(summaryTab.querySelector("svg")).not.toBeNull();
     expect(summaryTab.querySelectorAll("svg")).toHaveLength(1);
+    expect(transcriptTab.querySelector("svg")).not.toBeNull();
     expect(summaryTab.textContent).toBe("");
     expect(transcriptTab.textContent).toBe("");
     expect(summaryTab.getAttribute("title")).toBe(
@@ -456,6 +515,31 @@ describe("Header", () => {
     expect(
       screen.getByRole("button", { name: "Customer Call" }).textContent,
     ).toBe("Customer Call");
+  });
+
+  it("shows a spinner in the transcript tab while transcribing", () => {
+    const editorTabs: EditorView[] = [
+      { type: "enhanced", id: "note-1" },
+      { type: "raw" },
+      { type: "transcript" },
+    ];
+
+    render(
+      <Header
+        sessionId="session-1"
+        editorTabs={editorTabs}
+        currentTab={{ type: "raw" }}
+        handleTabChange={vi.fn()}
+        isTranscribing
+      />,
+    );
+
+    const transcriptTab = screen.getByRole("button", { name: "Transcript" });
+
+    expect(
+      transcriptTab.querySelector("[data-testid='tab-spinner']"),
+    ).not.toBeNull();
+    expect(transcriptTab.querySelector("svg")).toBeNull();
   });
 });
 

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -459,10 +459,12 @@ function HeaderTabEnhanced({
 
 function HeaderTabTranscript({
   isActive,
+  isTranscribing,
   onClick = () => {},
   sessionId,
 }: {
   isActive: boolean;
+  isTranscribing: boolean;
   onClick?: () => void;
   sessionId: string;
 }) {
@@ -543,7 +545,13 @@ function HeaderTabTranscript({
     <IconHeaderTab
       isActive={isActive}
       label={t`Transcript`}
-      icon={<AudioLinesIcon className="size-4" />}
+      icon={
+        isTranscribing ? (
+          <Spinner size={16} className="shrink-0" />
+        ) : (
+          <AudioLinesIcon className="size-4" />
+        )
+      }
       onClick={onClick}
       onContextMenu={showContextMenu}
     />
@@ -976,11 +984,13 @@ export function Header({
   editorTabs,
   currentTab,
   handleTabChange,
+  isTranscribing = false,
 }: {
   sessionId: string;
   editorTabs: EditorView[];
   currentTab: EditorView;
   handleTabChange: (view: EditorView) => void;
+  isTranscribing?: boolean;
 }) {
   const { t } = useLingui();
   const store = main.UI.useStore(main.STORE_ID);
@@ -1062,6 +1072,7 @@ export function Header({
                     key={view.type}
                     sessionId={sessionId}
                     isActive={currentTab.type === view.type}
+                    isTranscribing={isTranscribing}
                     onClick={() => handleTabChange(view)}
                   />
                 );

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -173,6 +173,7 @@ export const NoteInput = forwardRef<
               editorTabs={editorTabs}
               currentTab={currentTab}
               handleTabChange={handleTabChange}
+              isTranscribing={isMeetingInProgress}
             />
           </div>
         )}

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -128,6 +128,10 @@ function TabContentNoteInner({
   const sessionId = tab.id;
   const { skipReason } = useAutoEnhance(tab);
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
+  const isTranscribing =
+    sessionMode === "active" ||
+    sessionMode === "finalizing" ||
+    sessionMode === "running_batch";
   const { audioExists } = AudioPlayer.useAudioPlayer();
 
   useAutoFocusTitle({ sessionId, noteInputRef });
@@ -188,6 +192,7 @@ function TabContentNoteInner({
               editorTabs={editorTabs}
               currentTab={currentView}
               handleTabChange={handleTabChange}
+              isTranscribing={isTranscribing}
             />
           }
         />

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -170,6 +170,7 @@ function TabContentNoteInner({
   const showBottomAccessory = shouldShowSessionBottomAccessory({
     currentView,
     bottomAccessoryState,
+    sessionMode,
   });
   const showBottomTranscriptSurface =
     showBottomAccessory && currentView.type !== "transcript";


### PR DESCRIPTION
Suppress the batch transcription bottom accessory on the transcript tab while preserving other accessory states.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only i18n catalog updates with no runtime or security impact.
> 
> **Overview**
> This changeset only touches **desktop Lingui `messages.po` files** across locales. It does not modify application logic in the diff shown.
> 
> After edits to `session/components/note-input/header.tsx`, the `#:` source line comments for a few existing strings were bumped (for example **Search templates…**, **See all templates**, **Session note tabs**, and **Transcript**). English `msgid` / `msgstr` text is unchanged; translators’ work is unaffected aside from catalog metadata staying aligned with the extractor.
> 
> If the branch also hides the batch-transcribing bottom accessory on the transcript tab (per the PR title), that behavior would live outside this particular diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73faa912bea50ceca6f0b2543ed0307e0f038d71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5737 
- <kbd>&nbsp;1&nbsp;</kbd> #5727 👈 
<!-- GitButler Footer Boundary Bottom -->

