### PR TITLE
Make dark upgrade chip white

### DIFF
--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -629,7 +629,7 @@ function ModelSelectItem({
             "opacity-0 group-hover:opacity-100",
             "transition-all duration-150",
             isCloud
-              ? "bg-primary text-primary-foreground hover:bg-primary/90 py-1 shadow-xs hover:shadow-md"
+              ? "bg-primary text-primary-foreground hover:bg-primary/90 py-1 shadow-xs hover:shadow-md dark:!bg-white dark:!text-black dark:hover:!bg-white/90"
               : "from-muted to-accent text-foreground bg-linear-to-t py-0.5 shadow-xs hover:shadow-md",
           ])}
           onClick={handleAction}


### PR DESCRIPTION
Updates the disabled cloud model action so the upgrade chip uses a white background with black text in dark mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic className-only change on a settings button with no logic, auth, or data impact.
> 
> **Overview**
> The hover **Upgrade to use** chip for locked cloud STT models now forces a **white background and black text** in dark mode (`dark:!bg-white`, `dark:!text-black`, with a slightly dimmed hover), instead of inheriting the primary theme colors that were hard to read on dark UI.
> 
> Change is limited to the cloud-model action button in `select.tsx`; download styling for local models is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe259f3fe275b1b9c5948b533769aebb23d88d54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->