### PR TITLE
Add desktop 1.1.2 changelog

### DIFF
--- a/packages/changelog/content/1.1.2.md
+++ b/packages/changelog/content/1.1.2.md
@@ -1,0 +1,23 @@
+---
+date: "2026-06-25"
+summary: "Anarlog now switches note tabs faster, keeps transcript tabs relevant, smooths sidebar resizing, and polishes speech-to-text settings."
+---
+
+## Notes
+
+- Switching between Memo, Summary, and Transcript tabs now feels snappier and avoids unnecessary editor work
+- Live meeting notes no longer show an empty Transcript tab before transcript content is available
+- Note tab colors and tray styling are steadier in dark mode
+
+## Sidebar
+
+- Resizing the left sidebar now feels smoother and avoids unnecessary layout updates while dragging
+- Available update controls now sit at the far edge of the expanded sidebar row so the main sidebar actions stay grouped together
+
+## Speech-to-Text Settings
+
+- Cartesia and Gladia now use clearer provider icons in speech-to-text settings
+- Speech-to-text provider icons are more balanced across the provider list
+- Long selected model names now stay visible instead of being clipped in the picker
+- Local model row actions now keep a cleaner rounded shape on hover
+- Pro upgrade actions now stay legible in dark mode


### PR DESCRIPTION
Add the missing 1.1.2 desktop changelog entry for the shipped release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime or build logic changes.
> 
> **Overview**
> Adds the missing **1.1.2** desktop changelog at `packages/changelog/content/1.1.2.md`, with frontmatter dated **2026-06-25** and a short summary of what shipped in that release.
> 
> The entry documents user-facing fixes and polish across **Notes** (faster Memo/Summary/Transcript tab switching, hiding empty live Transcript tabs, dark-mode tab/tray styling), **Sidebar** (smoother resize while dragging, update controls aligned to the expanded row edge), and **Speech-to-Text Settings** (Cartesia/Gladia icons, balanced provider icons, long model names visible in the picker, local model hover styling, dark-mode Pro upgrade legibility).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55152b514d5daf9df73d0bb3d921be1f9c882219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->