### PR TITLE
Polish notification close button

### DIFF
--- a/crates/notification-macos/swift-lib/src/Constants.swift
+++ b/crates/notification-macos/swift-lib/src/Constants.swift
@@ -59,12 +59,14 @@ enum Colors {
   static let compactActionButtonElapsedBg = NSColor(calibratedWhite: 0.92, alpha: 0.98).cgColor
   static let compactActionButtonRemainingBg = NSColor(calibratedWhite: 0.78, alpha: 0.98)
     .cgColor
-  static let closeButtonHoverBg = NSColor(calibratedWhite: 0.95, alpha: 1.0).cgColor
-  static let closeButtonPressedBg = NSColor(calibratedWhite: 0.9, alpha: 1.0).cgColor
+  static let closeButtonNormalBg = NSColor(calibratedWhite: 1.0, alpha: 0.24).cgColor
+  static let closeButtonHoverBg = NSColor(calibratedWhite: 1.0, alpha: 0.38).cgColor
+  static let closeButtonPressedBg = NSColor(calibratedWhite: 1.0, alpha: 0.5).cgColor
+  static let closeButtonBorder = NSColor.white.withAlphaComponent(0.62).cgColor
   static let progressBarBg = NSColor(calibratedRed: 0.4, green: 0.6, blue: 0.9, alpha: 0.7).cgColor
 }
 
 enum CloseButtonConfig {
-  static let size: CGFloat = 20
-  static let symbolPointSize: CGFloat = 9
+  static let size: CGFloat = 22
+  static let symbolPointSize: CGFloat = 9.5
 }

--- a/crates/notification-macos/swift-lib/src/NotificationButtons.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationButtons.swift
@@ -20,6 +20,7 @@ extension TrackableButton where Self: NSView {
 
 class CloseButton: NSButton, TrackableButton {
   weak var notification: NotificationInstance?
+  weak var backdropView: CloseButtonBackdropView?
   var trackingArea: NSTrackingArea?
 
   override init(frame frameRect: NSRect) {
@@ -47,19 +48,17 @@ class CloseButton: NSButton, TrackableButton {
     } else {
       image = NSImage(named: NSImage.stopProgressTemplateName)
     }
-    contentTintColor = NSColor.black.withAlphaComponent(0.6)
+    contentTintColor = NSColor.black.withAlphaComponent(0.62)
 
     layer?.cornerRadius = CloseButtonConfig.size / 2
-    layer?.backgroundColor = NSColor.white.cgColor
-    layer?.borderColor = NSColor.black.withAlphaComponent(0.1).cgColor
-    layer?.borderWidth = 0.5
+    layer?.backgroundColor = NSColor.clear.cgColor
 
     layer?.shadowColor = NSColor.black.cgColor
-    layer?.shadowOpacity = 0.2
-    layer?.shadowOffset = CGSize(width: 0, height: 1)
-    layer?.shadowRadius = 3
+    layer?.shadowOpacity = 0.16
+    layer?.shadowOffset = CGSize(width: 0, height: 1.5)
+    layer?.shadowRadius = 4
 
-    layer?.zPosition = 1000
+    layer?.zPosition = 1001
 
     alphaValue = 0
     isHidden = true
@@ -80,9 +79,9 @@ class CloseButton: NSButton, TrackableButton {
   }
 
   override func mouseDown(with event: NSEvent) {
-    layer?.backgroundColor = Colors.closeButtonPressedBg
+    backdropView?.setFillColor(Colors.closeButtonPressedBg)
     DispatchQueue.main.asyncAfter(deadline: .now() + Timing.buttonPress) {
-      self.layer?.backgroundColor = NSColor.white.cgColor
+      self.backdropView?.setFillColor(Colors.closeButtonHoverBg)
     }
     notification?.dismissWithUserAction()
   }
@@ -90,13 +89,76 @@ class CloseButton: NSButton, TrackableButton {
   override func mouseEntered(with event: NSEvent) {
     super.mouseEntered(with: event)
     NSCursor.pointingHand.push()
-    layer?.backgroundColor = Colors.closeButtonHoverBg
+    backdropView?.setFillColor(Colors.closeButtonHoverBg)
   }
 
   override func mouseExited(with event: NSEvent) {
     super.mouseExited(with: event)
     NSCursor.pop()
-    layer?.backgroundColor = NSColor.white.cgColor
+    backdropView?.setFillColor(Colors.closeButtonNormalBg)
+  }
+}
+
+class CloseButtonBackdropView: NSVisualEffectView {
+  private let fillLayer = CALayer()
+  private let borderLayer = CALayer()
+
+  override init(frame frameRect: NSRect) {
+    super.init(frame: frameRect)
+    setup()
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    setup()
+  }
+
+  private func setup() {
+    material = .popover
+    state = .active
+    blendingMode = .behindWindow
+    wantsLayer = true
+
+    layer?.cornerRadius = CloseButtonConfig.size / 2
+    layer?.masksToBounds = true
+    if #available(macOS 11.0, *) {
+      layer?.cornerCurve = .continuous
+    }
+
+    fillLayer.backgroundColor = Colors.closeButtonNormalBg
+    layer?.addSublayer(fillLayer)
+
+    borderLayer.borderWidth = 0.8
+    borderLayer.borderColor = Colors.closeButtonBorder
+    layer?.addSublayer(borderLayer)
+
+    alphaValue = 0
+    isHidden = true
+  }
+
+  func setFillColor(_ color: CGColor) {
+    CATransaction.begin()
+    CATransaction.setAnimationDuration(Timing.hoverFade)
+    fillLayer.backgroundColor = color
+    CATransaction.commit()
+  }
+
+  override func layout() {
+    super.layout()
+    let radius = min(bounds.width, bounds.height) / 2
+    layer?.cornerRadius = radius
+
+    CATransaction.begin()
+    CATransaction.setDisableActions(true)
+    fillLayer.frame = bounds
+    borderLayer.frame = bounds
+    fillLayer.cornerRadius = radius
+    borderLayer.cornerRadius = radius
+    if #available(macOS 11.0, *) {
+      fillLayer.cornerCurve = .continuous
+      borderLayer.cornerCurve = .continuous
+    }
+    CATransaction.commit()
   }
 }
 

--- a/crates/notification-macos/swift-lib/src/NotificationManager+Creation.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationManager+Creation.swift
@@ -263,12 +263,17 @@ extension NotificationManager {
   func createCloseButton(
     clickableView: ClickableView, container: NSView, notification: NotificationInstance
   )
-    -> CloseButton
+    -> (CloseButton, CloseButtonBackdropView)
   {
+    let backdropView = CloseButtonBackdropView()
+    backdropView.translatesAutoresizingMaskIntoConstraints = false
+    clickableView.addSubview(backdropView, positioned: .above, relativeTo: container)
+
     let closeButton = CloseButton()
     closeButton.notification = notification
+    closeButton.backdropView = backdropView
     closeButton.translatesAutoresizingMaskIntoConstraints = false
-    clickableView.addSubview(closeButton, positioned: .above, relativeTo: nil)
+    clickableView.addSubview(closeButton, positioned: .above, relativeTo: backdropView)
 
     let horizontalButtonOffset =
       isMacOS26() ? (CloseButtonConfig.size / 2) + 4 : (CloseButtonConfig.size / 2) - 2
@@ -280,24 +285,41 @@ extension NotificationManager {
         equalTo: container.leadingAnchor, constant: horizontalButtonOffset),
       closeButton.widthAnchor.constraint(equalToConstant: CloseButtonConfig.size),
       closeButton.heightAnchor.constraint(equalToConstant: CloseButtonConfig.size),
+
+      backdropView.centerYAnchor.constraint(equalTo: closeButton.centerYAnchor),
+      backdropView.centerXAnchor.constraint(equalTo: closeButton.centerXAnchor),
+      backdropView.widthAnchor.constraint(equalTo: closeButton.widthAnchor),
+      backdropView.heightAnchor.constraint(equalTo: closeButton.heightAnchor),
     ])
-    return closeButton
+    return (closeButton, backdropView)
   }
 
