### PR TITLE
Fix changelog Tailwind source scanning

### DIFF
--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -8,6 +8,7 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @source "../../node_modules/streamdown/dist/index.js";
+@source "../../../../packages/changelog/src";
 @source "../../../../packages/editor/src";
 
 @theme {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3,6 +3,7 @@
 @plugin "@tailwindcss/typography";
 @import "../../../packages/ui/src/styles/scroll-fade.css";
 
+@source "../../../packages/changelog/src";
 @source "../../../packages/ui/src";
 
 @theme {


### PR DESCRIPTION
Include the shared changelog renderer in web and desktop Tailwind source inputs so list spacing utilities render consistently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time Tailwind content scanning only; no runtime logic, auth, or data changes.
> 
> **Overview**
> Adds `@source` entries for `packages/changelog/src` in **web** and **desktop** Tailwind entry CSS so Tailwind v4 scans the shared changelog renderer when building utilities.
> 
> Without this, classes used in that package (e.g. list spacing like `my-2`, `list-disc`, `pl-6` on `ul`/`ol`/`li`) were not included in the app CSS, so changelog lists could render without expected spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fa1acac6ef33d9bba364b3c8016d0045795efaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->