### PR TITLE
Move notification close button offset

### DIFF
--- a/crates/notification-macos/swift-lib/src/Constants.swift
+++ b/crates/notification-macos/swift-lib/src/Constants.swift
@@ -69,4 +69,5 @@ enum Colors {
 enum CloseButtonConfig {
   static let size: CGFloat = 22
   static let symbolPointSize: CGFloat = 9.5
+  static let positionAdjustment = CGSize(width: -10, height: 10)
 }

--- a/crates/notification-macos/swift-lib/src/NotificationManager+Creation.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationManager+Creation.swift
@@ -275,14 +275,19 @@ extension NotificationManager {
     closeButton.translatesAutoresizingMaskIntoConstraints = false
     clickableView.addSubview(closeButton, positioned: .above, relativeTo: backdropView)
 
+    let isLiquidGlassLayout = isMacOS26()
     let horizontalButtonOffset =
-      isMacOS26() ? (CloseButtonConfig.size / 2) + 4 : (CloseButtonConfig.size / 2) - 2
+      isLiquidGlassLayout ? (CloseButtonConfig.size / 2) + 4 : (CloseButtonConfig.size / 2) - 2
+    let horizontalPositionAdjustment =
+      isLiquidGlassLayout ? CloseButtonConfig.positionAdjustment.width : 0
     let verticalButtonOffset = buttonOverhang() - (CloseButtonConfig.size / 2)
     NSLayoutConstraint.activate([
       closeButton.centerYAnchor.constraint(
-        equalTo: container.topAnchor, constant: verticalButtonOffset),
+        equalTo: container.topAnchor,
+        constant: verticalButtonOffset + CloseButtonConfig.positionAdjustment.height),
       closeButton.centerXAnchor.constraint(
-        equalTo: container.leadingAnchor, constant: horizontalButtonOffset),
+        equalTo: container.leadingAnchor,
+        constant: horizontalButtonOffset + horizontalPositionAdjustment),
       closeButton.widthAnchor.constraint(equalToConstant: CloseButtonConfig.size),
       closeButton.heightAnchor.constraint(equalToConstant: CloseButtonConfig.size),
 


### PR DESCRIPTION
Move the native macOS notification close button 10px left and 10px down from its current position.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Auto Layout tweaks for notification chrome only; no auth, data, or shared API changes.
> 
> **Overview**
> Repositions the native macOS notification **close button** via a shared `CloseButtonConfig.positionAdjustment` of **10px down** and **10px left**.
> 
> In `createCloseButton`, the vertical constraint always adds the **+10** height adjustment. The **-10** horizontal shift applies only when **liquid glass** layout is active (`isMacOS26()`); older layouts keep the previous horizontal offset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7a55bd6af9b9ce9592182f927650ed46a46a4eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->