### PR TITLE
Use full calendar account header width

### DIFF
--- a/apps/desktop/src/calendar/components/calendar-selection.tsx
+++ b/apps/desktop/src/calendar/components/calendar-selection.tsx
@@ -163,31 +163,51 @@ function CalendarGroupAccordionHeader({
 }) {
   const showContextMenu = useNativeContextMenu(group.menuItems ?? []);
   const hasMenu = (group.menuItems?.length ?? 0) > 0;
+  const hoverPadding = hasMenu
+    ? "group-hover/calendar-group-row:pr-12 group-focus-within/calendar-group-row:pr-12"
+    : "group-hover/calendar-group-row:pr-6 group-focus-within/calendar-group-row:pr-6";
 
   return (
     <div
       onContextMenu={hasMenu ? showContextMenu : undefined}
       className={cn([
-        "group -mx-2 flex items-center gap-1 rounded-md px-2",
+        "group/calendar-group-row relative -mx-2 flex items-center rounded-md px-2",
         !disableHoverTone && "hover:bg-accent",
       ])}
     >
-      <AccordionHeader className="max-w-full min-w-0">
-        <AccordionTriggerPrimitive className="flex max-w-full min-w-0 cursor-pointer items-center py-2 text-left hover:no-underline">
+      <AccordionHeader className="min-w-0 flex-1">
+        <AccordionTriggerPrimitive
+          className={cn([
+            "flex w-full min-w-0 cursor-pointer items-center py-2 pr-0 text-left transition-[padding] duration-150 hover:no-underline",
+            hoverPadding,
+          ])}
+        >
           <span className="text-muted-foreground truncate text-xs font-medium">
             {group.sourceName}
           </span>
         </AccordionTriggerPrimitive>
       </AccordionHeader>
 
-      {hasMenu && <CalendarGroupMenuButton onClick={showContextMenu} />}
-
-      <ChevronDown
+      <div
         className={cn([
-          "text-muted-foreground size-4 shrink-0 opacity-0 transition-all duration-200 group-hover:opacity-100 focus-within:opacity-100",
-          "group-data-[state=open]/group:rotate-180",
+          "pointer-events-none absolute top-1/2 right-1 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity duration-150",
+          "group-focus-within/calendar-group-row:opacity-100 group-hover/calendar-group-row:opacity-100",
         ])}
-      />
+      >
+        {hasMenu && (
+          <CalendarGroupMenuButton
+            onClick={showContextMenu}
+            className="pointer-events-none opacity-100 group-focus-within/calendar-group-row:pointer-events-auto group-hover/calendar-group-row:pointer-events-auto"
+          />
+        )}
+
+        <ChevronDown
+          className={cn([
+            "text-muted-foreground pointer-events-none size-4 shrink-0 transition-transform duration-200",
+            "group-data-[state=open]/group:rotate-180",
+          ])}
+        />
+      </div>
     </div>
   );
 }
@@ -213,8 +233,10 @@ function CalendarGroupHeader({ group }: { group: CalendarGroup }) {
 
 function CalendarGroupMenuButton({
   onClick,
+  className,
 }: {
   onClick: (event: MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
 }) {
   const { t } = useLingui();
   return (
@@ -225,6 +247,7 @@ function CalendarGroupMenuButton({
         "text-muted-foreground shrink-0 rounded p-1 transition-colors",
         "opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
         "hover:bg-accent hover:text-muted-foreground",
+        className,
       ])}
       aria-label={t`Open calendar account actions`}
     >

--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -1124,7 +1124,7 @@ msgstr "Open Anarlog"
 msgid "Open calendar"
 msgstr "Open calendar"
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr "Open calendar account actions"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:229
+#: src/calendar/components/calendar-selection.tsx:252
 msgid "Open calendar account actions"
 msgstr ""
 


### PR DESCRIPTION
Move hover-only account header controls out of the header flow so long account names can use the available sidebar width at rest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only layout and Tailwind class changes in calendar selection; no data or auth logic touched.
> 
> **Overview**
> Reworks **calendar account group accordion headers** so long account names can use the full sidebar width when controls are hidden.
> 
> The ellipsis menu and expand chevron are **absolutely positioned** on the right and only fade in on row hover or focus. The accordion trigger adds **animated right padding** on hover/focus (`pr-12` when a context menu exists, `pr-6` otherwise) so the label does not sit under those controls. `CalendarGroupMenuButton` now accepts an optional **`className`** so the accordion row can keep the menu non-interactive until hover/focus while still showing it visibly in that overlay.
> 
> Locale `.po` files only update the **source line reference** for the unchanged string `Open calendar account actions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae27adf08241f5d9d916a0148badb5bec9a2db77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->