### PR TITLE
Fix sidebar timeline scroll reset

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Kennisgewings"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "ማሳወቂያዎች"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "الإشعارات"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "জাননীসমূহ"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Bildirişlər"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Хәбәр итеүҙәр"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Апавяшчэнні"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Известия"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "বিজ্ঞপ্তি"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "བརྡ་ཐོ"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Kemennadennoù"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Obaveštenja"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificacions"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Oznámení"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Hysbysiadau"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Underretninger"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Benachrichtigungen"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ειδοποιήσεις"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -500,7 +500,7 @@ msgstr "Delete Note"
 msgid "Delete recording"
 msgstr "Delete recording"
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr "Delete Selected ({sessionCount})"
 
@@ -740,7 +740,7 @@ msgstr "Get started"
 msgid "Get started for free"
 msgstr "Get started for free"
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr "Go back to now"
 
@@ -773,7 +773,7 @@ msgstr "Help Anarlog listen to others"
 msgid "Help Anarlog listen to you"
 msgstr "Help Anarlog listen to you"
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr "Hide Deleted Events"
 
@@ -895,7 +895,7 @@ msgstr "Match case"
 msgid "Match whole word"
 msgstr "Match whole word"
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr "Meeting"
 
@@ -1018,7 +1018,7 @@ msgstr "No content."
 msgid "No description provided."
 msgstr "No description provided."
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr "No items today"
 
@@ -1080,7 +1080,7 @@ msgstr "Notes"
 msgid "Notifications"
 msgstr "Notifications"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr "Now"
 
@@ -1110,8 +1110,8 @@ msgstr "Open {0} settings"
 msgid "Open Anarlog"
 msgstr "Open Anarlog"
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr "Open calendar"
 
@@ -1507,7 +1507,7 @@ msgstr "Show Anarlog in the Dock and app switcher."
 msgid "Show app in Dock"
 msgstr "Show app in Dock"
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr "Show Deleted Events"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificaciones"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Märguanded"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Jakinarazpenak"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "اعلان‌ها"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Noddaango"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ilmoitukset"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Fráboðanir"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifications"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Fógraí"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificacións"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "સૂચના"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Sanarwa"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "התראות"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "सूचनाएँ"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Obavijesti"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifikasyon"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Értesítések"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ծանուցումներ"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Pemberitahuan"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ọkwa"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Tilkynningar"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifiche"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "通知"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Kabar"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "შეტყობინებები"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Хабарландырулар"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "ការជូនដំណឹង"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "ಅಧಿಸೂಚನೆಗಳು"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "알림"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Agahdar"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Эскертмелер"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificationes"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifikatiounen"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ebimanyisibwa"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Mayebisi"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "ການແຈ້ງເຕືອນ"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Pranešimai"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Paziņojumi"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Fampandrenesana"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Whakamōhiotanga"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Известувања"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "അറിയിപ്പുകൾ"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Мэдэгдэл"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "सूचना"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Pemberitahuan"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifiki"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "သတိပေးချက်များ"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "सूचनाहरू"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Meldingen"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Varsler"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Varsler"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Zidziwitso"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificacions"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "ବିଜ୍ଞପ୍ତିଗୁଡିକ"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "ਸੂਚਨਾਵਾਂ"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Powiadomienia"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "اطلاعات"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificações"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificări"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Уведомления"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "सूचना"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "اطلاعات"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "දැනුම්දීම්"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Upozornenia"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Obvestila"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Zviziviso"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ogaysiisyo"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Njoftimet"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Обавештења"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Bewara"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Aviseringar"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Arifa"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "அறிவிப்புகள்"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "నోటిఫికేషన్‌లు"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Огоҳиҳо"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "การแจ้งเตือน"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Duýduryşlar"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Mga Notification"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Bildirimler"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Хәбәрләр"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Сповіщення"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "اطلاعات"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Bildirishnomalar"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Thông báo"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Yégle yi"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Izaziso"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "נאָטיפיקאַטיאָנס"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Awọn iwifunni"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "通知"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:379
+#: src/sidebar/timeline/index.tsx:382
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:754
+#: src/sidebar/timeline/index.tsx:778
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:388
+#: src/sidebar/timeline/index.tsx:391
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:590
+#: src/sidebar/timeline/index.tsx:614
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:853
+#: src/sidebar/timeline/index.tsx:877
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Izaziso"
 
