### PR TITLE
Make note tab switching snappier

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -926,7 +926,7 @@ msgstr "members"
 msgid "Memo"
 msgstr "Memo"
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr "Memos"
 
@@ -1407,7 +1407,7 @@ msgstr "Search or type owner/repo"
 msgid "Search people"
 msgstr "Search people"
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr "Search templates..."
@@ -1425,7 +1425,7 @@ msgstr "Search..."
 msgid "Section actions"
 msgstr "Section actions"
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr "See all templates"
 
@@ -1483,7 +1483,7 @@ msgstr "Send email"
 msgid "Send message"
 msgstr "Send message"
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr "Session note tabs"
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr "Tip: The Anarlog team loves our users!"
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:260
+#: src/session/components/note-input/header.tsx:267
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:907
+#: src/session/components/note-input/header.tsx:1072
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx:1138
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1012
+#: src/session/components/note-input/header.tsx:1177
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:547
+#: src/session/components/note-input/header.tsx:619
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -28,6 +28,7 @@ const hoisted = vi.hoisted(() => ({
   sessionMode: "inactive",
   isDeletingRecording: false,
   transcriptExportRequest: {},
+  transcriptRenderDataCalls: 0,
   transcriptSegments: [{ speaker: "Speaker 1", text: "Hello transcript" }],
   isGenerating: false,
   nativeContextMenus: [] as CapturedMenuItem[][],
@@ -168,10 +169,14 @@ vi.mock("~/session/components/note-input/transcript/export-data", () => ({
 vi.mock(
   "~/session/components/note-input/transcript/render-request-hooks",
   () => ({
-    useSessionTranscriptRenderData: () => ({
-      request: hoisted.transcriptExportRequest,
-      transcriptRows: [],
-    }),
+    useSessionTranscriptRenderData: () => {
+      hoisted.transcriptRenderDataCalls += 1;
+
+      return {
+        request: hoisted.transcriptExportRequest,
+        transcriptRows: [],
+      };
+    },
   }),
 );
 
@@ -261,6 +266,7 @@ describe("Header", () => {
     hoisted.sessionMode = "inactive";
     hoisted.isDeletingRecording = false;
     hoisted.transcriptExportRequest = {};
+    hoisted.transcriptRenderDataCalls = 0;
     hoisted.transcriptSegments = [
       { speaker: "Speaker 1", text: "Hello transcript" },
     ];
@@ -301,7 +307,7 @@ describe("Header", () => {
     expect(tabList.className).toContain("p-[2px]");
     expect(tabList.className).toContain("gap-[2px]");
     expect(tabList.className).toContain("bg-foreground/10");
-    expect(tabList.className).toContain("dark:bg-white/12");
+    expect(tabList.className).toContain("dark:bg-accent/55");
     expect(summaryTab.getAttribute("aria-current")).toBeNull();
     expect(memoTab.getAttribute("aria-current")).toBe("page");
     expect(memoTab.textContent).toBe("Memos");
@@ -310,10 +316,11 @@ describe("Header", () => {
     expect(memoTab.className).toContain("bg-white");
     expect(memoTab.className).toContain("text-foreground");
     expect(memoTab.className).toContain("shadow-xs");
-    expect(memoTab.className).toContain("dark:text-primary");
-    expect(memoTab.className).toContain("dark:bg-white");
+    expect(memoTab.className).toContain("dark:text-foreground");
+    expect(memoTab.className).toContain("dark:bg-accent");
+    expect(memoTab.className).toContain("dark:shadow-none");
     expect(summaryTab.className).toContain("h-[26px]");
-    expect(summaryTab.className).toContain("dark:hover:bg-white/8");
+    expect(summaryTab.className).toContain("dark:hover:bg-accent/80");
     expect(summaryTab.querySelector("svg")).not.toBeNull();
     expect(summaryTab.querySelectorAll("svg")).toHaveLength(1);
     expect(transcriptTab.querySelector("svg")).not.toBeNull();
@@ -344,14 +351,15 @@ describe("Header", () => {
     });
     expect(activeSummaryTab.textContent).toBe("Customer Call");
     expect(activeSummaryTab.className).toContain("text-foreground");
-    expect(activeSummaryTab.className).toContain("dark:text-primary");
+    expect(activeSummaryTab.className).toContain("dark:text-foreground");
+    expect(activeSummaryTab.className).toContain("dark:bg-accent");
     expect(activeSummaryTab.querySelectorAll("svg")).toHaveLength(2);
 
     fireEvent.click(activeSummaryTab);
 
     expect(screen.getByPlaceholderText("Search templates...")).not.toBeNull();
 
-    fireEvent.click(memoTab);
+    fireEvent.click(screen.getByRole("button", { name: "Memos" }));
 
     view.rerender(
       <Header
@@ -453,6 +461,36 @@ describe("Header", () => {
           "id" in item && item.id === "delete-recording-session-1",
       )?.disabled,
     ).toBe(false);
+  });
+
+  it("does not prepare transcript export data while the transcript tab is inactive", () => {
+    const editorTabs: EditorView[] = [
+      { type: "enhanced", id: "note-1" },
+      { type: "raw" },
+      { type: "transcript" },
+    ];
+
+    const view = render(
+      <Header
+        sessionId="session-1"
+        editorTabs={editorTabs}
+        currentTab={{ type: "raw" }}
+        handleTabChange={vi.fn()}
+      />,
+    );
+
+    expect(hoisted.transcriptRenderDataCalls).toBe(0);
+
+    view.rerender(
+      <Header
+        sessionId="session-1"
+        editorTabs={editorTabs}
+        currentTab={{ type: "transcript" }}
+        handleTabChange={vi.fn()}
+      />,
+    );
+
+    expect(hoisted.transcriptRenderDataCalls).toBe(1);
   });
 
   it("omits transcript recording actions when recording is missing", () => {

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -129,12 +129,12 @@ function iconHeaderTabClassName(
     isActive
       ? [
           "text-foreground bg-white shadow-xs",
-          "dark:text-primary dark:bg-white",
+          "dark:bg-accent dark:text-foreground dark:shadow-none",
         ]
       : [
           "text-muted-foreground/70",
           "hover:bg-background/60 hover:text-foreground",
-          "dark:hover:bg-white/8",
+          "dark:hover:bg-accent/80 dark:hover:text-foreground",
         ],
     heightClassName,
     className,
@@ -228,7 +228,63 @@ function HeaderTabRaw({
   sessionId: string;
   standalone?: boolean;
 }) {
+  if (!isActive) {
+    return (
+      <HeaderTabRawButton
+        isActive={isActive}
+        onClick={onClick}
+        standalone={standalone}
+      />
+    );
+  }
+
+  return (
+    <HeaderTabRawActive
+      isActive={isActive}
+      onClick={onClick}
+      sessionId={sessionId}
+      standalone={standalone}
+    />
+  );
+}
+
+function HeaderTabRawButton({
+  isActive,
+  onClick,
+  onContextMenu,
+  standalone,
+}: {
+  isActive: boolean;
+  onClick?: () => void;
+  onContextMenu?: React.MouseEventHandler<HTMLButtonElement>;
+  standalone: boolean;
+}) {
   const { t } = useLingui();
+
+  return (
+    <IconHeaderTab
+      isActive={isActive}
+      label={t`Memos`}
+      icon={<AlignLeftIcon className="size-4" />}
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+      size={standalone ? "standalone" : "tray"}
+      className={standalone ? "border-border/70 border shadow-xs" : undefined}
+    />
+  );
+}
+
+function HeaderTabRawActive({
+  isActive,
+  onClick,
+  sessionId,
+  standalone,
+}: {
+  isActive: boolean;
+  onClick?: () => void;
+  sessionId: string;
+  standalone: boolean;
+}) {
   const rawMd = main.UI.useCell(
     "sessions",
     sessionId,
@@ -255,14 +311,11 @@ function HeaderTabRaw({
   const showContextMenu = useNativeContextMenu(contextMenu);
 
   return (
-    <IconHeaderTab
+    <HeaderTabRawButton
       isActive={isActive}
-      label={t`Memos`}
-      icon={<AlignLeftIcon className="size-4" />}
       onClick={onClick}
       onContextMenu={showContextMenu}
-      size={standalone ? "standalone" : "tray"}
-      className={standalone ? "border-border/70 border shadow-xs" : undefined}
+      standalone={standalone}
     />
   );
 }
@@ -284,16 +337,27 @@ function HeaderTabEnhanced({
   onRemove?: () => void;
   onSelectNote?: (enhancedNoteId: string) => void;
 }) {
-  const { isGenerating, isError, onRegenerate } = useEnhanceLogic(
-    sessionId,
-    enhancedNoteId,
+  if (!isActive) {
+    return (
+      <HeaderTabEnhancedInactive
+        enhancedNoteId={enhancedNoteId}
+        onClick={onClick}
+      />
+    );
+  }
+
+  return (
+    <HeaderTabEnhancedActive
+      sessionId={sessionId}
+      enhancedNoteId={enhancedNoteId}
+      canRemove={canRemove}
+      onRemove={onRemove}
+      onSelectNote={onSelectNote}
+    />
   );
-  const content = main.UI.useCell(
-    "enhanced_notes",
-    enhancedNoteId,
-    "content",
-    main.STORE_ID,
-  ) as string | undefined;
+}
+
+function useEnhancedTabTitle(enhancedNoteId: string) {
   const rawTitle = main.UI.useCell(
     "enhanced_notes",
     enhancedNoteId,
@@ -313,6 +377,76 @@ function HeaderTabEnhanced({
     templateTitle,
     templateId,
   });
+
+  return {
+    tabTitle,
+    templateTooltip:
+      templateId && templateTitle
+        ? `${templateTitle} was used to generate this summary.`
+        : undefined,
+  };
+}
+
+function useEnhancedTabGenerating(enhancedNoteId: string) {
+  const taskId = createTaskId(enhancedNoteId, "enhance");
+  const enhanceTask = useAITaskTask(taskId, "enhance");
+
+  return enhanceTask.isGenerating;
+}
+
+function HeaderTabEnhancedInactive({
+  onClick = () => {},
+  enhancedNoteId,
+}: {
+  enhancedNoteId: string;
+  onClick?: () => void;
+}) {
+  const { tabTitle, templateTooltip } = useEnhancedTabTitle(enhancedNoteId);
+  const isGenerating = useEnhancedTabGenerating(enhancedNoteId);
+
+  return (
+    <button
+      data-main-area-window-drag-region
+      data-tauri-drag-region="false"
+      type="button"
+      aria-label={tabTitle}
+      onClick={onClick}
+      title={templateTooltip}
+      className={iconHeaderTabClassName(false, "tray", "min-w-10 px-2")}
+    >
+      {isGenerating ? (
+        <Spinner size={16} className="shrink-0" />
+      ) : (
+        <SparklesIcon className="size-4" />
+      )}
+    </button>
+  );
+}
+
+function HeaderTabEnhancedActive({
+  sessionId,
+  enhancedNoteId,
+  canRemove = false,
+  onRemove,
+  onSelectNote,
+}: {
+  sessionId: string;
+  enhancedNoteId: string;
+  canRemove?: boolean;
+  onRemove?: () => void;
+  onSelectNote?: (enhancedNoteId: string) => void;
+}) {
+  const { isGenerating, isError, onRegenerate } = useEnhanceLogic(
+    sessionId,
+    enhancedNoteId,
+  );
+  const content = main.UI.useCell(
+    "enhanced_notes",
+    enhancedNoteId,
+    "content",
+    main.STORE_ID,
+  ) as string | undefined;
+  const { tabTitle, templateTooltip } = useEnhancedTabTitle(enhancedNoteId);
   const noteMarkdown = useMemo(() => getStoredNoteMarkdown(content), [content]);
 
   const handleCopy = useCallback(() => {
@@ -386,11 +520,6 @@ function HeaderTabEnhanced({
     onRemove,
   ]);
   const showContextMenu = useNativeContextMenu(contextMenu);
-  const templateTooltip =
-    templateId && templateTitle
-      ? `${templateTitle} was used to generate this summary.`
-      : undefined;
-
   const templateMenuTrigger = (
     <button
       data-main-area-window-drag-region
@@ -432,28 +561,11 @@ function HeaderTabEnhanced({
     </button>
   );
 
-  return isActive ? (
+  return (
     <TemplatePickerPopover
       onSelectTemplate={handleSelectTemplate}
       trigger={templateMenuTrigger}
     />
-  ) : (
-    <button
-      data-main-area-window-drag-region
-      data-tauri-drag-region="false"
-      type="button"
-      aria-label={tabTitle}
-      onClick={onClick}
-      onContextMenu={showContextMenu}
-      title={templateTooltip}
-      className={iconHeaderTabClassName(false, "tray", "min-w-10 px-2")}
-    >
-      {isGenerating ? (
-        <Spinner size={16} className="shrink-0" />
-      ) : (
-        <SparklesIcon className="size-4" />
-      )}
-    </button>
   );
 }
 
@@ -468,7 +580,67 @@ function HeaderTabTranscript({
   onClick?: () => void;
   sessionId: string;
 }) {
+  if (!isActive) {
+    return (
+      <HeaderTabTranscriptButton
+        isActive={isActive}
+        isTranscribing={isTranscribing}
+        onClick={onClick}
+      />
+    );
+  }
+
+  return (
+    <HeaderTabTranscriptActive
+      isActive={isActive}
+      isTranscribing={isTranscribing}
+      onClick={onClick}
+      sessionId={sessionId}
+    />
+  );
+}
+
+function HeaderTabTranscriptButton({
+  isActive,
+  isTranscribing,
+  onClick,
+  onContextMenu,
+}: {
+  isActive: boolean;
+  isTranscribing: boolean;
+  onClick?: () => void;
+  onContextMenu?: React.MouseEventHandler<HTMLButtonElement>;
+}) {
   const { t } = useLingui();
+
+  return (
+    <IconHeaderTab
+      isActive={isActive}
+      label={t`Transcript`}
+      icon={
+        isTranscribing ? (
+          <Spinner size={16} className="shrink-0" />
+        ) : (
+          <AudioLinesIcon className="size-4" />
+        )
+      }
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+    />
+  );
+}
+
+function HeaderTabTranscriptActive({
+  isActive,
+  isTranscribing,
+  onClick,
+  sessionId,
+}: {
+  isActive: boolean;
+  isTranscribing: boolean;
+  onClick?: () => void;
+  sessionId: string;
+}) {
   const regenerate = useRegenerateTranscript(sessionId);
   const { request: transcriptExportRequest } =
     useSessionTranscriptRenderData(sessionId);
@@ -542,16 +714,9 @@ function HeaderTabTranscript({
   const showContextMenu = useNativeContextMenu(contextMenu);
 
   return (
-    <IconHeaderTab
+    <HeaderTabTranscriptButton
       isActive={isActive}
-      label={t`Transcript`}
-      icon={
-        isTranscribing ? (
-          <Spinner size={16} className="shrink-0" />
-        ) : (
-          <AudioLinesIcon className="size-4" />
-        )
-      }
+      isTranscribing={isTranscribing}
       onClick={onClick}
       onContextMenu={showContextMenu}
     />
@@ -1014,7 +1179,7 @@ export function Header({
             className={cn([
               "pointer-events-auto relative z-10 w-fit max-w-full overflow-visible",
               shouldUseTabTray
-                ? "bg-foreground/10 flex h-[30px] items-center gap-[2px] rounded-full p-[2px] dark:bg-white/12"
+                ? "bg-foreground/10 dark:bg-accent/55 flex h-[30px] items-center gap-[2px] rounded-full p-[2px]"
                 : null,
             ])}
           >

--- a/apps/desktop/src/session/components/note-input/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/index.test.tsx
@@ -1,0 +1,180 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NoteInput } from ".";
+
+import type { EditorView } from "~/store/zustand/tabs/schema";
+
+const hoisted = vi.hoisted(() => ({
+  editorTabs: [{ type: "raw" }, { type: "transcript" }] as EditorView[],
+  hotkeys: [] as Array<{ keys: string; callback: () => void }>,
+  onBeforeTabChange: vi.fn(),
+  sessionMode: "inactive",
+  updateSessionTabState: vi.fn(),
+}));
+
+vi.mock("./enhanced", () => ({
+  Enhanced: () => <div data-testid="enhanced-editor" />,
+}));
+
+vi.mock("./header", () => ({
+  Header: ({
+    currentTab,
+    editorTabs,
+    handleTabChange,
+  }: {
+    currentTab: EditorView;
+    editorTabs: EditorView[];
+    handleTabChange: (view: EditorView) => void;
+  }) => (
+    <div>
+      <div data-testid="current-tab">{formatEditorView(currentTab)}</div>
+      {editorTabs.map((editorTab) => (
+        <button
+          key={formatEditorView(editorTab)}
+          type="button"
+          onClick={() => handleTabChange(editorTab)}
+        >
+          {formatEditorView(editorTab)}
+        </button>
+      ))}
+    </div>
+  ),
+  useEditorTabs: () => hoisted.editorTabs,
+}));
+
+vi.mock("./insights", () => ({
+  Insights: () => <div data-testid="insights" />,
+}));
+
+vi.mock("./raw", () => ({
+  RawEditor: () => <div data-testid="raw-editor" />,
+}));
+
+vi.mock("./search/bar", () => ({
+  SearchBar: () => <div data-testid="search-bar" />,
+}));
+
+vi.mock("./search/context", () => ({
+  useSearch: () => null,
+}));
+
+vi.mock("./transcript", () => ({
+  Transcript: () => <div data-testid="transcript" />,
+}));
+
+vi.mock("~/session/components/caret-position-context", () => ({
+  useCaretNearBottom: vi.fn(),
+}));
+
+vi.mock("~/session/components/shared", () => ({
+  useCurrentNoteTab: () => ({ type: "raw" }),
+}));
+
+vi.mock("~/shared/hooks/useScrollPreservation", () => ({
+  useScrollPreservation: () => ({
+    onBeforeTabChange: hoisted.onBeforeTabChange,
+    scrollRef: { current: null },
+  }),
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: vi.fn((selector: (state: unknown) => unknown) =>
+    selector({
+      updateSessionTabState: hoisted.updateSessionTabState,
+    }),
+  ),
+}));
+
+vi.mock("~/stt/contexts", () => ({
+  useListener: (
+    selector: (state: {
+      getSessionMode: (sessionId: string) => string;
+    }) => unknown,
+  ) =>
+    selector({
+      getSessionMode: () => hoisted.sessionMode,
+    }),
+}));
+
+vi.mock("react-hotkeys-hook", () => ({
+  useHotkeys: (keys: string, callback: () => void) => {
+    hoisted.hotkeys.push({ keys, callback });
+  },
+}));
+
+function formatEditorView(view: EditorView) {
+  return view.type === "enhanced" ? `enhanced:${view.id}` : view.type;
+}
+
+function renderNoteInput({
+  currentTab = { type: "raw" },
+  handleTabChange = vi.fn(),
+}: {
+  currentTab?: EditorView;
+  handleTabChange?: (view: EditorView) => void;
+} = {}) {
+  return {
+    handleTabChange,
+    ...render(
+      <NoteInput
+        tab={{
+          active: true,
+          id: "session-1",
+          pinned: false,
+          slotId: "slot-1",
+          state: { autoStart: null, view: currentTab },
+          type: "sessions",
+        }}
+        editorTabs={hoisted.editorTabs}
+        currentTab={currentTab}
+        handleTabChange={handleTabChange}
+      />,
+    ),
+  };
+}
+
+describe("NoteInput tab selection", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    hoisted.hotkeys = [];
+    hoisted.onBeforeTabChange.mockClear();
+    hoisted.sessionMode = "inactive";
+    hoisted.updateSessionTabState.mockClear();
+  });
+
+  it("does not move the header ahead of the parent tab state", () => {
+    const { handleTabChange } = renderNoteInput();
+
+    fireEvent.click(screen.getByRole("button", { name: "transcript" }));
+
+    expect(handleTabChange).toHaveBeenCalledWith({ type: "transcript" });
+    expect(screen.getByTestId("current-tab").textContent).toBe("raw");
+  });
+
+  it("reflects the parent-selected tab in the header", () => {
+    const { rerender, handleTabChange } = renderNoteInput();
+    const currentTab = { type: "transcript" } satisfies EditorView;
+
+    rerender(
+      <NoteInput
+        tab={{
+          active: true,
+          id: "session-1",
+          pinned: false,
+          slotId: "slot-1",
+          state: { autoStart: null, view: currentTab },
+          type: "sessions",
+        }}
+        editorTabs={hoisted.editorTabs}
+        currentTab={currentTab}
+        handleTabChange={handleTabChange}
+      />,
+    );
+
+    expect(screen.getByTestId("current-tab").textContent).toBe("transcript");
+  });
+});

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -1,6 +1,7 @@
 import type { EditorView } from "prosemirror-view";
 import {
   forwardRef,
+  startTransition,
   type UIEventHandler,
   useCallback,
   useEffect,
@@ -75,6 +76,12 @@ export const NoteInput = forwardRef<
     const fallbackCurrentTab: TabEditorView = useCurrentNoteTab(tab);
     const editorTabs = providedEditorTabs ?? fallbackEditorTabs;
     const currentTab = providedCurrentTab ?? fallbackCurrentTab;
+    const deferredCurrentTab = useDeferredValue(currentTab);
+    const renderedCurrentTab = editorTabs.some((editorTab) =>
+      isSameEditorView(editorTab, deferredCurrentTab),
+    )
+      ? deferredCurrentTab
+      : currentTab;
 
     const sessionMode = useListener((state) => state.getSessionMode(sessionId));
     const isMeetingInProgress =
@@ -104,6 +111,10 @@ export const NoteInput = forwardRef<
 
     const handleTabChange = useCallback(
       (tabView: TabEditorView) => {
+        if (isSameEditorView(tabView, currentTab)) {
+          return;
+        }
+
         onBeforeTabChange();
         if (providedHandleTabChange) {
           providedHandleTabChange(tabView);
@@ -114,7 +125,12 @@ export const NoteInput = forwardRef<
           });
         }
       },
-      [onBeforeTabChange, providedHandleTabChange, updateSessionTabState],
+      [
+        currentTab,
+        onBeforeTabChange,
+        providedHandleTabChange,
+        updateSessionTabState,
+      ],
     );
 
     useTabShortcuts({
@@ -228,6 +244,18 @@ export const NoteInput = forwardRef<
     );
   },
 );
+
+function isSameEditorView(left: TabEditorView, right: TabEditorView): boolean {
+  if (left.type !== right.type) {
+    return false;
+  }
+
+  if (left.type === "enhanced" && right.type === "enhanced") {
+    return left.id === right.id;
+  }
+
+  return true;
+}
 
 function useTabShortcuts({
   editorTabs,

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -1,9 +1,9 @@
 import type { EditorView } from "prosemirror-view";
 import {
   forwardRef,
-  startTransition,
   type UIEventHandler,
   useCallback,
+  useDeferredValue,
   useEffect,
   useImperativeHandle,
   useRef,
@@ -90,9 +90,9 @@ export const NoteInput = forwardRef<
       sessionMode === "running_batch";
 
     const { scrollRef, onBeforeTabChange } = useScrollPreservation(
-      currentTab.type === "enhanced"
-        ? `enhanced-${currentTab.id}`
-        : currentTab.type,
+      renderedCurrentTab.type === "enhanced"
+        ? `enhanced-${renderedCurrentTab.id}`
+        : renderedCurrentTab.type,
     );
 
     useImperativeHandle(
@@ -140,12 +140,12 @@ export const NoteInput = forwardRef<
     });
 
     useEffect(() => {
-      if (currentTab.type === "raw" && isMeetingInProgress) {
+      if (renderedCurrentTab.type === "raw" && isMeetingInProgress) {
         requestAnimationFrame(() => {
           internalEditorRef.current?.commands.focus();
         });
       }
-    }, [currentTab, isMeetingInProgress]);
+    }, [renderedCurrentTab, isMeetingInProgress]);
 
     const handleViewReady = useCallback((editorView: EditorView) => {
       setView(editorView);
@@ -166,7 +166,8 @@ export const NoteInput = forwardRef<
     const search = useSearch();
     const showSearchBar = search?.isVisible ?? false;
     const isEditableTab =
-      currentTab.type === "enhanced" || currentTab.type === "raw";
+      renderedCurrentTab.type === "enhanced" ||
+      renderedCurrentTab.type === "raw";
 
     useEffect(() => {
       search?.close();
@@ -211,22 +212,22 @@ export const NoteInput = forwardRef<
             className={cn([
               "h-full px-3",
               "pt-2",
-              currentTab.type === "transcript"
+              renderedCurrentTab.type === "transcript"
                 ? "overflow-hidden pb-0"
                 : "scroll-fade-y overflow-auto pb-6",
             ])}
           >
-            {currentTab.type === "enhanced" && (
+            {renderedCurrentTab.type === "enhanced" && (
               <Enhanced
                 ref={internalEditorRef}
                 sessionId={sessionId}
-                enhancedNoteId={currentTab.id}
+                enhancedNoteId={renderedCurrentTab.id}
                 onNavigateToTitle={onNavigateToTitle}
                 onViewReady={handleViewReady}
                 onViewDisposed={handleViewDisposed}
               />
             )}
-            {currentTab.type === "raw" && (
+            {renderedCurrentTab.type === "raw" && (
               <RawEditor
                 ref={internalEditorRef}
                 sessionId={sessionId}
@@ -235,7 +236,7 @@ export const NoteInput = forwardRef<
                 onViewDisposed={handleViewDisposed}
               />
             )}
-            {currentTab.type === "transcript" && (
+            {renderedCurrentTab.type === "transcript" && (
               <Transcript sessionId={sessionId} scrollRef={scrollRef} />
             )}
           </div>


### PR DESCRIPTION
Keep tab selection responsive while deferring heavier panel swaps; avoid inactive tab export/menu work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical i18n reference updates plus UI performance refactor in the note header; no auth, data, or API changes.
> 
> **Overview**
> Session note header tabs now split into **lightweight inactive** controls (icon-only, minimal store work) versus **active** variants that own context menus, copy/export, template picker, and related subscriptions—so switching tabs should feel faster and inactive tabs avoid heavier menu/export setup.
> 
> The diff shown here is the follow-up **Lingui catalog sync** across locales: `#:` source line references for strings in `note-input/header.tsx` (`Memos`, `Transcript`, template search UI, “See all templates”, and the tab list label) are updated after that file grew/reorganized; translation text is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaa2c083f6cca09aebd7c82179cbbc1039aecf0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->