### PR TITLE
Move update button into sidebar icon row

### DIFF
--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -283,35 +283,48 @@ describe("ClassicMainBody", () => {
     expect(mocks.toggleLeftSidebar).toHaveBeenCalledTimes(1);
   });
 
-  it("shows the update button at the far end of expanded sidebar chrome", () => {
+  it("shows the update button at the far edge of the expanded sidebar chrome row", () => {
     mocks.sidebarUpdateControl.status = "available";
     mocks.sidebarUpdateControl.version = "1.0.34";
 
     render(<ClassicMainBody />);
 
     const sidebarToggle = screen.getByRole("button", { name: "Hide sidebar" });
+    const searchButton = screen.getByRole("button", { name: "Search" });
+    const newNoteButton = screen.getByRole("button", { name: "New note" });
+    const updateButton = screen.getByTestId("sidebar-update-button");
     const chrome = sidebarToggle.parentElement?.parentElement;
     const chromeFrame = chrome?.parentElement;
 
-    expect(screen.getByTestId("sidebar-update-button")).toBeTruthy();
+    expect(updateButton).toBeTruthy();
+    expect(updateButton.parentElement).toBe(chrome);
+    expect(updateButton.parentElement).not.toBe(sidebarToggle.parentElement);
+    expect(searchButton.compareDocumentPosition(newNoteButton)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(searchButton.parentElement).toBe(sidebarToggle.parentElement);
+    expect(newNoteButton.parentElement).toBe(sidebarToggle.parentElement);
     expect(chrome?.className).toContain("justify-between");
     expect(chromeFrame?.className).toContain("pr-1");
     expect(chromeFrame?.className).not.toContain("pr-3");
-    expect(chrome?.lastElementChild?.getAttribute("data-testid")).toBe(
-      "sidebar-update-button",
-    );
     expect(
       within(sidebarToggle).queryByTestId("collapsed-sidebar-update-badge"),
     ).toBeNull();
   });
 
-  it("shows ready updates in the far-right sidebar chrome slot", () => {
+  it("shows ready updates at the far edge of the expanded sidebar chrome row", () => {
     mocks.sidebarUpdateControl.status = "ready";
     mocks.sidebarUpdateControl.version = "1.0.34";
 
     render(<ClassicMainBody />);
 
-    expect(screen.getByTestId("sidebar-update-button")).toBeTruthy();
+    const sidebarToggle = screen.getByRole("button", { name: "Hide sidebar" });
+    const updateButton = screen.getByTestId("sidebar-update-button");
+    const chrome = sidebarToggle.parentElement?.parentElement;
+
+    expect(updateButton).toBeTruthy();
+    expect(updateButton.parentElement).toBe(chrome);
+    expect(updateButton.parentElement).not.toBe(sidebarToggle.parentElement);
   });
 
   it("shows an update badge on the collapsed sidebar toggle", () => {


### PR DESCRIPTION
Keep the desktop update action conditional while rendering it alongside the sidebar chrome icons. Update the sidebar chrome tests to assert the in-row placement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to desktop sidebar chrome layout expectations; no production logic in this diff.
> 
> **Overview**
> **Tightens `ClassicMainBody` tests** for where the desktop update control appears when the left sidebar is expanded.
> 
> Assertions no longer rely on the update button being the chrome row’s **last child**. They now require it to sit on the **same chrome row** as the sidebar controls but **outside** the grouped toggle/search/new-note cluster, with search and new note still ordered after each other in that group. The **available** and **ready** update cases both use this DOM placement check; test titles are renamed to describe the **far edge of the expanded sidebar chrome row**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d767a81fb2197a6c8de18375024e0babd0095482. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->