### PR TITLE
Center toast within main panel

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -335,6 +335,7 @@ export function ClassicMainBody() {
           }}
         >
           <div
+            data-main-content-panel
             className="h-full min-h-0 min-w-0 flex-1 overflow-auto"
             onClickCapture={mainAreaTopDrag.onClickCapture}
             onPointerCancel={mainAreaTopDrag.onPointerEnd}

--- a/apps/desktop/src/sidebar/toast/index.test.tsx
+++ b/apps/desktop/src/sidebar/toast/index.test.tsx
@@ -139,17 +139,32 @@ describe("ToastArea", () => {
     expect(toastContainer?.style.top).toBe("88px");
   });
 
-  it("positions the left sidebar toast relative to the main white surface", () => {
+  it("positions the left sidebar toast relative to the main content panel", () => {
+    const mainContentPanel = document.createElement("div");
+    mainContentPanel.setAttribute("data-main-content-panel", "");
+    vi.spyOn(mainContentPanel, "getBoundingClientRect").mockReturnValue({
+      bottom: 520,
+      height: 500,
+      left: 200,
+      right: 1_000,
+      top: 20,
+      width: 800,
+      x: 200,
+      y: 20,
+      toJSON: () => ({}),
+    });
+    document.body.appendChild(mainContentPanel);
+
     const mainSurface = document.createElement("div");
     mainSurface.setAttribute("data-chat-floating-anchor", "");
     vi.spyOn(mainSurface, "getBoundingClientRect").mockReturnValue({
       bottom: 520,
       height: 500,
-      left: 200,
-      right: 800,
+      left: 300,
+      right: 900,
       top: 20,
       width: 600,
-      x: 200,
+      x: 300,
       y: 20,
       toJSON: () => ({}),
     });
@@ -165,7 +180,7 @@ describe("ToastArea", () => {
       .getByText("Pro features available")
       .closest(".fixed") as HTMLElement | null;
 
-    expect(toastContainer?.style.left).toBe("500px");
+    expect(toastContainer?.style.left).toBe("600px");
     expect(toastContainer?.style.top).toBe("56px");
   });
 
@@ -208,6 +223,21 @@ describe("ToastArea", () => {
   });
 
   it("preserves the main surface vertical anchor when left sidebar placement is disabled", () => {
+    const mainContentPanel = document.createElement("div");
+    mainContentPanel.setAttribute("data-main-content-panel", "");
+    vi.spyOn(mainContentPanel, "getBoundingClientRect").mockReturnValue({
+      bottom: 520,
+      height: 500,
+      left: 200,
+      right: 1_000,
+      top: 0,
+      width: 800,
+      x: 200,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    document.body.appendChild(mainContentPanel);
+
     const mainSurface = document.createElement("div");
     mainSurface.setAttribute("data-chat-floating-anchor", "");
     vi.spyOn(mainSurface, "getBoundingClientRect").mockReturnValue({
@@ -233,7 +263,7 @@ describe("ToastArea", () => {
       .getByText("Pro features available")
       .closest(".fixed") as HTMLElement | null;
 
-    expect(toastContainer?.style.left).toBe("500px");
+    expect(toastContainer?.style.left).toBe("600px");
     expect(toastContainer?.style.top).toBe("56px");
 
     rerender(<ToastArea />);

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -30,7 +30,7 @@ type ToastAreaPosition = {
   left: number | string;
   top: number;
 };
-type MainSurfaceRect = {
+type ElementRect = {
   left: number;
   top: number;
   width: number;
@@ -39,6 +39,7 @@ type MainSurfaceRect = {
 const DEFAULT_TOP_OFFSET_PX = 56;
 const LEFT_SIDEBAR_TOP_OFFSET_PX = 36;
 const MAIN_SURFACE_SELECTOR = "[data-chat-floating-anchor]";
+const MAIN_CONTENT_PANEL_SELECTOR = "[data-main-content-panel]";
 
 export function ToastArea({
   placement = "default",
@@ -49,7 +50,8 @@ export function ToastArea({
   const { dismissToast, isDismissed } = useDismissedToasts();
   const shouldShowToast = useShouldShowToast();
   const contentOffset = useMainContentCenterOffset();
-  const mainSurfaceRect = useMainSurfaceRect();
+  const mainSurfaceRect = useElementRect(MAIN_SURFACE_SELECTOR);
+  const mainContentPanelRect = useElementRect(MAIN_CONTENT_PANEL_SELECTOR);
   const {
     hasActiveDownload,
     downloadProgress,
@@ -225,6 +227,7 @@ export function ToastArea({
   const position =
     getMainSurfacePosition({
       contentOffset,
+      mainContentPanelRect,
       mainSurfaceRect,
       placement,
     }) ?? getFallbackPosition({ contentOffset, placement });
@@ -311,39 +314,62 @@ function useMainContentCenterOffset() {
   return contentOffset;
 }
 
-function useMainSurfaceRect() {
-  const [rect, setRect] = useState<MainSurfaceRect | null>(null);
+function useElementRect(selector: string) {
+  const [rect, setRect] = useState<ElementRect | null>(null);
 
   useMountEffect(() => {
+    let observedElement: Element | null = null;
+
     const computeRect = () => {
-      const mainSurface = document.querySelector(MAIN_SURFACE_SELECTOR);
-      if (!mainSurface) {
+      const element = document.querySelector(selector);
+      if (!element) {
         setRect(null);
         return;
       }
 
-      const rect = mainSurface.getBoundingClientRect();
+      const rect = element.getBoundingClientRect();
       setRect({ left: rect.left, top: rect.top, width: rect.width });
     };
-
-    computeRect();
-    window.addEventListener("resize", computeRect);
-    window.addEventListener("scroll", computeRect, true);
 
     const resizeObserver =
       typeof ResizeObserver !== "undefined"
         ? new ResizeObserver(computeRect)
         : null;
+    const observeElement = () => {
+      const element = document.querySelector(selector);
+      if (element === observedElement) {
+        return;
+      }
 
-    const mainSurface = document.querySelector(MAIN_SURFACE_SELECTOR);
-    if (mainSurface) {
-      resizeObserver?.observe(mainSurface);
-    }
+      resizeObserver?.disconnect();
+      observedElement = element;
+
+      if (element) {
+        resizeObserver?.observe(element);
+      }
+    };
+    const mutationObserver =
+      typeof MutationObserver !== "undefined"
+        ? new MutationObserver(() => {
+            observeElement();
+            computeRect();
+          })
+        : null;
+
+    observeElement();
+    computeRect();
+    window.addEventListener("resize", computeRect);
+    window.addEventListener("scroll", computeRect, true);
+    mutationObserver?.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
 
     return () => {
       window.removeEventListener("resize", computeRect);
       window.removeEventListener("scroll", computeRect, true);
       resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
     };
   });
 
@@ -352,23 +378,27 @@ function useMainSurfaceRect() {
 
 function getMainSurfacePosition({
   contentOffset,
+  mainContentPanelRect,
   mainSurfaceRect,
   placement,
 }: {
   contentOffset: number;
-  mainSurfaceRect: MainSurfaceRect | null;
+  mainContentPanelRect: ElementRect | null;
+  mainSurfaceRect: ElementRect | null;
   placement: ToastAreaPlacement;
 }): ToastAreaPosition | null {
-  if (!mainSurfaceRect) {
+  const verticalAnchorRect = mainSurfaceRect ?? mainContentPanelRect;
+  const horizontalAnchorRect = mainContentPanelRect ?? mainSurfaceRect;
+  if (!verticalAnchorRect || !horizontalAnchorRect) {
     return null;
   }
 
   return {
     left:
       placement === "left-sidebar"
-        ? mainSurfaceRect.left + mainSurfaceRect.width / 2
+        ? horizontalAnchorRect.left + horizontalAnchorRect.width / 2
         : `calc(50% + ${contentOffset}px)`,
-    top: mainSurfaceRect.top + LEFT_SIDEBAR_TOP_OFFSET_PX,
+    top: verticalAnchorRect.top + LEFT_SIDEBAR_TOP_OFFSET_PX,
   };
 }
 


### PR DESCRIPTION
Measure the right main content panel for left-sidebar toast positioning and cover the mixed panel/surface case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only toast positioning and test updates; no auth, data, or API changes.
> 
> **Overview**
> Left-sidebar **toast** placement now centers horizontally on the full **main content panel** (`data-main-content-panel`) instead of only the narrower chat/note surface anchor, while still using the chat surface for vertical offset when present.
> 
> `ToastArea` tracks both `[data-main-content-panel]` and `[data-chat-floating-anchor]` via a shared `useElementRect` helper (with `MutationObserver` so anchors stay wired as the DOM changes). Tests cover the case where panel and surface rects differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba31ae71daeec1efd20edb1041c20951f416d9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->