### PR TITLE
Hide live transcript as stopping starts

### DIFF
--- a/apps/desktop/src/store/zustand/listener/general-live.ts
+++ b/apps/desktop/src/store/zustand/listener/general-live.ts
@@ -345,6 +345,17 @@ export const stopLiveSession = <T extends GeneralState>(
 ) => {
   const sessionId = get().live.sessionId;
 
+  if (sessionId) {
+    setLiveState(set, (live) => {
+      if (live.sessionId !== sessionId || live.status !== "active") {
+        return;
+      }
+
+      clearLiveInterval(live.intervalId);
+      markLiveFinalizing(live, sessionId);
+    });
+  }
+
   const program = Effect.gen(function* () {
     yield* stopSessionEffect();
   });
@@ -354,6 +365,23 @@ export const stopLiveSession = <T extends GeneralState>(
       onFailure: (cause) => {
         console.error("Failed to stop session:", cause);
         setLiveState(set, (live) => {
+          if (sessionId && live.sessionId === sessionId) {
+            delete live.finalizingBySession[sessionId];
+            if (live.status === "finalizing") {
+              const intervalId = setInterval(() => {
+                setLiveState(set, (currentLive) => {
+                  if (
+                    currentLive.sessionId === sessionId &&
+                    currentLive.status === "active"
+                  ) {
+                    currentLive.seconds += 1;
+                  }
+                });
+              }, 1000);
+              live.status = "active";
+              live.intervalId = intervalId;
+            }
+          }
           live.loading = false;
         });
       },

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -1,6 +1,70 @@
 import { create as mutate } from "mutative";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+const {
+  getIdentifierMock,
+  runEventHooksMock,
+  setRecordingIndicatorMock,
+  stopCaptureMock,
+  vaultBaseMock,
+} = vi.hoisted(() => ({
+  getIdentifierMock: vi.fn(),
+  runEventHooksMock: vi.fn(),
+  setRecordingIndicatorMock: vi.fn(),
+  stopCaptureMock: vi.fn(),
+  vaultBaseMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/app", () => ({
+  getIdentifier: getIdentifierMock,
+}));
+
+vi.mock("@hypr/plugin-detect", () => ({
+  commands: {
+    listMicUsingApplications: vi.fn(),
+  },
+}));
+
+vi.mock("@hypr/plugin-hooks", () => ({
+  commands: {
+    runEventHooks: runEventHooksMock,
+  },
+}));
+
+vi.mock("@hypr/plugin-icon", () => ({
+  commands: {
+    setRecordingIndicator: setRecordingIndicatorMock,
+  },
+}));
+
+vi.mock("@hypr/plugin-settings", () => ({
+  commands: {
+    vaultBase: vaultBaseMock,
+  },
+}));
+
+vi.mock("@hypr/plugin-transcription", () => ({
+  commands: {
+    setMicMuted: vi.fn(),
+    startCapture: vi.fn(),
+    startTranscription: vi.fn(),
+    stopCapture: stopCaptureMock,
+    stopTranscription: vi.fn(),
+    updateCaptureConfig: vi.fn(),
+  },
+  events: {
+    captureDataEvent: {
+      listen: vi.fn(),
+    },
+    captureLifecycleEvent: {
+      listen: vi.fn(),
+    },
+    captureStatusEvent: {
+      listen: vi.fn(),
+    },
+  },
+}));
+
 import { createListenerStore } from ".";
 import {
   getLiveCaptureUiMode,
@@ -13,6 +77,12 @@ let store: ReturnType<typeof createListenerStore>;
 describe("General Listener Slice", () => {
   beforeEach(() => {
     store = createListenerStore();
+    vi.clearAllMocks();
+    getIdentifierMock.mockResolvedValue("com.hyprnote.stable");
+    runEventHooksMock.mockResolvedValue({ status: "ok", data: null });
+    setRecordingIndicatorMock.mockResolvedValue({ status: "ok", data: null });
+    stopCaptureMock.mockResolvedValue({ status: "ok", data: null });
+    vaultBaseMock.mockResolvedValue({ status: "ok", data: "/tmp/anarlog" });
   });
 
   describe("Initial State", () => {
@@ -532,6 +602,27 @@ describe("General Listener Slice", () => {
     test("stop action exists and is callable", () => {
       const stop = store.getState().stop;
       expect(typeof stop).toBe("function");
+    });
+
+    test("marks the live session finalizing immediately when stop is requested", () => {
+      const intervalId = setInterval(() => {}, 1000);
+
+      store.setState((state) =>
+        mutate(state, (draft) => {
+          markLiveActive(draft.live, "session-1", intervalId, true, true, null);
+          draft.live.seconds = 42;
+        }),
+      );
+
+      store.getState().stop();
+
+      expect(store.getState().live.status).toBe("finalizing");
+      expect(store.getState().live.loading).toBe(true);
+      expect(store.getState().live.intervalId).toBeUndefined();
+      expect(store.getState().live.finalizingBySession["session-1"]).toEqual({
+        startedAtMs: expect.any(Number),
+        seconds: 42,
+      });
     });
   });
 


### PR DESCRIPTION
Mark live sessions finalizing immediately when stop is requested and cover the listener state transition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live session lifecycle and stop failure recovery; wrong rollback could leave timers or status inconsistent, but scope is limited to the listener store.
> 
> **Overview**
> When the user stops a live capture, **`stopLiveSession`** now transitions the current session to **`finalizing`** right away (clears the seconds timer, sets loading, records **`finalizingBySession`**) instead of waiting for the capture plugin’s lifecycle **`finalizing`** event. That lets the UI hide the live transcript as soon as stop begins.
> 
> If **`stopCapture`** fails, the store rolls back: it clears the optimistic finalizing entry and, when still on that session, restores **`active`** status and restarts the interval timer.
> 
> **`general.test.ts`** adds plugin/Tauri mocks so **`stop()`** can run in unit tests, plus a case asserting the immediate **`finalizing`** state and preserved elapsed seconds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 821db49cd86198716a5c603331e6e832e3212981. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->