-  func setupCloseButtonHover(clickableView: ClickableView, closeButton: CloseButton) {
-    closeButton.alphaValue = 0
-    closeButton.isHidden = true
+  func setupCloseButtonHover(
+    clickableView: ClickableView,
+    closeButton: CloseButton,
+    backdropView: CloseButtonBackdropView
+  ) {
+    let hoverViews: [NSView] = [backdropView, closeButton]
+    hoverViews.forEach {
+      $0.alphaValue = 0
+      $0.isHidden = true
+    }
 
     clickableView.onHover = { [weak clickableView] isHovering in
-      if isHovering { closeButton.isHidden = false }
+      if isHovering {
+        hoverViews.forEach { $0.isHidden = false }
+      }
       NSAnimationContext.runAnimationGroup(
         { context in
           context.duration = Timing.hoverFade
           context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-          closeButton.animator().alphaValue = isHovering ? 1.0 : 0
+          hoverViews.forEach { $0.animator().alphaValue = isHovering ? 1.0 : 0 }
         },
         completionHandler: {
-          if !isHovering { closeButton.isHidden = true }
+          if !isHovering {
+            backdropView.setFillColor(Colors.closeButtonNormalBg)
+            hoverViews.forEach { $0.isHidden = true }
+          }
         }
       )
 

--- a/crates/notification-macos/swift-lib/src/NotificationManager+Lifecycle.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationManager+Lifecycle.swift
@@ -64,8 +64,12 @@ extension NotificationManager {
 
     notification.compactContentView = contentView
 
-    let closeButton = createCloseButton(
+    let (closeButton, closeButtonBackdrop) = createCloseButton(
       clickableView: notification.clickableView, container: container, notification: notification)
-    setupCloseButtonHover(clickableView: notification.clickableView, closeButton: closeButton)
+    setupCloseButtonHover(
+      clickableView: notification.clickableView,
+      closeButton: closeButton,
+      backdropView: closeButtonBackdrop
+    )
   }
 }


### PR DESCRIPTION
Adds a liquid-glass hover dismiss control for native macOS notifications.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes in the macOS notification Swift UI; dismiss behavior and Rust bridge paths are unchanged.
> 
> **Overview**
> **Polishes the hover-only notification close (dismiss) control** with a liquid-glass look: a new `CloseButtonBackdropView` (`NSVisualEffectView` plus fill and border layers) sits behind the icon button, while the button itself keeps a clear layer and only the **xmark** plus shadow.
> 
> **Visual and interaction tweaks:** close colors move to semi-transparent white fills (`closeButtonNormalBg` / hover / pressed) and a light border; hit target grows slightly (22pt, 9.5pt symbol). Hover/press state updates the backdrop fill (with `Timing.hoverFade`) instead of painting the button background; on hover exit the fill resets to normal before hiding.
> 
> **Wiring:** `createCloseButton` returns `(CloseButton, CloseButtonBackdropView)`, constrains the backdrop to the button, and `setupCloseButtonHover` fades **both** views in and out together. Dismiss still goes through `dismissWithUserAction()` on click.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a23ea7d38494cf946abcb5cb4998b85208eb0fd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->