### PR TITLE
Preserve Soniqo batch chunk timing

### DIFF
--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -370,10 +370,10 @@ where
                     error = %error,
                     "soniqo_channel_transcription_failed"
                 );
-                output.push(hypr_transcribe_soniqo::FileTranscript {
-                    text: String::new(),
-                    duration_seconds: 0.05,
-                });
+                output.push(hypr_transcribe_soniqo::FileTranscript::new(
+                    String::new(),
+                    0.05,
+                ));
             }
         }
     }
@@ -418,6 +418,7 @@ fn transcribe_soniqo_channel_chunks(
     mut on_chunk_completed: impl FnMut(),
 ) -> std::result::Result<hypr_transcribe_soniqo::FileTranscript, String> {
     let mut texts = Vec::new();
+    let mut transcript_chunks = Vec::new();
     let mut successful_chunks = 0usize;
     let mut failed_chunks = 0usize;
     let channel_index = plan.channel_index;
@@ -473,6 +474,12 @@ fn transcribe_soniqo_channel_chunks(
         let text = text.trim();
         if !text.is_empty() {
             texts.push(text.to_string());
+            transcript_chunks.push(hypr_transcribe_soniqo::FileTranscriptChunk {
+                text: text.to_string(),
+                start_seconds: chunk.sample_start as f64 / TARGET_SAMPLE_RATE as f64,
+                duration_seconds: (chunk.sample_end - chunk.sample_start) as f64
+                    / TARGET_SAMPLE_RATE as f64,
+            });
         }
     }
 
@@ -493,10 +500,17 @@ fn transcribe_soniqo_channel_chunks(
         );
     }
 
