### PR TITLE
Omit deprecated temperature for Claude 4.8

### DIFF
--- a/apps/desktop/src/ai/model-settings.test.ts
+++ b/apps/desktop/src/ai/model-settings.test.ts
@@ -1,0 +1,52 @@
+import type { LanguageModel } from "ai";
+import { describe, expect, it } from "vitest";
+
+import { deterministicGenerationSettings } from "./model-settings";
+
+function model(provider: string, modelId: string): LanguageModel {
+  return {
+    specificationVersion: "v3",
+    provider,
+    modelId,
+    supportedUrls: {},
+    doGenerate: async () => {
+      throw new Error("not implemented");
+    },
+    doStream: async () => {
+      throw new Error("not implemented");
+    },
+  };
+}
+
+describe("deterministicGenerationSettings", () => {
+  it("omits temperature for Anthropic Claude 4.8 models", () => {
+    expect(
+      deterministicGenerationSettings(model("anthropic", "claude-opus-4-8")),
+    ).toEqual({});
+  });
+
+  it("omits temperature for hosted Anthropic Claude 4.8 models", () => {
+    expect(
+      deterministicGenerationSettings(
+        model("openrouter", "anthropic/claude-opus-4-8"),
+      ),
+    ).toEqual({});
+    expect(
+      deterministicGenerationSettings(
+        model("hyprnote", "anthropic/claude-opus-4-8"),
+      ),
+    ).toEqual({});
+  });
+
+  it("omits temperature for dotted Claude 4.8 model ids", () => {
+    expect(
+      deterministicGenerationSettings(model("anthropic", "claude-opus-4.8")),
+    ).toEqual({});
+  });
+
+  it("keeps deterministic temperature for other models", () => {
+    expect(
+      deterministicGenerationSettings(model("anthropic", "claude-opus-4-5")),
+    ).toEqual({ temperature: 0 });
+  });
+});

--- a/apps/desktop/src/ai/model-settings.ts
+++ b/apps/desktop/src/ai/model-settings.ts
@@ -1,0 +1,30 @@
+import type { LanguageModel } from "ai";
+
+export function deterministicGenerationSettings(model: LanguageModel): {
+  temperature?: number;
+} {
+  if (usesDeprecatedTemperature(model)) {
+    return {};
+  }
+
+  return { temperature: 0 };
+}
+
+function usesDeprecatedTemperature(model: LanguageModel): boolean {
+  if (typeof model === "string") {
+    return false;
+  }
+
+  const provider = "provider" in model ? model.provider : "";
+  const modelId = "modelId" in model ? model.modelId : "";
+  const normalizedModelId = modelId.toLowerCase().replace(/\./g, "-");
+  const modelName = normalizedModelId.includes("/")
+    ? normalizedModelId.split("/").pop()!
+    : normalizedModelId;
+
+  return (
+    (provider.startsWith("anthropic") ||
+      normalizedModelId.startsWith("anthropic/")) &&
+    /^claude-(?:opus|sonnet|haiku)-4-8(?:$|-)/.test(modelName)
+  );
+}

--- a/apps/desktop/src/chat/store/chat-title.ts
+++ b/apps/desktop/src/chat/store/chat-title.ts
@@ -1,5 +1,7 @@
 import { generateText, type LanguageModel } from "ai";
 
+import { deterministicGenerationSettings } from "~/ai/model-settings";
+
 const FALLBACK_CHAT_TITLE_MAX_LENGTH = 50;
 const GENERATED_CHAT_TITLE_MAX_LENGTH = 60;
 const INITIAL_REQUEST_MAX_LENGTH = 4000;
