### PR TITLE
Use handwritten changelog detail title

### DIFF
--- a/apps/web/src/routes/changelog/$version.tsx
+++ b/apps/web/src/routes/changelog/$version.tsx
@@ -65,7 +65,7 @@ function Component() {
         </Link>
 
         <header className="pt-10 pb-12">
-          <h1 className="font-sans text-5xl leading-[1.02] font-semibold tracking-normal text-balance text-black md:text-7xl">
+          <h1 className="font-hand text-5xl leading-[1.02] font-semibold tracking-normal text-balance text-black md:text-7xl">
             v{entry.version}
           </h1>
           {entry.date && (


### PR DESCRIPTION
Switches the release detail heading to the changelog handwritten font.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on a display heading; no logic, data, or routing impact.
> 
> **Overview**
> The changelog **release detail** page (`/changelog/$version`) now renders the version heading (`v{version}`) with **`font-hand`** instead of **`font-sans`**, matching the handwritten title treatment used on blog pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55a02058a6f02dfd7f38e15269ad783db646db5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->