### PR TITLE
Show batch transcription progress

### DIFF
--- a/apps/desktop/src/store/zustand/listener/general-batch.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.test.ts
@@ -85,6 +85,34 @@ describe("runBatchSession", () => {
         api_key: "",
       }),
     ).toBe(false);
+    expect(
+      shouldUseSyntheticBatchProgress({
+        session_id: "session-1",
+        provider: "am",
+        file_path: "/tmp/session.wav",
+        base_url: "https://api.deepgram.com/v1",
+        api_key: "",
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseSyntheticBatchProgress({
+        session_id: "session-1",
+        provider: "am",
+        file_path: "/tmp/session.wav",
+        base_url: "http://localhost:50060/v1",
+        api_key: "",
+      }),
+    ).toBe(false);
+    expect(
+      shouldUseSyntheticBatchProgress({
+        session_id: "session-1",
+        provider: "am",
+        file_path: "/tmp/session.wav",
+        model: "gpt-4o-transcribe",
+        base_url: "https://api.openai.com/v1",
+        api_key: "",
+      }),
+    ).toBe(false);
   });
 
   test("caps synthetic progress before completion", () => {
@@ -189,6 +217,103 @@ describe("runBatchSession", () => {
       const callCount = updateBatchProgress.mock.calls.length;
       vi.advanceTimersByTime(1_600);
       expect(updateBatchProgress).toHaveBeenCalledTimes(callCount);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("keeps synthetic progress when the backend emits started", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const handleBatchStarted = vi.fn();
+      const handleBatchResponse = vi.fn();
+      const handleBatchCompleted = vi.fn();
+      const clearBatchPersist = vi.fn();
+      const clearBatchSession = vi.fn();
+      const handleBatchResponseStreamed = vi.fn();
+      const handleBatchFailed = vi.fn();
+      const handleBatchStopped = vi.fn();
+      const updateBatchProgress = vi.fn();
+      const setBatchPersist = vi.fn();
+
+      let handler:
+        | ((event: {
+            payload: {
+              type: string;
+              session_id: string;
+              response?: unknown;
+              mode?: "direct" | "streamed";
+            };
+          }) => void)
+        | undefined;
+      let resolveStart: ((value: unknown) => void) | undefined;
+
+      listenMock.mockImplementation(async (cb) => {
+        handler = cb;
+        return vi.fn();
+      });
+
+      startTranscriptionMock.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveStart = resolve;
+          }),
+      );
+
+      const runPromise = runBatchSession(
+        () => ({
+          batch: {},
+          batchPreview: {},
+          batchPersist: {},
+          handleBatchStarted,
+          handleBatchResponse,
+          handleBatchCompleted,
+          clearBatchPersist,
+          clearBatchSession,
+          handleBatchResponseStreamed,
+          handleBatchFailed,
+          handleBatchStopped,
+          updateBatchProgress,
+          setBatchPersist,
+        }),
+        "session-1",
+        {
+          session_id: "session-1",
+          provider: "hyprnote",
+          file_path: "/tmp/session.wav",
+          base_url: "",
+          api_key: "",
+        },
+      );
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      handler?.({
+        payload: {
+          type: "started",
+          session_id: "session-1",
+        },
+      });
+
+      expect(handleBatchStarted).toHaveBeenCalledTimes(1);
+      expect(updateBatchProgress).toHaveBeenCalledWith("session-1", 0.06);
+
+      handler?.({
+        payload: {
+          type: "completed",
+          session_id: "session-1",
+          mode: "direct",
+          response: {
+            metadata: null,
+            results: { channels: [] },
+          },
+        },
+      });
+      resolveStart?.({ status: "ok", data: null });
+
+      await runPromise;
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/store/zustand/listener/general-batch.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.test.ts
@@ -4,6 +4,8 @@ import { EMPTY_BATCH_TRANSCRIPT_ERROR } from "./batch";
 import {
   runBatchSession,
   showBatchCompletedNotification,
+  shouldUseSyntheticBatchProgress,
+  syntheticBatchProgress,
 } from "./general-batch";
 
 import { parseBatchCompletedNotificationKey } from "~/stt/batch-completed-notification";
@@ -52,6 +54,144 @@ describe("runBatchSession", () => {
     isFocusedMock.mockResolvedValue(true);
     isVisibleMock.mockResolvedValue(true);
     showNotificationMock.mockResolvedValue({ status: "ok", data: null });
+  });
+
+  test("uses synthetic progress only for blocking batch providers", () => {
+    expect(
+      shouldUseSyntheticBatchProgress({
+        session_id: "session-1",
+        provider: "hyprnote",
+        file_path: "/tmp/session.wav",
+        base_url: "",
+        api_key: "",
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseSyntheticBatchProgress({
+        session_id: "session-1",
+        provider: "soniqo",
+        file_path: "/tmp/session.wav",
+        base_url: "soniqo://local",
+        api_key: "",
+      }),
+    ).toBe(false);
+    expect(
+      shouldUseSyntheticBatchProgress({
+        session_id: "session-1",
+        provider: "openai",
+        file_path: "/tmp/session.wav",
+        model: "gpt-4o-transcribe",
+        base_url: "",
+        api_key: "",
+      }),
+    ).toBe(false);
+  });
+
+  test("caps synthetic progress before completion", () => {
+    expect(syntheticBatchProgress(0)).toBe(0.06);
+    expect(syntheticBatchProgress(60_000)).toBeLessThan(0.88);
+    expect(syntheticBatchProgress(10_000_000)).toBe(0.88);
+  });
+
+  test("ticks synthetic progress for blocking batch providers", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const handleBatchStarted = vi.fn();
+      const handleBatchResponse = vi.fn();
+      const handleBatchCompleted = vi.fn();
+      const clearBatchPersist = vi.fn();
+      const clearBatchSession = vi.fn();
+      const handleBatchResponseStreamed = vi.fn();
+      const handleBatchFailed = vi.fn();
+      const handleBatchStopped = vi.fn();
+      const updateBatchProgress = vi.fn();
+      const setBatchPersist = vi.fn();
+
+      let handler:
+        | ((event: {
+            payload: {
+              type: string;
+              session_id: string;
+              response?: unknown;
+              mode?: "direct" | "streamed";
+            };
+          }) => void)
+        | undefined;
+      let resolveStart: ((value: unknown) => void) | undefined;
+
+      listenMock.mockImplementation(async (cb) => {
+        handler = cb;
+        return vi.fn();
+      });
+
+      startTranscriptionMock.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveStart = resolve;
+          }),
+      );
+
+      const runPromise = runBatchSession(
+        () => ({
+          batch: {},
+          batchPreview: {},
+          batchPersist: {},
+          handleBatchStarted,
+          handleBatchResponse,
+          handleBatchCompleted,
+          clearBatchPersist,
+          clearBatchSession,
+          handleBatchResponseStreamed,
+          handleBatchFailed,
+          handleBatchStopped,
+          updateBatchProgress,
+          setBatchPersist,
+        }),
+        "session-1",
+        {
+          session_id: "session-1",
+          provider: "hyprnote",
+          file_path: "/tmp/session.wav",
+          base_url: "",
+          api_key: "",
+        },
+      );
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(updateBatchProgress).toHaveBeenCalledWith("session-1", 0.06);
+
+      vi.advanceTimersByTime(1_600);
+
+      expect(
+        updateBatchProgress.mock.calls.some(
+          ([, percentage]) => percentage > 0.06 && percentage < 0.88,
+        ),
+      ).toBe(true);
+
+      handler?.({
+        payload: {
+          type: "completed",
+          session_id: "session-1",
+          mode: "direct",
+          response: {
+            metadata: null,
+            results: { channels: [] },
+          },
+        },
+      });
+      resolveStart?.({ status: "ok", data: null });
+
+      await runPromise;
+
+      const callCount = updateBatchProgress.mock.calls.length;
+      vi.advanceTimersByTime(1_600);
+      expect(updateBatchProgress).toHaveBeenCalledTimes(callCount);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("resolves from the completed event and persists the response", async () => {

--- a/apps/desktop/src/store/zustand/listener/general-batch.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.ts
@@ -201,7 +201,6 @@ export const runBatchSession = async <T extends BatchStore>(
         }
 
         if (payload.type === "started") {
-          get().handleBatchStarted(payload.session_id);
           return;
         }
 
@@ -274,7 +273,7 @@ export function shouldUseSyntheticBatchProgress(params: TranscriptionParams) {
   }
 
   if (params.provider === "am") {
-    return false;
+    return !expectsAmProgressiveBatch(params);
   }
 
   if (params.provider === "openai") {
@@ -282,6 +281,42 @@ export function shouldUseSyntheticBatchProgress(params: TranscriptionParams) {
   }
 
   return true;
+}
+
+function expectsAmProgressiveBatch(params: TranscriptionParams) {
+  if (isLocalArgmaxUrl(params.base_url)) {
+    return true;
+  }
+
+  if (isOpenAIUrl(params.base_url)) {
+    return OPENAI_PROGRESSIVE_BATCH_MODELS.has(params.model ?? "");
+  }
+
+  return false;
+}
+
+function isLocalArgmaxUrl(baseUrl: string) {
+  try {
+    const url = new URL(baseUrl);
+    return isLocalHost(url.hostname) && !url.pathname.includes("/stt");
+  } catch {
+    return false;
+  }
+}
+
+function isOpenAIUrl(baseUrl: string) {
+  try {
+    const hostname = new URL(baseUrl).hostname;
+    return hostname === "openai.com" || hostname.endsWith(".openai.com");
+  } catch {
+    return false;
+  }
+}
+
+function isLocalHost(hostname: string) {
+  return (
+    hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
+  );
 }
 
 export function syntheticBatchProgress(elapsedMs: number) {

--- a/apps/desktop/src/store/zustand/listener/general-batch.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.ts
@@ -19,6 +19,16 @@ import { createBatchCompletedNotificationKey } from "~/stt/batch-completed-notif
 
 type BatchStore = BatchActions & BatchState;
 
+const SYNTHETIC_BATCH_PROGRESS_INITIAL = 0.06;
+const SYNTHETIC_BATCH_PROGRESS_MAX = 0.88;
+const SYNTHETIC_BATCH_PROGRESS_INTERVAL_MS = 800;
+const SYNTHETIC_BATCH_PROGRESS_TIME_CONSTANT_MS = 32_000;
+const OPENAI_PROGRESSIVE_BATCH_MODELS = new Set([
+  "gpt-4o-transcribe",
+  "gpt-4o-mini-transcribe",
+  "gpt-4o-mini-transcribe-2025-12-15",
+]);
+
 async function shouldNotifyBatchCompleted() {
   try {
     const window = getCurrentWindow();
@@ -78,9 +88,19 @@ export const runBatchSession = async <T extends BatchStore>(
   get().handleBatchStarted(sessionId);
 
   let unlisten: (() => void) | undefined;
+  let syntheticProgressTimer: ReturnType<typeof setInterval> | undefined;
   let settled = false;
 
+  const stopSyntheticProgress = () => {
+    if (syntheticProgressTimer) {
+      clearInterval(syntheticProgressTimer);
+      syntheticProgressTimer = undefined;
+    }
+  };
+
   const cleanup = (clearSession = true) => {
+    stopSyntheticProgress();
+
     if (unlisten) {
       unlisten();
       unlisten = undefined;
@@ -92,6 +112,17 @@ export const runBatchSession = async <T extends BatchStore>(
       get().clearBatchSession(sessionId);
     }
   };
+
+  if (shouldUseSyntheticBatchProgress(params)) {
+    const startedAt = Date.now();
+    get().updateBatchProgress(sessionId, SYNTHETIC_BATCH_PROGRESS_INITIAL);
+    syntheticProgressTimer = setInterval(() => {
+      get().updateBatchProgress(
+        sessionId,
+        syntheticBatchProgress(Date.now() - startedAt),
+      );
+    }, SYNTHETIC_BATCH_PROGRESS_INTERVAL_MS);
+  }
 
   const resolveSuccess = (
     output: {
@@ -175,6 +206,7 @@ export const runBatchSession = async <T extends BatchStore>(
         }
 
         if (payload.type === "progress") {
+          stopSyntheticProgress();
           get().handleBatchResponseStreamed(sessionId, payload.event);
           return;
         }
@@ -231,3 +263,34 @@ export const runBatchSession = async <T extends BatchStore>(
 
   await showBatchCompletedNotification(sessionId);
 };
+
+export function shouldUseSyntheticBatchProgress(params: TranscriptionParams) {
+  if (params.provider === "soniqo") {
+    return false;
+  }
+
+  if (params.provider === "argmax" || params.provider === "whispercpp") {
+    return false;
+  }
+
+  if (params.provider === "am") {
+    return false;
+  }
+
+  if (params.provider === "openai") {
+    return !OPENAI_PROGRESSIVE_BATCH_MODELS.has(params.model ?? "");
+  }
+
+  return true;
+}
+
+export function syntheticBatchProgress(elapsedMs: number) {
+  const elapsed = Math.max(0, elapsedMs);
+  const eased =
+    1 - Math.exp(-elapsed / SYNTHETIC_BATCH_PROGRESS_TIME_CONSTANT_MS);
+  return Math.min(
+    SYNTHETIC_BATCH_PROGRESS_MAX,
+    SYNTHETIC_BATCH_PROGRESS_INITIAL +
+      eased * (SYNTHETIC_BATCH_PROGRESS_MAX - SYNTHETIC_BATCH_PROGRESS_INITIAL),
+  );
+}

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -1,7 +1,12 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { getBatchProvider, getSessionSpeakerCount } from "./useRunBatch";
+import {
+  canRunBatchTranscription,
+  getBatchFallbackTarget,
+  getBatchProvider,
+  getSessionSpeakerCount,
+} from "./useRunBatch";
 import { useRunBatch } from "./useRunBatch";
 
 const {
@@ -11,7 +16,11 @@ const {
   useIndexesMock,
   useValuesMock,
   useSTTConnectionMock,
+  useAuthMock,
+  useBillingAccessMock,
   useConfigValueMock,
+  isSupportedLanguagesBatchMock,
+  sonnerToastMessageMock,
   settingsUseStoreMock,
   deleteProcessedAudioForRetentionMock,
   saveMock,
@@ -23,7 +32,11 @@ const {
   useIndexesMock: vi.fn(),
   useValuesMock: vi.fn(),
   useSTTConnectionMock: vi.fn(),
+  useAuthMock: vi.fn(),
+  useBillingAccessMock: vi.fn(),
   useConfigValueMock: vi.fn(),
+  isSupportedLanguagesBatchMock: vi.fn(),
+  sonnerToastMessageMock: vi.fn(),
   settingsUseStoreMock: vi.fn(),
   deleteProcessedAudioForRetentionMock: vi.fn(),
   saveMock: vi.fn(),
@@ -42,6 +55,26 @@ vi.mock("./useSTTConnection", () => ({
   useSTTConnection: useSTTConnectionMock,
 }));
 
+vi.mock("@hypr/ui/components/ui/toast", () => ({
+  sonnerToast: {
+    message: sonnerToastMessageMock,
+  },
+}));
+
+vi.mock("~/auth", () => ({
+  useAuth: useAuthMock,
+}));
+
+vi.mock("~/auth/billing", () => ({
+  useBillingAccess: useBillingAccessMock,
+}));
+
+vi.mock("~/env", () => ({
+  env: {
+    VITE_API_URL: "https://api.test",
+  },
+}));
+
 vi.mock("~/services/audio-retention", () => ({
   deleteProcessedAudioForRetention: deleteProcessedAudioForRetentionMock,
 }));
@@ -53,6 +86,38 @@ vi.mock("~/shared/config", () => ({
 vi.mock("~/shared/utils", () => ({
   id: idMock,
 }));
+
+vi.mock("~/stt/capabilities", () => {
+  const baseLanguageCode = (language: string) =>
+    language.split(/[-_]/)[0]?.toLowerCase() ?? "";
+
+  return {
+    getTranscriptionLanguages: (
+      mainLanguage: string | null | undefined,
+      spokenLanguages: readonly string[] | null | undefined,
+    ) => {
+      const seen = new Set<string>();
+      const languages: string[] = [];
+
+      for (const language of [mainLanguage, ...(spokenLanguages ?? [])]) {
+        if (!language) {
+          continue;
+        }
+
+        const baseCode = baseLanguageCode(language);
+        if (!baseCode || seen.has(baseCode)) {
+          continue;
+        }
+
+        seen.add(baseCode);
+        languages.push(language);
+      }
+
+      return languages;
+    },
+    isSupportedLanguagesBatch: isSupportedLanguagesBatchMock,
+  };
+});
 
 vi.mock("~/store/tinybase/store/main", () => ({
   STORE_ID: "main",
@@ -149,6 +214,52 @@ describe("getBatchProvider", () => {
   });
 });
 
+describe("canRunBatchTranscription", () => {
+  test("allows post-capture batch so useRunBatch can choose a fallback", () => {
+    expect(canRunBatchTranscription(null)).toBe(true);
+    expect(
+      canRunBatchTranscription({
+        provider: "custom",
+        model: "realtime-only",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("getBatchFallbackTarget", () => {
+  test("uses hosted cloud transcription for paid users with a session", () => {
+    expect(
+      getBatchFallbackTarget({
+        isPaid: true,
+        accessToken: "token",
+        apiBaseUrl: "https://api.test",
+      }),
+    ).toEqual({
+      provider: "hyprnote",
+      model: "cloud",
+      baseUrl: "https://api.test/stt",
+      apiKey: "token",
+      label: "Pro cloud transcription",
+    });
+  });
+
+  test("uses local Soniqo batch transcription otherwise", () => {
+    expect(
+      getBatchFallbackTarget({
+        isPaid: false,
+        accessToken: null,
+        apiBaseUrl: "https://api.test",
+      }),
+    ).toEqual({
+      provider: "soniqo",
+      model: "soniqo-parakeet-batch",
+      baseUrl: "soniqo://local",
+      apiKey: "",
+      label: "Soniqo batch transcription",
+    });
+  });
+});
+
 describe("useRunBatch", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -157,6 +268,7 @@ describe("useRunBatch", () => {
     idMock.mockImplementation(() => `generated-${++nextId}`);
     saveMock.mockResolvedValue(undefined);
     deleteProcessedAudioForRetentionMock.mockResolvedValue(undefined);
+    isSupportedLanguagesBatchMock.mockResolvedValue(true);
     useListenerMock.mockImplementation((selector) =>
       selector({ startTranscription: startTranscriptionMock }),
     );
@@ -172,6 +284,15 @@ describe("useRunBatch", () => {
         baseUrl: "https://api.deepgram.com/v1/listen",
         apiKey: "test-key",
       },
+    });
+    useAuthMock.mockReturnValue({
+      session: {
+        access_token: "paid-token",
+        user: { id: "user-1" },
+      },
+    });
+    useBillingAccessMock.mockReturnValue({
+      isPaid: false,
     });
     useConfigValueMock.mockImplementation((key) =>
       key === "ai_language" ? "en" : [],
@@ -271,6 +392,72 @@ describe("useRunBatch", () => {
         languages: ["de", "en"],
       }),
       expect.any(Object),
+    );
+  });
+
+  test("falls back to local Soniqo when the selected provider is not batch-capable", async () => {
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "custom",
+        model: "realtime-only",
+        baseUrl: "https://custom.test",
+        apiKey: "custom-key",
+      },
+    });
+    startTranscriptionMock.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await act(async () => {
+      await result.current("/tmp/session.wav");
+    });
+
+    expect(startTranscriptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "soniqo",
+        model: "soniqo-parakeet-batch",
+        base_url: "soniqo://local",
+        api_key: "",
+      }),
+      expect.any(Object),
+    );
+    expect(sonnerToastMessageMock).toHaveBeenCalledWith(
+      "Using a batch transcription provider",
+      expect.objectContaining({
+        description:
+          "realtime-only is not available for batch transcription. Using Soniqo batch transcription instead.",
+      }),
+    );
+  });
+
+  test("falls back to hosted cloud transcription for paid users", async () => {
+    isSupportedLanguagesBatchMock.mockResolvedValue(false);
+    useBillingAccessMock.mockReturnValue({
+      isPaid: true,
+    });
+    startTranscriptionMock.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await act(async () => {
+      await result.current("/tmp/session.wav");
+    });
+
+    expect(startTranscriptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "hyprnote",
+        model: "cloud",
+        base_url: "https://api.test/stt",
+        api_key: "paid-token",
+      }),
+      expect.any(Object),
+    );
+    expect(sonnerToastMessageMock).toHaveBeenCalledWith(
+      "Using a batch transcription provider",
+      expect.objectContaining({
+        description:
+          "nova-3 is not available for batch transcription. Using Pro cloud transcription instead.",
+      }),
     );
   });
 });

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -2,18 +2,25 @@ import { useCallback } from "react";
 
 import type { TranscriptionParams } from "@hypr/plugin-transcription";
 import type { TranscriptStorage } from "@hypr/store";
+import { sonnerToast } from "@hypr/ui/components/ui/toast";
 
 import { useListener } from "./contexts";
 import { useKeywords } from "./useKeywords";
 import { useSTTConnection } from "./useSTTConnection";
 
+import { useAuth } from "~/auth";
+import { useBillingAccess } from "~/auth/billing";
+import { env } from "~/env";
 import { deleteProcessedAudioForRetention } from "~/services/audio-retention";
 import { useConfigValue } from "~/shared/config";
 import { id } from "~/shared/utils";
 import * as main from "~/store/tinybase/store/main";
 import * as settings from "~/store/tinybase/store/settings";
 import type { BatchPersistCallback } from "~/store/zustand/listener/transcript";
-import { getTranscriptionLanguages } from "~/stt/capabilities";
+import {
+  getTranscriptionLanguages,
+  isSupportedLanguagesBatch,
+} from "~/stt/capabilities";
 import type { SpeakerHintWithId, WordWithId } from "~/stt/types";
 import {
   createTranscriptAccumulator,
@@ -33,6 +40,13 @@ type RunOptions = {
 };
 
 type Store = NonNullable<ReturnType<typeof main.UI.useStore>>;
+type BatchTarget = {
+  provider: TranscriptionParams["provider"];
+  model: string;
+  baseUrl: string;
+  apiKey: string;
+  label: string;
+};
 
 const DIRECT_BATCH_PROVIDERS: Set<TranscriptionParams["provider"]> = new Set([
   "deepgram",
@@ -49,6 +63,13 @@ const DIRECT_BATCH_PROVIDERS: Set<TranscriptionParams["provider"]> = new Set([
 ]);
 
 export const STOPPED_TRANSCRIPTION_ERROR_MESSAGE = "Transcription stopped.";
+const LOCAL_SONIQO_BATCH_TARGET = {
+  provider: "soniqo",
+  model: "soniqo-parakeet-batch",
+  baseUrl: "soniqo://local",
+  apiKey: "",
+  label: "Soniqo batch transcription",
+} satisfies BatchTarget;
 
 export function getBatchProvider(
   provider: string,
@@ -70,14 +91,58 @@ export function getBatchProvider(
 }
 
 export function canRunBatchTranscription(
+  _conn: { provider: string; model: string } | null,
+  _modelOverride?: string,
+) {
+  return true;
+}
+
+export function getBatchFallbackTarget({
+  isPaid,
+  accessToken,
+  apiBaseUrl,
+}: {
+  isPaid: boolean;
+  accessToken?: string | null;
+  apiBaseUrl: string;
+}): BatchTarget {
+  if (isPaid && accessToken) {
+    return {
+      provider: "hyprnote",
+      model: "cloud",
+      baseUrl: new URL("/stt", apiBaseUrl).toString(),
+      apiKey: accessToken,
+      label: "Pro cloud transcription",
+    };
+  }
+
+  return LOCAL_SONIQO_BATCH_TARGET;
+}
+
+async function canUseBatchTarget(
+  provider: TranscriptionParams["provider"],
+  model: string,
+  languages: readonly string[],
+) {
+  return isSupportedLanguagesBatch(provider, model, languages);
+}
+
+function selectedProviderLabel(
   conn: { provider: string; model: string } | null,
   modelOverride?: string,
 ) {
   if (!conn) {
-    return false;
+    return "the selected speech-to-text provider";
   }
 
-  return getBatchProvider(conn.provider, modelOverride ?? conn.model) != null;
+  return modelOverride ?? conn.model ?? conn.provider;
+}
+
+function sameBatchTarget(
+  a: Pick<BatchTarget, "provider" | "model"> | null,
+  b: Pick<BatchTarget, "provider" | "model">,
+) {
+  return a?.provider === b.provider && a.model === b.model;
 }
 
 export function isStoppedTranscriptionError(error: unknown) {
@@ -136,27 +201,65 @@ export const useRunBatch = (sessionId: string) => {
 
   const startTranscription = useListener((state) => state.startTranscription);
   const { conn } = useSTTConnection();
+  const auth = useAuth();
+  const billing = useBillingAccess();
   const keywords = useKeywords(sessionId);
   const aiLanguage = useConfigValue("ai_language");
   const spokenLanguages = useConfigValue("spoken_languages");
 
   return useCallback(
     async (filePath: string, options?: RunOptions) => {
-      if (!store || !conn || !startTranscription) {
+      if (!store || !startTranscription) {
         throw new Error(
           "STT connection is not available. Please configure your speech-to-text provider.",
         );
       }
 
-      const provider = getBatchProvider(
-        conn.provider,
-        options?.model ?? conn.model,
-      );
+      const languages =
+        options?.languages ??
+        getTranscriptionLanguages(aiLanguage, spokenLanguages);
+      const selectedModel = options?.model ?? conn?.model;
+      const selectedProvider =
+        conn && selectedModel
+          ? getBatchProvider(conn.provider, selectedModel)
+          : null;
+      const selectedTarget =
+        conn && selectedModel && selectedProvider
+          ? {
+              provider: selectedProvider,
+              model: selectedModel,
+              baseUrl: options?.baseUrl ?? conn.baseUrl,
+              apiKey: options?.apiKey ?? conn.apiKey,
+              label: selectedModel,
+            }
+          : null;
+      const selectedTargetSupported = selectedTarget
+        ? await canUseBatchTarget(
+            selectedTarget.provider,
+            selectedTarget.model,
+            languages,
+          )
+        : false;
+      const fallbackTarget = getBatchFallbackTarget({
+        isPaid: billing.isPaid,
+        accessToken: auth?.session?.access_token,
+        apiBaseUrl: env.VITE_API_URL,
+      });
+      const shouldUseSelectedTarget =
+        selectedTargetSupported ||
+        sameBatchTarget(selectedTarget, fallbackTarget);
+      const target = shouldUseSelectedTarget
+        ? (selectedTarget ?? fallbackTarget)
+        : fallbackTarget;
 
-      if (!provider) {
-        throw new Error(
-          `Batch transcription is not supported for provider: ${conn.provider}`,
-        );
+      if (!shouldUseSelectedTarget) {
+        sonnerToast.message("Using a batch transcription provider", {
+          description: `${
+            selectedTarget
+              ? selectedProviderLabel(conn, selectedModel)
+              : selectedProviderLabel(conn)
+          } is not available for batch transcription. Using ${target.label} instead.`,
+        });
       }
 
       const createdAt = new Date().toISOString();
@@ -267,7 +370,7 @@ export const useRunBatch = (sessionId: string) => {
               word_id: wordId,
               type: "provider_speaker_index",
               value: JSON.stringify({
-                provider: hint.data.provider ?? conn.provider,
+                provider: hint.data.provider ?? target.provider,
                 channel: hint.data.channel ?? word.channel,
                 speaker_index: hint.data.speaker_index,
               }),
@@ -287,15 +390,13 @@ export const useRunBatch = (sessionId: string) => {
 
       const params: TranscriptionParams = {
         session_id: sessionId,
-        provider,
+        provider: target.provider,
         file_path: filePath,
-        model: options?.model ?? conn.model,
-        base_url: options?.baseUrl ?? conn.baseUrl,
-        api_key: options?.apiKey ?? conn.apiKey,
+        model: target.model,
+        base_url: target.baseUrl,
+        api_key: target.apiKey,
         keywords: options?.keywords ?? keywords ?? [],
-        languages:
-          options?.languages ??
-          getTranscriptionLanguages(aiLanguage, spokenLanguages),
+        languages,
         num_speakers: options?.numSpeakers ?? inferredNumSpeakers,
         min_speakers: options?.minSpeakers,
         max_speakers: options?.maxSpeakers,
@@ -322,7 +423,9 @@ export const useRunBatch = (sessionId: string) => {
     },
     [
       conn,
+      auth?.session?.access_token,
       aiLanguage,
+      billing.isPaid,
       indexes,
       keywords,
       spokenLanguages,

--- a/crates/listener2-core/src/batch/mod.rs
+++ b/crates/listener2-core/src/batch/mod.rs
@@ -203,7 +203,7 @@ async fn run_batch_inner(
         BatchProvider::WhisperLocal => {
             run_progressive_batch_session(runtime, params, listen_params).await
         }
-        BatchProvider::Soniqo => run_soniqo_batch(params, listen_params).await,
+        BatchProvider::Soniqo => run_soniqo_batch(runtime, params, listen_params).await,
         BatchProvider::OpenAI => {
             if OpenAIAdapter::supports_progressive_batch_model(listen_params.model.as_deref()) {
                 run_progressive_batch_session(runtime, params, listen_params).await

--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Instant;
 
 use owhisper_client::{
@@ -6,6 +7,7 @@ use owhisper_client::{
     CartesiaAdapter, DeepgramAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter,
     HyprnoteAdapter, MistralAdapter, OpenAIAdapter, PyannoteAdapter, SonioxAdapter,
 };
+use owhisper_interface::batch_stream::BatchStreamEvent;
 use tracing::Instrument;
 
 use hypr_audio_chunking::AudioChunk;
@@ -15,8 +17,12 @@ use hypr_transcribe_core::{
 };
 
 use super::{BatchParams, BatchRunMode, BatchRunOutput, format_user_friendly_error, session_span};
+use crate::{BatchEvent, BatchRuntime};
 
 const SONIQO_PARAKEET_MAX_CHUNK_SAMPLES: usize = TARGET_SAMPLE_RATE as usize * 59 / 2;
+const SONIQO_PROGRESS_PLANNED: f64 = 0.05;
+const SONIQO_PROGRESS_RANGE: f64 = 0.90;
+const SONIQO_PROGRESS_MAX: f64 = 0.95;
 
 macro_rules! dispatch_batch {
     ($ak:expr, $params:expr, $lp:expr,
@@ -103,6 +109,7 @@ async fn run_direct_batch<A: BatchSttAdapter>(
 }
 
 pub(super) async fn run_soniqo_batch(
+    runtime: Arc<dyn BatchRuntime>,
     params: BatchParams,
     listen_params: owhisper_interface::ListenParams,
 ) -> crate::Result<BatchRunOutput> {
@@ -147,8 +154,13 @@ pub(super) async fn run_soniqo_batch(
             "soniqo_batch_start"
         );
 
+        let session_id = params.session_id.clone();
         let transcribed = tokio::task::spawn_blocking(move || {
-            transcribe_soniqo_file(model, &file_path, language_hint.as_deref())
+            let progress = SoniqoProgressReporter {
+                runtime,
+                session_id,
+            };
+            transcribe_soniqo_file(model, &file_path, language_hint.as_deref(), Some(&progress))
         })
         .await
         .map_err(|e| {
@@ -202,6 +214,7 @@ fn transcribe_soniqo_file(
     model: hypr_transcribe_soniqo::SoniqoModel,
     file_path: &str,
     language: Option<&str>,
+    progress: Option<&SoniqoProgressReporter>,
 ) -> std::result::Result<Vec<hypr_transcribe_soniqo::FileTranscript>, String> {
     let source = hypr_audio_utils::source_from_path(file_path).map_err(|e| e.to_string())?;
     let channel_count = u16::from(source.channels()).max(1) as usize;
@@ -222,13 +235,21 @@ fn transcribe_soniqo_file(
     );
 
     if channel_count <= 1 && !uses_resilient_soniqo_chunking(model) {
+        if let Some(progress) = progress {
+            progress.emit(SONIQO_PROGRESS_PLANNED);
+        }
         tracing::info!(
             hyprnote.stt.provider.name = "soniqo",
             hyprnote.stt.model = %model,
             "soniqo_single_channel_native_inference_start"
         );
         return hypr_transcribe_soniqo::transcribe_file(model, file_path, language)
-            .map(|transcript| vec![transcript])
+            .map(|transcript| {
+                if let Some(progress) = progress {
+                    progress.emit(SONIQO_PROGRESS_MAX);
+                }
+                vec![transcript]
+            })
             .map_err(|e| e.to_string());
     }
 
@@ -255,11 +276,49 @@ fn transcribe_soniqo_file(
         "soniqo_channels_prepared"
     );
 
-    collect_soniqo_channel_transcripts(channel_samples.into_iter().enumerate().map(
-        |(channel_index, samples)| {
-            transcribe_soniqo_channel(model, channel_index, &samples, language)
-        },
-    ))
+    let plans = channel_samples
+        .into_iter()
+        .enumerate()
+        .map(|(channel_index, samples)| soniqo_channel_plan(model, channel_index, &samples))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let total_chunks = plans.iter().map(|plan| plan.chunks.len()).sum::<usize>();
+    let mut completed_chunks = 0usize;
+
+    if let Some(progress) = progress {
+        progress.emit(soniqo_batch_progress(0, total_chunks));
+    }
+
+    collect_soniqo_channel_transcripts(plans.into_iter().map(|plan| {
+        transcribe_soniqo_channel_chunks(model, plan, language, || {
+            completed_chunks += 1;
+            if let Some(progress) = progress {
+                progress.emit(soniqo_batch_progress(completed_chunks, total_chunks));
+            }
+        })
+    }))
+}
+
+struct SoniqoProgressReporter {
+    runtime: Arc<dyn BatchRuntime>,
+    session_id: String,
+}
+
+impl SoniqoProgressReporter {
+    fn emit(&self, percentage: f64) {
+        self.runtime.emit(BatchEvent::BatchResponseStreamed {
+            session_id: self.session_id.clone(),
+            event: BatchStreamEvent::Progress {
+                percentage,
+                partial_text: None,
+            },
+        });
+    }
+}
+
+struct SoniqoChannelPlan {
+    channel_index: usize,
+    duration_seconds: f64,
+    chunks: Vec<AudioChunk>,
 }
 
 fn soniqo_language_hint(language: Option<&str>) -> Option<String> {
@@ -277,6 +336,15 @@ fn soniqo_language_hint(language: Option<&str>) -> Option<String> {
 
 fn uses_resilient_soniqo_chunking(model: hypr_transcribe_soniqo::SoniqoModel) -> bool {
     matches!(model, hypr_transcribe_soniqo::SoniqoModel::ParakeetBatch)
+}
+
+fn soniqo_batch_progress(completed_chunks: usize, total_chunks: usize) -> f64 {
+    if total_chunks == 0 {
+        return SONIQO_PROGRESS_PLANNED;
+    }
+
+    let ratio = completed_chunks as f64 / total_chunks as f64;
+    (SONIQO_PROGRESS_PLANNED + ratio * SONIQO_PROGRESS_RANGE).min(SONIQO_PROGRESS_MAX)
 }
 
 fn collect_soniqo_channel_transcripts<I>(
@@ -319,12 +387,11 @@ where
     Ok(output)
 }
 
-fn transcribe_soniqo_channel(
+fn soniqo_channel_plan(
     model: hypr_transcribe_soniqo::SoniqoModel,
     channel_index: usize,
     samples: &[f32],
-    language: Option<&str>,
-) -> std::result::Result<hypr_transcribe_soniqo::FileTranscript, String> {
+) -> std::result::Result<SoniqoChannelPlan, String> {
     let duration_seconds = channel_duration_sec(samples);
     let chunks = soniqo_channel_chunks(model, samples)?;
     tracing::info!(
@@ -337,11 +404,25 @@ fn transcribe_soniqo_channel(
         "soniqo_channel_chunked"
     );
 
+    Ok(SoniqoChannelPlan {
+        channel_index,
+        duration_seconds,
+        chunks,
+    })
+}
+
+fn transcribe_soniqo_channel_chunks(
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    plan: SoniqoChannelPlan,
+    language: Option<&str>,
+    mut on_chunk_completed: impl FnMut(),
+) -> std::result::Result<hypr_transcribe_soniqo::FileTranscript, String> {
     let mut texts = Vec::new();
     let mut successful_chunks = 0usize;
     let mut failed_chunks = 0usize;
+    let channel_index = plan.channel_index;
 
-    for (chunk_index, chunk) in chunks.into_iter().enumerate() {
+    for (chunk_index, chunk) in plan.chunks.into_iter().enumerate() {
         let chunk_duration_ms =
             (chunk.sample_end - chunk.sample_start) * 1000 / TARGET_SAMPLE_RATE as usize;
         let chunk_started_at = Instant::now();
@@ -373,9 +454,11 @@ fn transcribe_soniqo_channel(
                     error = %e,
                     "soniqo_chunk_native_inference_failed"
                 );
+                on_chunk_completed();
                 continue;
             }
         };
+        on_chunk_completed();
 
         tracing::info!(
             hyprnote.stt.provider.name = "soniqo",
@@ -412,7 +495,7 @@ fn transcribe_soniqo_channel(
 
     Ok(hypr_transcribe_soniqo::FileTranscript {
         text: texts.join(" "),
-        duration_seconds,
+        duration_seconds: plan.duration_seconds,
     })
 }
 
@@ -564,6 +647,19 @@ mod tests {
         assert!(!uses_resilient_soniqo_chunking(
             hypr_transcribe_soniqo::SoniqoModel::Omnilingual
         ));
+    }
+
+    #[test]
+    fn soniqo_progress_starts_after_chunk_planning() {
+        assert_eq!(soniqo_batch_progress(0, 10), SONIQO_PROGRESS_PLANNED);
+        assert_eq!(soniqo_batch_progress(0, 0), SONIQO_PROGRESS_PLANNED);
+    }
+
+    #[test]
+    fn soniqo_progress_caps_before_completion() {
+        assert!((soniqo_batch_progress(5, 10) - 0.5).abs() < 1e-9);
+        assert_eq!(soniqo_batch_progress(10, 10), SONIQO_PROGRESS_MAX);
+        assert_eq!(soniqo_batch_progress(11, 10), SONIQO_PROGRESS_MAX);
     }
 
     #[test]


### PR DESCRIPTION
Adds Soniqo chunk progress, synthetic progress for blocking batch providers, and fallback routing for unsupported batch selections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which provider runs batch transcription (billing/auth tokens, language checks) and progress behavior across many provider branches; mistakes could route paid traffic incorrectly or show misleading progress.
> 
> **Overview**
> Improves **batch transcription UX** with real and estimated progress, and stops hard-failing when the user’s realtime STT choice doesn’t support batch.
> 
> **Progress:** Local **Soniqo** batch now emits **chunk-based progress** from the Rust listener (`BatchResponseStreamed`). For **blocking** batch paths (e.g. Hyprnote cloud, non-progressive `am`), the desktop store runs **synthetic eased progress** (capped below completion) until a real `progress` event arrives, then switches to streamed updates. Backend `started` no longer double-triggers batch start handling.
> 
> **Routing:** `useRunBatch` always allows post-capture batch and **picks a fallback** when the selected provider/model isn’t batch-capable or languages aren’t supported: **Pro cloud** (`hyprnote` + session token) for paid users, otherwise **local Soniqo batch**, with a toast explaining the switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d39814386ec146b4155c2dda8d4452d71b32096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->