### PR TITLE
Show transcript scroll chips after movement

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -4,6 +4,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TranscriptViewer } from "./index";
 
+const mocks = vi.hoisted(() => ({
+  scrollToBottom: vi.fn(),
+  scrollToTop: vi.fn(),
+  scrollDetection: {
+    isAtTop: true,
+    isAtBottom: true,
+    autoScrollEnabled: true,
+    scrollTarget: null as "top" | "bottom" | null,
+  },
+}));
+
 vi.mock("react-hotkeys-hook", () => ({
   useHotkeys: vi.fn(),
 }));
@@ -40,15 +51,21 @@ vi.mock("./viewport-hooks", () => ({
   useAutoScroll: vi.fn(),
   usePlaybackAutoScroll: vi.fn(),
   useScrollDetection: () => ({
-    isAtBottom: true,
-    autoScrollEnabled: true,
-    scrollToBottom: vi.fn(),
+    ...mocks.scrollDetection,
+    scrollToBottom: mocks.scrollToBottom,
+    scrollToTop: mocks.scrollToTop,
   }),
 }));
 
 describe("TranscriptViewer", () => {
   beforeEach(() => {
     cleanup();
+    mocks.scrollToBottom.mockReset();
+    mocks.scrollToTop.mockReset();
+    mocks.scrollDetection.isAtTop = true;
+    mocks.scrollDetection.isAtBottom = true;
+    mocks.scrollDetection.autoScrollEnabled = true;
+    mocks.scrollDetection.scrollTarget = null;
   });
 
   it("does not pin inactive transcript sessions to the bottom on open", () => {
@@ -83,5 +100,62 @@ describe("TranscriptViewer", () => {
         .getByTestId("render-transcript")
         .getAttribute("data-should-scroll-to-end"),
     ).toBe("true");
+  });
+
+  it("does not show a scroll chip before scroll movement starts", () => {
+    mocks.scrollDetection.isAtBottom = false;
+
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive
+        scrollRef={createRef()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
+  });
+
+  it("shows the bottom chip after upward scroll movement", () => {
+    mocks.scrollDetection.isAtTop = false;
+    mocks.scrollDetection.isAtBottom = false;
+    mocks.scrollDetection.scrollTarget = "bottom";
+
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive
+        scrollRef={createRef()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Go to bottom" });
+    button.click();
+
+    expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
+    expect(mocks.scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the top chip after downward scroll movement", () => {
+    mocks.scrollDetection.isAtTop = false;
+    mocks.scrollDetection.scrollTarget = "top";
+
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive
+        scrollRef={createRef()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Go to top" });
+    button.click();
+
+    expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
+    expect(mocks.scrollToTop).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -46,8 +46,14 @@ export function TranscriptViewer({
     [scrollRef],
   );
 
-  const { isAtBottom, autoScrollEnabled, scrollToBottom } =
-    useScrollDetection(containerRef);
+  const {
+    isAtTop,
+    isAtBottom,
+    autoScrollEnabled,
+    scrollTarget,
+    scrollToTop,
+    scrollToBottom,
+  } = useScrollDetection(containerRef);
 
   const {
     state: playerState,
@@ -85,7 +91,18 @@ export function TranscriptViewer({
     shouldAutoScroll,
   );
 
-  const shouldShowButton = !isAtBottom && currentActive;
+  const scrollChip =
+    currentActive && scrollTarget === "bottom" && !isAtBottom
+      ? {
+          label: "Go to bottom",
+          onClick: scrollToBottom,
+        }
+      : currentActive && scrollTarget === "top" && !isAtTop
+        ? {
+            label: "Go to top",
+            onClick: scrollToTop,
+          }
+        : null;
 
   const handleSelectionAction = (action: string, selectedText: string) => {
     if (action === "copy") {
@@ -132,20 +149,21 @@ export function TranscriptViewer({
         />
       </div>
 
-      <button
-        onClick={scrollToBottom}
-        className={cn([
-          "absolute bottom-3 left-1/2 z-30 -translate-x-1/2",
-          "rounded-full px-4 py-2",
-          "from-muted to-accent text-foreground bg-linear-to-t",
-          "shadow-xs hover:scale-[102%] hover:shadow-md active:scale-[98%]",
-          "text-xs font-light",
-          "transition-opacity duration-150",
-          shouldShowButton ? "opacity-100" : "pointer-events-none opacity-0",
-        ])}
-      >
-        Go to bottom
-      </button>
+      {scrollChip && (
+        <button
+          onClick={scrollChip.onClick}
+          className={cn([
+            "absolute bottom-[calc(5rem+env(safe-area-inset-bottom))] left-1/2 z-30 -translate-x-1/2",
+            "rounded-full px-4 py-2",
+            "from-muted to-accent text-foreground bg-linear-to-t",
+            "shadow-xs hover:scale-[102%] hover:shadow-md active:scale-[98%]",
+            "text-xs font-light",
+            "transition-opacity duration-150",
+          ])}
+        >
+          {scrollChip.label}
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
@@ -10,8 +10,12 @@ import {
 export function useScrollDetection(
   containerRef: RefObject<HTMLDivElement | null>,
 ) {
+  const [isAtTop, setIsAtTop] = useState(true);
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
+  const [scrollTarget, setScrollTarget] = useState<"top" | "bottom" | null>(
+    null,
+  );
   const lastScrollTopRef = useRef(0);
   const userScrolledAwayRef = useRef(false);
 
@@ -24,10 +28,13 @@ export function useScrollDetection(
     lastScrollTopRef.current = element.scrollTop;
 
     const handleScroll = () => {
-      const threshold = 100;
+      const topThreshold = 40;
+      const bottomThreshold = 100;
       const distanceToBottom =
         element.scrollHeight - element.scrollTop - element.clientHeight;
-      const isNearBottom = distanceToBottom < threshold;
+      const isNearTop = element.scrollTop < topThreshold;
+      const isNearBottom = distanceToBottom < bottomThreshold;
+      setIsAtTop(isNearTop);
       setIsAtBottom(isNearBottom);
 
       const currentTop = element.scrollTop;
@@ -35,9 +42,15 @@ export function useScrollDetection(
       lastScrollTopRef.current = currentTop;
 
       const scrolledUp = currentTop < prevTop - 2;
+      const scrolledDown = currentTop > prevTop + 2;
       if (scrolledUp) {
         userScrolledAwayRef.current = true;
         setAutoScrollEnabled(false);
+        setScrollTarget("bottom");
+      }
+
+      if (scrolledDown) {
+        setScrollTarget("top");
       }
 
       if (isNearBottom && !userScrolledAwayRef.current) {
@@ -57,10 +70,27 @@ export function useScrollDetection(
     }
     userScrolledAwayRef.current = false;
     setAutoScrollEnabled(true);
+    setScrollTarget(null);
     element.scrollTo({ top: element.scrollHeight, behavior: "smooth" });
   };
 
-  return { isAtBottom, autoScrollEnabled, scrollToBottom };
+  const scrollToTop = () => {
+    const element = containerRef.current;
+    if (!element) {
+      return;
+    }
+    setScrollTarget(null);
+    element.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  return {
+    isAtTop,
+    isAtBottom,
+    autoScrollEnabled,
+    scrollTarget,
+    scrollToTop,
+    scrollToBottom,
+  };
 }
 
 export function useAutoScroll(


### PR DESCRIPTION
Adds directional top and bottom transcript scroll chips with more bottom clearance and renderer coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized transcript viewer scroll UX and hook changes with no auth, data, or API impact; behavior is covered by new unit tests.
> 
> **Overview**
> Replaces the always-on **Go to bottom** affordance in the active transcript viewer with **directional scroll chips** that appear only after the user has scrolled, so chips are not shown on initial open merely because the viewport is not at the bottom.
> 
> `useScrollDetection` now tracks **top** proximity, scroll direction (`scrollTarget`: `"top"` | `"bottom"` | `null`), and exposes **`scrollToTop`**. Upward movement sets the bottom chip target and disables auto-scroll as before; downward movement sets the top chip target. Chip actions clear `scrollTarget` and smooth-scroll to the appropriate edge.
> 
> The floating control is **conditionally rendered** (not opacity-hidden), sits higher with **`safe-area-inset-bottom`**, and **`TranscriptViewer` tests** cover no chip before movement, bottom/top chip visibility, and click handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f045fc35c8966ca3244975c96fd3e3a756f93f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->