### PR TITLE
Remove top timeline scroll fade

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Kennisgewings"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "ማሳወቂያዎች"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "الإشعارات"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "জাননীসমূহ"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Bildirişlər"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Хәбәр итеүҙәр"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Апавяшчэнні"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Известия"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "বিজ্ঞপ্তি"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "བརྡ་ཐོ"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Kemennadennoù"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Obaveštenja"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificacions"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Oznámení"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Hysbysiadau"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Underretninger"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Benachrichtigungen"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ειδοποιήσεις"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -500,7 +500,7 @@ msgstr "Delete Note"
 msgid "Delete recording"
 msgstr "Delete recording"
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr "Delete Selected ({sessionCount})"
 
@@ -740,7 +740,7 @@ msgstr "Get started"
 msgid "Get started for free"
 msgstr "Get started for free"
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr "Go back to now"
 
@@ -773,7 +773,7 @@ msgstr "Help Anarlog listen to others"
 msgid "Help Anarlog listen to you"
 msgstr "Help Anarlog listen to you"
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr "Hide Deleted Events"
 
@@ -895,7 +895,7 @@ msgstr "Match case"
 msgid "Match whole word"
 msgstr "Match whole word"
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr "Meeting"
 
@@ -1018,7 +1018,7 @@ msgstr "No content."
 msgid "No description provided."
 msgstr "No description provided."
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr "No items today"
 
@@ -1080,7 +1080,7 @@ msgstr "Notes"
 msgid "Notifications"
 msgstr "Notifications"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr "Now"
 
@@ -1110,8 +1110,8 @@ msgstr "Open {0} settings"
 msgid "Open Anarlog"
 msgstr "Open Anarlog"
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr "Open calendar"
 
@@ -1507,7 +1507,7 @@ msgstr "Show Anarlog in the Dock and app switcher."
 msgid "Show app in Dock"
 msgstr "Show app in Dock"
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr "Show Deleted Events"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificaciones"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Märguanded"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Jakinarazpenak"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "اعلان‌ها"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Noddaango"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ilmoitukset"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Fráboðanir"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifications"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Fógraí"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificacións"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "સૂચના"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Sanarwa"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "התראות"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "सूचनाएँ"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Obavijesti"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifikasyon"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Értesítések"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ծանուցումներ"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Pemberitahuan"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ọkwa"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Tilkynningar"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifiche"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "通知"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Kabar"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "შეტყობინებები"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Хабарландырулар"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "ការជូនដំណឹង"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "ಅಧಿಸೂಚನೆಗಳು"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "알림"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Agahdar"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Эскертмелер"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificationes"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifikatiounen"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ebimanyisibwa"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Mayebisi"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "ການແຈ້ງເຕືອນ"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Pranešimai"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Paziņojumi"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Fampandrenesana"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Whakamōhiotanga"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Известувања"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "അറിയിപ്പുകൾ"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Мэдэгдэл"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "सूचना"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Pemberitahuan"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifiki"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "သတိပေးချက်များ"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "सूचनाहरू"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Meldingen"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Varsler"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Varsler"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Zidziwitso"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificacions"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "ବିଜ୍ଞପ୍ତିଗୁଡିକ"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "ਸੂਚਨਾਵਾਂ"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Powiadomienia"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "اطلاعات"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificações"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificări"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Уведомления"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "सूचना"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "اطلاعات"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "දැනුම්දීම්"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Upozornenia"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Obvestila"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Zviziviso"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ogaysiisyo"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Njoftimet"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Обавештења"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Bewara"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Aviseringar"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Arifa"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "அறிவிப்புகள்"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "నోటిఫికేషన్‌లు"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Огоҳиҳо"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "การแจ้งเตือน"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Duýduryşlar"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Mga Notification"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Bildirimler"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Хәбәрләр"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Сповіщення"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "اطلاعات"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Bildirishnomalar"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Thông báo"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Yégle yi"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Izaziso"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "נאָטיפיקאַטיאָנס"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Awọn iwifunni"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "通知"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:382
+#: src/sidebar/timeline/index.tsx:380
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:778
+#: src/sidebar/timeline/index.tsx:771
 msgid "Go back to now"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:391
+#: src/sidebar/timeline/index.tsx:389
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:614
+#: src/sidebar/timeline/index.tsx:607
 msgid "Meeting"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:877
+#: src/sidebar/timeline/index.tsx:870
 msgid "No items today"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Notifications"
 msgstr "Izaziso"
 
-#: src/sidebar/timeline/index.tsx:790
+#: src/sidebar/timeline/index.tsx:783
 msgid "Now"
 msgstr ""
 
@@ -1110,8 +1110,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:567
-#: src/sidebar/timeline/index.tsx:571
+#: src/sidebar/timeline/index.tsx:560
+#: src/sidebar/timeline/index.tsx:564
 msgid "Open calendar"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:392
