### PR TITLE
Keep STT actions on row hover state

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -238,7 +238,7 @@ msgstr "Back"
 msgid "Base URL"
 msgstr "Base URL"
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr "Batch"
 
@@ -543,7 +543,7 @@ msgstr "Don't save"
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr "Don't show notifications when Do-Not-Disturb is enabled on your system"
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr "Download"
 
@@ -1250,7 +1250,7 @@ msgstr "Pro trial"
 msgid "Ready to go"
 msgstr "Ready to go"
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr "Realtime"
 
@@ -1839,7 +1839,7 @@ msgstr "Upgrade to Pro for {0}"
 msgid "Upgrade to Pro to use this provider."
 msgstr "Upgrade to Pro to use this provider."
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr "Upgrade to use"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Batch"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Download"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:676
+#: src/settings/ai/stt/select.tsx:677
 msgid "Realtime"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:639
+#: src/settings/ai/stt/select.tsx:640
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -576,6 +576,7 @@ function ModelSelectItem({
           key={model.id}
           value={model.id}
           className={cn([
+            "group-hover/model-row:bg-accent group-hover/model-row:text-accent-foreground",
             showLocalActions && "pr-20",
             isDeprecated && "text-muted-foreground focus:text-muted-foreground",
           ])}
@@ -717,7 +718,6 @@ function LocalModelDropdownActions({ model }: { model: LocalModel }) {
     <div
       className={cn([
         "absolute top-0 right-0 bottom-0 z-10 flex items-center justify-end gap-1 rounded-r-full pl-6",
-        "via-accent/95 to-accent bg-linear-to-r from-transparent",
         "pointer-events-none opacity-0 transition-opacity duration-150",
         "group-hover/model-row:pointer-events-auto group-hover/model-row:opacity-100",
         "group-focus-within/model-row:pointer-events-auto group-focus-within/model-row:opacity-100",


### PR DESCRIPTION
Removes the separate action overlay background and keeps downloaded model rows highlighted while hovering the Finder and delete icons.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic hover/layout change in AI STT settings plus automatic i18n reference updates; no auth, data, or transcription logic.
> 
> **Overview**
> **Downloaded local STT models** in the settings picker no longer use a separate background on the action strip. Finder and delete controls still appear on row hover, but the **whole row** keeps the same accent highlight via a `group/model-row` hover on the `SelectItem`, so the UI does not flash or look like a second panel over the row.
> 
> The diff in this PR is almost entirely **Lingui catalog updates** (`messages.po` across locales): source line references for strings in `stt/select.tsx` (e.g. Download, Batch, Realtime, Upgrade to use) shift by one line after the layout/class changes in that file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb26851d9cecb9719c1abc8a0e7c27a6798ce932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->