@@ -32,7 +34,7 @@ export async function generateChatTitle({
 
   const result = await generateText({
     model,
-    temperature: 0,
+    ...deterministicGenerationSettings(model),
     maxRetries: 2,
     maxOutputTokens: 32,
     system:

--- a/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
+++ b/apps/desktop/src/session/components/bottom-accessory/past-notes.ts
@@ -13,6 +13,7 @@ import systemPromptTemplate from "./past-note-key-facts.system.md.jinja?raw";
 import userPromptTemplate from "./past-note-key-facts.user.md.jinja?raw";
 
 import { useLanguageModel } from "~/ai/hooks";
+import { deterministicGenerationSettings } from "~/ai/model-settings";
 import { extractPlainText } from "~/search/contexts/engine/utils";
 import { getSessionEvent } from "~/session/utils";
 import { showTransientToast } from "~/sidebar/toast/transient";
@@ -386,7 +387,7 @@ async function generatePastSessionKeyFacts({
 
   const result = await generateText({
     model,
-    temperature: 0,
+    ...deterministicGenerationSettings(model),
     system,
     prompt,
     output: Output.object({ schema: keyFactsSchema }),

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
@@ -13,6 +13,7 @@ import type {
   SessionEvent,
 } from "@hypr/store";
 
+import { deterministicGenerationSettings } from "~/ai/model-settings";
 import { DEFAULT_USER_ID, id } from "~/shared/utils";
 import type * as main from "~/store/tinybase/store/main";
 
@@ -106,7 +107,7 @@ export async function extractEventContacts({
 
   const result = await generateText({
     model,
-    temperature: 0,
+    ...deterministicGenerationSettings(model),
     maxRetries: 2,
     maxOutputTokens: 384,
     system,

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-workflow.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-workflow.ts
@@ -19,6 +19,7 @@ import type { TaskArgsMapTransformed, TaskConfig } from ".";
 import type { EnhanceImageContext } from "./enhance-images";
 import { createEnhanceValidator } from "./enhance-validator";
 
+import { deterministicGenerationSettings } from "~/ai/model-settings";
 import type { Store } from "~/store/tinybase/store/main";
 import { normalizeBulletPoints } from "~/store/zustand/ai-task/shared/transform_impl";
 import { withEarlyValidationRetry } from "~/store/zustand/ai-task/shared/validate";
@@ -205,7 +206,7 @@ async function generateStructuredOutput<T extends z.ZodTypeAny>(params: {
   try {
     const result = await generateText({
       model,
-      temperature: 0,
+      ...deterministicGenerationSettings(model),
       output: Output.object({ schema }),
       abortSignal: signal,
       maxRetries: AI_GENERATION_MAX_RETRIES,
@@ -222,7 +223,7 @@ async function generateStructuredOutput<T extends z.ZodTypeAny>(params: {
     try {
       const fallbackResult = await generateText({
         model,
-        temperature: 0,
+        ...deterministicGenerationSettings(model),
         abortSignal: signal,
         maxRetries: AI_GENERATION_MAX_RETRIES,
         maxOutputTokens: TEMPLATE_MAX_OUTPUT_TOKENS,

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-workflow.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-workflow.ts
@@ -4,6 +4,7 @@ import { commands as templateCommands } from "@hypr/plugin-template";
 
 import type { TaskArgsMapTransformed, TaskConfig } from ".";
 
+import { deterministicGenerationSettings } from "~/ai/model-settings";
 import type { Store } from "~/store/tinybase/store/main";
 
 const AI_GENERATION_MAX_RETRIES = 4;
@@ -34,7 +35,7 @@ async function* executeWorkflow(params: {
   const id = generateId();
   const result = streamText({
     model,
-    temperature: 0,
+    ...deterministicGenerationSettings(model),
     system,
     prompt,
     abortSignal: signal,


### PR DESCRIPTION
Avoid sending temperature to Anthropic Claude 4.8 model calls and cover the guard with a focused test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted request-parameter change for a specific model family; other models keep `temperature: 0` and behavior is covered by tests.
> 
> **Overview**
> Adds **`deterministicGenerationSettings`** so deterministic desktop AI calls still use `temperature: 0` by default, but **omit temperature** for Anthropic Claude 4.8 (`opus` / `sonnet` / `haiku`), including hosted IDs (`openrouter`, `hyprnote`, `anthropic/...`) and dotted model names like `4.8`.
> 
> Replaces inline `temperature: 0` with that helper in chat title generation, past-note key facts, event contact extraction, enhance structured-output (and JSON fallback), and session title streaming. **Vitest** covers the Claude 4.8 vs other-model behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dae3e8770361e9b152d4ae4716e293906c96a0b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->