### PR TITLE
Add desktop 1.1.4 changelog

### DIFF
--- a/packages/changelog/content/1.1.4.md
+++ b/packages/changelog/content/1.1.4.md
@@ -1,0 +1,31 @@
+---
+date: "2026-06-26"
+summary: "Anarlog chat can use meeting notes more reliably, transcription feels steadier, and personalization settings are easier to manage."
+---
+
+## Chat
+
+- Chat can now search meeting notes before answering open-ended questions when no note is attached
+- Corrections like "it was X, not Y" can now update the matching summary or transcript instead of only replying in chat
+- The first assistant response in a chat now starts more reliably
+- Pressing Enter now sends chat messages, while Shift+Enter still adds a new line
+- Context chips now show a clearer remove control when you detach note context
+- Opening chat now protects the note surface by collapsing the sidebar when space is tight
+
+## Transcription
+
+- Long transcripts now render more smoothly during active recordings
+- Live transcription now keeps Parakeet models in streaming mode instead of switching to a slower batch path
+- Soniqo batch transcripts now preserve chunk timing more accurately
+- STT model labels now match the selected model more reliably
+- The live transcript panel now stays focused on the session transcript without an extra bottom accessory
+
+## Notes
+
+- Session metadata now loads before note content so sidebar details are available more reliably after startup
+- Active session transcript state now restores correctly when returning to a live note
+
+## Settings
+
+- Personalization dictionary settings now make it easier to manage custom names and terms for transcription
+- LLM providers now require their configured API keys and base URLs before use, making provider setup clearer


### PR DESCRIPTION
## Summary
- Add desktop 1.1.4 changelog notes for the chat-focused release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime or application code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.1.4.md`**, the desktop **1.1.4** changelog entry (dated 2026-06-26), using the same frontmatter `summary` plus sectioned bullets as prior releases.
> 
> The new notes highlight **chat** (note search without attached context, in-chat corrections that update summary/transcript, Enter-to-send, context chips, sidebar collapse), **transcription** (smoother long transcripts, Parakeet streaming, Soniqo timing, STT labels, live panel UI), **notes** (metadata load order, live session restore), and **settings** (personalization dictionary, stricter LLM API key/base URL validation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7909adf958393b01ebce82d49c668a4091425ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->