-    Ok(hypr_transcribe_soniqo::FileTranscript {
-        text: texts.join(" "),
-        duration_seconds: plan.duration_seconds,
-    })
+    if transcript_chunks.is_empty() {
+        return Ok(hypr_transcribe_soniqo::FileTranscript::new(
+            texts.join(" "),
+            plan.duration_seconds,
+        ));
+    }
+
+    Ok(hypr_transcribe_soniqo::FileTranscript::from_chunks(
+        transcript_chunks,
+        plan.duration_seconds,
+    ))
 }
 
 fn transcribe_soniqo_samples(
@@ -665,10 +679,10 @@ mod tests {
     #[test]
     fn collect_soniqo_channel_transcripts_keeps_channel_slots() {
         let transcripts = collect_soniqo_channel_transcripts([
-            Ok(hypr_transcribe_soniqo::FileTranscript {
-                text: "hello".to_string(),
-                duration_seconds: 1.0,
-            }),
+            Ok(hypr_transcribe_soniqo::FileTranscript::new(
+                "hello".to_string(),
+                1.0,
+            )),
             Err("native chunk failed".to_string()),
         ])
         .unwrap();
@@ -682,10 +696,10 @@ mod tests {
     fn collect_soniqo_channel_transcripts_preserves_later_channel_index() {
         let transcripts = collect_soniqo_channel_transcripts([
             Err("first failed".to_string()),
-            Ok(hypr_transcribe_soniqo::FileTranscript {
-                text: "system audio".to_string(),
-                duration_seconds: 1.0,
-            }),
+            Ok(hypr_transcribe_soniqo::FileTranscript::new(
+                "system audio".to_string(),
+                1.0,
+            )),
         ])
         .unwrap();
 

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -213,6 +213,40 @@ pub struct ModelDownloadState {
 pub struct FileTranscript {
     pub text: String,
     pub duration_seconds: f64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub chunks: Vec<FileTranscriptChunk>,
+}
+
+impl FileTranscript {
+    pub fn new(text: String, duration_seconds: f64) -> Self {
+        Self {
+            text,
+            duration_seconds,
+            chunks: Vec::new(),
+        }
+    }
+
+    pub fn from_chunks(chunks: Vec<FileTranscriptChunk>, duration_seconds: f64) -> Self {
+        let text = chunks
+            .iter()
+            .map(|chunk| chunk.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        Self {
+            text,
+            duration_seconds,
+            chunks,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileTranscriptChunk {
+    pub text: String,
+    pub start_seconds: f64,
+    pub duration_seconds: f64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -486,13 +520,7 @@ pub fn batch_response_from_text(
     text: String,
     duration_seconds: f64,
 ) -> batch::Response {
-    batch_response_from_channels(
-        model,
-        vec![FileTranscript {
-            text,
-            duration_seconds,
-        }],
-    )
+    batch_response_from_channels(model, vec![FileTranscript::new(text, duration_seconds)])
 }
 
 pub fn batch_response_from_channels(
@@ -500,10 +528,7 @@ pub fn batch_response_from_channels(
     channels: Vec<FileTranscript>,
 ) -> batch::Response {
     let channels = if channels.is_empty() {
-        vec![FileTranscript {
-            text: String::new(),
-            duration_seconds: 0.05,
-        }]
+        vec![FileTranscript::new(String::new(), 0.05)]
     } else {
         channels
     };
@@ -521,14 +546,20 @@ pub fn batch_response_from_channels(
                 .enumerate()
                 .map(|(channel_index, channel)| {
                     let transcript = normalize_transcript_text(&channel.text);
-                    let synthetic_duration = synthetic_text_duration(&transcript);
+                    let words = if channel.chunks.is_empty() {
+                        let synthetic_duration = synthetic_text_duration(&transcript);
+                        batch_words_from_text(
+                            &transcript,
+                            0.0,
+                            synthetic_duration,
+                            channel_index as i32,
+                        )
+                    } else {
+                        batch_words_from_chunks(&channel.chunks, channel_index as i32)
+                    };
                     batch::Channel {
                         alternatives: vec![batch::Alternatives {
-                            words: batch_words_from_text(
-                                &transcript,
-                                synthetic_duration,
-                                channel_index as i32,
-                            ),
+                            words,
                             transcript,
                             confidence: 1.0,
                         }],
@@ -596,7 +627,20 @@ fn stream_words_from_text(text: &str, start: f64, duration: f64) -> Vec<stream::
         .collect()
 }
 
-fn batch_words_from_text(text: &str, duration: f64, channel: i32) -> Vec<batch::Word> {
+fn batch_words_from_chunks(chunks: &[FileTranscriptChunk], channel: i32) -> Vec<batch::Word> {
+    chunks
+        .iter()
+        .flat_map(|chunk| {
+            let text = normalize_transcript_text(&chunk.text);
+            let duration = synthetic_text_duration(&text)
+                .min(chunk.duration_seconds.max(MIN_SYNTHETIC_DURATION_SECONDS));
+            let start = chunk.start_seconds.max(0.0);
+            batch_words_from_text(&text, start, duration, channel)
+        })
+        .collect()
+}
+
+fn batch_words_from_text(text: &str, start: f64, duration: f64, channel: i32) -> Vec<batch::Word> {
     let word_strs = split_words(text);
     let count = word_strs.len();
 
@@ -609,8 +653,8 @@ fn batch_words_from_text(text: &str, duration: f64, channel: i32) -> Vec<batch::
         .enumerate()
         .map(|(index, word)| batch::Word {
             word: word.to_string(),
-            start: (index as f64 / count as f64) * duration,
-            end: ((index + 1) as f64 / count as f64) * duration,
+            start: start + (index as f64 / count as f64) * duration,
+            end: start + ((index + 1) as f64 / count as f64) * duration,
             confidence: 1.0,
             channel,
             speaker: None,
@@ -742,6 +786,7 @@ mod platform {
         Ok(FileTranscript {
             text: result.text,
             duration_seconds: result.duration_seconds,
+            chunks: Vec::new(),
         })
     }
 
@@ -979,14 +1024,8 @@ mod tests {
         let response = batch_response_from_channels(
             SoniqoModel::Omnilingual,
             vec![
-                FileTranscript {
-                    text: "mic words".to_string(),
-                    duration_seconds: 2.0,
-                },
-                FileTranscript {
-                    text: "speaker words".to_string(),
-                    duration_seconds: 3.0,
-                },
+                FileTranscript::new("mic words".to_string(), 2.0),
+                FileTranscript::new("speaker words".to_string(), 3.0),
             ],
         );
 
@@ -1025,6 +1064,35 @@ mod tests {
         assert_eq!(words[3].end, 4.0 * SYNTHETIC_BATCH_WORD_SECONDS);
         assert!(words[3].end < 3.0);
         assert_eq!(response.metadata["duration"], 120.0);
+    }
+
+    #[test]
+    fn batch_response_offsets_synthetic_words_by_chunk_start() {
+        let response = batch_response_from_channels(
+            SoniqoModel::ParakeetBatch,
+            vec![FileTranscript::from_chunks(
+                vec![
+                    FileTranscriptChunk {
+                        text: "early words".to_string(),
+                        start_seconds: 0.0,
+                        duration_seconds: 29.5,
+                    },
+                    FileTranscriptChunk {
+                        text: "later words".to_string(),
+                        start_seconds: 29.5,
+                        duration_seconds: 29.5,
+                    },
+                ],
+                59.0,
+            )],
+        );
+        let words = &response.results.channels[0].alternatives[0].words;
+
+        assert_eq!(words[0].start, 0.0);
+        assert_eq!(words[1].start, SYNTHETIC_BATCH_WORD_SECONDS);
+        assert_eq!(words[2].start, 29.5);
+        assert_eq!(words[3].start, 29.5 + SYNTHETIC_BATCH_WORD_SECONDS);
+        assert_eq!(response.metadata["timing_source"], "synthetic_text");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add chunk offsets to local Soniqo batch transcripts.
- Preserve wall-clock word order across channels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch STT word timing for chunked Soniqo paths, which can affect UI ordering and merge logic that depends on `start`/`end`; behavior is covered by new tests and unchanged when chunks are absent.
> 
> **Overview**
> Local Soniqo batch transcription now records **per-chunk wall-clock offsets** when audio is split for inference, so downstream batch word timings are not all anchored at 0.
> 
> `FileTranscript` gains optional `chunks` (`FileTranscriptChunk` with text, `start_seconds`, `duration_seconds`) plus `new` / `from_chunks` helpers. In `listener2-core`, chunked channel transcription builds those chunks from each window’s `sample_start` / `sample_end` and returns `from_chunks` when any chunk has text; single-file and empty-chunk paths still use text-only transcripts.
> 
> `batch_response_from_channels` uses chunk metadata when present: synthetic word timings are offset by each chunk’s start (still capped by chunk duration), instead of treating the full channel text as starting at 0. Native one-shot file transcription continues to emit transcripts with no chunks, preserving the previous behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c167f90402e64d842acd35e24cdb01225f7b8dcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->