### PR TITLE
Keep toast vertical position stable

### DIFF
--- a/apps/desktop/src/sidebar/toast/index.test.tsx
+++ b/apps/desktop/src/sidebar/toast/index.test.tsx
@@ -109,6 +109,36 @@ describe("ToastArea", () => {
     expect(toastContainer?.style.top).toBe("56px");
   });
 
+  it("keeps default placement centered while anchoring vertically to the main surface", () => {
+    const mainSurface = document.createElement("div");
+    mainSurface.setAttribute("data-chat-floating-anchor", "");
+    vi.spyOn(mainSurface, "getBoundingClientRect").mockReturnValue({
+      bottom: 552,
+      height: 500,
+      left: 200,
+      right: 800,
+      top: 52,
+      width: 600,
+      x: 200,
+      y: 52,
+      toJSON: () => ({}),
+    });
+    document.body.appendChild(mainSurface);
+
+    render(<ToastArea />);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    const toastContainer = screen
+      .getByText("Pro features available")
+      .closest(".fixed") as HTMLElement | null;
+
+    expect(toastContainer?.style.left).toBe("calc(50% + 0px)");
+    expect(toastContainer?.style.top).toBe("88px");
+  });
+
   it("positions the left sidebar toast relative to the main white surface", () => {
     const mainSurface = document.createElement("div");
     mainSurface.setAttribute("data-chat-floating-anchor", "");
@@ -177,7 +207,7 @@ describe("ToastArea", () => {
     expect(toastContainer?.style.top).toBe("88px");
   });
 
-  it("uses fallback placement immediately when left sidebar anchoring is disabled", () => {
+  it("preserves the main surface vertical anchor when left sidebar placement is disabled", () => {
     const mainSurface = document.createElement("div");
     mainSurface.setAttribute("data-chat-floating-anchor", "");
     vi.spyOn(mainSurface, "getBoundingClientRect").mockReturnValue({

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from "motion/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { cn } from "@hypr/utils";
@@ -30,6 +30,11 @@ type ToastAreaPosition = {
   left: number | string;
   top: number;
 };
+type MainSurfaceRect = {
+  left: number;
+  top: number;
+  width: number;
+};
 
 const DEFAULT_TOP_OFFSET_PX = 56;
 const LEFT_SIDEBAR_TOP_OFFSET_PX = 36;
@@ -44,9 +49,7 @@ export function ToastArea({
   const { dismissToast, isDismissed } = useDismissedToasts();
   const shouldShowToast = useShouldShowToast();
   const contentOffset = useMainContentCenterOffset();
-  const mainSurfacePosition = useMainSurfaceToastPosition(
-    placement === "left-sidebar",
-  );
+  const mainSurfaceRect = useMainSurfaceRect();
   const {
     hasActiveDownload,
     downloadProgress,
@@ -220,11 +223,11 @@ export function ToastArea({
 
   const dismissAction = displayToast?.dismissible ? handleDismiss : undefined;
   const position =
-    mainSurfacePosition ??
-    getFallbackPosition({
+    getMainSurfacePosition({
       contentOffset,
+      mainSurfaceRect,
       placement,
-    });
+    }) ?? getFallbackPosition({ contentOffset, placement });
 
   if (!shouldShowToast || !displayToast) {
     return null;
@@ -308,36 +311,28 @@ function useMainContentCenterOffset() {
   return contentOffset;
 }
 
-function useMainSurfaceToastPosition(enabled: boolean) {
-  const [position, setPosition] = useState<ToastAreaPosition | null>(null);
+function useMainSurfaceRect() {
+  const [rect, setRect] = useState<MainSurfaceRect | null>(null);
 
-  useEffect(() => {
-    if (!enabled) {
-      setPosition(null);
-      return;
-    }
-
-    const computePosition = () => {
+  useMountEffect(() => {
+    const computeRect = () => {
       const mainSurface = document.querySelector(MAIN_SURFACE_SELECTOR);
       if (!mainSurface) {
-        setPosition(null);
+        setRect(null);
         return;
       }
 
       const rect = mainSurface.getBoundingClientRect();
-      setPosition({
-        left: rect.left + rect.width / 2,
-        top: rect.top + LEFT_SIDEBAR_TOP_OFFSET_PX,
-      });
+      setRect({ left: rect.left, top: rect.top, width: rect.width });
     };
 
-    computePosition();
-    window.addEventListener("resize", computePosition);
-    window.addEventListener("scroll", computePosition, true);
+    computeRect();
+    window.addEventListener("resize", computeRect);
+    window.addEventListener("scroll", computeRect, true);
 
     const resizeObserver =
       typeof ResizeObserver !== "undefined"
-        ? new ResizeObserver(computePosition)
+        ? new ResizeObserver(computeRect)
         : null;
 
     const mainSurface = document.querySelector(MAIN_SURFACE_SELECTOR);
@@ -346,13 +341,35 @@ function useMainSurfaceToastPosition(enabled: boolean) {
     }
 
     return () => {
-      window.removeEventListener("resize", computePosition);
-      window.removeEventListener("scroll", computePosition, true);
+      window.removeEventListener("resize", computeRect);
+      window.removeEventListener("scroll", computeRect, true);
       resizeObserver?.disconnect();
     };
-  }, [enabled]);
+  });
 
-  return enabled ? position : null;
+  return rect;
+}
+
+function getMainSurfacePosition({
+  contentOffset,
+  mainSurfaceRect,
+  placement,
+}: {
+  contentOffset: number;
+  mainSurfaceRect: MainSurfaceRect | null;
+  placement: ToastAreaPlacement;
+}): ToastAreaPosition | null {
+  if (!mainSurfaceRect) {
+    return null;
+  }
+
+  return {
+    left:
+      placement === "left-sidebar"
+        ? mainSurfaceRect.left + mainSurfaceRect.width / 2
+        : `calc(50% + ${contentOffset}px)`,
+    top: mainSurfaceRect.top + LEFT_SIDEBAR_TOP_OFFSET_PX,
+  };
 }
 
 function getFallbackPosition({


### PR DESCRIPTION
Anchor the toast Y position to the main surface while preserving placement-specific horizontal centering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only toast positioning with fallback when the anchor is missing; no auth, data, or API changes.
> 
> **Overview**
> **Toast vertical placement** now follows the `[data-chat-floating-anchor]` main surface for both `default` and `left-sidebar` modes when that element is present, instead of only computing surface-relative position for left-sidebar.
> 
> `useMainSurfaceToastPosition` (gated on left-sidebar) is replaced by **`useMainSurfaceRect`**, which always tracks the anchor’s bounds on resize/scroll. **`getMainSurfacePosition`** sets **top** from `mainSurfaceRect.top + LEFT_SIDEBAR_TOP_OFFSET_PX` for every placement, while **left** stays placement-specific: `calc(50% + contentOffset)` for default, or the main surface horizontal center for left-sidebar. If no anchor is found, behavior still falls back to **`getFallbackPosition`**.
> 
> Tests cover default placement staying horizontally centered but moving **top** with the surface (e.g. `88px` when the surface top is `52`), and that switching off left-sidebar keeps the same vertical anchor rather than reverting to a fixed chrome offset only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8c51a4a63eabd66622bd31ca03caf909793080. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->