### PR TITLE
Show rolling live caption history

### DIFF
--- a/apps/desktop/src/meeting-float/host.test.ts
+++ b/apps/desktop/src/meeting-float/host.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getCurrentFloatingBarColorScheme,
   getFloatingRouteState,
+  getLiveCaptionDisplayText,
   getLiveCaptionMinimizedForSessionDefault,
   getLiveCaptionRouteState,
   shouldShowFloatingLiveCaptionToggle,
@@ -289,6 +290,38 @@ describe("getLiveCaptionRouteState", () => {
       position: "topCenter",
       minimized: false,
     });
+  });
+});
+
+describe("getLiveCaptionDisplayText", () => {
+  it("shows a rolling recent caption window", () => {
+    const text =
+      "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega";
+
+    const singleLine = getLiveCaptionDisplayText(text, {
+      liveCaptionWidth: 260,
+      liveCaptionLineCount: 1,
+    });
+    const expanded = getLiveCaptionDisplayText(text, {
+      liveCaptionWidth: 260,
+      liveCaptionLineCount: 3,
+    });
+
+    expect(singleLine).toMatch(/^\.\.\. /);
+    expect(expanded).toMatch(/^\.\.\. /);
+    expect(singleLine.endsWith("omega")).toBe(true);
+    expect(expanded.endsWith("omega")).toBe(true);
+    expect(expanded.length).toBeGreaterThan(singleLine.length);
+    expect(expanded.endsWith(singleLine.replace(/^\.\.\. /, ""))).toBe(true);
+  });
+
+  it("keeps short captions unchanged", () => {
+    expect(
+      getLiveCaptionDisplayText("  hello   there  ", {
+        liveCaptionWidth: 260,
+        liveCaptionLineCount: 1,
+      }),
+    ).toBe("hello there");
   });
 });
 

--- a/apps/desktop/src/meeting-float/host.tsx
+++ b/apps/desktop/src/meeting-float/host.tsx
@@ -83,6 +83,8 @@ const LIVE_CAPTION_MIN_WIDTH = 260;
 const LIVE_CAPTION_MAX_WIDTH = 640;
 const LIVE_CAPTION_MIN_LINE_COUNT = 1;
 const LIVE_CAPTION_MAX_LINE_COUNT = 4;
+const LIVE_CAPTION_HORIZONTAL_PADDING_PX = 32;
+const LIVE_CAPTION_AVERAGE_CHARACTER_WIDTH_PX = 7.8;
 
 const LIVE_CAPTION_POSITIONS: ReadonlySet<string> = new Set([
   "topCenter",
@@ -679,9 +681,11 @@ export function getLiveCaptionRouteState(
     return null;
   }
 
+  const text = getLiveCaptionDisplayText(state.liveCaptionText, settings);
+
   return {
     sessionId: state.live.sessionId,
-    text: state.liveCaptionText.trim(),
+    text,
     opacity: settings.liveCaptionOpacity,
     width: settings.liveCaptionWidth,
     lineCount: settings.liveCaptionLineCount,
@@ -928,6 +932,47 @@ async function showLiveCaptionWindow(
   return true;
 }
 
+export function getLiveCaptionDisplayText(
+  text: string,
+  settings: Pick<
+    FloatingOverlaySettings,
+    "liveCaptionWidth" | "liveCaptionLineCount"
+  > = DEFAULT_FLOATING_OVERLAY_SETTINGS,
+) {
+  const normalizedText = text.trim().replace(/\s+/g, " ");
+  if (!normalizedText) {
+    return "";
+  }
+
+  const contentWidth = Math.max(
+    settings.liveCaptionWidth - LIVE_CAPTION_HORIZONTAL_PADDING_PX,
+    LIVE_CAPTION_MIN_WIDTH - LIVE_CAPTION_HORIZONTAL_PADDING_PX,
+  );
+  const charactersPerLine = Math.max(
+    12,
+    Math.floor(contentWidth / LIVE_CAPTION_AVERAGE_CHARACTER_WIDTH_PX),
+  );
+  const maxCharacters = Math.max(
+    24,
+    charactersPerLine * settings.liveCaptionLineCount,
+  );
+
+  if (normalizedText.length <= maxCharacters) {
+    return normalizedText;
+  }
+
+  return `... ${getTextSuffixAtWordBoundary(normalizedText, maxCharacters - 4)}`;
+}
+
+function getTextSuffixAtWordBoundary(text: string, maxCharacters: number) {
+  const suffix = text.slice(-maxCharacters).trimStart();
+  const firstWhitespaceIndex = suffix.search(/\s/);
+  if (firstWhitespaceIndex > 0 && firstWhitespaceIndex < suffix.length - 1) {
+    return suffix.slice(firstWhitespaceIndex).trimStart();
+  }
+
+  return suffix;
+}
 function normalizeOpacity(
   value: unknown,
   fallback: number,


### PR DESCRIPTION
Limit native live caption text to a recent window sized by caption width and line count, with tests for expanded captions and AX target text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting for the floating live caption overlay; no auth, persistence, or transcription pipeline changes.
> 
> **Overview**
> Live caption overlays no longer pass through the full accumulated transcript when it exceeds what fits on screen. **`getLiveCaptionDisplayText`** normalizes whitespace, estimates capacity from **caption width**, **line count**, and fixed padding/character-width heurics, then keeps short text intact or prefixes **`... `** with a **recent suffix** trimmed at a word boundary.
> 
> **`getLiveCaptionRouteState`** now feeds the native live caption panel this formatted string instead of a simple trim. Unit tests cover the rolling window (1 vs 3 lines) and unchanged short captions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4626d712fad9831a39d1e37e0f49e2ec3899b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->