### PR TITLE
Transcribe dropped audio files

### DIFF
--- a/apps/desktop/src/session/components/note-input/audio-drop-target.tsx
+++ b/apps/desktop/src/session/components/note-input/audio-drop-target.tsx
@@ -1,0 +1,58 @@
+import { AudioLinesIcon } from "lucide-react";
+import type { HTMLAttributes, ReactNode } from "react";
+
+import { cn } from "@hypr/utils";
+
+import { AUDIO_EXTENSIONS } from "~/stt/useUploadFile";
+
+const supportedAudioFormats = formatAudioExtensionList(AUDIO_EXTENSIONS);
+
+export function AudioDropTarget({
+  children,
+  className,
+  isActive,
+  targetProps,
+}: {
+  children: ReactNode;
+  className?: string;
+  isActive: boolean;
+  targetProps: HTMLAttributes<HTMLDivElement>;
+}) {
+  return (
+    <div {...targetProps} className={cn(["relative min-h-full", className])}>
+      {isActive && (
+        <div
+          role="status"
+          className={cn([
+            "pointer-events-none absolute inset-0 z-30 flex items-center justify-center rounded-lg border border-dashed",
+            "border-border/70 bg-background/90 text-muted-foreground dark:bg-background/85 shadow-inner backdrop-blur-[1px]",
+            "[background-image:radial-gradient(circle_at_center,_rgba(113,113,122,0.34)_1px,_transparent_1px)]",
+            "[background-size:18px_18px]",
+          ])}
+        >
+          <div className="border-border/70 bg-card/95 text-foreground flex items-center gap-3 rounded-md border px-4 py-3 shadow-sm">
+            <AudioLinesIcon className="text-muted-foreground size-5 shrink-0" />
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <p className="text-sm font-medium">
+                Drop to upload and transcribe audio
+              </p>
+              <p className="text-muted-foreground text-xs">
+                {supportedAudioFormats} audio
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}
+
+function formatAudioExtensionList(extensions: string[]) {
+  const labels = extensions.map((extension) => extension.toUpperCase());
+  if (labels.length <= 1) {
+    return labels.join("");
+  }
+
+  return `${labels.slice(0, -1).join(", ")}, or ${labels[labels.length - 1]}`;
+}

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, render } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { EnhancedEditor } from "./editor";
@@ -8,7 +14,24 @@ const hoisted = vi.hoisted(() => ({
   sessionTitle: "Weekly sync",
   persistContent: vi.fn(),
   persistSessionTitle: vi.fn(),
+  fileUpload: vi.fn(),
+  processAudioFile: vi.fn(),
+  showWindow: vi.fn(),
+  unminimizeWindow: vi.fn(),
+  focusWindow: vi.fn(),
   noteEditorProps: [] as Record<string, unknown>[],
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  isTauri: () => true,
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    show: hoisted.showWindow,
+    unminimize: hoisted.unminimizeWindow,
+    setFocus: hoisted.focusWindow,
+  }),
 }));
 
 vi.mock("@hypr/editor/markdown", () => ({
@@ -44,7 +67,17 @@ vi.mock("~/editor-bridge/session-view", () => ({
 }));
 
 vi.mock("~/shared/hooks/useFileUpload", () => ({
-  useFileUpload: () => vi.fn(),
+  useFileUpload: () => hoisted.fileUpload,
+}));
+
+vi.mock("~/stt/useUploadFile", () => ({
+  AUDIO_EXTENSIONS: ["wav", "mp3", "ogg", "mp4", "m4a", "flac"],
+  isAudioUploadFile: (file: Pick<File, "name" | "type">) =>
+    file.type.startsWith("audio/") ||
+    ["wav", "mp3", "ogg", "mp4", "m4a", "flac"].some((extension) =>
+      file.name.endsWith(`.${extension}`),
+    ),
+  useUploadFile: () => ({ processAudioFile: hoisted.processAudioFile }),
 }));
 
 vi.mock("~/store/tinybase/store/main", () => ({
@@ -75,6 +108,14 @@ describe("EnhancedEditor", () => {
     hoisted.sessionTitle = "Weekly sync";
     hoisted.persistContent = vi.fn();
     hoisted.persistSessionTitle = vi.fn();
+    hoisted.fileUpload = vi.fn();
+    hoisted.processAudioFile = vi.fn();
+    hoisted.showWindow.mockReset();
+    hoisted.unminimizeWindow.mockReset();
+    hoisted.focusWindow.mockReset();
+    hoisted.showWindow.mockResolvedValue(undefined);
+    hoisted.unminimizeWindow.mockResolvedValue(undefined);
+    hoisted.focusWindow.mockResolvedValue(undefined);
   });
 
   it("shows the session title as the first line for persisted notes", () => {
@@ -172,4 +213,60 @@ describe("EnhancedEditor", () => {
       ],
     });
   });
+
+  it("routes dropped audio files to transcription", () => {
+    render(<EnhancedEditor sessionId="session-1" enhancedNoteId="note-1" />);
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+    const fileHandlerConfig = props?.fileHandlerConfig as {
+      onDrop: (files: File[]) => boolean | void;
+    };
+    const file = { name: "clip.mp3", type: "audio/mpeg" } as File;
+
+    expect(fileHandlerConfig.onDrop([file])).toBe(true);
+    expect(hoisted.processAudioFile).toHaveBeenCalledWith(file);
+  });
+
+  it("shows an audio upload overlay and intercepts audio drops", async () => {
+    render(<EnhancedEditor sessionId="session-1" enhancedNoteId="note-1" />);
+
+    const file = new File(["audio"], "clip.m4a", { type: "" });
+    const dataTransfer = audioDataTransfer(file);
+    const dropTarget = screen.getByText("Note editor").parentElement;
+
+    expect(dropTarget).not.toBeNull();
+    fireEvent.dragEnter(dropTarget!, { dataTransfer });
+
+    expect(
+      screen.getByText("Drop to upload and transcribe audio"),
+    ).not.toBeNull();
+    expect(
+      screen.getByText("WAV, MP3, OGG, MP4, M4A, or FLAC audio"),
+    ).not.toBeNull();
+    await waitFor(() => expect(hoisted.focusWindow).toHaveBeenCalledTimes(1));
+    expect(hoisted.showWindow).toHaveBeenCalledTimes(1);
+    expect(hoisted.unminimizeWindow).toHaveBeenCalledTimes(1);
+
+    fireEvent.drop(dropTarget!, { dataTransfer });
+
+    expect(hoisted.processAudioFile).toHaveBeenCalledWith(file);
+    expect(
+      screen.queryByText("Drop to upload and transcribe audio"),
+    ).toBeNull();
+  });
 });
+
+function audioDataTransfer(file: File) {
+  return {
+    files: [file],
+    items: [
+      {
+        kind: "file",
+        type: file.type,
+        getAsFile: () => file,
+      },
+    ],
+    types: ["Files"],
+    dropEffect: "none",
+  } as unknown as DataTransfer;
+}

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
@@ -71,11 +71,11 @@ vi.mock("~/shared/hooks/useFileUpload", () => ({
 }));
 
 vi.mock("~/stt/useUploadFile", () => ({
-  AUDIO_EXTENSIONS: ["wav", "mp3", "ogg", "mp4", "m4a", "flac"],
+  AUDIO_EXTENSIONS: ["wav", "mp3", "ogg", "mp4", "m4a", "flac", "webm", "aac"],
   isAudioUploadFile: (file: Pick<File, "name" | "type">) =>
     file.type.startsWith("audio/") ||
-    ["wav", "mp3", "ogg", "mp4", "m4a", "flac"].some((extension) =>
-      file.name.endsWith(`.${extension}`),
+    ["wav", "mp3", "ogg", "mp4", "m4a", "flac", "webm", "aac"].some(
+      (extension) => file.name.endsWith(`.${extension}`),
     ),
   useUploadFile: () => ({ processAudioFile: hoisted.processAudioFile }),
 }));
@@ -219,12 +219,48 @@ describe("EnhancedEditor", () => {
 
     const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
     const fileHandlerConfig = props?.fileHandlerConfig as {
-      onDrop: (files: File[]) => boolean | void;
+      onDrop: (files: File[]) => boolean | void | { remainingFiles: File[] };
     };
     const file = { name: "clip.mp3", type: "audio/mpeg" } as File;
 
     expect(fileHandlerConfig.onDrop([file])).toBe(true);
     expect(hoisted.processAudioFile).toHaveBeenCalledWith(file);
+  });
+
+  it("keeps non-audio files available when audio is dropped with attachments", () => {
+    render(<EnhancedEditor sessionId="session-1" enhancedNoteId="note-1" />);
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+    const fileHandlerConfig = props?.fileHandlerConfig as {
+      onDrop: (files: File[]) => boolean | void | { remainingFiles: File[] };
+    };
+    const audioFile = { name: "clip.mp3", type: "audio/mpeg" } as File;
+    const imageFile = { name: "photo.png", type: "image/png" } as File;
+
+    expect(fileHandlerConfig.onDrop([audioFile, imageFile])).toEqual({
+      remainingFiles: [imageFile],
+    });
+    expect(hoisted.processAudioFile).toHaveBeenCalledTimes(1);
+    expect(hoisted.processAudioFile).toHaveBeenCalledWith(audioFile);
+  });
+
+  it("only imports the first audio file from a multi-audio drop", () => {
+    render(<EnhancedEditor sessionId="session-1" enhancedNoteId="note-1" />);
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+    const fileHandlerConfig = props?.fileHandlerConfig as {
+      onDrop: (files: File[]) => boolean | void | { remainingFiles: File[] };
+    };
+    const firstAudioFile = { name: "first.mp3", type: "audio/mpeg" } as File;
+    const secondAudioFile = { name: "second.m4a", type: "" } as File;
+
+    expect(fileHandlerConfig.onDrop([firstAudioFile, secondAudioFile])).toEqual(
+      {
+        remainingFiles: [secondAudioFile],
+      },
+    );
+    expect(hoisted.processAudioFile).toHaveBeenCalledTimes(1);
+    expect(hoisted.processAudioFile).toHaveBeenCalledWith(firstAudioFile);
   });
 
   it("shows an audio upload overlay and intercepts audio drops", async () => {
@@ -241,7 +277,7 @@ describe("EnhancedEditor", () => {
       screen.getByText("Drop to upload and transcribe audio"),
     ).not.toBeNull();
     expect(
-      screen.getByText("WAV, MP3, OGG, MP4, M4A, or FLAC audio"),
+      screen.getByText("WAV, MP3, OGG, MP4, M4A, FLAC, WEBM, or AAC audio"),
     ).not.toBeNull();
     await waitFor(() => expect(hoisted.focusWindow).toHaveBeenCalledTimes(1));
     expect(hoisted.showWindow).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -8,6 +8,9 @@ import {
   type NoteEditorRef,
 } from "@hypr/editor/note";
 
+import { AudioDropTarget } from "../audio-drop-target";
+import { useNoteFileHandlerConfig } from "../file-handler";
+
 import { AppLinkView } from "~/editor-bridge/app-link-view";
 import { useMentionConfig } from "~/editor-bridge/mention-config";
 import { openEditorLink } from "~/editor-bridge/open-editor-link";
@@ -18,7 +21,6 @@ import {
   ensureFirstLineTitle,
   extractFirstLineTitle,
 } from "~/session/title-content";
-import { useFileUpload } from "~/shared/hooks/useFileUpload";
 import * as main from "~/store/tinybase/store/main";
 
 const extraNodeViews = { appLink: AppLinkView, session: SessionNodeView };
@@ -45,7 +47,8 @@ export const EnhancedEditor = forwardRef<
     },
     ref,
   ) => {
-    const onFileUpload = useFileUpload(sessionId);
+    const { audioDropTargetProps, fileHandlerConfig, isAudioDragActive } =
+      useNoteFileHandlerConfig(sessionId);
     const content = main.UI.useCell(
       "enhanced_notes",
       enhancedNoteId,
@@ -98,11 +101,14 @@ export const EnhancedEditor = forwardRef<
       [content, persistContent, persistSessionTitle],
     );
 
-    const fileHandlerConfig = useMemo(() => ({ onFileUpload }), [onFileUpload]);
     const mentionConfig = useMentionConfig();
 
     return (
-      <div className="h-full">
+      <AudioDropTarget
+        className="h-full"
+        targetProps={audioDropTargetProps}
+        isActive={isAudioDragActive}
+      >
         <NoteEditor
           ref={ref}
           className="session-note-editor enhanced-summary-editor"
@@ -124,7 +130,7 @@ export const EnhancedEditor = forwardRef<
           onViewDisposed={onViewDisposed}
           syncContentWhenFocused={!persistChanges}
         />
-      </div>
+      </AudioDropTarget>
     );
   },
 );

--- a/apps/desktop/src/session/components/note-input/file-handler.ts
+++ b/apps/desktop/src/session/components/note-input/file-handler.ts
@@ -20,22 +20,33 @@ export function useNoteFileHandlerConfig(sessionId: string) {
   const [isAudioDragActive, setIsAudioDragActive] = useState(false);
   const audioDragDepthRef = useRef(0);
 
-  const processAudioFiles = useCallback(
-    (files: File[]) => {
-      const audioFiles = files.filter(isAudioUploadFile);
-      if (audioFiles.length === 0) {
-        return false;
+  const processAudioDrop = useCallback(
+    (files: File[], items?: DataTransferItemList) => {
+      const audioDrop = getAudioDrop(files, items);
+      if (!audioDrop) {
+        return null;
       }
 
-      audioFiles.forEach((file) => processAudioFile(file));
-      return true;
+      if (audioDrop.allowUnknownAudio) {
+        processAudioFile(audioDrop.audioFile, { allowUnknownAudio: true });
+      } else {
+        processAudioFile(audioDrop.audioFile);
+      }
+      return { remainingFiles: audioDrop.remainingFiles };
     },
     [processAudioFile],
   );
 
   const handleDrop = useCallback(
-    (files: File[]) => (processAudioFiles(files) ? true : undefined),
-    [processAudioFiles],
+    (files: File[], _pos?: number, items?: DataTransferItemList) => {
+      const result = processAudioDrop(files, items);
+      if (!result) {
+        return undefined;
+      }
+
+      return result.remainingFiles.length === 0 ? true : result;
+    },
+    [processAudioDrop],
   );
 
   const resetAudioDrag = useCallback(() => {
@@ -55,7 +66,7 @@ export function useNoteFileHandlerConfig(sessionId: string) {
 
   const handleDragEnterCapture = useCallback(
     (event: DragEvent<HTMLDivElement>) => {
-      if (!hasAudioUploadDrag(event.dataTransfer)) {
+      if (!hasSingleAudioUploadDrag(event.dataTransfer)) {
         return;
       }
 
@@ -73,7 +84,7 @@ export function useNoteFileHandlerConfig(sessionId: string) {
     (event: DragEvent<HTMLDivElement>) => {
       if (
         audioDragDepthRef.current === 0 &&
-        !hasAudioUploadDrag(event.dataTransfer)
+        !hasSingleAudioUploadDrag(event.dataTransfer)
       ) {
         return;
       }
@@ -87,7 +98,7 @@ export function useNoteFileHandlerConfig(sessionId: string) {
     (event: DragEvent<HTMLDivElement>) => {
       if (
         audioDragDepthRef.current === 0 &&
-        !hasAudioUploadDrag(event.dataTransfer)
+        !hasSingleAudioUploadDrag(event.dataTransfer)
       ) {
         return;
       }
@@ -105,15 +116,30 @@ export function useNoteFileHandlerConfig(sessionId: string) {
   const handleDropCapture = useCallback(
     (event: DragEvent<HTMLDivElement>) => {
       const files = Array.from(event.dataTransfer.files ?? []);
-      if (!processAudioFiles(files)) {
+      if (files.length !== 1) {
         return;
       }
 
+      const audioDrop = getAudioDrop(files, event.dataTransfer.items);
+      if (!audioDrop) {
+        return;
+      }
+
+      if (audioDrop.remainingFiles.length > 0) {
+        resetAudioDrag();
+        return;
+      }
+
+      if (audioDrop.allowUnknownAudio) {
+        processAudioFile(audioDrop.audioFile, { allowUnknownAudio: true });
+      } else {
+        processAudioFile(audioDrop.audioFile);
+      }
       event.preventDefault();
       event.stopPropagation();
       resetAudioDrag();
     },
-    [processAudioFiles, resetAudioDrag],
+    [processAudioFile, resetAudioDrag],
   );
 
   const fileHandlerConfig = useMemo<FileHandlerConfig>(
@@ -148,24 +174,48 @@ export function useNoteFileHandlerConfig(sessionId: string) {
   );
 }
 
-function hasAudioUploadDrag(dataTransfer: DataTransfer) {
+function hasSingleAudioUploadDrag(dataTransfer: DataTransfer) {
   const items = Array.from(dataTransfer.items ?? []);
   if (items.length > 0) {
-    return items.some((item) => {
-      if (item.kind !== "file") {
-        return false;
-      }
+    if (items.length !== 1) {
+      return false;
+    }
 
-      if (item.type.startsWith("audio/")) {
-        return true;
-      }
+    const [item] = items;
+    if (item.kind !== "file") {
+      return false;
+    }
 
-      const file = item.getAsFile();
-      return file ? isAudioUploadFile(file) : false;
-    });
+    if (item.type.startsWith("audio/")) {
+      return true;
+    }
+
+    const file = item.getAsFile();
+    return file ? isAudioUploadFile(file) : false;
   }
 
-  return Array.from(dataTransfer.files ?? []).some(isAudioUploadFile);
+  const files = Array.from(dataTransfer.files ?? []);
+  return files.length === 1 && isAudioUploadFile(files[0]);
+}
+
+function getAudioDrop(files: File[], items?: DataTransferItemList) {
+  const dataTransferItems = Array.from(items ?? []);
+  const audioFile = files.find((file, index) =>
+    isAudioDropFile(file, dataTransferItems[index]),
+  );
+  if (!audioFile) {
+    return null;
+  }
+
+  return {
+    allowUnknownAudio: !isAudioUploadFile(audioFile),
+    audioFile,
+    remainingFiles: files.filter((file) => file !== audioFile),
+  };
+}
+
+function isAudioDropFile(file: File, item?: DataTransferItem) {
+  return isAudioUploadFile(file) || item?.type.startsWith("audio/") === true;
 }
 
 function focusCurrentWindowForAudioDrop() {

--- a/apps/desktop/src/session/components/note-input/file-handler.ts
+++ b/apps/desktop/src/session/components/note-input/file-handler.ts
@@ -1,0 +1,188 @@
+import { isTauri } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import {
+  type DragEvent,
+  type HTMLAttributes,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import type { FileHandlerConfig } from "@hypr/editor/note";
+
+import { useFileUpload } from "~/shared/hooks/useFileUpload";
+import { isAudioUploadFile, useUploadFile } from "~/stt/useUploadFile";
+
+export function useNoteFileHandlerConfig(sessionId: string) {
+  const onFileUpload = useFileUpload(sessionId);
+  const { processAudioFile } = useUploadFile(sessionId);
+  const [isAudioDragActive, setIsAudioDragActive] = useState(false);
+  const audioDragDepthRef = useRef(0);
+
+  const processAudioFiles = useCallback(
+    (files: File[]) => {
+      const audioFiles = files.filter(isAudioUploadFile);
+      if (audioFiles.length === 0) {
+        return false;
+      }
+
+      audioFiles.forEach((file) => processAudioFile(file));
+      return true;
+    },
+    [processAudioFile],
+  );
+
+  const handleDrop = useCallback(
+    (files: File[]) => (processAudioFiles(files) ? true : undefined),
+    [processAudioFiles],
+  );
+
+  const resetAudioDrag = useCallback(() => {
+    audioDragDepthRef.current = 0;
+    setIsAudioDragActive(false);
+  }, []);
+
+  const prepareAudioDragEvent = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      event.dataTransfer.dropEffect = "copy";
+      setIsAudioDragActive(true);
+    },
+    [],
+  );
+
+  const handleDragEnterCapture = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (!hasAudioUploadDrag(event.dataTransfer)) {
+        return;
+      }
+
+      if (audioDragDepthRef.current === 0) {
+        focusCurrentWindowForAudioDrop();
+      }
+
+      audioDragDepthRef.current += 1;
+      prepareAudioDragEvent(event);
+    },
+    [prepareAudioDragEvent],
+  );
+
+  const handleDragOverCapture = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (
+        audioDragDepthRef.current === 0 &&
+        !hasAudioUploadDrag(event.dataTransfer)
+      ) {
+        return;
+      }
+
+      prepareAudioDragEvent(event);
+    },
+    [prepareAudioDragEvent],
+  );
+
+  const handleDragLeaveCapture = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      if (
+        audioDragDepthRef.current === 0 &&
+        !hasAudioUploadDrag(event.dataTransfer)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      audioDragDepthRef.current = Math.max(0, audioDragDepthRef.current - 1);
+      if (audioDragDepthRef.current === 0) {
+        setIsAudioDragActive(false);
+      }
+    },
+    [],
+  );
+
+  const handleDropCapture = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      const files = Array.from(event.dataTransfer.files ?? []);
+      if (!processAudioFiles(files)) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      resetAudioDrag();
+    },
+    [processAudioFiles, resetAudioDrag],
+  );
+
+  const fileHandlerConfig = useMemo<FileHandlerConfig>(
+    () => ({ onFileUpload, onDrop: handleDrop }),
+    [handleDrop, onFileUpload],
+  );
+
+  const audioDropTargetProps = useMemo<HTMLAttributes<HTMLDivElement>>(
+    () => ({
+      onDragEnterCapture: handleDragEnterCapture,
+      onDragOverCapture: handleDragOverCapture,
+      onDragLeaveCapture: handleDragLeaveCapture,
+      onDropCapture: handleDropCapture,
+      onDragEndCapture: resetAudioDrag,
+    }),
+    [
+      handleDragEnterCapture,
+      handleDragLeaveCapture,
+      handleDragOverCapture,
+      handleDropCapture,
+      resetAudioDrag,
+    ],
+  );
+
+  return useMemo(
+    () => ({
+      audioDropTargetProps,
+      fileHandlerConfig,
+      isAudioDragActive,
+    }),
+    [audioDropTargetProps, fileHandlerConfig, isAudioDragActive],
+  );
+}
+
+function hasAudioUploadDrag(dataTransfer: DataTransfer) {
+  const items = Array.from(dataTransfer.items ?? []);
+  if (items.length > 0) {
+    return items.some((item) => {
+      if (item.kind !== "file") {
+        return false;
+      }
+
+      if (item.type.startsWith("audio/")) {
+        return true;
+      }
+
+      const file = item.getAsFile();
+      return file ? isAudioUploadFile(file) : false;
+    });
+  }
+
+  return Array.from(dataTransfer.files ?? []).some(isAudioUploadFile);
+}
+
+function focusCurrentWindowForAudioDrop() {
+  if (!isTauri()) {
+    return;
+  }
+
+  void bringCurrentWindowToFront();
+}
+
+async function bringCurrentWindowToFront() {
+  try {
+    const currentWindow = getCurrentWindow();
+    await currentWindow.show();
+    await currentWindow.unminimize();
+    await currentWindow.setFocus();
+  } catch (error) {
+    console.error("Failed to focus window for audio drop", error);
+  }
+}

--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -1,5 +1,6 @@
 import {
   cleanup,
+  createEvent,
   fireEvent,
   render,
   screen,
@@ -84,11 +85,11 @@ vi.mock("~/shared/hooks/useFileUpload", () => ({
 }));
 
 vi.mock("~/stt/useUploadFile", () => ({
-  AUDIO_EXTENSIONS: ["wav", "mp3", "ogg", "mp4", "m4a", "flac"],
+  AUDIO_EXTENSIONS: ["wav", "mp3", "ogg", "mp4", "m4a", "flac", "webm", "aac"],
   isAudioUploadFile: (file: Pick<File, "name" | "type">) =>
     file.type.startsWith("audio/") ||
-    ["wav", "mp3", "ogg", "mp4", "m4a", "flac"].some((extension) =>
-      file.name.endsWith(`.${extension}`),
+    ["wav", "mp3", "ogg", "mp4", "m4a", "flac", "webm", "aac"].some(
+      (extension) => file.name.endsWith(`.${extension}`),
     ),
   useUploadFile: () => ({ processAudioFile: hoisted.processAudioFile }),
 }));
@@ -155,12 +156,84 @@ describe("RawEditor", () => {
 
     const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
     const fileHandlerConfig = props?.fileHandlerConfig as {
-      onDrop: (files: File[]) => boolean | void;
+      onDrop: (
+        files: File[],
+        pos?: number,
+        items?: DataTransferItemList,
+      ) => boolean | void | { remainingFiles: File[] };
     };
     const file = { name: "clip.mp3", type: "audio/mpeg" } as File;
 
     expect(fileHandlerConfig.onDrop([file])).toBe(true);
     expect(hoisted.processAudioFile).toHaveBeenCalledWith(file);
+  });
+
+  it("keeps non-audio files available when audio is dropped with attachments", () => {
+    render(<RawEditor sessionId="session-1" />);
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+    const fileHandlerConfig = props?.fileHandlerConfig as {
+      onDrop: (files: File[]) => boolean | void | { remainingFiles: File[] };
+    };
+    const audioFile = { name: "clip.mp3", type: "audio/mpeg" } as File;
+    const imageFile = { name: "photo.png", type: "image/png" } as File;
+
+    expect(fileHandlerConfig.onDrop([audioFile, imageFile])).toEqual({
+      remainingFiles: [imageFile],
+    });
+    expect(hoisted.processAudioFile).toHaveBeenCalledTimes(1);
+    expect(hoisted.processAudioFile).toHaveBeenCalledWith(audioFile);
+  });
+
+  it("uses drag item MIME for mixed drops handled by the editor", () => {
+    render(<RawEditor sessionId="session-1" />);
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+    const fileHandlerConfig = props?.fileHandlerConfig as {
+      onDrop: (
+        files: File[],
+        pos?: number,
+        items?: DataTransferItemList,
+      ) => boolean | void | { remainingFiles: File[] };
+    };
+    const audioFile = new File(["audio"], "clip", { type: "" });
+    const imageFile = new File(["image"], "photo.png", { type: "image/png" });
+    const dataTransfer = audioDataTransfer(
+      [audioFile, imageFile],
+      ["audio/mpeg", imageFile.type],
+    );
+
+    expect(
+      fileHandlerConfig.onDrop(
+        [audioFile, imageFile],
+        undefined,
+        dataTransfer.items,
+      ),
+    ).toEqual({
+      remainingFiles: [imageFile],
+    });
+    expect(hoisted.processAudioFile).toHaveBeenCalledWith(audioFile, {
+      allowUnknownAudio: true,
+    });
+  });
+
+  it("only imports the first audio file from a multi-audio drop", () => {
+    render(<RawEditor sessionId="session-1" />);
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+    const fileHandlerConfig = props?.fileHandlerConfig as {
+      onDrop: (files: File[]) => boolean | void | { remainingFiles: File[] };
+    };
+    const firstAudioFile = { name: "first.mp3", type: "audio/mpeg" } as File;
+    const secondAudioFile = { name: "second.m4a", type: "" } as File;
+
+    expect(fileHandlerConfig.onDrop([firstAudioFile, secondAudioFile])).toEqual(
+      {
+        remainingFiles: [secondAudioFile],
+      },
+    );
+    expect(hoisted.processAudioFile).toHaveBeenCalledTimes(1);
+    expect(hoisted.processAudioFile).toHaveBeenCalledWith(firstAudioFile);
   });
 
   it("shows an audio upload overlay and intercepts audio drops", async () => {
@@ -177,7 +250,7 @@ describe("RawEditor", () => {
       screen.getByText("Drop to upload and transcribe audio"),
     ).not.toBeNull();
     expect(
-      screen.getByText("WAV, MP3, OGG, MP4, M4A, or FLAC audio"),
+      screen.getByText("WAV, MP3, OGG, MP4, M4A, FLAC, WEBM, or AAC audio"),
     ).not.toBeNull();
     await waitFor(() => expect(hoisted.focusWindow).toHaveBeenCalledTimes(1));
     expect(hoisted.showWindow).toHaveBeenCalledTimes(1);
@@ -190,18 +263,58 @@ describe("RawEditor", () => {
       screen.queryByText("Drop to upload and transcribe audio"),
     ).toBeNull();
   });
+
+  it("does not capture mixed audio and attachment drops on the wrapper", () => {
+    render(<RawEditor sessionId="session-1" />);
+
+    const audioFile = new File(["audio"], "clip.mp3", { type: "audio/mpeg" });
+    const imageFile = new File(["image"], "photo.png", { type: "image/png" });
+    const dataTransfer = audioDataTransfer([audioFile, imageFile]);
+    const dropTarget = screen.getByText("Note editor").parentElement;
+
+    expect(dropTarget).not.toBeNull();
+    const dropEvent = createEvent.drop(dropTarget!, { dataTransfer });
+    fireEvent(dropTarget!, dropEvent);
+
+    expect(dropEvent.defaultPrevented).toBe(false);
+    expect(hoisted.processAudioFile).not.toHaveBeenCalled();
+  });
+
+  it("uses the drag item MIME when dropped audio has no MIME or extension", async () => {
+    render(<RawEditor sessionId="session-1" />);
+
+    const file = new File(["audio"], "clip", { type: "" });
+    const dataTransfer = audioDataTransfer(file, "audio/mpeg");
+    const dropTarget = screen.getByText("Note editor").parentElement;
+
+    expect(dropTarget).not.toBeNull();
+    fireEvent.dragEnter(dropTarget!, { dataTransfer });
+
+    expect(
+      screen.getByText("Drop to upload and transcribe audio"),
+    ).not.toBeNull();
+
+    fireEvent.drop(dropTarget!, { dataTransfer });
+
+    expect(hoisted.processAudioFile).toHaveBeenCalledWith(file, {
+      allowUnknownAudio: true,
+    });
+  });
 });
 
-function audioDataTransfer(file: File) {
+function audioDataTransfer(input: File | File[], itemType?: string | string[]) {
+  const files = Array.isArray(input) ? input : [input];
+  const itemTypes = Array.isArray(itemType)
+    ? itemType
+    : files.map((file) => itemType ?? file.type);
+
   return {
-    files: [file],
-    items: [
-      {
-        kind: "file",
-        type: file.type,
-        getAsFile: () => file,
-      },
-    ],
+    files,
+    items: files.map((file, index) => ({
+      kind: "file",
+      type: itemTypes[index] ?? file.type,
+      getAsFile: () => file,
+    })),
     types: ["Files"],
     dropEffect: "none",
   } as unknown as DataTransfer;

--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, render } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RawEditor } from "./raw";
@@ -7,7 +13,24 @@ const hoisted = vi.hoisted(() => ({
   rawMd: JSON.stringify({ type: "doc", content: [] }),
   sessionTitle: "Weekly sync",
   persistChange: vi.fn(),
+  fileUpload: vi.fn(),
+  processAudioFile: vi.fn(),
+  showWindow: vi.fn(),
+  unminimizeWindow: vi.fn(),
+  focusWindow: vi.fn(),
   noteEditorProps: [] as Record<string, unknown>[],
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  isTauri: () => true,
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    show: hoisted.showWindow,
+    unminimize: hoisted.unminimizeWindow,
+    setFocus: hoisted.focusWindow,
+  }),
 }));
 
 vi.mock("@hypr/editor/markdown", () => ({
@@ -57,7 +80,17 @@ vi.mock("~/session/raw-editor-sync", () => ({
 }));
 
 vi.mock("~/shared/hooks/useFileUpload", () => ({
-  useFileUpload: () => vi.fn(),
+  useFileUpload: () => hoisted.fileUpload,
+}));
+
+vi.mock("~/stt/useUploadFile", () => ({
+  AUDIO_EXTENSIONS: ["wav", "mp3", "ogg", "mp4", "m4a", "flac"],
+  isAudioUploadFile: (file: Pick<File, "name" | "type">) =>
+    file.type.startsWith("audio/") ||
+    ["wav", "mp3", "ogg", "mp4", "m4a", "flac"].some((extension) =>
+      file.name.endsWith(`.${extension}`),
+    ),
+  useUploadFile: () => ({ processAudioFile: hoisted.processAudioFile }),
 }));
 
 vi.mock("~/store/tinybase/store/main", () => ({
@@ -88,6 +121,14 @@ describe("RawEditor", () => {
     hoisted.rawMd = JSON.stringify({ type: "doc", content: [] });
     hoisted.sessionTitle = "Weekly sync";
     hoisted.persistChange = vi.fn();
+    hoisted.fileUpload = vi.fn();
+    hoisted.processAudioFile = vi.fn();
+    hoisted.showWindow.mockReset();
+    hoisted.unminimizeWindow.mockReset();
+    hoisted.focusWindow.mockReset();
+    hoisted.showWindow.mockResolvedValue(undefined);
+    hoisted.unminimizeWindow.mockResolvedValue(undefined);
+    hoisted.focusWindow.mockResolvedValue(undefined);
   });
 
   it("uses the shared session note editor styling", () => {
@@ -108,4 +149,60 @@ describe("RawEditor", () => {
       ],
     });
   });
+
+  it("routes dropped audio files to transcription", () => {
+    render(<RawEditor sessionId="session-1" />);
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+    const fileHandlerConfig = props?.fileHandlerConfig as {
+      onDrop: (files: File[]) => boolean | void;
+    };
+    const file = { name: "clip.mp3", type: "audio/mpeg" } as File;
+
+    expect(fileHandlerConfig.onDrop([file])).toBe(true);
+    expect(hoisted.processAudioFile).toHaveBeenCalledWith(file);
+  });
+
+  it("shows an audio upload overlay and intercepts audio drops", async () => {
+    render(<RawEditor sessionId="session-1" />);
+
+    const file = new File(["audio"], "clip.flac", { type: "" });
+    const dataTransfer = audioDataTransfer(file);
+    const dropTarget = screen.getByText("Note editor").parentElement;
+
+    expect(dropTarget).not.toBeNull();
+    fireEvent.dragEnter(dropTarget!, { dataTransfer });
+
+    expect(
+      screen.getByText("Drop to upload and transcribe audio"),
+    ).not.toBeNull();
+    expect(
+      screen.getByText("WAV, MP3, OGG, MP4, M4A, or FLAC audio"),
+    ).not.toBeNull();
+    await waitFor(() => expect(hoisted.focusWindow).toHaveBeenCalledTimes(1));
+    expect(hoisted.showWindow).toHaveBeenCalledTimes(1);
+    expect(hoisted.unminimizeWindow).toHaveBeenCalledTimes(1);
+
+    fireEvent.drop(dropTarget!, { dataTransfer });
+
+    expect(hoisted.processAudioFile).toHaveBeenCalledWith(file);
+    expect(
+      screen.queryByText("Drop to upload and transcribe audio"),
+    ).toBeNull();
+  });
 });
+
+function audioDataTransfer(file: File) {
+  return {
+    files: [file],
+    items: [
+      {
+        kind: "file",
+        type: file.type,
+        getAsFile: () => file,
+      },
+    ],
+    types: ["Files"],
+    dropEffect: "none",
+  } as unknown as DataTransfer;
+}

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -10,6 +10,9 @@ import {
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 import { cn } from "@hypr/utils";
 
+import { AudioDropTarget } from "./audio-drop-target";
+import { useNoteFileHandlerConfig } from "./file-handler";
+
 import { AppLinkView } from "~/editor-bridge/app-link-view";
 import { useMentionConfig } from "~/editor-bridge/mention-config";
 import { openEditorLink } from "~/editor-bridge/open-editor-link";
@@ -21,7 +24,6 @@ import {
   ensureFirstLineTitle,
   extractFirstLineTitle,
 } from "~/session/title-content";
-import { useFileUpload } from "~/shared/hooks/useFileUpload";
 import * as main from "~/store/tinybase/store/main";
 
 const extraNodeViews = { appLink: AppLinkView, session: SessionNodeView };
@@ -62,7 +64,8 @@ export const RawEditor = forwardRef<
       "title",
       main.STORE_ID,
     ) as string | undefined;
-    const onFileUpload = useFileUpload(sessionId);
+    const { audioDropTargetProps, fileHandlerConfig, isAudioDragActive } =
+      useNoteFileHandlerConfig(sessionId);
     const syncSourceId = useRawEditorSyncSourceId();
 
     const initialContent = useMemo<JSONContent>(
@@ -124,29 +127,33 @@ export const RawEditor = forwardRef<
       [persistChange, sessionId, syncSourceId, hasNonEmptyText],
     );
 
-    const fileHandlerConfig = useMemo(() => ({ onFileUpload }), [onFileUpload]);
     const mentionConfig = useMentionConfig();
 
     return (
-      <NoteEditor
-        ref={ref}
-        className={cn(["session-note-editor", className])}
-        key={`session-${sessionId}-raw`}
-        initialContent={initialContent}
-        handleChange={handleChange}
-        mentionConfig={mentionConfig}
-        sessionMentionDropConfig={sessionMentionDropConfig}
-        onNavigateToTitle={onNavigateToTitle}
-        onLinkOpen={openEditorLink}
-        fileHandlerConfig={fileHandlerConfig}
-        taskSource={
-          syncTasks ? { type: "session_raw_note", id: sessionId } : undefined
-        }
-        extraNodeViews={extraNodeViews}
-        showFormatToolbar={showFormatToolbar}
-        onViewReady={onViewReady}
-        onViewDisposed={onViewDisposed}
-      />
+      <AudioDropTarget
+        targetProps={audioDropTargetProps}
+        isActive={isAudioDragActive}
+      >
+        <NoteEditor
+          ref={ref}
+          className={cn(["session-note-editor", className])}
+          key={`session-${sessionId}-raw`}
+          initialContent={initialContent}
+          handleChange={handleChange}
+          mentionConfig={mentionConfig}
+          sessionMentionDropConfig={sessionMentionDropConfig}
+          onNavigateToTitle={onNavigateToTitle}
+          onLinkOpen={openEditorLink}
+          fileHandlerConfig={fileHandlerConfig}
+          taskSource={
+            syncTasks ? { type: "session_raw_note", id: sessionId } : undefined
+          }
+          extraNodeViews={extraNodeViews}
+          showFormatToolbar={showFormatToolbar}
+          onViewReady={onViewReady}
+          onViewDisposed={onViewDisposed}
+        />
+      </AudioDropTarget>
     );
   },
 );

--- a/apps/desktop/src/stt/useUploadFile.test.tsx
+++ b/apps/desktop/src/stt/useUploadFile.test.tsx
@@ -3,7 +3,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { useUploadFile } from "./useUploadFile";
+import { isAudioUploadFile, useUploadFile } from "./useUploadFile";
 
 const {
   audioImportDataMock,
@@ -165,4 +165,35 @@ describe("useUploadFile", () => {
     );
     expect(handleBatchFailedMock).not.toHaveBeenCalled();
   });
+
+  test.each(["webm", "aac"])(
+    "imports pathless .%s drops without MIME",
+    async (extension) => {
+      const { result } = renderHook(() => useUploadFile("session-1"), {
+        wrapper: createWrapper(),
+      });
+      const file = new File([new Uint8Array([1, 2, 3])], `drop.${extension}`, {
+        type: "",
+        lastModified: 1_700_000_000_000,
+      });
+      Object.defineProperty(file, "arrayBuffer", {
+        value: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]).buffer),
+      });
+
+      expect(isAudioUploadFile(file)).toBe(true);
+
+      act(() => {
+        result.current.processAudioFile(file);
+      });
+
+      await waitFor(() => {
+        expect(audioImportDataMock).toHaveBeenCalled();
+      });
+      expect(audioImportDataMock).toHaveBeenCalledWith(
+        "session-1",
+        [1, 2, 3],
+        `drop.${extension}`,
+      );
+    },
+  );
 });

--- a/apps/desktop/src/stt/useUploadFile.test.tsx
+++ b/apps/desktop/src/stt/useUploadFile.test.tsx
@@ -1,0 +1,168 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { useUploadFile } from "./useUploadFile";
+
+const {
+  audioImportDataMock,
+  audioImportMock,
+  audioImportListenMock,
+  handleBatchFailedMock,
+  handleBatchStartedMock,
+  updateBatchProgressMock,
+  clearBatchSessionMock,
+  runBatchMock,
+  useStoreMock,
+  useValuesMock,
+  useTabsMock,
+  updateSessionTabStateMock,
+} = vi.hoisted(() => ({
+  audioImportDataMock: vi.fn(),
+  audioImportMock: vi.fn(),
+  audioImportListenMock: vi.fn(),
+  handleBatchFailedMock: vi.fn(),
+  handleBatchStartedMock: vi.fn(),
+  updateBatchProgressMock: vi.fn(),
+  clearBatchSessionMock: vi.fn(),
+  runBatchMock: vi.fn(),
+  useStoreMock: vi.fn(),
+  useValuesMock: vi.fn(),
+  useTabsMock: vi.fn(),
+  updateSessionTabStateMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/path", () => ({
+  downloadDir: vi.fn(),
+  resolveResource: vi.fn((path: string) =>
+    Promise.resolve(`/resources/${path}`),
+  ),
+  sep: vi.fn().mockReturnValue("/"),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-fs-sync", () => ({
+  commands: {
+    audioImport: audioImportMock,
+    audioImportData: audioImportDataMock,
+    audioSourceMetadata: vi.fn(),
+  },
+  events: {
+    audioImportEvent: {
+      listen: audioImportListenMock,
+    },
+  },
+}));
+
+vi.mock("./contexts", () => ({
+  useListener: (selector: (state: unknown) => unknown) =>
+    selector({
+      handleBatchStarted: handleBatchStartedMock,
+      handleBatchFailed: handleBatchFailedMock,
+      updateBatchProgress: updateBatchProgressMock,
+      clearBatchSession: clearBatchSessionMock,
+    }),
+}));
+
+vi.mock("./useRunBatch", () => ({
+  isStoppedTranscriptionError: vi.fn(() => false),
+  useRunBatch: vi.fn(() => runBatchMock),
+}));
+
+vi.mock("~/services/enhancer", () => ({
+  getEnhancerService: vi.fn(() => ({
+    enhance: vi.fn(),
+    queueAutoEnhanceIfSummaryEmpty: vi.fn(),
+  })),
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useStore: useStoreMock,
+    useValues: useValuesMock,
+  },
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: useTabsMock,
+}));
+
+function createStore() {
+  const sessions = new Map<string, Record<string, unknown>>([
+    ["session-1", { event_json: "" }],
+  ]);
+
+  return {
+    getCell: (tableId: string, rowId: string, cellId: string) =>
+      tableId === "sessions" ? sessions.get(rowId)?.[cellId] : undefined,
+    setCell: vi.fn(),
+    setRow: vi.fn(),
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useUploadFile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    audioImportDataMock.mockResolvedValue({
+      status: "ok",
+      data: "/vault/sessions/session-1/audio.wav",
+    });
+    audioImportListenMock.mockResolvedValue(vi.fn());
+    runBatchMock.mockResolvedValue(undefined);
+    useStoreMock.mockReturnValue(createStore());
+    useValuesMock.mockReturnValue({ user_id: "user-1" });
+    useTabsMock.mockImplementation((selector) =>
+      selector({
+        tabs: [],
+        updateSessionTabState: updateSessionTabStateMock,
+      }),
+    );
+  });
+
+  test("imports pathless dropped audio using file bytes", async () => {
+    const { result } = renderHook(() => useUploadFile("session-1"), {
+      wrapper: createWrapper(),
+    });
+    const file = new File([new Uint8Array([1, 2, 3])], "drop.wav", {
+      type: "audio/wav",
+      lastModified: 1_700_000_000_000,
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      value: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]).buffer),
+    });
+
+    act(() => {
+      result.current.processAudioFile(file);
+    });
+
+    await waitFor(() => {
+      expect(audioImportDataMock).toHaveBeenCalled();
+    });
+    expect(audioImportDataMock).toHaveBeenCalledWith(
+      "session-1",
+      [1, 2, 3],
+      "drop.wav",
+    );
+    expect(audioImportMock).not.toHaveBeenCalled();
+    expect(runBatchMock).toHaveBeenCalledWith(
+      "/vault/sessions/session-1/audio.wav",
+    );
+    expect(handleBatchFailedMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/stt/useUploadFile.ts
+++ b/apps/desktop/src/stt/useUploadFile.ts
@@ -22,7 +22,16 @@ import { getEnhancerService } from "~/services/enhancer";
 import * as main from "~/store/tinybase/store/main";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 
-export const AUDIO_EXTENSIONS = ["wav", "mp3", "ogg", "mp4", "m4a", "flac"];
+export const AUDIO_EXTENSIONS = [
+  "wav",
+  "mp3",
+  "ogg",
+  "mp4",
+  "m4a",
+  "flac",
+  "webm",
+  "aac",
+];
 const TRANSCRIPT_EXTENSIONS = ["vtt", "srt"];
 
 function fileExtension(value: string) {

--- a/apps/desktop/src/stt/useUploadFile.ts
+++ b/apps/desktop/src/stt/useUploadFile.ts
@@ -22,8 +22,24 @@ import { getEnhancerService } from "~/services/enhancer";
 import * as main from "~/store/tinybase/store/main";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 
-const AUDIO_EXTENSIONS = ["wav", "mp3", "ogg", "mp4", "m4a", "flac"];
+export const AUDIO_EXTENSIONS = ["wav", "mp3", "ogg", "mp4", "m4a", "flac"];
 const TRANSCRIPT_EXTENSIONS = ["vtt", "srt"];
+
+function fileExtension(value: string) {
+  const extension = value.toLowerCase().split(".").pop();
+  return extension && extension !== value.toLowerCase() ? extension : "";
+}
+
+export function isAudioUploadFile(file: Pick<File, "name" | "type">) {
+  return (
+    AUDIO_EXTENSIONS.includes(fileExtension(file.name)) ||
+    file.type.startsWith("audio/")
+  );
+}
+
+function isAudioUploadPath(path: string) {
+  return AUDIO_EXTENSIONS.includes(fileExtension(path));
+}
 
 export function useUploadFile(sessionId: string) {
   const runBatch = useRunBatch(sessionId);
@@ -93,6 +109,134 @@ export function useUploadFile(sessionId: string) {
     [sessionId, store],
   );
 
+  const applyDroppedAudioNoteDate = useCallback(
+    async (file: File) => {
+      try {
+        if (!store) {
+          return;
+        }
+
+        const eventJson = store.getCell("sessions", sessionId, "event_json");
+        if (typeof eventJson === "string" && eventJson.trim()) {
+          return;
+        }
+
+        if (!Number.isFinite(file.lastModified) || file.lastModified <= 0) {
+          return;
+        }
+
+        store.setCell(
+          "sessions",
+          sessionId,
+          "created_at",
+          new Date(file.lastModified).toISOString(),
+        );
+      } catch (error) {
+        console.error("[upload] dropped audio date inspection failed:", error);
+      }
+    },
+    [sessionId, store],
+  );
+
+  const importWithProgress = useCallback(
+    async (
+      runImport: () => Promise<
+        | { status: "ok"; data: string }
+        | {
+            status: "error";
+            error: string;
+          }
+      >,
+    ) => {
+      const unlisten = await fsSyncEvents.audioImportEvent.listen((e) => {
+        if (
+          e.payload.type === "audioImportProgress" &&
+          e.payload.session_id === sessionId
+        ) {
+          updateBatchProgress(sessionId, e.payload.percentage);
+        }
+      });
+
+      try {
+        const result = await runImport();
+        if (result.status === "error") {
+          throw new Error(result.error);
+        }
+        return result.data;
+      } finally {
+        unlisten();
+      }
+    },
+    [sessionId, updateBatchProgress],
+  );
+
+  const runAudioImport = useCallback(
+    (
+      importAudio: () => Promise<string>,
+      inspectAudioDate: () => Promise<void>,
+    ) => {
+      const program = pipe(
+        Effect.promise(inspectAudioDate),
+        Effect.tap(() =>
+          Effect.sync(() => {
+            handleBatchStarted(sessionId, "importing");
+          }),
+        ),
+        Effect.flatMap(() =>
+          Effect.tryPromise({
+            try: importAudio,
+            catch: (error) =>
+              error instanceof Error ? error : new Error(String(error)),
+          }),
+        ),
+        Effect.tap(() =>
+          Effect.sync(() => {
+            void analyticsCommands.event({
+              event: "file_uploaded",
+              file_type: "audio",
+            });
+            void queryClient.invalidateQueries({
+              queryKey: ["audio", sessionId, "exist"],
+            });
+            void queryClient.invalidateQueries({
+              queryKey: ["audio", sessionId, "url"],
+            });
+          }),
+        ),
+        Effect.tap(() => Effect.sync(() => clearBatchSession(sessionId))),
+        Effect.flatMap((importedPath) =>
+          Effect.tryPromise({
+            try: () => runBatch(importedPath),
+            catch: (error) => error,
+          }),
+        ),
+        Effect.tap(() => Effect.sync(() => triggerEnhanceIfSummaryEmpty())),
+        Effect.catchAll((error: unknown) =>
+          Effect.sync(() => {
+            if (isStoppedTranscriptionError(error)) {
+              return;
+            }
+            const msg = error instanceof Error ? error.message : String(error);
+            handleBatchFailed(sessionId, msg);
+          }),
+        ),
+      );
+
+      Effect.runPromise(program).catch((error) => {
+        console.error("[upload] audio failed:", error);
+      });
+    },
+    [
+      clearBatchSession,
+      handleBatchFailed,
+      handleBatchStarted,
+      queryClient,
+      runBatch,
+      sessionId,
+      triggerEnhanceIfSummaryEmpty,
+    ],
+  );
+
   const processFile = useCallback(
     (filePath: string, kind: "audio" | "transcript") => {
       const normalizedPath = filePath.toLowerCase();
@@ -157,107 +301,53 @@ export function useUploadFile(sessionId: string) {
         return;
       }
 
-      if (
-        !normalizedPath.endsWith(".wav") &&
-        !normalizedPath.endsWith(".mp3") &&
-        !normalizedPath.endsWith(".ogg") &&
-        !normalizedPath.endsWith(".mp4") &&
-        !normalizedPath.endsWith(".m4a") &&
-        !normalizedPath.endsWith(".flac")
-      ) {
+      if (!isAudioUploadPath(normalizedPath)) {
         return;
       }
 
-      const program = pipe(
-        Effect.promise(() => applyEstimatedAudioNoteDate(filePath)),
-        Effect.tap(() =>
-          Effect.sync(() => {
-            handleBatchStarted(sessionId, "importing");
-          }),
-        ),
-        Effect.flatMap(() =>
-          Effect.tryPromise({
-            try: async () => {
-              const unlisten = await fsSyncEvents.audioImportEvent.listen(
-                (e) => {
-                  if (
-                    e.payload.type === "audioImportProgress" &&
-                    e.payload.session_id === sessionId
-                  ) {
-                    updateBatchProgress(sessionId, e.payload.percentage);
-                  }
-                },
-              );
-              try {
-                const result = await fsSyncCommands.audioImport(
-                  sessionId,
-                  filePath,
-                );
-                if (result.status === "error") {
-                  throw new Error(result.error);
-                }
-                return result.data;
-              } finally {
-                unlisten();
-              }
-            },
-            catch: (error) =>
-              error instanceof Error ? error : new Error(String(error)),
-          }),
-        ),
-        Effect.tap(() =>
-          Effect.sync(() => {
-            void analyticsCommands.event({
-              event: "file_uploaded",
-              file_type: "audio",
-            });
-            void queryClient.invalidateQueries({
-              queryKey: ["audio", sessionId, "exist"],
-            });
-            void queryClient.invalidateQueries({
-              queryKey: ["audio", sessionId, "url"],
-            });
-          }),
-        ),
-        Effect.tap(() => Effect.sync(() => clearBatchSession(sessionId))),
-        Effect.flatMap((importedPath) =>
-          Effect.tryPromise({
-            try: () => runBatch(importedPath),
-            catch: (error) => error,
-          }),
-        ),
-        Effect.tap(() => Effect.sync(() => triggerEnhanceIfSummaryEmpty())),
-        Effect.catchAll((error: unknown) =>
-          Effect.sync(() => {
-            if (isStoppedTranscriptionError(error)) {
-              return;
-            }
-            const msg = error instanceof Error ? error.message : String(error);
-            handleBatchFailed(sessionId, msg);
-          }),
-        ),
+      runAudioImport(
+        () =>
+          importWithProgress(() =>
+            fsSyncCommands.audioImport(sessionId, filePath),
+          ),
+        () => applyEstimatedAudioNoteDate(filePath),
       );
-
-      Effect.runPromise(program).catch((error) => {
-        console.error("[upload] audio failed:", error);
-      });
     },
     [
-      clearBatchSession,
-      handleBatchFailed,
-      handleBatchStarted,
-      updateBatchProgress,
-      queryClient,
-      runBatch,
       sessionId,
-      sessionTab,
       store,
       triggerEnhance,
-      triggerEnhanceIfSummaryEmpty,
       applyEstimatedAudioNoteDate,
-      updateSessionTabState,
+      importWithProgress,
+      runAudioImport,
       user_id,
     ],
+  );
+
+  const processAudioFile = useCallback(
+    (file: File, options?: { allowUnknownAudio?: boolean }) => {
+      if (!options?.allowUnknownAudio && !isAudioUploadFile(file)) {
+        return;
+      }
+
+      const filePath = audioUploadFilePath(file);
+      runAudioImport(
+        async () => {
+          if (filePath) {
+            return importWithProgress(() =>
+              fsSyncCommands.audioImport(sessionId, filePath),
+            );
+          }
+
+          const data = Array.from(new Uint8Array(await file.arrayBuffer()));
+          return importWithProgress(() =>
+            fsSyncCommands.audioImportData(sessionId, data, file.name),
+          );
+        },
+        () => applyDroppedAudioNoteDate(file),
+      );
+    },
+    [applyDroppedAudioNoteDate, importWithProgress, runAudioImport, sessionId],
   );
 
   const selectAndUpload = useCallback(
@@ -305,5 +395,10 @@ export function useUploadFile(sessionId: string) {
     [selectAndUpload],
   );
 
-  return { uploadAudio, uploadTranscript, processFile };
+  return { uploadAudio, uploadTranscript, processFile, processAudioFile };
+}
+
+function audioUploadFilePath(file: File) {
+  const value = (file as { path?: unknown }).path;
+  return typeof value === "string" && value.trim() ? value : null;
 }

--- a/packages/editor/src/plugins/file-handler.ts
+++ b/packages/editor/src/plugins/file-handler.ts
@@ -106,6 +106,7 @@ export function fileHandlerPlugin(config: FileHandlerConfig) {
 
         if (config.onDrop) {
           const result = config.onDrop(files, pos);
+          if (result === true) return true;
           if (result === false) return false;
         }
 
@@ -119,6 +120,7 @@ export function fileHandlerPlugin(config: FileHandlerConfig) {
 
         if (config.onPaste) {
           const result = config.onPaste(files);
+          if (result === true) return true;
           if (result === false) return false;
         }
 

--- a/packages/editor/src/plugins/file-handler.ts
+++ b/packages/editor/src/plugins/file-handler.ts
@@ -7,8 +7,14 @@ export type FileUploadResult = {
   path: string;
 };
 
+export type FileDropResult = boolean | void | { remainingFiles: File[] };
+
 export type FileHandlerConfig = {
-  onDrop?: (files: File[], pos?: number) => boolean | void;
+  onDrop?: (
+    files: File[],
+    pos?: number,
+    items?: DataTransferItemList,
+  ) => FileDropResult;
   onPaste?: (files: File[]) => boolean | void;
   onFileUpload?: (file: File) => Promise<FileUploadResult>;
 };
@@ -17,6 +23,17 @@ const IMAGE_MIME_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
 
 function isImageFile(file: File) {
   return IMAGE_MIME_TYPES.includes(file.type);
+}
+
+function isFileDropRemainder(
+  result: FileDropResult,
+): result is { remainingFiles: File[] } {
+  return Boolean(
+    result &&
+    typeof result === "object" &&
+    "remainingFiles" in result &&
+    Array.isArray(result.remainingFiles),
+  );
 }
 
 export function fileHandlerPlugin(config: FileHandlerConfig) {
@@ -105,9 +122,15 @@ export function fileHandlerPlugin(config: FileHandlerConfig) {
         })?.pos;
 
         if (config.onDrop) {
-          const result = config.onDrop(files, pos);
+          const result = config.onDrop(files, pos, event.dataTransfer?.items);
           if (result === true) return true;
           if (result === false) return false;
+          if (isFileDropRemainder(result)) {
+            if (result.remainingFiles.length === 0) return true;
+
+            handleFiles(view, result.remainingFiles, pos);
+            return true;
+          }
         }
 
         handleFiles(view, files, pos);

--- a/plugins/fs-sync/build.rs
+++ b/plugins/fs-sync/build.rs
@@ -12,6 +12,7 @@ const COMMANDS: &[&str] = &[
     "audio_delete",
     "audio_delete_orphaned_expired",
     "audio_import",
+    "audio_import_data",
     "audio_source_metadata",
     "audio_path",
     "session_dir",

--- a/plugins/fs-sync/js/bindings.gen.ts
+++ b/plugins/fs-sync/js/bindings.gen.ts
@@ -110,6 +110,14 @@ async audioImport(sessionId: string, sourcePath: string) : Promise<Result<string
     else return { status: "error", error: e  as any };
 }
 },
+async audioImportData(sessionId: string, data: number[], filename: string) : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:fs-sync|audio_import_data", { sessionId, data, filename }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async audioSourceMetadata(sourcePath: string) : Promise<Result<AudioSourceMetadata, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("plugin:fs-sync|audio_source_metadata", { sourcePath }) };

--- a/plugins/fs-sync/permissions/autogenerated/commands/audio_import_data.toml
+++ b/plugins/fs-sync/permissions/autogenerated/commands/audio_import_data.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-audio-import-data"
+description = "Enables the audio_import_data command without any pre-configured scope."
+commands.allow = ["audio_import_data"]
+
+[[permission]]
+identifier = "deny-audio-import-data"
+description = "Denies the audio_import_data command without any pre-configured scope."
+commands.deny = ["audio_import_data"]

--- a/plugins/fs-sync/permissions/autogenerated/reference.md
+++ b/plugins/fs-sync/permissions/autogenerated/reference.md
@@ -17,6 +17,7 @@ Default permissions for the fs-sync plugin
 - `allow-audio-delete`
 - `allow-audio-delete-orphaned-expired`
 - `allow-audio-import`
+- `allow-audio-import-data`
 - `allow-audio-source-metadata`
 - `allow-audio-path`
 - `allow-session-dir`
@@ -243,6 +244,32 @@ Enables the audio_import command without any pre-configured scope.
 <td>
 
 Denies the audio_import command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`fs-sync:allow-audio-import-data`
+
+</td>
+<td>
+
+Enables the audio_import_data command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`fs-sync:deny-audio-import-data`
+
+</td>
+<td>
+
+Denies the audio_import_data command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/fs-sync/permissions/default.toml
+++ b/plugins/fs-sync/permissions/default.toml
@@ -14,6 +14,7 @@ permissions = [
     "allow-audio-delete",
     "allow-audio-delete-orphaned-expired",
     "allow-audio-import",
+    "allow-audio-import-data",
     "allow-audio-source-metadata",
     "allow-audio-path",
     "allow-session-dir",

--- a/plugins/fs-sync/permissions/schemas/schema.json
+++ b/plugins/fs-sync/permissions/schemas/schema.json
@@ -391,6 +391,18 @@
           "markdownDescription": "Denies the audio_import command without any pre-configured scope."
         },
         {
+          "description": "Enables the audio_import_data command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-audio-import-data",
+          "markdownDescription": "Enables the audio_import_data command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the audio_import_data command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-audio-import-data",
+          "markdownDescription": "Denies the audio_import_data command without any pre-configured scope."
+        },
+        {
           "description": "Enables the audio_path command without any pre-configured scope.",
           "type": "string",
           "const": "allow-audio-path",
@@ -607,10 +619,10 @@
           "markdownDescription": "Denies the write_json_batch command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the fs-sync plugin\n#### This default permission set includes:\n\n- `allow-deserialize`\n- `allow-write-json-batch`\n- `allow-write-document-batch`\n- `allow-read-document-batch`\n- `allow-list-folders`\n- `allow-move-session`\n- `allow-create-folder`\n- `allow-rename-folder`\n- `allow-delete-folder`\n- `allow-audio-exist`\n- `allow-audio-delete`\n- `allow-audio-delete-orphaned-expired`\n- `allow-audio-import`\n- `allow-audio-source-metadata`\n- `allow-audio-path`\n- `allow-session-dir`\n- `allow-load-session-content`\n- `allow-delete-session-folder`\n- `allow-scan-and-read`\n- `allow-chat-dir`\n- `allow-entity-dir`\n- `allow-attachment-save`\n- `allow-attachment-list`\n- `allow-attachment-read`\n- `allow-attachment-remove`",
+          "description": "Default permissions for the fs-sync plugin\n#### This default permission set includes:\n\n- `allow-deserialize`\n- `allow-write-json-batch`\n- `allow-write-document-batch`\n- `allow-read-document-batch`\n- `allow-list-folders`\n- `allow-move-session`\n- `allow-create-folder`\n- `allow-rename-folder`\n- `allow-delete-folder`\n- `allow-audio-exist`\n- `allow-audio-delete`\n- `allow-audio-delete-orphaned-expired`\n- `allow-audio-import`\n- `allow-audio-import-data`\n- `allow-audio-source-metadata`\n- `allow-audio-path`\n- `allow-session-dir`\n- `allow-load-session-content`\n- `allow-delete-session-folder`\n- `allow-scan-and-read`\n- `allow-chat-dir`\n- `allow-entity-dir`\n- `allow-attachment-save`\n- `allow-attachment-list`\n- `allow-attachment-read`\n- `allow-attachment-remove`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the fs-sync plugin\n#### This default permission set includes:\n\n- `allow-deserialize`\n- `allow-write-json-batch`\n- `allow-write-document-batch`\n- `allow-read-document-batch`\n- `allow-list-folders`\n- `allow-move-session`\n- `allow-create-folder`\n- `allow-rename-folder`\n- `allow-delete-folder`\n- `allow-audio-exist`\n- `allow-audio-delete`\n- `allow-audio-delete-orphaned-expired`\n- `allow-audio-import`\n- `allow-audio-source-metadata`\n- `allow-audio-path`\n- `allow-session-dir`\n- `allow-load-session-content`\n- `allow-delete-session-folder`\n- `allow-scan-and-read`\n- `allow-chat-dir`\n- `allow-entity-dir`\n- `allow-attachment-save`\n- `allow-attachment-list`\n- `allow-attachment-read`\n- `allow-attachment-remove`"
+          "markdownDescription": "Default permissions for the fs-sync plugin\n#### This default permission set includes:\n\n- `allow-deserialize`\n- `allow-write-json-batch`\n- `allow-write-document-batch`\n- `allow-read-document-batch`\n- `allow-list-folders`\n- `allow-move-session`\n- `allow-create-folder`\n- `allow-rename-folder`\n- `allow-delete-folder`\n- `allow-audio-exist`\n- `allow-audio-delete`\n- `allow-audio-delete-orphaned-expired`\n- `allow-audio-import`\n- `allow-audio-import-data`\n- `allow-audio-source-metadata`\n- `allow-audio-path`\n- `allow-session-dir`\n- `allow-load-session-content`\n- `allow-delete-session-folder`\n- `allow-scan-and-read`\n- `allow-chat-dir`\n- `allow-entity-dir`\n- `allow-attachment-save`\n- `allow-attachment-list`\n- `allow-attachment-read`\n- `allow-attachment-remove`"
         }
       ]
     }

--- a/plugins/fs-sync/src/commands.rs
+++ b/plugins/fs-sync/src/commands.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use rayon::prelude::*;
 use serde_json::Value;
@@ -235,6 +236,62 @@ pub(crate) async fn audio_import<R: tauri::Runtime>(
         crate::audio::import_to_session(&runtime, &session_id, &session_dir, &source_path)
             .map(|path| path.to_string_lossy().to_string())
             .map_err(|e| e.to_string())
+    })
+}
+
+fn audio_import_source_extension(filename: &str) -> String {
+    let extension = Path::new(filename)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase);
+
+    match extension.as_deref() {
+        Some("wav" | "mp3" | "ogg" | "mp4" | "m4a" | "flac") => extension.unwrap(),
+        _ => "mp3".to_string(),
+    }
+}
+
+fn audio_import_source_path(session_dir: &Path, filename: &str) -> PathBuf {
+    let extension = audio_import_source_extension(filename);
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+
+    session_dir.join(format!(
+        "audio-upload-{}-{}.{}",
+        std::process::id(),
+        nonce,
+        extension
+    ))
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn audio_import_data<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    session_id: String,
+    data: Vec<u8>,
+    filename: String,
+) -> Result<String, String> {
+    let session_dir = resolve_session_dir(&app, &session_id)?;
+    let runtime = crate::runtime::TauriAudioImportRuntime::new(app);
+    spawn_blocking!({
+        std::fs::create_dir_all(&session_dir).map_err(|e| e.to_string())?;
+
+        let source_path = audio_import_source_path(&session_dir, &filename);
+        std::fs::write(&source_path, data).map_err(|e| e.to_string())?;
+
+        let result =
+            crate::audio::import_to_session(&runtime, &session_id, &session_dir, &source_path)
+                .map(|path| path.to_string_lossy().to_string())
+                .map_err(|e| e.to_string());
+
+        if source_path.exists() {
+            let _ = std::fs::remove_file(&source_path);
+        }
+
+        result
     })
 }
 

--- a/plugins/fs-sync/src/lib.rs
+++ b/plugins/fs-sync/src/lib.rs
@@ -24,6 +24,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::audio_delete::<tauri::Wry>,
             commands::audio_delete_orphaned_expired::<tauri::Wry>,
             commands::audio_import::<tauri::Wry>,
+            commands::audio_import_data::<tauri::Wry>,
             commands::audio_source_metadata,
             commands::audio_path::<tauri::Wry>,
             commands::session_dir::<tauri::Wry>,


### PR DESCRIPTION
Route note editor audio drops into the existing upload transcription flow and add fs-sync byte import support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session audio import, transcription batching, and new native fs-sync I/O; behavior is well covered by tests but wrong drop/MIME handling could mis-route files or skip transcription.
> 
> **Overview**
> **Session raw and enhanced note editors** now accept **audio drag-and-drop** for upload and transcription, with a **“Drop to upload and transcribe audio”** overlay and shared handling via `useNoteFileHandlerConfig` and `AudioDropTarget`.
> 
> Dropped audio is routed through **`processAudioFile`** into the existing import → batch transcription flow. **Only the first audio file** in a drop is transcribed; **other files** (e.g. images) still go through normal editor attachment upload. **Mixed multi-file drops** on the wrapper are not fully captured so attachments can still be handled in the editor. **Single-file** drags bring the Tauri window to the front.
> 
> **`useUploadFile`** adds **`processAudioFile`**, expands supported extensions (**webm**, **aac**), and refactors path-based audio import. Pathless drops use new **`audioImportData`**; session **`created_at`** can be set from **`file.lastModified`** when there is no calendar event.
> 
> The **editor file-handler plugin** passes **`DataTransferItemList`** into **`onDrop`** and supports **`remainingFiles`** so consumers can peel off audio and leave the rest for default upload.
> 
> **fs-sync** exposes **`audio_import_data`** (write bytes to a temp file, import, delete temp) with permissions and bindings updated. Tests cover editor drop behavior and byte import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f5362e2734ea587b6424baaa65d5f0c4516b19c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->