-#: src/sidebar/timeline/index.tsx:766
+#: src/sidebar/timeline/index.tsx:790
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:543
-#: src/sidebar/timeline/index.tsx:547
+#: src/sidebar/timeline/index.tsx:567
+#: src/sidebar/timeline/index.tsx:571
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:389
+#: src/sidebar/timeline/index.tsx:392
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -117,7 +117,9 @@ vi.mock("./shell-sidebar", () => ({
   ClassicMainSidebar: ({ forceMount = false }: { forceMount?: boolean }) =>
     (forceMount || mocks.leftsidebar.expanded) &&
     mocks.currentTab?.type !== "onboarding" ? (
-      <aside data-testid="classic-main-sidebar" />
+      <aside data-testid="classic-main-sidebar">
+        <div data-sidebar-timeline-scroll />
+      </aside>
     ) : null,
 }));
 
@@ -292,6 +294,33 @@ describe("ClassicMainBody", () => {
       "flex-grow",
     );
     expect(mocks.leftsidebar.toggleExpanded).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes wheel gestures from sidebar chrome into the timeline scroller", () => {
+    render(<ClassicMainBody />);
+
+    const sidebarChrome = document.querySelector<HTMLElement>(
+      "[data-left-sidebar-chrome]",
+    );
+    const timelineScroller = document.querySelector<HTMLElement>(
+      "[data-sidebar-timeline-scroll]",
+    );
+
+    expect(sidebarChrome).toBeInstanceOf(HTMLElement);
+    expect(timelineScroller).toBeInstanceOf(HTMLElement);
+
+    Object.defineProperty(timelineScroller, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(timelineScroller, "scrollHeight", {
+      configurable: true,
+      value: 1200,
+    });
+
+    fireEvent.wheel(sidebarChrome!, { deltaY: 96 });
+
+    expect(timelineScroller!.scrollTop).toBe(96);
   });
 
   it("does not reserve a sidebar panel during onboarding", () => {

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -11,6 +11,7 @@ import {
   type CSSProperties,
   type MouseEvent,
   type PointerEvent,
+  type WheelEvent,
   useCallback,
   useMemo,
   useRef,
@@ -36,6 +37,7 @@ import { useClassicMainTabsShortcuts } from "./useTabsShortcuts";
 
 import { useShell } from "~/contexts/shell";
 import { GlobalLiveTranscriptAccessory } from "~/session/components/bottom-accessory/global-live";
+import { scrollElementByWheel } from "~/shared/dom/scroll-wheel";
 import { NOTE_SURFACE_MIN_WIDTH_PX } from "~/shared/main/layout-widths";
 import { useOpenNoteDialog } from "~/shared/open-note-dialog";
 import { useNewNote } from "~/shared/useNewNote";
@@ -124,6 +126,21 @@ export function ClassicMainBody() {
     setLeftSidebarResizing(false);
     leftsidebar.toggleExpanded();
   }, [leftsidebar.toggleExpanded]);
+  const handleLeftSidebarChromeWheel = useCallback(
+    (event: WheelEvent<HTMLDivElement>) => {
+      if (!showSidebarTimeline) {
+        return;
+      }
+
+      const timelineScroller =
+        event.currentTarget.parentElement?.querySelector<HTMLElement>(
+          "[data-sidebar-timeline-scroll]",
+        ) ?? null;
+
+      scrollElementByWheel(timelineScroller, event);
+    },
+    [showSidebarTimeline],
+  );
   const leftSidebarChromeStyle = useMemo(
     () =>
       ({
@@ -158,6 +175,7 @@ export function ClassicMainBody() {
           data-tauri-drag-region
           data-left-sidebar-chrome
           style={leftSidebarChromeStyle}
+          onWheel={handleLeftSidebarChromeWheel}
           className={cn([
             "absolute top-0 z-40 h-12",
             leftsidebar.expanded ? "left-0" : "left-1",

--- a/apps/desktop/src/shared/dom/scroll-wheel.ts
+++ b/apps/desktop/src/shared/dom/scroll-wheel.ts
@@ -1,0 +1,47 @@
+import type { WheelEvent as ReactWheelEvent } from "react";
+
+export function scrollElementByWheel(
+  element: HTMLElement | null,
+  event: ReactWheelEvent<Element>,
+): boolean {
+  if (!element || event.defaultPrevented) {
+    return false;
+  }
+
+  const deltaY = getWheelDeltaY(event, element.clientHeight);
+  if (deltaY === 0) {
+    return false;
+  }
+
+  const maxScrollTop = Math.max(0, element.scrollHeight - element.clientHeight);
+  const nextScrollTop = clamp(element.scrollTop + deltaY, 0, maxScrollTop);
+
+  if (nextScrollTop === element.scrollTop) {
+    return false;
+  }
+
+  event.preventDefault();
+  element.scrollTop = nextScrollTop;
+  element.dispatchEvent(new Event("scroll"));
+
+  return true;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getWheelDeltaY(
+  event: ReactWheelEvent<Element>,
+  pageScrollHeight: number,
+): number {
+  if (event.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+    return event.deltaY * 16;
+  }
+
+  if (event.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
+    return event.deltaY * pageScrollHeight;
+  }
+
+  return event.deltaY;
+}

--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -275,7 +275,7 @@ describe("TimelineView", () => {
     expect(
       container.querySelector("[data-sidebar-timeline-top-chip-stack]")
         ?.className,
-    ).toContain("top-10");
+    ).toContain("top-11");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
     ).toContain("h-18");
@@ -283,6 +283,77 @@ describe("TimelineView", () => {
     fireEvent.click(calendarButton);
 
     expect(mocks.openNew).toHaveBeenCalledWith({ type: "calendar" });
+  });
+
+  it("keeps the open calendar spacer stable when leaving the top edge", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.smartCurrentTimeMs = Date.now();
+    mocks.timelineSessionsTable = {
+      later: {
+        title: "Quarterly planning",
+        created_at: "2024-01-17T12:00:00.000Z",
+      },
+    };
+
+    const { container } = render(<TimelineView topChromeInset />);
+    const scroller = container.querySelector("[data-sidebar-timeline-scroll]");
+    const topSpacer = container.querySelector(
+      "[data-sidebar-timeline-top-spacer]",
+    );
+
+    expect(scroller).toBeInstanceOf(HTMLDivElement);
+    expect(topSpacer?.className).toContain("h-18");
+
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 1200,
+    });
+    scroller!.scrollTop = 120;
+    fireEvent.scroll(scroller!);
+
+    expect(screen.queryByRole("button", { name: "Open calendar" })).toBeNull();
+    expect(topSpacer?.className).toContain("h-18");
+    expect(getTopFade(container).className).toContain("h-16");
+  });
+
+  it("routes wheel gestures from the open calendar chip into the timeline scroller", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.smartCurrentTimeMs = Date.now();
+    mocks.timelineSessionsTable = {
+      later: {
+        title: "Quarterly planning",
+        created_at: "2024-01-17T12:00:00.000Z",
+      },
+    };
+
+    const { container } = render(<TimelineView topChromeInset />);
+    const scroller = container.querySelector("[data-sidebar-timeline-scroll]");
+    const calendarButton = screen.getByRole("button", {
+      name: "Open calendar",
+    });
+
+    expect(scroller).toBeInstanceOf(HTMLDivElement);
+
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 1200,
+    });
+
+    fireEvent.wheel(calendarButton, { deltaY: 80 });
+
+    expect(scroller!.scrollTop).toBe(80);
   });
 
   it("keeps the first bucket below the sidebar action chrome", () => {
@@ -369,7 +440,7 @@ describe("TimelineView", () => {
     expect(
       container.querySelector("[data-sidebar-timeline-top-chip-stack]")
         ?.className,
-    ).toContain("top-4");
+    ).toContain("top-5");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
     ).toContain("h-10");
@@ -605,6 +676,10 @@ describe("TimelineView", () => {
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
     ).toContain("h-8");
+    expect(
+      container.querySelector("[data-sidebar-timeline-top-chip-stack]")
+        ?.className,
+    ).toContain("top-11");
     expect(screen.queryByText("Now")).toBeNull();
 
     fireEvent.click(chip!);
@@ -742,6 +817,10 @@ describe("TimelineView", () => {
     expect(scroller).toBeInstanceOf(HTMLDivElement);
 
     expect(screen.getByRole("button", { name: "Go back to now" })).toBeTruthy();
+    expect(
+      container.querySelector("[data-sidebar-timeline-top-chip-stack]")
+        ?.className,
+    ).toContain("top-11");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
     ).toContain("h-8");

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -8,6 +8,7 @@ import {
 import {
   type ReactNode,
   type RefCallback,
+  type WheelEvent as ReactWheelEvent,
   useCallback,
   useEffect,
   useMemo,
@@ -40,6 +41,7 @@ import {
 } from "./utils";
 
 import { useConfigValue } from "~/shared/config";
+import { scrollElementByWheel } from "~/shared/dom/scroll-wheel";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { useNativeContextMenu } from "~/shared/hooks/useNativeContextMenu";
 import { useIgnoredEvents } from "~/store/tinybase/hooks";
@@ -80,6 +82,8 @@ export function TimelineView({
 
   const showOpenCalendarChip =
     showOpenCalendarButton && isScrolledToTop && hasMoreFutureItems;
+  const reserveOpenCalendarChipSpace =
+    showOpenCalendarButton && hasMoreFutureItems;
 
   const hasToday = useMemo(
     () => buckets.some((bucket) => bucket.label === "Today"),
@@ -171,14 +175,13 @@ export function TimelineView({
     Boolean(upcomingMeetingStatus) && !isUpcomingMeetingVisible;
   const showTopNowChip =
     !showUpcomingMeetingChip && !isTodayVisible && isScrolledPastToday;
-  const hasReservedTopChromeChip = showOpenCalendarChip;
   const topSpacerClassName = topChromeInset
-    ? hasReservedTopChromeChip
+    ? reserveOpenCalendarChipSpace
       ? "h-18"
       : "h-8"
     : "h-10";
   const bucketHeaderTopClassName = topChromeInset
-    ? hasReservedTopChromeChip
+    ? showOpenCalendarChip
       ? "top-18"
       : "top-8"
     : "top-0";
@@ -401,9 +404,30 @@ export function TimelineView({
   );
 
   const showContextMenu = useNativeContextMenu(contextMenuItems);
+  const handleWheelCapture = useCallback(
+    (event: ReactWheelEvent<HTMLDivElement>) => {
+      const container = containerRef.current;
+      const target = event.target;
+
+      if (
+        !container ||
+        event.defaultPrevented ||
+        (target instanceof Node && container.contains(target))
+      ) {
+        return;
+      }
+
+      scrollElementByWheel(container, event);
+    },
+    [containerRef],
+  );
 
   return (
-    <div className="relative h-full">
+    <div
+      data-sidebar-timeline-root
+      className="relative h-full"
+      onWheelCapture={handleWheelCapture}
+    >
       <div
         ref={containerRef}
         data-sidebar-timeline-scroll
@@ -523,7 +547,7 @@ export function TimelineView({
           data-sidebar-timeline-top-fade
           className={cn([
             "pointer-events-none absolute inset-x-0 top-0 z-[15]",
-            hasReservedTopChromeChip
+            showOpenCalendarChip
               ? "bg-background h-18"
               : "from-background via-background/95 to-background/0 h-16 bg-linear-to-b from-60% via-85%",
           ])}
@@ -535,7 +559,7 @@ export function TimelineView({
           data-sidebar-timeline-top-chip-stack
           className={cn([
             "absolute left-1/2 z-20 flex -translate-x-1/2 transform flex-col items-center gap-2",
-            topChromeInset ? "top-10" : "top-4",
+            topChromeInset ? "top-11" : "top-5",
           ])}
         >
           {showOpenCalendarChip && (


### PR DESCRIPTION
Keep the open-calendar spacer stable and forward wheel gestures from sidebar chrome into the timeline scroller.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5733 
- <kbd>&nbsp;2&nbsp;</kbd> #5730 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5729 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical i18n reference updates with no runtime logic or translation content changes.
> 
> **Overview**
> This PR **only updates Lingui catalog metadata** across locale `messages.po` files: the `#:` source line comments for sidebar timeline strings now point at the current locations in `timeline/index.tsx` (e.g. delete/hide-deleted actions, “Go back to now”, “Now”, “Open calendar”, “Meeting”, “No items today”) after that file grew by roughly two dozen lines.
> 
> No `msgid` / `msgstr` text changes appear in the diff—just refreshed file:line references so extract/merge tooling stays aligned with the timeline UI edits described in the stack (top spacer / wheel forwarding), which are **not** part of this patch itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc276b4dfc42b576e1a3ade25eaaa46c0d20265a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->