### PR TITLE
Fix notification close button overhang

### DIFF
--- a/crates/notification-macos/swift-lib/src/NotificationManager+Creation.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationManager+Creation.swift
@@ -6,7 +6,7 @@ extension NotificationManager {
   }
 
   func buttonOverhang() -> CGFloat {
-    isMacOS26() ? 0 : Layout.buttonOverhang
+    Layout.buttonOverhang
   }
 
   func notificationCornerRadius() -> CGFloat {


### PR DESCRIPTION
Keep the macOS notification overhang on macOS 26 so the dismiss control has room to render at the top-left corner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line layout constant change in macOS notification UI with no auth, data, or API impact.
> 
> **Overview**
> **`buttonOverhang()`** no longer returns **0** on macOS 26; it always uses **`Layout.buttonOverhang`** (8pt), matching older macOS behavior.
> 
> That overhang is what reserves space above/left of the notification body for the dismiss control and panel layout (`createContainer`, close-button constraints, slide-in final X). macOS 26 still uses liquid-glass corner radius via **`notificationCornerRadius()`**—only the overhang special-case was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aff8ffbcde9bdd0aef8b03989a59f4db280da51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->