### PR TITLE
Fix metadata popover scrolling

### DIFF
--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -40,9 +40,9 @@ export function MetadataButton({
       <PopoverContent
         variant="app"
         align="end"
-        className="w-85 overflow-visible"
+        className="w-85 overflow-hidden"
       >
-        <AppFloatingPanel className="flex max-h-[80vh] min-h-0 flex-col overflow-visible">
+        <AppFloatingPanel className="scrollbar-soft max-h-[80vh] min-h-0 overflow-x-hidden overflow-y-auto overscroll-contain">
           <ContentInner sessionId={sessionId} />
         </AppFloatingPanel>
       </PopoverContent>
@@ -91,14 +91,14 @@ function ContentInner({ sessionId }: { sessionId: string }) {
     : null;
 
   return (
-    <div className="flex min-h-0 flex-col overflow-visible">
-      <div className="flex min-h-0 flex-col gap-4 overflow-y-auto p-4 pb-0">
-        {!eventDisplayData && <DateEditor sessionId={sessionId} />}
-        {eventDisplayData && <EventDisplay event={eventDisplayData} />}
-      </div>
-      <div className="px-4 pt-2 pb-4">
-        <ParticipantsDisplay sessionId={sessionId} />
-      </div>
+    <div className="flex flex-col gap-4 p-4">
+      {!eventDisplayData && <DateEditor sessionId={sessionId} />}
+      {eventDisplayData && (
+        <EventDisplay event={eventDisplayData}>
+          <ParticipantsDisplay sessionId={sessionId} />
+        </EventDisplay>
+      )}
+      {!eventDisplayData && <ParticipantsDisplay sessionId={sessionId} />}
     </div>
   );
 }
@@ -230,7 +230,7 @@ export function EventDisplay({
       {event.description && (
         <>
           <div className="bg-accent h-px" />
-          <div className="select-text-deep text-muted-foreground max-h-40 overflow-y-auto text-sm break-words whitespace-pre-wrap">
+          <div className="select-text-deep text-muted-foreground text-sm break-words whitespace-pre-wrap">
             {renderDescriptionWithLinks(event.description)}
           </div>
         </>

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/dropdown.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/dropdown.tsx
@@ -1,5 +1,5 @@
 import { CornerDownLeft } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { type CSSProperties, useEffect, useRef } from "react";
 
 import { cn } from "@hypr/utils";
 
@@ -13,11 +13,15 @@ type DropdownOption = {
 };
 
 export function ParticipantDropdown({
+  floatingRef,
+  floatingStyles,
   options,
   selectedIndex,
   onSelect,
   onHover,
 }: {
+  floatingRef: (node: HTMLDivElement | null) => void;
+  floatingStyles: CSSProperties;
   options: DropdownOption[];
   selectedIndex: number;
   onSelect: (option: DropdownOption) => void;
@@ -40,7 +44,15 @@ export function ParticipantDropdown({
   }
 
   return (
-    <div className="bg-popover absolute z-50 mt-1 w-full overflow-hidden rounded-md border shadow-md">
+    <div
+      ref={floatingRef}
+      style={floatingStyles}
+      className="bg-popover z-50 overflow-hidden rounded-md border shadow-md"
+      onMouseDown={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+    >
       <div ref={listRef} className="max-h-50 overflow-auto py-1">
         {options.map((option, index) => (
           <button

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
@@ -1,3 +1,12 @@
+import {
+  autoUpdate,
+  flip,
+  FloatingPortal,
+  offset,
+  shift,
+  size,
+  useFloating,
+} from "@floating-ui/react";
 import { useMutation } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef, useState } from "react";
 
@@ -37,10 +46,35 @@ export function ParticipantInput({ sessionId }: { sessionId: string }) {
       : "Who was in this meeting?";
 
   const inputRef = useRef<HTMLInputElement>(null);
-  const containerRef = useAutoCloser(() => setShowDropdown(false), {
+  const autoCloserRef = useAutoCloser(() => setShowDropdown(false), {
     esc: false,
     outside: true,
   });
+  const { refs, floatingStyles } = useFloating({
+    placement: "bottom-start",
+    strategy: "fixed",
+    whileElementsMounted: autoUpdate,
+    middleware: [
+      offset(4),
+      flip({ padding: 8 }),
+      shift({ padding: 8 }),
+      size({
+        apply({ rects, elements }) {
+          Object.assign(elements.floating.style, {
+            width: `${rects.reference.width}px`,
+          });
+        },
+      }),
+    ],
+  });
+
+  const setContainerRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      autoCloserRef.current = node;
+      refs.setReference(node);
+    },
+    [autoCloserRef, refs],
+  );
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if ((e.key === "Enter" || e.key === "Tab") && inputValue.trim()) {
@@ -70,7 +104,7 @@ export function ParticipantInput({ sessionId }: { sessionId: string }) {
   };
 
   return (
-    <div className="relative" ref={containerRef}>
+    <div className="relative" ref={setContainerRef}>
       <div
         className="flex min-h-[38px] w-full cursor-text flex-wrap items-center gap-2"
         onClick={() => inputRef.current?.focus()}
@@ -99,12 +133,16 @@ export function ParticipantInput({ sessionId }: { sessionId: string }) {
       </div>
 
       {showDropdown && inputValue.trim() && (
-        <ParticipantDropdown
-          options={dropdownOptions}
-          selectedIndex={selectedIndex}
-          onSelect={handleSelect}
-          onHover={setSelectedIndex}
-        />
+        <FloatingPortal>
+          <ParticipantDropdown
+            floatingRef={refs.setFloating}
+            floatingStyles={floatingStyles}
+            options={dropdownOptions}
+            selectedIndex={selectedIndex}
+            onSelect={handleSelect}
+            onHover={setSelectedIndex}
+          />
+        </FloatingPortal>
       )}
     </div>
   );

--- a/apps/desktop/src/styles/scrollbar.utilities.css
+++ b/apps/desktop/src/styles/scrollbar.utilities.css
@@ -5,3 +5,15 @@
     display: none;
   }
 }
+
+@utility scrollbar-soft {
+  scrollbar-color: hsl(var(--muted-foreground) / 0.18) transparent;
+
+  &::-webkit-scrollbar-thumb {
+    background: hsl(var(--muted-foreground) / 0.18);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--muted-foreground) / 0.28);
+  }
+}


### PR DESCRIPTION
Move participants above event descriptions and make the floating panel the only scroll container with a softer contained scrollbar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop session metadata UI and styling only; no changes to persistence, auth, or core business logic.
> 
> **Overview**
> Fixes awkward nested scrolling in the session **metadata popover** by making **`AppFloatingPanel`** the only vertical scroll area (`overflow-hidden` on the shell, `overflow-y-auto` + new **`scrollbar-soft`** styling on the panel) and dropping the inner content/description scroll regions.
> 
> For calendar-linked events, **participants** now render inside **`EventDisplay`** (after date/time, before the description) instead of in a separate footer block; long descriptions scroll with the rest of the panel rather than in a capped sub-region.
> 
> The participant typeahead **dropdown** is rendered through **`FloatingPortal`** with **`@floating-ui/react`** (fixed positioning, flip/shift, width matched to the input) so it isn’t clipped by the popover’s overflow, with **`mousedown`** handling to keep focus stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533878374652b5c7a520aa2d5fc89384e03a78eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->