### PR TITLE
Smooth left sidebar resize

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   },
   onPanelLayout: null as null | ((sizes: number[]) => void),
   onResizeDragging: null as null | ((isDragging: boolean) => void),
+  tabContentRenderCount: 0,
 }));
 
 vi.mock("@hypr/ui/components/ui/resizable", () => ({
@@ -124,9 +125,10 @@ vi.mock("./shell-sidebar", () => ({
 }));
 
 vi.mock("./tab-content", () => ({
-  ClassicMainTabContent: ({ tab }: { tab: { type: string } }) => (
-    <div data-tab-type={tab.type} data-testid="tab-content" />
-  ),
+  ClassicMainTabContent: ({ tab }: { tab: { type: string } }) => {
+    mocks.tabContentRenderCount += 1;
+    return <div data-tab-type={tab.type} data-testid="tab-content" />;
+  },
 }));
 
 vi.mock("./update-banner", () => ({
@@ -177,6 +179,7 @@ describe("ClassicMainBody", () => {
     mocks.leftsidebar.toggleExpanded.mockClear();
     mocks.onPanelLayout = null;
     mocks.onResizeDragging = null;
+    mocks.tabContentRenderCount = 0;
   });
 
   it("wraps the expanded left sidebar in a persistent resizable panel", () => {
@@ -204,7 +207,7 @@ describe("ClassicMainBody", () => {
     expect(panels[0]?.dataset.defaultSize).toBe("12.5");
     expect(panels[0]?.dataset.minSize).toBe("12.5");
     expect(panels[0]?.dataset.maxSize).toBe("22.5");
-    expect(panels[0]?.dataset.flexGrow).toBe("12.5");
+    expect(panels[0]?.dataset.flexGrow).toBe("var(--left-sidebar-panel-size)");
     expect(panels[0]?.dataset.minWidth).toBe("200");
     expect(panels[0]?.dataset.maxWidth).toBe("360");
     expect(panels[0]?.dataset.transition).toContain("flex-grow");
@@ -220,16 +223,86 @@ describe("ClassicMainBody", () => {
 
     expect(sidebarContent?.className).toContain("translate-x-0");
     expect(sidebarContent?.getAttribute("aria-hidden")).toBe("false");
-    expect(sidebarChrome?.style.width).toBe("12.5%");
+    expect(sidebarChrome?.style.width).toBe("var(--left-sidebar-panel-width)");
     expect(sidebarChrome?.style.minWidth).toBe("200px");
     expect(sidebarChrome?.style.maxWidth).toBe("360px");
     expect(sidebarChrome?.className).not.toContain("w-[200px]");
+
+    const bodyRoot = screen.getByTestId("panel-group").parentElement;
+    expect(bodyRoot?.getAttribute("style")).toContain(
+      "--left-sidebar-panel-size: 12.5",
+    );
 
     act(() => {
       mocks.onPanelLayout?.([24, 76]);
     });
 
-    expect(sidebarChrome?.style.width).toBe("24%");
+    expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-size")).toBe(
+      "24",
+    );
+    expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-width")).toBe(
+      "24%",
+    );
+  });
+
+  it("updates sidebar sizing during drag without rerendering tab content", () => {
+    render(<ClassicMainBody />);
+
+    const bodyRoot = screen.getByTestId("panel-group").parentElement;
+
+    act(() => {
+      mocks.onResizeDragging?.(true);
+    });
+
+    const renderCountAfterDragStart = mocks.tabContentRenderCount;
+
+    act(() => {
+      mocks.onPanelLayout?.([14, 86]);
+      mocks.onPanelLayout?.([16, 84]);
+      mocks.onPanelLayout?.([18, 82]);
+    });
+
+    expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-size")).toBe(
+      "18",
+    );
+    expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-width")).toBe(
+      "18%",
+    );
+    expect(mocks.tabContentRenderCount).toBe(renderCountAfterDragStart);
+
+    act(() => {
+      mocks.onResizeDragging?.(false);
+    });
+
+    expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-size")).toBe(
+      "18",
+    );
+  });
+
+  it("keeps near-equal sidebar size commits in sync with drag-time CSS variables", () => {
+    render(<ClassicMainBody />);
+
+    const bodyRoot = screen.getByTestId("panel-group").parentElement;
+
+    act(() => {
+      mocks.onResizeDragging?.(true);
+      mocks.onPanelLayout?.([12.505, 87.495]);
+    });
+
+    expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-size")).toBe(
+      "12.505",
+    );
+
+    act(() => {
+      mocks.onResizeDragging?.(false);
+    });
+
+    expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-size")).toBe(
+      "12.505",
+    );
+    expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-width")).toBe(
+      "12.505%",
+    );
   });
 
   it("keeps the note content panel at least 500px wide", () => {

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -61,6 +61,10 @@ type MainAreaWindowDragStart = {
   clientY: number;
   dragging: boolean;
 };
+type LeftSidebarSizeStyle = CSSProperties & {
+  "--left-sidebar-panel-size": string;
+  "--left-sidebar-panel-width": string;
+};
 
 export function ClassicMainBody() {
   const { leftsidebar } = useShell();
@@ -72,6 +76,9 @@ export function ClassicMainBody() {
   const [leftSidebarPanelSize, setLeftSidebarPanelSize] = useState(
     leftSidebarPanelConstraints.defaultSize,
   );
+  const bodyRootRef = useRef<HTMLDivElement>(null);
+  const leftSidebarPanelSizeRef = useRef(leftSidebarPanelSize);
+  const leftSidebarResizeDraggingRef = useRef(false);
 
   const isOnboarding = currentTab?.type === "onboarding";
   const isChangelog = currentTab?.type === "changelog";
@@ -106,6 +113,18 @@ export function ClassicMainBody() {
   const handleOpenNoteDialog = useCallback(() => {
     openNoteDialog.open();
   }, [openNoteDialog]);
+  const applyLeftSidebarPanelSize = useCallback((size: number) => {
+    const bodyRoot = bodyRootRef.current;
+    if (!bodyRoot) {
+      return;
+    }
+
+    bodyRoot.style.setProperty("--left-sidebar-panel-size", `${size}`);
+    bodyRoot.style.setProperty("--left-sidebar-panel-width", `${size}%`);
+  }, []);
+  const commitLeftSidebarPanelSize = useCallback((size: number) => {
+    setLeftSidebarPanelSize(size);
+  }, []);
   const handlePanelLayout = useCallback(
     (sizes: number[]) => {
       if (!showLeftSidebarPanel) {
@@ -114,18 +133,37 @@ export function ClassicMainBody() {
 
       const sidebarSize = sizes[0];
       if (typeof sidebarSize === "number") {
-        setLeftSidebarPanelSize(sidebarSize);
+        leftSidebarPanelSizeRef.current = sidebarSize;
+        applyLeftSidebarPanelSize(sidebarSize);
+
+        if (!leftSidebarResizeDraggingRef.current) {
+          commitLeftSidebarPanelSize(sidebarSize);
+        }
       }
     },
-    [showLeftSidebarPanel],
+    [
+      applyLeftSidebarPanelSize,
+      commitLeftSidebarPanelSize,
+      showLeftSidebarPanel,
+    ],
   );
-  const handleLeftSidebarResizeDragging = useCallback((isDragging: boolean) => {
-    setLeftSidebarResizing(isDragging);
-  }, []);
+  const handleLeftSidebarResizeDragging = useCallback(
+    (isDragging: boolean) => {
+      leftSidebarResizeDraggingRef.current = isDragging;
+      setLeftSidebarResizing(isDragging);
+
+      if (!isDragging) {
+        commitLeftSidebarPanelSize(leftSidebarPanelSizeRef.current);
+      }
+    },
+    [commitLeftSidebarPanelSize],
+  );
   const handleToggleLeftSidebar = useCallback(() => {
+    leftSidebarResizeDraggingRef.current = false;
     setLeftSidebarResizing(false);
+    commitLeftSidebarPanelSize(leftSidebarPanelSizeRef.current);
     leftsidebar.toggleExpanded();
-  }, [leftsidebar.toggleExpanded]);
+  }, [commitLeftSidebarPanelSize, leftsidebar.toggleExpanded]);
   const handleLeftSidebarChromeWheel = useCallback(
     (event: WheelEvent<HTMLDivElement>) => {
       if (!showSidebarTimeline) {
@@ -144,16 +182,16 @@ export function ClassicMainBody() {
   const leftSidebarChromeStyle = useMemo(
     () =>
       ({
-        width: `${leftSidebarPanelSize}%`,
+        width: "var(--left-sidebar-panel-width)",
         minWidth: LEFT_SIDEBAR_MIN_WIDTH_PX,
         maxWidth: LEFT_SIDEBAR_MAX_WIDTH_PX,
       }) satisfies CSSProperties,
-    [leftSidebarPanelSize],
+    [],
   );
   const leftSidebarPanelStyle = useMemo(
     () =>
       ({
-        flexGrow: leftsidebar.expanded ? leftSidebarPanelSize : 0,
+        flexGrow: leftsidebar.expanded ? "var(--left-sidebar-panel-size)" : 0,
         maxWidth: leftsidebar.expanded ? LEFT_SIDEBAR_MAX_WIDTH_PX : 0,
         minWidth: leftsidebar.expanded ? LEFT_SIDEBAR_MIN_WIDTH_PX : 0,
         transition:
@@ -165,11 +203,22 @@ export function ClassicMainBody() {
                 "min-width 180ms ease-out",
               ].join(", "),
       }) satisfies CSSProperties,
-    [leftSidebarPanelSize, leftSidebarResizing, leftsidebar.expanded],
+    [leftSidebarResizing, leftsidebar.expanded],
   );
+  const renderedLeftSidebarPanelSize = leftSidebarResizeDraggingRef.current
+    ? leftSidebarPanelSizeRef.current
+    : leftSidebarPanelSize;
+  const leftSidebarSizeStyle = {
+    "--left-sidebar-panel-size": `${renderedLeftSidebarPanelSize}`,
+    "--left-sidebar-panel-width": `${renderedLeftSidebarPanelSize}%`,
+  } as LeftSidebarSizeStyle;
 
   return (
-    <div className="relative flex h-full min-w-0 flex-1 flex-col">
+    <div
+      ref={bodyRootRef}
+      style={leftSidebarSizeStyle}
+      className="relative flex h-full min-w-0 flex-1 flex-col"
+    >
       {isOnboarding ? null : showSidebarTimelineChrome ? (
         <div
           data-tauri-drag-region


### PR DESCRIPTION
Route live sidebar resize dimensions through CSS variables so drag ticks do not rerender the active tab.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop main-layout resize behavior with added regression tests; no auth, data, or API changes.
> 
> **Overview**
> Left sidebar resize no longer triggers React state updates on every layout tick while dragging, so the active tab content should not rerender during resize.
> 
> **`ClassicMainBody`** now sets `--left-sidebar-panel-size` and `--left-sidebar-panel-width` on the body root (and updates them imperatively during drag). Panel `flexGrow` and sidebar chrome width read those variables instead of inline percentages from state. React state for sidebar size is committed only when the user is not dragging or when the resize handle reports drag end; toggling the sidebar also flushes the latest size from a ref.
> 
> Tests assert the new variable-based styling and add coverage that repeated `onPanelLayout` calls during an active drag update CSS without increasing `ClassicMainTabContent` render count, including fractional sizes like `12.505`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fddf09c9ed36c59731b21418e1725f8a53f16e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->