### PR TITLE
Unclamp selected STT model value

### DIFF
--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -229,7 +229,7 @@ export function SelectProviderAndModel() {
               <SelectTrigger
                 className={cn([
                   "bg-card text-left shadow-none focus:ring-0",
-                  "[&>span]:flex [&>span]:w-full [&>span]:items-center [&>span]:justify-between [&>span]:gap-2",
+                  "[&>span]:!flex [&>span]:w-full [&>span]:min-w-0 [&>span]:items-center [&>span]:justify-start [&>span]:gap-2 [&>span]:overflow-visible [&>span]:[-webkit-line-clamp:unset]",
                   isConfigured && "[&>svg:last-child]:hidden",
                 ])}
               >
@@ -645,11 +645,11 @@ function ModelSelectedValue({ model }: { model: ModelEntry }) {
   const isDeprecated = model.isDeprecated === true;
 
   return (
-    <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
+    <div className="flex max-w-full min-w-0 items-center gap-2">
       <LocalModelLabel
         model={model.id}
         label={model.displayName ?? displayModelId(model.id)}
-        className={cn(["min-w-0 flex-1", isDeprecated && "opacity-60"])}
+        className={cn(["min-w-0", isDeprecated && "opacity-60"])}
         labelClassName={cn([isDeprecated && "text-muted-foreground"])}
       />
       <ModelModeBadge mode={model.mode} />


### PR DESCRIPTION
Overrides the shared select value line clamp so the selected on-device label can use the available trigger width.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes in the STT settings select; no transcription, auth, or data logic.
> 
> **Overview**
> Fixes **truncated on-device STT model names** in the settings “Model being used” dropdown by overriding the shared `SelectTrigger` `[&>span]:line-clamp-1` styling on that control only.
> 
> The STT model trigger now forces the value `span` to **flex left-aligned** with `min-w-0`, visible overflow, and `-webkit-line-clamp: unset`, and **`ModelSelectedValue`** drops `justify-between` / `flex-1` so the label and mode badge share width without squeezing the name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4dfc170342b0616eaa62ce961c0cfd1b4a427a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->