### PR TITLE
Hide transcript spinner during active meetings

### DIFF
--- a/apps/desktop/src/session/components/note-input/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/index.test.tsx
@@ -22,13 +22,16 @@ vi.mock("./header", () => ({
     currentTab,
     editorTabs,
     handleTabChange,
+    isTranscribing,
   }: {
     currentTab: EditorView;
     editorTabs: EditorView[];
     handleTabChange: (view: EditorView) => void;
+    isTranscribing?: boolean;
   }) => (
     <div>
       <div data-testid="current-tab">{formatEditorView(currentTab)}</div>
+      <div data-testid="is-transcribing">{String(isTranscribing)}</div>
       {editorTabs.map((editorTab) => (
         <button
           key={formatEditorView(editorTab)}
@@ -176,5 +179,21 @@ describe("NoteInput tab selection", () => {
     );
 
     expect(screen.getByTestId("current-tab").textContent).toBe("transcript");
+  });
+
+  it("does not show the transcript spinner while a meeting is active", () => {
+    hoisted.sessionMode = "active";
+
+    renderNoteInput();
+
+    expect(screen.getByTestId("is-transcribing").textContent).toBe("false");
+  });
+
+  it("keeps the transcript spinner while finalizing", () => {
+    hoisted.sessionMode = "finalizing";
+
+    renderNoteInput();
+
+    expect(screen.getByTestId("is-transcribing").textContent).toBe("true");
   });
 });

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -82,6 +82,8 @@ export const NoteInput = forwardRef<
       sessionMode === "active" ||
       sessionMode === "finalizing" ||
       sessionMode === "running_batch";
+    const shouldShowTranscriptSpinner =
+      sessionMode === "finalizing" || sessionMode === "running_batch";
 
     const { scrollRef, onBeforeTabChange } = useScrollPreservation(
       renderedCurrentTab.type === "enhanced"
@@ -184,7 +186,7 @@ export const NoteInput = forwardRef<
               editorTabs={editorTabs}
               currentTab={currentTab}
               handleTabChange={handleTabChange}
-              isTranscribing={isMeetingInProgress}
+              isTranscribing={shouldShowTranscriptSpinner}
             />
           </div>
         )}


### PR DESCRIPTION
Show the transcript tab spinner only while finalizing or running batch transcription, and cover active/finalizing NoteInput behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI gating change in session note header with unit test coverage; no auth, data, or API impact.
> 
> **Overview**
> The transcript tab header spinner no longer appears while a session is in **active** live meeting mode; it only shows when the session is **finalizing** or **running batch** transcription.
> 
> `NoteInput` now passes a dedicated `shouldShowTranscriptSpinner` flag to `Header` instead of reusing the broader “meeting in progress” signal. Other behavior that still keys off full in-progress state (e.g. raw-tab focus during meetings) is unchanged.
> 
> Tests assert `isTranscribing` is false for `active` and true for `finalizing`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff04ecfbe3c29246e29a224e391eb236e038f711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->