### PR TITLE
Pad Soniqo batch chunks to CoreML window

### DIFF
--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -16,7 +16,7 @@ use hypr_transcribe_core::{
 
 use super::{BatchParams, BatchRunMode, BatchRunOutput, format_user_friendly_error, session_span};
 
-const SONIQO_PARAKEET_MAX_CHUNK_SAMPLES: usize = TARGET_SAMPLE_RATE as usize * 39 / 2;
+const SONIQO_PARAKEET_MAX_CHUNK_SAMPLES: usize = TARGET_SAMPLE_RATE as usize * 59 / 2;
 
 macro_rules! dispatch_batch {
     ($ak:expr, $params:expr, $lp:expr,
@@ -326,9 +326,7 @@ fn transcribe_soniqo_channel(
     language: Option<&str>,
 ) -> std::result::Result<hypr_transcribe_soniqo::FileTranscript, String> {
     let duration_seconds = channel_duration_sec(samples);
-    let chunks =
-        chunk_channel_audio::<hypr_audio_chunking::Error>(samples).map_err(|e| e.to_string())?;
-    let chunks = split_soniqo_native_chunks(model, chunks);
+    let chunks = soniqo_channel_chunks(model, samples)?;
     tracing::info!(
         hyprnote.stt.provider.name = "soniqo",
         hyprnote.stt.model = %model,
@@ -446,37 +444,26 @@ fn transcribe_soniqo_samples(
     hypr_transcribe_soniqo::transcribe_file(model, file.path(), language).map_err(|e| e.to_string())
 }
 
-fn split_soniqo_native_chunks(
+fn soniqo_channel_chunks(
     model: hypr_transcribe_soniqo::SoniqoModel,
-    chunks: Vec<AudioChunk>,
-) -> Vec<AudioChunk> {
-    let max_samples = match model {
-        hypr_transcribe_soniqo::SoniqoModel::ParakeetBatch => SONIQO_PARAKEET_MAX_CHUNK_SAMPLES,
-        _ => return chunks,
-    };
-
-    chunks
-        .into_iter()
-        .flat_map(|chunk| split_audio_chunk(chunk, max_samples))
-        .collect()
-}
-
-fn split_audio_chunk(chunk: AudioChunk, max_samples: usize) -> Vec<AudioChunk> {
-    if chunk.samples.len() <= max_samples {
-        return vec![chunk];
+    samples: &[f32],
+) -> std::result::Result<Vec<AudioChunk>, String> {
+    if model == hypr_transcribe_soniqo::SoniqoModel::ParakeetBatch {
+        return Ok(split_audio_samples(
+            samples,
+            SONIQO_PARAKEET_MAX_CHUNK_SAMPLES,
+        ));
     }
 
-    let AudioChunk {
-        samples,
-        sample_start,
-        ..
-    } = chunk;
+    chunk_channel_audio::<hypr_audio_chunking::Error>(samples).map_err(|e| e.to_string())
+}
 
+fn split_audio_samples(samples: &[f32], max_samples: usize) -> Vec<AudioChunk> {
     samples
         .chunks(max_samples)
         .enumerate()
         .map(|(index, window)| {
-            let sample_start = sample_start + index * max_samples;
+            let sample_start = index * max_samples;
             let sample_end = sample_start + window.len();
             AudioChunk {
                 samples: window.to_vec(),
@@ -535,42 +522,29 @@ mod tests {
     }
 
     #[test]
-    fn splits_parakeet_chunks_below_largest_coreml_shape() {
-        let sample_start = TARGET_SAMPLE_RATE as usize * 4;
-        let oversized = SONIQO_PARAKEET_MAX_CHUNK_SAMPLES + TARGET_SAMPLE_RATE as usize;
-        let chunks = split_soniqo_native_chunks(
-            hypr_transcribe_soniqo::SoniqoModel::ParakeetBatch,
-            vec![AudioChunk {
-                samples: vec![0.0; oversized],
-                sample_start,
-                sample_end: sample_start + oversized,
-            }],
-        );
+    fn parakeet_batch_uses_fixed_audio_windows() {
+        let samples =
+            vec![0.0; SONIQO_PARAKEET_MAX_CHUNK_SAMPLES * 2 + TARGET_SAMPLE_RATE as usize];
+        let chunks =
+            soniqo_channel_chunks(hypr_transcribe_soniqo::SoniqoModel::ParakeetBatch, &samples)
+                .unwrap();
 
-        assert_eq!(chunks.len(), 2);
-        assert_eq!(chunks[0].sample_start, sample_start);
-        assert_eq!(
-            chunks[0].sample_end,
-            sample_start + SONIQO_PARAKEET_MAX_CHUNK_SAMPLES
-        );
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(chunks[0].sample_start, 0);
+        assert_eq!(chunks[0].sample_end, SONIQO_PARAKEET_MAX_CHUNK_SAMPLES);
         assert_eq!(chunks[1].sample_start, chunks[0].sample_end);
-        assert_eq!(chunks[1].samples.len(), TARGET_SAMPLE_RATE as usize);
+        assert_eq!(chunks[1].sample_end, SONIQO_PARAKEET_MAX_CHUNK_SAMPLES * 2);
+        assert_eq!(chunks[2].sample_start, chunks[1].sample_end);
+        assert_eq!(chunks[2].samples.len(), TARGET_SAMPLE_RATE as usize);
     }
 
     #[test]
-    fn leaves_non_parakeet_chunks_unchanged() {
-        let oversized = SONIQO_PARAKEET_MAX_CHUNK_SAMPLES + TARGET_SAMPLE_RATE as usize;
-        let chunks = split_soniqo_native_chunks(
-            hypr_transcribe_soniqo::SoniqoModel::Omnilingual,
-            vec![AudioChunk {
-                samples: vec![0.0; oversized],
-                sample_start: 0,
-                sample_end: oversized,
-            }],
-        );
+    fn parakeet_batch_window_bounds_force_coreml_shape_3000() {
+        let minimum_mel_frames = TARGET_SAMPLE_RATE as usize * 20 / 160 + 1;
+        let maximum_mel_frames = SONIQO_PARAKEET_MAX_CHUNK_SAMPLES / 160 + 1;
 
-        assert_eq!(chunks.len(), 1);
-        assert_eq!(chunks[0].samples.len(), oversized);
+        assert!(minimum_mel_frames > 2000);
+        assert!(maximum_mel_frames <= 3000);
     }
 
     #[test]

--- a/crates/transcribe-soniqo/swift-lib/src/lib.swift
+++ b/crates/transcribe-soniqo/swift-lib/src/lib.swift
@@ -17,8 +17,8 @@ private enum SoniqoBridgeError: LocalizedError {
 }
 
 private let soniqoFileTranscriptionSampleRate = 16_000
-private let parakeetBatchMinimumChunkSeconds = 5.0
-private let parakeetBatchMaximumChunkSeconds = 19.5
+private let parakeetBatchMinimumChunkSeconds = 20.0
+private let parakeetBatchMaximumChunkSeconds = 29.5
 
 private enum SpeechModelKind: String, CaseIterable {
   case parakeetStreaming = "soniqo-parakeet-streaming"


### PR DESCRIPTION
Set the Parakeet batch minimum chunk size to the fixed CoreML input window so short batch chunks are padded before native inference.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Parakeet batch audio is segmented and padded, which can affect transcript boundaries and handling of short clips, but stays localized to Soniqo batch/CoreML constraints.
> 
> **Overview**
> **Parakeet batch** transcription now uses **~20–29.5s** fixed audio windows instead of the previous **~5–19.5s** range, so chunks stay within the CoreML mel-frame cap (tests assert max mel frames ≤ 3000 and min window > 2000 frames).
> 
> On the **Rust batch path**, `ParakeetBatch` no longer runs generic `chunk_channel_audio` and then splitting oversized chunks—it splits the resampled channel straight into fixed sample windows (`59/2` seconds at the target rate). Other Soniqo models still use the existing chunking helper.
> 
> The **Swift bridge** updates the same min/max chunk constants so direct file transcription and trailing-chunk merge logic match; short chunks are still **zero-padded** up to the 20s minimum before inference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f541a2c429cef30f0bd44c6be1179ccb8d2c71a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->