### PR TITLE
Round STT row action overlay

### DIFF
--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -569,7 +569,7 @@ function ModelSelectItem({
 
   if (model.isDownloaded) {
     return (
-      <div className="group/model-row relative">
+      <div className="group/model-row relative overflow-hidden rounded-full">
         <SelectItem
           key={model.id}
           value={model.id}
@@ -714,7 +714,7 @@ function LocalModelDropdownActions({ model }: { model: LocalModel }) {
   return (
     <div
       className={cn([
-        "absolute top-0 right-1 bottom-0 z-10 flex items-center justify-end gap-1 pl-6",
+        "absolute top-0 right-0 bottom-0 z-10 flex items-center justify-end gap-1 rounded-r-full pl-6",
         "via-accent/95 to-accent bg-linear-to-r from-transparent",
         "pointer-events-none opacity-0 transition-opacity duration-150",
         "group-hover/model-row:pointer-events-auto group-hover/model-row:opacity-100",


### PR DESCRIPTION
Clips downloaded model rows to the pill shape and rounds the right-side action overlay so hover actions do not leave a square edge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes to STT model dropdown row styling with no behavior or data handling impact.
> 
> **Overview**
> Downloaded on-device STT model rows in the settings model dropdown now use **`overflow-hidden rounded-full`** on the row wrapper so row content (including the hover action strip) is clipped to the same pill shape as other select items.
> 
> The **`LocalModelDropdownActions`** overlay is nudged flush to the right (`right-0` instead of `right-1`) and gets **`rounded-r-full`** so the gradient action area no longer shows a square corner when Show in Finder / Delete appear on hover or focus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360231d748fa015a75256398a7ffe1d7f755e1cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->