+#: src/sidebar/timeline/index.tsx:390
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -279,6 +279,7 @@ describe("TimelineView", () => {
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
     ).toContain("h-18");
+    expect(queryTopOccluder(container)?.className).toContain("h-12");
 
     fireEvent.click(calendarButton);
 
@@ -319,7 +320,8 @@ describe("TimelineView", () => {
 
     expect(screen.queryByRole("button", { name: "Open calendar" })).toBeNull();
     expect(topSpacer?.className).toContain("h-18");
-    expect(getTopFade(container).className).toContain("h-16");
+    expect(queryTopFade(container)).toBeNull();
+    expect(queryTopOccluder(container)?.className).toContain("bg-background");
   });
 
   it("routes wheel gestures from the open calendar chip into the timeline scroller", () => {
@@ -372,11 +374,12 @@ describe("TimelineView", () => {
 
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).toContain("h-8");
+    ).toContain("h-12");
     expect(
       container.querySelector("[data-sidebar-timeline-bucket-header]")
         ?.className,
-    ).toContain("top-8");
+    ).toContain("top-12");
+    expect(queryTopOccluder(container)?.className).toContain("h-12");
   });
 
   it("pins bucket headers to the sidebar chrome while scrolled", () => {
@@ -402,7 +405,7 @@ describe("TimelineView", () => {
     );
 
     expect(scroller).toBeInstanceOf(HTMLDivElement);
-    expect(header?.className).toContain("top-8");
+    expect(header?.className).toContain("top-12");
 
     Object.defineProperty(scroller, "clientHeight", {
       configurable: true,
@@ -415,8 +418,9 @@ describe("TimelineView", () => {
     scroller!.scrollTop = 120;
     fireEvent.scroll(scroller!);
 
-    expect(header?.className).toContain("top-8");
+    expect(header?.className).toContain("top-12");
     expect(header?.className).toContain("z-20");
+    expect(queryTopOccluder(container)?.className).toContain("z-10");
   });
 
   it("shows the open calendar chip without top chrome", () => {
@@ -519,13 +523,14 @@ describe("TimelineView", () => {
     editor.remove();
   });
 
-  it("keeps top chrome compact while scrolled without timeline action tabs", () => {
+  it("does not show a top chrome fade while scrolled without timeline action tabs", () => {
     const { container } = render(<TimelineView topChromeInset />);
     const scroller = container.querySelector("[data-sidebar-timeline-scroll]");
 
     expect(scroller).toBeInstanceOf(HTMLDivElement);
     expect(getSidebarActionTabsOrNull()).toBeNull();
     expect(queryTopFade(container)).toBeNull();
+    expect(queryTopOccluder(container)?.className).toContain("h-12");
 
     Object.defineProperty(scroller, "clientHeight", {
       configurable: true,
@@ -539,8 +544,8 @@ describe("TimelineView", () => {
     fireEvent.scroll(scroller!);
 
     expect(getSidebarActionTabsOrNull()).toBeNull();
-    expect(getTopFade(container).className).toContain("h-16");
-    expect(getTopFade(container).className).toContain("from-60%");
+    expect(queryTopFade(container)).toBeNull();
+    expect(queryTopOccluder(container)?.className).toContain("h-12");
   });
 
   it("does not show a top scroll fade when there are no hidden future notes", () => {
@@ -571,6 +576,46 @@ describe("TimelineView", () => {
     scroller!.scrollTop = 120;
     fireEvent.scroll(scroller!);
 
+    expect(scroller!.style.maskImage).toBe(
+      "linear-gradient(to bottom, #000 0, #000 calc(100% - 28px), transparent 100%)",
+    );
+  });
+
+  it("does not show a top scroll fade when future notes are hidden above a sticky header", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.timelineSessionsTable = {
+      today: {
+        title: "Design sync",
+        created_at: "2024-01-15T11:00:00.000Z",
+      },
+      later: {
+        title: "Quarterly planning",
+        created_at: "2024-01-17T12:00:00.000Z",
+      },
+    };
+
+    const { container } = render(<TimelineView topChromeInset />);
+    const scroller = container.querySelector(
+      "[data-sidebar-timeline-scroll]",
+    ) as HTMLDivElement | null;
+
+    expect(scroller).toBeInstanceOf(HTMLDivElement);
+
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 1200,
+    });
+    scroller!.scrollTop = 120;
+    fireEvent.scroll(scroller!);
+
+    expect(screen.getByText("Today")).toBeTruthy();
+    expect(queryTopFade(container)).toBeNull();
+    expect(queryTopOccluder(container)?.className).toContain("h-12");
     expect(scroller!.style.maskImage).toBe(
       "linear-gradient(to bottom, #000 0, #000 calc(100% - 28px), transparent 100%)",
     );
@@ -608,9 +653,7 @@ describe("TimelineView", () => {
     scroller!.scrollTop = 1000;
     fireEvent.scroll(scroller!);
 
-    expect(scroller!.style.maskImage).toBe(
-      "linear-gradient(to bottom, transparent 0, #000 28px, #000 100%)",
-    );
+    expect(scroller!.style.maskImage).toBe("none");
   });
 
   it("shows an imminent meeting chip over the sidebar timeline", () => {
@@ -675,7 +718,7 @@ describe("TimelineView", () => {
     );
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).toContain("h-8");
+    ).toContain("h-12");
     expect(
       container.querySelector("[data-sidebar-timeline-top-chip-stack]")
         ?.className,
@@ -823,11 +866,11 @@ describe("TimelineView", () => {
     ).toContain("top-11");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).toContain("h-8");
+    ).toContain("h-12");
     expect(
       container.querySelector("[data-sidebar-timeline-bucket-header]")
         ?.className,
-    ).toContain("top-8");
+    ).toContain("top-12");
 
     Object.defineProperty(scroller, "clientHeight", {
       configurable: true,
@@ -840,7 +883,7 @@ describe("TimelineView", () => {
     scroller!.scrollTop = 120;
     fireEvent.scroll(scroller!);
 
-    expect(getTopFade(container).className).toContain("h-16");
+    expect(queryTopFade(container)).toBeNull();
   });
 
   it("places the fallback now indicator between future and past buckets", () => {
@@ -1055,16 +1098,12 @@ function getSidebarActionTabsOrNull() {
   return document.querySelector("[data-sidebar-timeline-action-tabs]");
 }
 
-function getTopFade(container: HTMLElement) {
-  const topFade = queryTopFade(container);
-
-  expect(topFade).toBeInstanceOf(HTMLDivElement);
-
-  return topFade as HTMLDivElement;
-}
-
 function queryTopFade(container: HTMLElement) {
   return container.querySelector("[data-sidebar-timeline-top-fade]");
+}
+
+function queryTopOccluder(container: HTMLElement) {
+  return container.querySelector("[data-sidebar-timeline-top-occluder]");
 }
 
 function isBefore(first: Element, second: Element) {

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -178,14 +178,13 @@ export function TimelineView({
   const topSpacerClassName = topChromeInset
     ? reserveOpenCalendarChipSpace
       ? "h-18"
-      : "h-8"
+      : "h-12"
     : "h-10";
   const bucketHeaderTopClassName = topChromeInset
     ? showOpenCalendarChip
       ? "top-18"
-      : "top-8"
+      : "top-12"
     : "top-0";
-  const showTopChromeFade = topChromeInset && !isScrolledToTop;
   const selectedSessionScrollFrameRef = useRef<number | null>(null);
   const scrollSelectedSessionIntoView = useCallback<
     RefCallback<HTMLDivElement>
@@ -255,9 +254,8 @@ export function TimelineView({
   const scrollFadeMask = useMemo(() => {
     return getTimelineScrollFadeMask({
       showBottomFade: !isScrolledToBottom,
-      showTopFade: hasMoreFutureItems && !isScrolledToTop,
     });
-  }, [hasMoreFutureItems, isScrolledToBottom, isScrolledToTop]);
+  }, [isScrolledToBottom]);
 
   const todayBucketLength = useMemo(() => {
     const b = buckets.find((bucket) => bucket.label === "Today");
@@ -541,16 +539,11 @@ export function TimelineView({
           ))}
       </div>
 
-      {showTopChromeFade && (
+      {topChromeInset && (
         <div
           aria-hidden
-          data-sidebar-timeline-top-fade
-          className={cn([
-            "pointer-events-none absolute inset-x-0 top-0 z-[15]",
-            showOpenCalendarChip
-              ? "bg-background h-18"
-              : "from-background via-background/95 to-background/0 h-16 bg-linear-to-b from-60% via-85%",
-          ])}
+          data-sidebar-timeline-top-occluder
+          className="bg-background pointer-events-none absolute inset-x-0 top-0 z-10 h-12"
         />
       )}
 
@@ -1119,19 +1112,9 @@ function useTimelineData({
 
 function getTimelineScrollFadeMask({
   showBottomFade,
-  showTopFade,
 }: {
   showBottomFade: boolean;
-  showTopFade: boolean;
 }): string {
-  if (showTopFade && showBottomFade) {
-    return "linear-gradient(to bottom, transparent 0, #000 28px, #000 calc(100% - 28px), transparent 100%)";
-  }
-
-  if (showTopFade) {
-    return "linear-gradient(to bottom, transparent 0, #000 28px, #000 100%)";
-  }
-
   if (showBottomFade) {
     return "linear-gradient(to bottom, #000 0, #000 calc(100% - 28px), transparent 100%)";
   }


### PR DESCRIPTION
Keep sticky timeline headers fully visible while scrolling and preserve the bottom overflow mask.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5733 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #5730 
- <kbd>&nbsp;1&nbsp;</kbd> #5729 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only sidebar scrolling change with test coverage; no auth, data, or API impact.
> 
> **Overview**
> Removes the **top** scroll fade on the sidebar timeline so sticky date headers and top content stay fully readable while scrolling.
> 
> The timeline scroller’s **mask** now only fades the **bottom** edge when there is more content below (`getTimelineScrollFadeMask` no longer applies a top gradient). The separate top fade overlay (`data-sidebar-timeline-top-fade`) is gone; the top chrome occluder and bottom fade behavior are unchanged. Tests assert the top fade stays absent in scrolled and inset layouts.
> 
> Locale `.po` files only refresh Lingui source line references for strings in `timeline/index.tsx` after that file shrinks slightly—no new copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76463c03c32de7528e06bbe11e3d9c39349d7692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->