### PR TITLE
Fix trial dialog dark buttons

### DIFF
--- a/apps/desktop/src/billing/trial-ended-dialog.tsx
+++ b/apps/desktop/src/billing/trial-ended-dialog.tsx
@@ -43,7 +43,7 @@ export function TrialEndedDialog({
             Maybe later
           </Button>
           <Button
-            className="bg-primary text-primary-foreground hover:bg-primary/90 h-8 rounded-full px-4 text-xs font-medium shadow-sm"
+            className="bg-primary text-primary-foreground hover:bg-primary/90 h-8 rounded-full px-4 text-xs font-medium shadow-sm dark:bg-white dark:text-black dark:hover:bg-white/90"
             onClick={() => {
               onUpgrade();
               onOpenChange(false);

--- a/apps/desktop/src/billing/trial-started-dialog.tsx
+++ b/apps/desktop/src/billing/trial-started-dialog.tsx
@@ -37,7 +37,7 @@ export function TrialStartedDialog({
         </DialogHeader>
         <DialogFooter className="px-4 pt-4 pb-4 sm:justify-center">
           <Button
-            className="bg-primary text-primary-foreground hover:bg-primary/90 h-8 w-full rounded-full px-4 text-xs font-medium shadow-sm"
+            className="bg-primary text-primary-foreground hover:bg-primary/90 h-8 w-full rounded-full px-4 text-xs font-medium shadow-sm dark:bg-white dark:text-black dark:hover:bg-white/90"
             onClick={() => onOpenChange(false)}
           >
             Got it


### PR DESCRIPTION
Set trial dialog primary CTAs to white backgrounds with black text in dark mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only tweaks on two billing dialog buttons; no behavior or data changes.
> 
> **Overview**
> Fixes **dark mode styling** for the primary call-to-action buttons on the Pro trial dialogs so they stay readable and visually distinct from the default `primary` theme tokens.
> 
> Adds `dark:bg-white`, `dark:text-black`, and `dark:hover:bg-white/90` to the **Upgrade to Pro** button in `trial-ended-dialog` and the **Got it** button in `trial-started-dialog`. Light-mode classes are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a49ce77cb49f5569e3f41a5d21818efe4b0c46a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->