### PR TITLE
Hide empty live transcript tab

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -926,7 +926,7 @@ msgstr "members"
 msgid "Memo"
 msgstr "Memo"
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr "Memos"
 
@@ -1407,7 +1407,7 @@ msgstr "Search or type owner/repo"
 msgid "Search people"
 msgstr "Search people"
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr "Search templates..."
@@ -1425,7 +1425,7 @@ msgstr "Search..."
 msgid "Section actions"
 msgstr "Section actions"
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr "See all templates"
 
@@ -1483,7 +1483,7 @@ msgstr "Send email"
 msgid "Send message"
 msgstr "Send message"
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr "Session note tabs"
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr "Tip: The Anarlog team loves our users!"
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:267
+#: src/session/components/note-input/header.tsx:266
 msgid "Memos"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1072
+#: src/session/components/note-input/header.tsx:1071
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1138
+#: src/session/components/note-input/header.tsx:1137
 msgid "See all templates"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1177
+#: src/session/components/note-input/header.tsx:1176
 msgid "Session note tabs"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
 #: src/session/components/bottom-accessory/index.tsx:152
-#: src/session/components/note-input/header.tsx:619
+#: src/session/components/note-input/header.tsx:618
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/session/components/compute-note-tab.ts
+++ b/apps/desktop/src/session/components/compute-note-tab.ts
@@ -7,7 +7,10 @@ export function computeCurrentNoteTab(
   canShowTranscript = false,
 ): EditorView {
   if (isLiveSessionActive) {
-    if (tabView?.type === "raw" || tabView?.type === "transcript") {
+    if (tabView?.type === "raw") {
+      return tabView;
+    }
+    if (tabView?.type === "transcript" && canShowTranscript) {
       return tabView;
     }
     if (tabView?.type === "enhanced" && firstEnhancedNoteId) {

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -25,6 +25,8 @@ const hoisted = vi.hoisted(() => ({
   activeTemplateTitle: "Customer Call",
   audioExists: true,
   hasTranscript: true,
+  liveSegments: [] as unknown[],
+  liveSessionId: null as string | null,
   sessionMode: "inactive",
   isDeletingRecording: false,
   transcriptExportRequest: {},
@@ -141,6 +143,16 @@ vi.mock("~/session/enhance-config", () => ({
 
 vi.mock("~/session/components/shared", () => ({
   useHasTranscript: () => hoisted.hasTranscript,
+  useCanShowTranscript: (
+    sessionId: string,
+    { audioExists = false }: { audioExists?: boolean } = {},
+  ) =>
+    hoisted.hasTranscript ||
+    (audioExists &&
+      hoisted.sessionMode !== "active" &&
+      hoisted.sessionMode !== "finalizing") ||
+    (hoisted.liveSessionId === sessionId && hoisted.liveSegments.length > 0) ||
+    hoisted.sessionMode === "running_batch",
 }));
 
 vi.mock("~/session/hooks/useEnhancedNotes", () => ({
@@ -238,9 +250,23 @@ vi.mock("~/stt/contexts", () => ({
   useListener: (
     selector: (state: {
       batch: Record<string, unknown>;
+      live: {
+        sessionId: string | null;
+        finalizingBySession: Record<string, unknown>;
+      };
+      liveSegments: unknown[];
       getSessionMode: () => string;
     }) => unknown,
-  ) => selector({ batch: {}, getSessionMode: () => hoisted.sessionMode }),
+  ) =>
+    selector({
+      batch: {},
+      live: {
+        sessionId: hoisted.liveSessionId,
+        finalizingBySession: {},
+      },
+      liveSegments: hoisted.liveSegments,
+      getSessionMode: () => hoisted.sessionMode,
+    }),
 }));
 
 vi.mock("~/templates", () => ({
@@ -263,6 +289,8 @@ describe("Header", () => {
     hoisted.activeTemplateTitle = "Customer Call";
     hoisted.audioExists = true;
     hoisted.hasTranscript = true;
+    hoisted.liveSegments = [];
+    hoisted.liveSessionId = null;
     hoisted.sessionMode = "inactive";
     hoisted.isDeletingRecording = false;
     hoisted.transcriptExportRequest = {};
@@ -612,6 +640,38 @@ describe("Header", () => {
 
     const { result } = renderHook(() =>
       useEditorTabs({ sessionId: "session-1", audioExists: true }),
+    );
+
+    expect(result.current).toEqual([
+      { type: "enhanced", id: "note-1" },
+      { type: "raw" },
+      { type: "transcript" },
+    ]);
+  });
+
+  it("omits the transcript tab for active meetings without transcript evidence", () => {
+    hoisted.hasTranscript = false;
+    hoisted.sessionMode = "active";
+    hoisted.liveSessionId = "session-1";
+
+    const { result } = renderHook(() =>
+      useEditorTabs({ sessionId: "session-1", audioExists: true }),
+    );
+
+    expect(result.current).toEqual([
+      { type: "enhanced", id: "note-1" },
+      { type: "raw" },
+    ]);
+  });
+
+  it("includes the transcript tab for active meetings with live segments", () => {
+    hoisted.hasTranscript = false;
+    hoisted.liveSegments = [{ id: "segment-1" }];
+    hoisted.liveSessionId = "session-1";
+    hoisted.sessionMode = "active";
+
+    const { result } = renderHook(() =>
+      useEditorTabs({ sessionId: "session-1", audioExists: false }),
     );
 
     expect(result.current).toEqual([

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -34,7 +34,7 @@ import {
   formatTranscriptExportSegments,
 } from "~/session/components/note-input/transcript/export-data";
 import { useSessionTranscriptRenderData } from "~/session/components/note-input/transcript/render-request-hooks";
-import { useHasTranscript } from "~/session/components/shared";
+import { useCanShowTranscript } from "~/session/components/shared";
 import { shouldShowEmptySummaryConfigError } from "~/session/enhance-config";
 import { useEnsureDefaultSummary } from "~/session/hooks/useEnhancedNotes";
 import {
@@ -46,7 +46,6 @@ import * as main from "~/store/tinybase/store/main";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { type EditorView } from "~/store/zustand/tabs/schema";
-import { useListener } from "~/stt/contexts";
 import {
   filterWebTemplatesAgainstUserTemplates,
   parseWebTemplates,
@@ -1260,16 +1259,7 @@ export function useEditorTabs({
   sessionId: string;
 }): EditorView[] {
   useEnsureDefaultSummary(sessionId);
-  const hasTranscript = useHasTranscript(sessionId);
-  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
-  const batchError = useListener((state) => state.batch[sessionId]?.error);
-  const canShowTranscript =
-    hasTranscript ||
-    audioExists ||
-    sessionMode === "active" ||
-    sessionMode === "finalizing" ||
-    sessionMode === "running_batch" ||
-    Boolean(batchError);
+  const canShowTranscript = useCanShowTranscript(sessionId, { audioExists });
 
   const enhancedNoteIds = main.UI.useSliceRowIds(
     main.INDEXES.enhancedNotesBySession,

--- a/apps/desktop/src/session/components/shared.test.ts
+++ b/apps/desktop/src/session/components/shared.test.ts
@@ -2,14 +2,21 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { computeCurrentNoteTab } from "./compute-note-tab";
-import { hasStoredNoteContent, useCurrentNoteTab } from "./shared";
+import {
+  hasStoredNoteContent,
+  useCanShowTranscript,
+  useCurrentNoteTab,
+} from "./shared";
 
 import type { Tab } from "~/store/zustand/tabs/schema";
 
 const hoisted = vi.hoisted(() => ({
   batchError: null as string | null,
   enhancedNoteIds: ["note-1"] as string[],
+  finalizingBySession: {} as Record<string, unknown>,
   hasTranscript: false,
+  liveSegments: [] as unknown[],
+  liveSessionId: null as string | null,
   sessionMode: "inactive",
 }));
 
@@ -17,11 +24,21 @@ vi.mock("~/stt/contexts", () => ({
   useListener: (
     selector: (state: {
       batch: Record<string, { error: string | null } | undefined>;
+      live: {
+        sessionId: string | null;
+        finalizingBySession: Record<string, unknown>;
+      };
+      liveSegments: unknown[];
       getSessionMode: () => string;
     }) => unknown,
   ) =>
     selector({
       batch: { "session-1": { error: hoisted.batchError } },
+      live: {
+        sessionId: hoisted.liveSessionId,
+        finalizingBySession: hoisted.finalizingBySession,
+      },
+      liveSegments: hoisted.liveSegments,
       getSessionMode: () => hoisted.sessionMode,
     }),
 }));
@@ -65,7 +82,10 @@ describe("useCurrentNoteTab", () => {
   beforeEach(() => {
     hoisted.batchError = null;
     hoisted.enhancedNoteIds = ["note-1"];
+    hoisted.finalizingBySession = {};
     hoisted.hasTranscript = false;
+    hoisted.liveSegments = [];
+    hoisted.liveSessionId = null;
     hoisted.sessionMode = "inactive";
   });
 
@@ -81,6 +101,57 @@ describe("useCurrentNoteTab", () => {
     const { result } = renderHook(() => useCurrentNoteTab(tab));
 
     expect(result.current).toEqual({ type: "raw" });
+  });
+
+  it("normalizes active transcript view when no transcript evidence exists", () => {
+    hoisted.sessionMode = "active";
+    hoisted.liveSessionId = "session-1";
+
+    const { result } = renderHook(() => useCurrentNoteTab(tab));
+
+    expect(result.current).toEqual({ type: "raw" });
+  });
+
+  it("normalizes active transcript view when only in-progress audio exists", () => {
+    hoisted.sessionMode = "active";
+    hoisted.liveSessionId = "session-1";
+
+    const { result } = renderHook(() =>
+      useCurrentNoteTab(tab, { audioExists: true }),
+    );
+
+    expect(result.current).toEqual({ type: "raw" });
+  });
+});
+
+describe("useCanShowTranscript", () => {
+  beforeEach(() => {
+    hoisted.batchError = null;
+    hoisted.finalizingBySession = {};
+    hoisted.hasTranscript = false;
+    hoisted.liveSegments = [];
+    hoisted.liveSessionId = null;
+    hoisted.sessionMode = "inactive";
+  });
+
+  it("shows transcript evidence for live segments owned by the session", () => {
+    hoisted.liveSessionId = "session-1";
+    hoisted.liveSegments = [{ id: "segment-1" }];
+
+    const { result } = renderHook(() => useCanShowTranscript("session-1"));
+
+    expect(result.current).toBe(true);
+  });
+
+  it("ignores live segments from another active session while finalizing", () => {
+    hoisted.finalizingBySession = { "session-1": { startedAt: 1 } };
+    hoisted.liveSessionId = "session-2";
+    hoisted.liveSegments = [{ id: "segment-1" }];
+    hoisted.sessionMode = "finalizing";
+
+    const { result } = renderHook(() => useCanShowTranscript("session-1"));
+
+    expect(result.current).toBe(false);
   });
 });
 
@@ -132,14 +203,24 @@ describe("computeCurrentNoteTab", () => {
       expect(result).toEqual({ type: "raw" });
     });
 
-    it("preserves transcript view", () => {
+    it("preserves transcript view when transcript can show", () => {
+      const result = computeCurrentNoteTab(
+        { type: "transcript" },
+        true,
+        "note-1",
+        true,
+      );
+      expect(result).toEqual({ type: "transcript" });
+    });
+
+    it("normalizes transcript view when transcript cannot show", () => {
       const result = computeCurrentNoteTab(
         { type: "transcript" },
         true,
         "note-1",
         false,
       );
-      expect(result).toEqual({ type: "transcript" });
+      expect(result).toEqual({ type: "raw" });
     });
 
     it("returns raw view when no persisted view", () => {

--- a/apps/desktop/src/session/components/shared.tsx
+++ b/apps/desktop/src/session/components/shared.tsx
@@ -69,15 +69,7 @@ export function useCurrentNoteTab(
 ): EditorView {
   const sessionMode = useListener((state) => state.getSessionMode(tab.id));
   const isLiveSessionActive = sessionMode === "active";
-  const batchError = useListener((state) => state.batch[tab.id]?.error ?? null);
-  const hasTranscript = useHasTranscript(tab.id);
-  const canShowTranscript =
-    hasTranscript ||
-    audioExists ||
-    sessionMode === "active" ||
-    sessionMode === "finalizing" ||
-    sessionMode === "running_batch" ||
-    Boolean(batchError);
+  const canShowTranscript = useCanShowTranscript(tab.id, { audioExists });
 
   const enhancedNoteIds = main.UI.useSliceRowIds(
     main.INDEXES.enhancedNotesBySession,
@@ -100,6 +92,29 @@ export function useCurrentNoteTab(
       firstEnhancedNoteId,
       canShowTranscript,
     ],
+  );
+}
+
+export function useCanShowTranscript(
+  sessionId: string,
+  { audioExists = false }: { audioExists?: boolean } = {},
+): boolean {
+  const hasTranscript = useHasTranscript(sessionId);
+  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
+  const batchError = useListener((state) => state.batch[sessionId]?.error);
+  const isLiveCapture =
+    sessionMode === "active" || sessionMode === "finalizing";
+  const hasLiveSegments = useListener(
+    (state) =>
+      state.live.sessionId === sessionId && state.liveSegments.length > 0,
+  );
+
+  return (
+    hasTranscript ||
+    (audioExists && !isLiveCapture) ||
+    hasLiveSegments ||
+    sessionMode === "running_batch" ||
+    Boolean(batchError)
   );
 }
 


### PR DESCRIPTION
Only show the transcript tab when transcript/audio/live/batch evidence exists and add active-meeting regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only tab gating in the session note header; wrong conditions could hide the tab during live capture or leave users on a removed transcript view.
> 
> **Overview**
> Hides the session **Transcript** note tab until there is something to show, instead of exposing it as soon as recording starts or audio exists.
> 
> **Tab visibility** now goes through `useCanShowTranscript` and is wired into `useEditorTabs` / `computeCurrentNoteTab`. During **active** or **finalizing** meetings, **audio alone** no longer qualifies; the tab appears when there is stored transcript content, **live segments** for that session, or **batch** transcription is in progress (and the prior rules still apply outside live capture).
> 
> **Tests** in `header.test.tsx` and `shared.test.tsx` cover active meetings with and without transcript evidence.
> 
> The PR diff also refreshes **i18n** `.po` source line references for strings in `note-input/header.tsx` after that file shifted by a line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7879a91ce475b7dfcb0d58fd77e30f95417e5e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->