### PR TITLE
Use event titles for contact enrichment

### DIFF
--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
@@ -242,6 +242,177 @@ describe("event contact extraction", () => {
     );
   });
 
+  test("keeps model email and company when inferred title contact appears first", async () => {
+    const store = createStore();
+    store.setRow("sessions", "session-1", {
+      user_id: "user-1",
+      created_at: "2026-06-16T05:00:00.000Z",
+      title: "Tom Yang <> john",
+      raw_md: "",
+      event_json: JSON.stringify({
+        tracking_id: "event-tracking-1",
+        calendar_id: "calendar-1",
+        title: "Tom Yang <> john",
+        started_at: "2026-06-16T05:00:00.000Z",
+        ended_at: "2026-06-16T05:20:00.000Z",
+        is_all_day: false,
+        has_recurrence_rules: false,
+        description: "What:\nTom Yang <> john\n\nWho:\nJohn Jeong - Organizer",
+      }),
+    });
+    store.setRow("humans", "human-1", {
+      user_id: "user-1",
+      created_at: "2026-06-16T05:00:00.000Z",
+      name: "Tom Yang",
+      email: "",
+      phone: "",
+      org_id: "",
+      job_title: "",
+      linkedin_username: "",
+      memo: "",
+      pinned: false,
+    });
+    store.setRow("mapping_session_participant", "mapping-1", {
+      user_id: "user-1",
+      session_id: "session-1",
+      human_id: "human-1",
+      source: "manual",
+    });
+
+    const context = buildEventContactExtractionContext(store, "session-1", {
+      tracking_id: "event-tracking-1",
+      calendar_id: "calendar-1",
+      title: "Tom Yang <> john",
+      started_at: "2026-06-16T05:00:00.000Z",
+      ended_at: "2026-06-16T05:20:00.000Z",
+      is_all_day: false,
+      has_recurrence_rules: false,
+      description: "What:\nTom Yang <> john\n\nWho:\nJohn Jeong - Organizer",
+    });
+
+    vi.mocked(generateText).mockResolvedValue({
+      text: JSON.stringify({
+        contacts: [
+          {
+            name: "Tom Yang",
+            email: "tom@kestroll.com",
+            companyName: "Kestroll",
+          },
+        ],
+      }),
+    } as any);
+
+    const extraction = await extractEventContacts({
+      model: {} as any,
+      context,
+    });
+    const result = applyExtractedContactToHuman(
+      store,
+      "session-1",
+      "human-1",
+      extraction.contacts,
+      { userId: "user-1" },
+    );
+
+    expect(extraction.contacts).toEqual([
+      {
+        name: "Tom Yang",
+        email: "tom@kestroll.com",
+        companyName: "Kestroll",
+      },
+    ]);
+    expect(result).toMatchObject({
+      updated: 1,
+      matched: true,
+    });
+    expect(store.getCell("humans", "human-1", "email")).toBe(
+      "tom@kestroll.com",
+    );
+    const organizationEntry = Object.entries(
+      store.getTable("organizations"),
+    ).find(([, organization]) => organization.name === "Kestroll");
+    expect(store.getCell("humans", "human-1", "org_id")).toBe(
+      organizationEntry?.[0],
+    );
+  });
+
+  test("falls back to event title names when the model misses an email-only participant", async () => {
+    const store = createStore();
+    store.setRow("sessions", "session-1", {
+      user_id: "user-1",
+      created_at: "2026-06-26T00:00:00.000Z",
+      title: "30 Min Meeting between Gonzalo Soto and Yujong Lee",
+      raw_md: "",
+      event_json: JSON.stringify({
+        tracking_id: "event-tracking-1",
+        calendar_id: "calendar-1",
+        title: "30 Min Meeting between Gonzalo Soto and Yujong Lee",
+        started_at: "2026-06-26T08:30:00.000Z",
+        ended_at: "2026-06-26T09:00:00.000Z",
+        is_all_day: false,
+        has_recurrence_rules: false,
+        description:
+          "What:\n30 Min Meeting between Gonzalo Soto and Yujong Lee\n\nInvitee timezone:\nAsia/Seoul",
+      }),
+    });
+    store.setRow("humans", "human-1", {
+      user_id: "user-1",
+      created_at: "2026-06-26T00:00:00.000Z",
+      name: "gonzalo@gumloop.com",
+      email: "gonzalo@gumloop.com",
+      phone: "",
+      org_id: "",
+      job_title: "",
+      linkedin_username: "",
+      memo: "",
+      pinned: false,
+    });
+    store.setRow("mapping_session_participant", "mapping-1", {
+      user_id: "user-1",
+      session_id: "session-1",
+      human_id: "human-1",
+      source: "auto",
+    });
+
+    const context = buildEventContactExtractionContext(store, "session-1", {
+      tracking_id: "event-tracking-1",
+      calendar_id: "calendar-1",
+      title: "30 Min Meeting between Gonzalo Soto and Yujong Lee",
+      started_at: "2026-06-26T08:30:00.000Z",
+      ended_at: "2026-06-26T09:00:00.000Z",
+      is_all_day: false,
+      has_recurrence_rules: false,
+      description:
+        "What:\n30 Min Meeting between Gonzalo Soto and Yujong Lee\n\nInvitee timezone:\nAsia/Seoul",
+    });
+
+    vi.mocked(generateText).mockResolvedValue({
+      text: JSON.stringify({ contacts: [] }),
+    } as any);
+
+    const extraction = await extractEventContacts({
+      model: {} as any,
+      context,
+    });
+    const result = applyExtractedContactToHuman(
+      store,
+      "session-1",
+      "human-1",
+      extraction.contacts,
+      { userId: "user-1" },
+    );
+
+    expect(extraction.contacts).toContainEqual({
+      name: "Gonzalo Soto",
+      email: "gonzalo@gumloop.com",
+    });
+    expect(result).toMatchObject({
+      updated: 1,
+      matched: true,
+    });
+    expect(store.getCell("humans", "human-1", "name")).toBe("Gonzalo Soto");
+  });
+
   test("reuses an existing organization when applying extracted company", () => {
     const store = createStore();
     store.setRow("organizations", "org-1", {

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
@@ -413,6 +413,49 @@ describe("event contact extraction", () => {
     expect(store.getCell("humans", "human-1", "name")).toBe("Gonzalo Soto");
   });
 
+  test("does not infer a title prefix from a between line with delimiters", async () => {
+    const context = {
+      title: "30 Min Meeting between Gonzalo Soto and Yujong Lee <> john",
+      description:
+        "What:\n30 Min Meeting between Gonzalo Soto and Yujong Lee <> john",
+      candidates: [
+        {
+          name: "John Jeong",
+          email: "john@example.com",
+          isCurrentUser: true,
+        },
+        {
+          name: "Gonzalo Soto",
+          email: "gonzalo@gumloop.com",
+        },
+        {
+          name: "Yujong Lee",
+          email: "yujong@example.com",
+        },
+      ],
+    };
+
+    vi.mocked(generateText).mockResolvedValue({
+      text: JSON.stringify({ contacts: [] }),
+    } as any);
+
+    await expect(
+      extractEventContacts({ model: {} as any, context }),
+    ).resolves.toEqual({
+      source: "model",
+      contacts: [
+        {
+          name: "Gonzalo Soto",
+          email: "gonzalo@gumloop.com",
+        },
+        {
+          name: "Yujong Lee",
+          email: "yujong@example.com",
+        },
+      ],
+    });
+  });
+
   test("reuses an existing organization when applying extracted company", () => {
     const store = createStore();
     store.setRow("organizations", "org-1", {

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
@@ -336,6 +336,49 @@ describe("event contact extraction", () => {
     );
   });
 
+  test("replaces an inferred email when the model returns a different email for the same person", async () => {
+    const context = {
+      title: "Tom Yang <> john",
+      description: "What:\nTom Yang <> john",
+      candidates: [
+        {
+          name: "John Jeong",
+          email: "john@example.com",
+          isCurrentUser: true,
+        },
+        {
+          name: "Tom Yang",
+          email: "tom@old.example",
+        },
+      ],
+    };
+
+    vi.mocked(generateText).mockResolvedValue({
+      text: JSON.stringify({
+        contacts: [
+          {
+            name: "Tom Yang",
+            email: "tom@kestroll.com",
+            companyName: "Kestroll",
+          },
+        ],
+      }),
+    } as any);
+
+    await expect(
+      extractEventContacts({ model: {} as any, context }),
+    ).resolves.toEqual({
+      source: "model",
+      contacts: [
+        {
+          name: "Tom Yang",
+          email: "tom@kestroll.com",
+          companyName: "Kestroll",
+        },
+      ],
+    });
+  });
+
   test("falls back to event title names when the model misses an email-only participant", async () => {
     const store = createStore();
     store.setRow("sessions", "session-1", {

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
@@ -583,6 +583,7 @@ function inferContactsFromEventText(
     );
     if (betweenMatch?.[1]) {
       addDelimitedNames(betweenMatch[1], addName);
+      continue;
     }
 
     if (line.includes("<>")) {

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
@@ -658,6 +658,9 @@ function normalizeExtractedContacts(
 
     const existingEmail = normalizeEmail(existingContact.email);
     if (matchedEmail && existingEmail && existingEmail !== matchedEmail) {
+      if (existingKey) {
+        deduped.delete(existingKey);
+      }
       deduped.set(key, normalizedContact);
       keysByName.set(nameKey, key);
       continue;

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
@@ -115,7 +115,10 @@ export async function extractEventContacts({
   });
 
   const contacts = normalizeExtractedContacts(
-    parseExtractionJson(result.text).contacts,
+    [
+      ...inferContactsFromEventText(context),
+      ...parseExtractionJson(result.text).contacts,
+    ],
     context.candidates,
   );
 
@@ -546,6 +549,56 @@ function trimEventText(value: string | undefined): string {
   return stripHtml(value).trim().slice(0, MAX_EVENT_TEXT_CHARS);
 }
 
+function inferContactsFromEventText(
+  context: EventContactExtractionContext,
+): ExtractedEventContact[] {
+  const contacts = new Map<string, ExtractedEventContact>();
+  const lines = [context.title, context.description]
+    .flatMap((value) => trimEventText(value).split(/\n+/))
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const addName = (value: string) => {
+    const name = cleanNameHint(
+      value
+        .replace(/^[\w\s]+:\s*/, "")
+        .replace(/<[^>]*@[^>]*>/g, "")
+        .replace(/\([^)]*(organizer|host|required|optional)[^)]*\)/gi, ""),
+    );
+    const key = normalizeName(name);
+    if (
+      !key ||
+      !isLikelyPersonName(name) ||
+      isSelfReference(name, context.candidates)
+    ) {
+      return;
+    }
+
+    contacts.set(key, { name });
+  };
+
+  for (const line of lines) {
+    const betweenMatch = line.match(
+      /\bbetween\s+(.+?)(?:\s+(?:at|on|for)\b|$)/i,
+    );
+    if (betweenMatch?.[1]) {
+      addDelimitedNames(betweenMatch[1], addName);
+    }
+
+    if (line.includes("<>")) {
+      addDelimitedNames(line, addName);
+    }
+  }
+
+  return Array.from(contacts.values());
+}
+
+function addDelimitedNames(value: string, addName: (name: string) => void) {
+  for (const part of value.split(/\s*(?:<>|<->)\s*|\s+\band\b\s+|\s+&\s+/i)) {
+    addName(part);
+  }
+}
+
 function stripHtml(value: string): string {
   return value
     .replace(/<br\s*\/?>/gi, "\n")
@@ -567,6 +620,7 @@ function normalizeExtractedContacts(
   candidates: EventContactCandidate[],
 ): ExtractedEventContact[] {
   const deduped = new Map<string, ExtractedEventContact>();
+  const keysByName = new Map<string, string>();
 
   for (const contact of contacts) {
     const name = cleanNameHint(contact.name ?? "");
@@ -591,24 +645,42 @@ function normalizeExtractedContacts(
       continue;
     }
 
-    const key = matchedEmail
-      ? `email:${matchedEmail}`
-      : `name:${normalizeName(name)}`;
-    if (!deduped.has(key)) {
+    const nameKey = normalizeName(name);
+    const key = matchedEmail ? `email:${matchedEmail}` : `name:${nameKey}`;
+    const existingKey = deduped.has(key) ? key : keysByName.get(nameKey);
+    const existingContact = existingKey ? deduped.get(existingKey) : undefined;
+    if (!existingContact) {
       deduped.set(key, normalizedContact);
-    } else if (
-      !deduped.get(key)?.companyName &&
-      normalizedContact.companyName
-    ) {
-      const existingContact = deduped.get(key);
-      if (!existingContact) {
-        continue;
-      }
-      deduped.set(key, {
-        ...existingContact,
-        companyName: normalizedContact.companyName,
-      });
+      keysByName.set(nameKey, key);
+      continue;
     }
+
+    const existingEmail = normalizeEmail(existingContact.email);
+    if (matchedEmail && existingEmail && existingEmail !== matchedEmail) {
+      deduped.set(key, normalizedContact);
+      keysByName.set(nameKey, key);
+      continue;
+    }
+
+    const mergedContact: ExtractedEventContact = { name: existingContact.name };
+    const mergedEmail = existingContact.email ?? normalizedContact.email;
+    const mergedCompanyName =
+      existingContact.companyName ?? normalizedContact.companyName;
+    if (mergedEmail) {
+      mergedContact.email = mergedEmail;
+    }
+    if (mergedCompanyName) {
+      mergedContact.companyName = mergedCompanyName;
+    }
+    const mergedKey = mergedContact.email
+      ? `email:${mergedContact.email}`
+      : `name:${nameKey}`;
+
+    if (existingKey && existingKey !== mergedKey) {
+      deduped.delete(existingKey);
+    }
+    deduped.set(mergedKey, mergedContact);
+    keysByName.set(nameKey, mergedKey);
   }
 
   return Array.from(deduped.values()).slice(0, MAX_CONTACTS_TO_EXTRACT);


### PR DESCRIPTION
Seed contact enrichment from obvious event title and description names before applying model output, with a regression covering email-only Gonzalo Soto chips.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how participant humans get names, emails, and org links during session metadata enrichment; wrong parsing could mis-attribute contacts, though scope is limited to heuristic title/description patterns and existing candidate matching.
> 
> **Overview**
> **Event contact enrichment** now seeds contacts from calendar **title** and **description** before merging in model output, so obvious participant names still apply when the LLM returns nothing or partial data.
> 
> `inferContactsFromEventText` pulls names from lines with **`between … and …`**, **`<>`** / **`<->`**, **`and`**, and **`&`** delimiters, with guards so meeting prefixes and the current user are not treated as contacts. `normalizeExtractedContacts` merges inferred and model rows by name, prefers the model when emails disagree for the same person, and fills in email/company from candidates when only a name was inferred.
> 
> New tests cover title-first vs model email/company, email replacement, email-only chips renamed from titles (e.g. Gonzalo Soto), and avoiding bogus names from cluttered `between` lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41adb53b6cf2d8447e3c35b58f3e71c7396f03a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->