### PR TITLE
Reduce note tab switch lag

### DIFF
--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -3,7 +3,6 @@ import {
   forwardRef,
   type UIEventHandler,
   useCallback,
-  useDeferredValue,
   useEffect,
   useImperativeHandle,
   useRef,
@@ -76,12 +75,7 @@ export const NoteInput = forwardRef<
     const fallbackCurrentTab: TabEditorView = useCurrentNoteTab(tab);
     const editorTabs = providedEditorTabs ?? fallbackEditorTabs;
     const currentTab = providedCurrentTab ?? fallbackCurrentTab;
-    const deferredCurrentTab = useDeferredValue(currentTab);
-    const renderedCurrentTab = editorTabs.some((editorTab) =>
-      isSameEditorView(editorTab, deferredCurrentTab),
-    )
-      ? deferredCurrentTab
-      : currentTab;
+    const renderedCurrentTab = currentTab;
 
     const sessionMode = useListener((state) => state.getSessionMode(sessionId));
     const isMeetingInProgress =

--- a/apps/desktop/src/session/components/note-input/transcript/cache.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/cache.ts
@@ -1,0 +1,1 @@
+export const TRANSCRIPT_RENDER_CACHE_TIME_MS = 5 * 60 * 1000;

--- a/apps/desktop/src/session/components/note-input/transcript/export-data.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/export-data.ts
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import type { TranscriptItem } from "@hypr/plugin-export";
 import type { RenderTranscriptRequest } from "@hypr/plugin-transcription";
 
+import { TRANSCRIPT_RENDER_CACHE_TIME_MS } from "./cache";
 import { useSessionTranscriptRenderData } from "./render-request-hooks";
 
 import {
@@ -48,7 +49,8 @@ export function useTranscriptExportSegments(sessionId: string): {
       return buildTranscriptExportSegments(request);
     },
     enabled: !!request,
-    gcTime: 0,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: TRANSCRIPT_RENDER_CACHE_TIME_MS,
   });
 
   return { data, isLoading };

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TRANSCRIPT_RENDER_CACHE_TIME_MS } from "../cache";
+import { useRenderedTranscriptData } from "./data-hooks";
+
+const mocks = vi.hoisted(() => ({
+  getRenderTranscriptRequestKey: vi.fn(() => "request-key"),
+  renderTranscriptSegments: vi.fn(),
+  useQuery: vi.fn(),
+  useTranscriptRenderData: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: mocks.useQuery,
+}));
+
+vi.mock("../render-request-hooks", () => ({
+  useTranscriptRenderData: mocks.useTranscriptRenderData,
+  useTranscriptRowsRevision: vi.fn(() => 0),
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useCell: vi.fn(() => "session-1"),
+    useSliceRowIds: vi.fn(() => ["transcript-1"]),
+    useStore: vi.fn(() => ({
+      getCell: vi.fn(() => 0),
+    })),
+  },
+  INDEXES: {
+    transcriptBySession: "transcriptBySession",
+  },
+}));
+
+vi.mock("~/stt/render-transcript", () => ({
+  getRenderTranscriptRequestKey: mocks.getRenderTranscriptRequestKey,
+  renderTranscriptSegments: mocks.renderTranscriptSegments,
+}));
+
+describe("useRenderedTranscriptData", () => {
+  beforeEach(() => {
+    mocks.useQuery.mockReturnValue({ data: [] });
+    mocks.useTranscriptRenderData.mockReturnValue({
+      request: {
+        humans: [],
+        participant_human_ids: [],
+        self_human_id: undefined,
+        transcripts: [],
+      },
+    });
+  });
+
+  it("keeps rendered transcript data cached across short tab remounts", () => {
+    renderHook(() => useRenderedTranscriptData("transcript-1"));
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [
+          "rendered-transcript-segments",
+          "transcript-1",
+          "request-key",
+        ],
+        enabled: true,
+        staleTime: Number.POSITIVE_INFINITY,
+        gcTime: TRANSCRIPT_RENDER_CACHE_TIME_MS,
+      }),
+    );
+  });
+});

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
+import { TRANSCRIPT_RENDER_CACHE_TIME_MS } from "../cache";
 import {
   useTranscriptRenderData,
   useTranscriptRowsRevision,
@@ -42,7 +43,8 @@ export function useRenderedTranscriptData(transcriptId: string): {
       return renderTranscriptSegments(request);
     },
     enabled: !!request,
-    gcTime: 0,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: TRANSCRIPT_RENDER_CACHE_TIME_MS,
   });
 
   const maxSpeakerNumber = useMemo(


### PR DESCRIPTION
Cache rendered transcript segments across short tab switches and render parent-selected tabs immediately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI performance and client-side caching only; query keys still invalidate when transcript inputs change.
> 
> **Overview**
> **Reduces lag when switching note tabs** by rendering the active tab immediately and keeping expensive transcript segment renders in React Query for a few minutes.
> 
> `NoteInput` no longer uses `useDeferredValue` for the selected tab—it always renders `currentTab` so parent-controlled tab changes show up right away instead of waiting on a deferred pass.
> 
> Transcript **render** and **export** queries now share `TRANSCRIPT_RENDER_CACHE_TIME_MS` (5 minutes): `staleTime: Infinity` avoids refetching unchanged data, and `gcTime` replaces the previous `gcTime: 0` so cached segments survive brief unmounts when hopping between tabs. Cache keys still follow `getRenderTranscriptRequestKey`, so content changes get fresh data.
> 
> A unit test asserts `useRenderedTranscriptData` wires those query options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b134b8f72a245e719d4c2e6b3a3307fb9062523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->