### PR TITLE
Respect note width when opening chat panel

### DIFF
--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -262,6 +262,29 @@ describe("MainChatPanels", () => {
     );
   });
 
+  it("collapses the left sidebar when docked chat would make the note surface narrower than 500px", () => {
+    mocks.chatMode = "RightPanelOpen";
+    mocks.currentTab = { type: "sessions" };
+    mocks.leftSidebarExpanded = true;
+    mockPanelWidths({
+      bodyPanelWidth: 650,
+      leftSidebarWidth: 200,
+      rightPanelWidth: 320,
+    });
+
+    render(
+      <MainChatPanels>
+        <div data-left-sidebar-chrome />
+        <div data-chat-floating-anchor>
+          <div data-session-surface />
+        </div>
+      </MainChatPanels>,
+    );
+
+    expect(mocks.setLeftSidebarExpanded).toHaveBeenCalledWith(false);
+    expect(mocks.windowExpandWidth).not.toHaveBeenCalled();
+  });
+
   it("expands right when docked chat renders narrower than 320px", () => {
     mocks.chatMode = "RightPanelOpen";
     mocks.currentTab = { type: "sessions" };

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -165,10 +165,6 @@ function useNoteSurfaceWindowWidthGuard({
       return;
     }
 
-    if (!isTauri()) {
-      return;
-    }
-
     const bodyPanel = bodyPanelContainerRef.current;
     if (!bodyPanel) {
       return;
@@ -179,8 +175,23 @@ function useNoteSurfaceWindowWidthGuard({
       return;
     }
 
-    const leftSidebarWidth = getLeftSidebarWidth(bodyPanel, leftPanelOpen);
+    let leftSidebarWidth = getLeftSidebarWidth(bodyPanel, leftPanelOpen);
     const rightPanelWidth = getRightPanelWidth(bodyPanel, rightPanelOpen);
+    const shouldCollapseLeftPanelForRightPanel =
+      rightPanelJustOpened &&
+      leftPanelOpen &&
+      leftSidebarWidth > 0 &&
+      bodyWidth - leftSidebarWidth < NOTE_SURFACE_MIN_WIDTH_PX;
+
+    if (shouldCollapseLeftPanelForRightPanel) {
+      collapseLeftPanel();
+      leftSidebarWidth = 0;
+    }
+
+    if (!isTauri()) {
+      return;
+    }
+
     const requiredBodyWidth = NOTE_SURFACE_MIN_WIDTH_PX + leftSidebarWidth;
     const requiredTotalWidth =
       requiredBodyWidth + (rightPanelOpen ? RIGHT_CHAT_PANEL_MIN_WIDTH_PX : 0);
@@ -208,6 +219,7 @@ function useNoteSurfaceWindowWidthGuard({
     );
   }, [
     bodyPanelContainerRef,
+    collapseLeftPanel,
     enabled,
     leftPanelOpen,
     restoreWidthExpansions,


### PR DESCRIPTION
Collapse the left sidebar when opening the docked chat would make the session note surface narrower than its minimum width.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop layout behavior in `useNoteSurfaceWindowWidthGuard` with test coverage; no auth or data changes.
> 
> **Overview**
> When the **docked right chat panel** opens on a session tab, the layout guard now **collapses the left sidebar** if keeping it open would leave the note area below **500px** (`NOTE_SURFACE_MIN_WIDTH_PX`), instead of only trying to grow the window.
> 
> The collapse runs **before** the Tauri `windowExpandWidth` path, so narrow layouts prefer hiding the sidebar over (or without) window expansion. A unit test covers the case where collapse happens and **no** width expansion is requested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 914537821b921e4b345fdbc48589b66f4918eee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->