### PR TITLE
Add desktop 1.1.3 changelog

### DIFF
--- a/packages/changelog/content/1.1.3.md
+++ b/packages/changelog/content/1.1.3.md
@@ -1,0 +1,28 @@
+---
+date: "2026-06-26"
+summary: "Anarlog now shows upcoming meetings more clearly, keeps live transcript and notification controls steadier, and smooths core desktop chrome."
+---
+
+## Sidebar
+
+- Upcoming meetings now show a clear countdown in the sidebar when they are about to start
+- The collapsed sidebar badge now matches the timeline's deleted-event visibility setting
+- Upcoming meeting countdown labels now respect the app language
+- Toasts now stay centered within the main panel
+
+## Live Notes
+
+- Live captions now keep a rolling history so recent speech remains easier to follow
+- Transcript loading and stopping states now avoid stale or distracting bottom chrome
+- Switching note tabs is faster and avoids extra editor work
+
+## Notifications
+
+- macOS notification close controls now sit in a cleaner, easier-to-hit position
+- Notification close-button spacing and overhang have been polished
+
+## Polish
+
+- Metadata popovers now scroll more reliably
+- Trial dialog buttons are easier to read in dark mode
+- Stale developer-tool panel actions have been removed


### PR DESCRIPTION
## Summary
- Add the desktop 1.1.3 changelog entry for the next stable release.

## Verification
- pnpm exec dprint fmt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no application or runtime code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.1.3.md`** for the next stable desktop release (dated **2026-06-26**), with front matter and a short summary line.
> 
> The entry documents user-facing changes in **Sidebar** (upcoming-meeting countdown, collapsed badge vs deleted-event visibility, localized labels, centered toasts), **Live Notes** (rolling caption history, cleaner transcript loading/stopping UI, faster tab switches), **Notifications** (macOS close-button layout), and **Polish** (metadata popover scrolling, trial dialog dark mode, removal of stale dev-tool actions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 976e841c9fbe7779df672741625532af44581ab0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->