### PR TITLE
Search notes for unattached chat questions

### DIFF
--- a/apps/desktop/src/chat/tools/note-files.ts
+++ b/apps/desktop/src/chat/tools/note-files.ts
@@ -558,7 +558,7 @@ export const buildReadNoteTool = (deps: ToolDependencies) =>
 export const buildGrepNotesTool = (deps: ToolDependencies) =>
   tool({
     description:
-      "Lexically search local note files and transcripts. Use this for find/search requests before answering from memory. This is filesystem-backed text search, not vector search.",
+      "Lexically search local note files and transcripts for exact words or phrases. Use search_sessions first for open-ended questions about past meetings, people, decisions, or topics. This is filesystem-backed text search, not vector search.",
     inputSchema: z.object({
       query: z.string().describe("Text to search for in note files"),
       sessionIds: z

--- a/apps/desktop/src/chat/tools/search-sessions.ts
+++ b/apps/desktop/src/chat/tools/search-sessions.ts
@@ -105,6 +105,7 @@ export const buildSearchSessionsTool = (deps: ToolDependencies) =>
   tool({
     description: `
 Search for sessions (meeting notes) using query and filters.
+Use this first for open-ended questions about past meetings, people, decisions, or topics when the answer may be in meeting notes and no meeting note context is attached.
 Use filters.created_at.kind="relative" with recent_days for natural-language date ranges.
 Use an empty query string when the user only wants sessions by date/time filter.
 Returns relevant sessions with their content.

--- a/apps/desktop/src/chat/transport/use-transport.test.ts
+++ b/apps/desktop/src/chat/transport/use-transport.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { appendFileContextToolGuidance } from "./use-transport";
+
+describe("chat transport prompt guidance", () => {
+  it("tells chat to search meeting notes when no meeting note context is attached", () => {
+    const prompt = appendFileContextToolGuidance("Base prompt");
+
+    expect(prompt).toContain("Base prompt");
+    expect(prompt).toContain("When no meeting note context is attached");
+    expect(prompt).toContain("use search_sessions");
+    expect(prompt).toContain(
+      "Do not ask the user to open or share a meeting note",
+    );
+  });
+});

--- a/apps/desktop/src/chat/transport/use-transport.ts
+++ b/apps/desktop/src/chat/transport/use-transport.ts
@@ -13,11 +13,13 @@ import { useToolRegistry } from "~/contexts/tool";
 import { useConfigValue } from "~/shared/config";
 import * as main from "~/store/tinybase/store/main";
 
-const FILE_CONTEXT_TOOL_GUIDANCE = `
+export const FILE_CONTEXT_TOOL_GUIDANCE = `
 Context and local-note tool guidance:
+- When no meeting note context is attached and the user asks a factual question that could be answered by meeting notes, use search_sessions with the key names, topics, and date hints before answering. If the result looks relevant, answer from the returned meeting context or call read_note with the returned session id for more detail.
 - When the user asks about "this note", "this meeting", "the current note", or pronouns that likely refer to the open note, use read_current_note before answering.
-- When the user asks to find or search for something in notes, use grep_notes. If the answer needs the full source after a match, use read_note with the returned session id.
+- When the user asks to find or search for exact wording in notes, use grep_notes. If the answer needs the full source after a match, use read_note with the returned session id.
 - When the user asks about people from the current note or related meetings, use list_related_notes and then read_note as needed.
+- Do not ask the user to open or share a meeting note until search_sessions, grep_notes, or read_note cannot find enough local context.
 - Do not assume note contents from chat history when a file-backed tool can read the current source of truth.
 
 Web search guidance:
@@ -26,7 +28,7 @@ Web search guidance:
 - Do not use web_search for questions that only need local notes, contacts, or calendar events.
 `.trim();
 
-function appendFileContextToolGuidance(
+export function appendFileContextToolGuidance(
   prompt: string | undefined,
 ): string | undefined {
   if (prompt === undefined) {


### PR DESCRIPTION
Guide chat to search local meeting notes for open-ended factual questions when no context is attached.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only changes to system guidance and tool descriptions; no search, transport, or tool execution logic changed.
> 
> **Overview**
> When chat has **no meeting note attached**, the model is now steered to answer factual questions from local notes instead of asking the user to open a note.
> 
> **System prompt** (`FILE_CONTEXT_TOOL_GUIDANCE` via `appendFileContextToolGuidance`): use **`search_sessions`** first with names, topics, and date hints; follow with **`read_note`** when needed; reserve **`grep_notes`** for exact wording; and **do not** ask the user to open or share a note until search/read/grep fail to find enough context.
> 
> **Tool descriptions** align with that flow: **`search_sessions`** is documented as the first step for open-ended past-meeting questions; **`grep_notes`** points to **`search_sessions`** first and narrows its role to lexical/exact-phrase search.
> 
> Exports **`FILE_CONTEXT_TOOL_GUIDANCE`** and **`appendFileContextToolGuidance`** for testing; a new Vitest file asserts the appended guidance includes the search-first and no-prompt-to-open-note rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59f4d7f089ebb001df4380f304fb4caa51c0cf18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5780 
- <kbd>&nbsp;1&nbsp;</kbd> #5779 👈 
<!-- GitButler Footer Boundary Bottom -->

