### PR TITLE
Add desktop 1.1.1 changelog

### DIFF
--- a/packages/changelog/content/1.1.1.md
+++ b/packages/changelog/content/1.1.1.md
@@ -1,0 +1,32 @@
+---
+date: "2026-06-25"
+summary: "Anarlog now handles batch transcription more clearly, supports audio file drops, improves transcript navigation, and smooths sidebar and note controls."
+---
+
+## Transcription
+
+- Batch transcription now shows clearer progress, keeps the stop control visible while work is running, and falls back more gracefully when a selected provider cannot handle batch work
+- Soniqo Parakeet batch transcription now handles selected languages more reliably and continues past isolated chunk failures instead of stopping the whole batch
+- Dropping audio files into a note can now start transcription directly, while mixed file drops continue through the normal editor upload flow
+- Sessions with saved audio but no transcript now show a Transcript tab and an explicit regenerate action
+- Upload actions are now hidden during live meetings so active recordings are not interrupted by manual file actions
+
+## Notes
+
+- Transcript scrolling now has clearer top and bottom jump chips after manual movement, with extra space so the controls do not crowd the bottom of the view
+- Transcript tabs now show transcription progress more clearly, while the bottom panel stays out of the way on the transcript view
+- Note tabs have better contrast in dark mode, and a single Memo tab no longer shows an unnecessary tray
+- Session overflow menus now include a note-window action for opening a session in its own window
+- Opening the Insights panel no longer starts generation automatically; regeneration stays tied to the explicit panel action
+
+## Sidebar and Settings
+
+- Sidebar timeline scrolling is steadier, with improved wheel handling, cleaner sticky headers, and more predictable top and bottom spacing
+- The sidebar now supports selecting all visible notes with Cmd+A
+- Settings menu labels now render consistently across the full menu
+- More desktop UI copy is now covered by translations, improving localized settings, chat, onboarding, and session screens
+- Claude 4.8 requests no longer include a deprecated temperature setting, improving compatibility with the latest Anthropic models
+
+## Changelog
+
+- In-app and web changelog lists now render list spacing consistently


### PR DESCRIPTION
## Summary
- Add the 1.1.1 desktop changelog entry for the next stable release.

## Verification
- pnpm exec dprint fmt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no application or runtime behavior changes.
> 
> **Overview**
> Adds the **1.1.1** desktop changelog entry at `packages/changelog/content/1.1.1.md` (dated 2026-06-25), using the same frontmatter and section layout as prior version files.
> 
> The new post documents the stable release for in-app and web changelog consumers, grouped into **Transcription**, **Notes**, **Sidebar and Settings**, and **Changelog** (batch transcription UX, audio drops, transcript navigation, sidebar Cmd+A, translations, Claude 4.8 temperature removal, list spacing, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db08764a19239fdd5659eddb61ee5577ff4d84a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->