### PR TITLE
Tune dark note tab contrast

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -918,7 +918,7 @@ msgstr "members"
 msgid "Memo"
 msgstr "Memo"
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr "Memos"
 
@@ -1398,7 +1398,7 @@ msgstr "Search or type owner/repo"
 msgid "Search people"
 msgstr "Search people"
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr "Search templates..."
@@ -1416,7 +1416,7 @@ msgstr "Search..."
 msgid "Section actions"
 msgstr "Section actions"
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr "See all templates"
 
@@ -1474,7 +1474,7 @@ msgstr "Send email"
 msgid "Send message"
 msgstr "Send message"
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr "Session note tabs"
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr "Tip: The Anarlog team loves our users!"
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:243
+#: src/session/components/note-input/header.tsx:260
 msgid "Memos"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:876
+#: src/session/components/note-input/header.tsx:899
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:942
+#: src/session/components/note-input/header.tsx:965
 msgid "See all templates"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:978
+#: src/session/components/note-input/header.tsx:1002
 msgid "Session note tabs"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:522
+#: src/session/components/note-input/header.tsx:545
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -208,17 +208,25 @@ describe("Header", () => {
     const summaryTab = screen.getByRole("button", { name: "Customer Call" });
     const memoTab = screen.getByRole("button", { name: "Memos" });
     const transcriptTab = screen.getByRole("button", { name: "Transcript" });
+    const tabList = screen.getByRole("tablist");
 
     expect(summaryTab.getAttribute("data-state")).toBeNull();
-    expect(
-      screen.getByRole("tablist").getAttribute("data-tauri-drag-region"),
-    ).toBe("false");
+    expect(tabList.getAttribute("data-tauri-drag-region")).toBe("false");
+    expect(tabList.className).toContain("h-[30px]");
+    expect(tabList.className).toContain("p-[2px]");
+    expect(tabList.className).toContain("gap-[2px]");
+    expect(tabList.className).toContain("bg-foreground/10");
+    expect(tabList.className).toContain("dark:bg-white/12");
     expect(summaryTab.getAttribute("aria-current")).toBeNull();
     expect(memoTab.getAttribute("aria-current")).toBe("page");
     expect(memoTab.textContent).toBe("Memos");
-    expect(memoTab.className).toContain("h-[30px]");
-    expect(memoTab.className).toContain("-my-px");
-    expect(summaryTab.className).toContain("h-7");
+    expect(memoTab.className).toContain("h-[26px]");
+    expect(memoTab.className).not.toContain("-my-px");
+    expect(memoTab.className).toContain("bg-white");
+    expect(memoTab.className).toContain("shadow-xs");
+    expect(memoTab.className).toContain("dark:bg-white");
+    expect(summaryTab.className).toContain("h-[26px]");
+    expect(summaryTab.className).toContain("dark:hover:bg-white/8");
     expect(summaryTab.querySelector("svg")).not.toBeNull();
     expect(summaryTab.querySelectorAll("svg")).toHaveLength(1);
     expect(summaryTab.textContent).toBe("");
@@ -271,6 +279,29 @@ describe("Header", () => {
       type: "enhanced",
       id: "note-1",
     });
+  });
+
+  it("renders a raw-only memo tab without the tab tray", () => {
+    render(
+      <Header
+        sessionId="session-1"
+        editorTabs={[{ type: "raw" }]}
+        currentTab={{ type: "raw" }}
+        handleTabChange={vi.fn()}
+      />,
+    );
+
+    const memoTab = screen.getByRole("button", { name: "Memos" });
+    const tabList = screen.getByRole("tablist");
+
+    expect(tabList.className).not.toContain("h-[30px]");
+    expect(tabList.className).not.toContain("bg-foreground/10");
+    expect(tabList.className).not.toContain("rounded-full");
+    expect(memoTab.textContent).toBe("Memos");
+    expect(memoTab.className).toContain("h-7");
+    expect(memoTab.className).toContain("bg-white");
+    expect(memoTab.className).toContain("border");
+    expect(memoTab.className).not.toContain("bg-foreground/10");
   });
 
   it("can switch from transcript back to memo or summary tabs", () => {

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -81,6 +81,8 @@ function IconHeaderTab({
   onClick,
   onContextMenu,
   title,
+  size = "tray",
+  className,
 }: {
   isActive: boolean;
   label: string;
@@ -88,6 +90,8 @@ function IconHeaderTab({
   onClick?: () => void;
   onContextMenu?: React.MouseEventHandler<HTMLButtonElement>;
   title?: string;
+  size?: "tray" | "standalone";
+  className?: string;
 }) {
   return (
     <button
@@ -101,7 +105,8 @@ function IconHeaderTab({
       title={title}
       className={iconHeaderTabClassName(
         isActive,
-        cn(["min-w-10 px-2", isActive ? "max-w-40 gap-1.5" : null]),
+        size,
+        cn(["min-w-10 px-2", isActive ? "max-w-40 gap-1.5" : null, className]),
       )}
     >
       {icon}
@@ -112,16 +117,26 @@ function IconHeaderTab({
   );
 }
 
-function iconHeaderTabClassName(isActive: boolean, className?: string) {
+function iconHeaderTabClassName(
+  isActive: boolean,
+  size: "tray" | "standalone" = "tray",
+  className?: string,
+) {
+  const heightClassName = size === "tray" ? "h-[26px]" : "h-7";
+
   return cn([
     "flex shrink-0 items-center justify-center rounded-full transition-colors select-none [&>svg]:shrink-0",
     isActive
-      ? ["bg-foreground/10 text-foreground -my-px h-[30px]"]
+      ? [
+          "text-foreground bg-white shadow-xs",
+          "dark:text-primary dark:bg-white",
+        ]
       : [
-          "h-7",
           "text-muted-foreground/70",
           "hover:bg-background/60 hover:text-foreground",
+          "dark:hover:bg-white/8",
         ],
+    heightClassName,
     className,
   ]);
 }
@@ -206,10 +221,12 @@ function HeaderTabRaw({
   isActive,
   onClick = () => {},
   sessionId,
+  standalone = false,
 }: {
   isActive: boolean;
   onClick?: () => void;
   sessionId: string;
+  standalone?: boolean;
 }) {
   const { t } = useLingui();
   const rawMd = main.UI.useCell(
@@ -244,6 +261,8 @@ function HeaderTabRaw({
       icon={<AlignLeftIcon className="size-4" />}
       onClick={onClick}
       onContextMenu={showContextMenu}
+      size={standalone ? "standalone" : "tray"}
+      className={standalone ? "border-border/70 border shadow-xs" : undefined}
     />
   );
 }
@@ -387,6 +406,7 @@ function HeaderTabEnhanced({
       title={templateTooltip}
       className={iconHeaderTabClassName(
         true,
+        "tray",
         cn([
           "max-w-56 min-w-[62px] gap-1.5 pr-1.5 pl-2",
           isGenerating ? "cursor-not-allowed opacity-70" : "cursor-pointer",
@@ -395,7 +415,10 @@ function HeaderTabEnhanced({
                 "text-red-600 hover:bg-red-50 hover:text-red-700 focus-visible:bg-red-50",
                 "dark:text-red-400 dark:hover:bg-red-950/50 dark:hover:text-red-300 dark:focus-visible:bg-red-950/50",
               ]
-            : "focus-visible:bg-background focus-visible:text-foreground",
+            : [
+                "focus-visible:text-foreground focus-visible:bg-white",
+                "dark:focus-visible:text-primary dark:focus-visible:bg-white",
+              ],
         ]),
       )}
     >
@@ -423,7 +446,7 @@ function HeaderTabEnhanced({
       onClick={onClick}
       onContextMenu={showContextMenu}
       title={templateTooltip}
-      className={iconHeaderTabClassName(false, "min-w-10 px-2")}
+      className={iconHeaderTabClassName(false, "tray", "min-w-10 px-2")}
     >
       {isGenerating ? (
         <Spinner size={16} className="shrink-0" />
@@ -965,6 +988,7 @@ export function Header({
     (view): view is Extract<EditorView, { type: "enhanced" }> =>
       view.type === "enhanced",
   )?.id;
+  const shouldUseTabTray = editorTabs.length > 1;
 
   return (
     <div data-tauri-drag-region className="flex flex-col pl-1">
@@ -977,7 +1001,12 @@ export function Header({
             role="tablist"
             aria-label={t`Session note tabs`}
             data-tauri-drag-region="false"
-            className="bg-muted/25 pointer-events-auto relative z-10 flex h-7 w-fit max-w-full items-center gap-0.5 overflow-visible rounded-full"
+            className={cn([
+              "pointer-events-auto relative z-10 w-fit max-w-full overflow-visible",
+              shouldUseTabTray
+                ? "bg-foreground/10 flex h-[30px] items-center gap-[2px] rounded-full p-[2px] dark:bg-white/12"
+                : null,
+            ])}
           >
             {editorTabs.map((view, index) => {
               if (view.type === "enhanced") {
@@ -1021,6 +1050,7 @@ export function Header({
                     key={view.type}
                     sessionId={sessionId}
                     isActive={currentTab.type === view.type}
+                    standalone={!shouldUseTabTray}
                     onClick={() => handleTabChange(view)}
                   />
                 );


### PR DESCRIPTION
Darkens the session note tab tray and makes the selected tab lighter in dark mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only dark mode styling in the session note header; i18n changes are reference metadata only.
> 
> **Overview**
> **Dark mode contrast** for session note tabs in `note-input/header.tsx`: the multi-tab **tray** uses a darker background (`dark:bg-white/12` vs the light-mode `bg-foreground/10`), and **active** tabs stay on a light pill (`dark:bg-white` / `dark:text-primary`) so the selected tab reads clearly against the tray.
> 
> The diff also refreshes **Lingui** `messages.po` files across locales—only `#:` line references for existing strings in `header.tsx` (e.g. Memos, Session note tabs, Transcript), after the header file shifted line numbers. No new user-facing copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c8c4f413c097968a03d2ae8dd037a5ace7e2540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->