### PR TITLE
Fix STT model display mismatch

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Wys drywende balk"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "ተንሳፋፊ አሞሌ አሳይ"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "إظهار الشريط العائم"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "ভাসমান বাৰ দেখুৱাওক"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Üzən çubuğu göstər"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Йөҙөүсе һыҙыҡты күрһәтеү"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Паказаць плаваючую панэль"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Показване на плаваща лента"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "ভাসমান বার দেখান"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "འཕྱོ་བའི་ཕྲ་རིང་སྟོན།"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Diskouez ar varrenn o nijal"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Prikaži plutajuću traku"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Mostra la barra flotant"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Zobrazit plovoucí lištu"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Dangos bar arnofio"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Vis flydende bjælke"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Schwebende Leiste anzeigen"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Εμφάνιση αιωρούμενης γραμμής"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -34,7 +34,7 @@ msgstr "{trialDaysRemaining} days left"
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 
@@ -238,7 +238,7 @@ msgstr "Back"
 msgid "Base URL"
 msgstr "Base URL"
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr "Batch"
 
@@ -491,7 +491,7 @@ msgstr "Delete All Recurring Events"
 msgid "Delete Event"
 msgstr "Delete Event"
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr "Delete model"
 
@@ -544,7 +544,7 @@ msgstr "Don't save"
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr "Don't show notifications when Do-Not-Disturb is enabled on your system"
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr "Download"
 
@@ -586,7 +586,7 @@ msgstr "Enhance contact"
 msgid "Enhance contact {label}"
 msgstr "Enhance contact {label}"
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr "Enter a model identifier"
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr "Microphone detection"
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr "Model being used"
 
@@ -1239,7 +1239,7 @@ msgstr "Preparing transcript..."
 msgid "Previous match"
 msgstr "Previous match"
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr "Pro"
 
@@ -1251,7 +1251,7 @@ msgstr "Pro trial"
 msgid "Ready to go"
 msgstr "Ready to go"
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr "Realtime"
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr "Select a different folder"
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr "Select a model"
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr "Select a person to view details"
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr "Select a provider"
 
@@ -1527,7 +1527,7 @@ msgstr "Show Event"
 msgid "Show floating bar"
 msgstr "Show floating bar"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr "Show in Finder"
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr "Upgrade to Pro for {0}"
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr "Upgrade to Pro to use this provider."
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr "Upgrade to use"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Mostrar barra flotante"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Kuva ujuv riba"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Erakutsi barra mugikorra"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "نمایش نوار شناور"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Hollit barme ɓuuɓɗo"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Näytä kelluva palkki"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Vís flótandi striku"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Afficher la barre flottante"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Taispeáin barra ar snámh"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Mostrar barra flotante"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "ફ્લોટિંગ બાર બતાવો"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Nuna mashaya mai iyo"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "הצג סרגל צף"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "फ़्लोटिंग बार दिखाएँ"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Prikaži plutajuću traku"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Montre ba k ap flote"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Lebegő sáv megjelenítése"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Ցուցադրել լողացող սանդղակը"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Tampilkan bilah mengambang"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Gosi mmanya na-ese n'elu mmiri"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Sýna fljótandi stiku"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Mostra barra flottante"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "フローティングバーを表示"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Tampilake bar ngambang"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "მცურავი ზოლის ჩვენება"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Қалқымалы жолақты көрсету"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "បង្ហាញរបារអណ្តែតទឹក"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "ಫ್ಲೋಟಿಂಗ್ ಬಾರ್ ತೋರಿಸು"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "플로팅 바 표시"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Barika herikîn nîşan bide"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Калкуучу тилкени көрсөтүү"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Ostende vectem nare"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Schwiewend Bar weisen"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Laga ebbaala etengejja"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Lakisa barre oyo ezali kopumbwa"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "ສະແດງແຖບເລື່ອນ"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Rodyti slankią juostą"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Rādīt peldošo joslu"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Asehoy ny bara mitsingevana"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Whakaatuhia te pae rewa"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Прикажи пловечка лента"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "ഫ്ലോട്ടിംഗ് ബാർ കാണിക്കുക"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Хөвөгч мөрийг харуулах"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "फ्लोटिंग बार दर्शवा"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Tunjukkan bar terapung"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Uri bar floating"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "ရေပေါ်ဘားကိုပြပါ"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "फ्लोटिंग बार देखाउनुहोस्"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Zwevende balk weergeven"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Vis flytende søyle"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Vis flytende søyle"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Onetsani mipiringidzo yoyandama"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Afichar la barra flotanta"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "ଭାସମାନ ଦଣ୍ଡ ଦେଖାନ୍ତୁ |"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "ਫਲੋਟਿੰਗ ਬਾਰ ਦਿਖਾਓ"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Pokaż pływający pasek"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "مړونکی بار وښایاست"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Mostrar barra flutuante"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Afișați bara plutitoare"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Показать плавающую панель"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "प्लवमानं पट्टिकां दर्शयतु"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "سچل بار ڏيکاريو"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "පාවෙන තීරුව පෙන්වන්න"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Zobraziť plávajúcu lištu"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Prikaži plavajočo vrstico"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Ratidza bara rinoyangarara"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "muuji bar sabaynaysa"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Shfaq shiritin lundrues"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Прикажи плутајућу траку"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Témbongkeun palang ngambang"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Visa flytande stapel"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Onyesha upau unaoelea"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "மிதக்கும் பட்டியைக் காட்டு"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "ఫ్లోటింగ్ బార్‌ను చూపు"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Намоиш додани сатри шинокунанда"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "แสดงแถบลอย"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "floüzýän paneli görkez"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Ipakita ang floating bar"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Kayan çubuğu göster"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Йөзүче тактаны күрсәтегез"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Показати плаваючу панель"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "تیرتی بار دکھائیں"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Suzuvchi satrni ko'rsatish"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Hiển thị thanh nổi"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Wone barab buy féey"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Bonisa ibha edadayo"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "ווייַז פלאָוטינג באַר"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Fi ọpa lilefoofo han"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "显示浮动栏"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:146
+#: src/settings/ai/stt/select.tsx:148
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Batch"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:741
+#: src/settings/ai/stt/select.tsx:743
 msgid "Delete model"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Download"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:219
+#: src/settings/ai/stt/select.tsx:221
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:158
+#: src/settings/ai/stt/select.tsx:160
 msgid "Model being used"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:194
+#: src/settings/ai/stt/select.tsx:196
 msgid "Pro"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Ready to go"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:674
+#: src/settings/ai/stt/select.tsx:676
 msgid "Realtime"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:165
-#: src/settings/ai/stt/select.tsx:236
+#: src/settings/ai/stt/select.tsx:238
 msgid "Select a model"
 msgstr ""
 
@@ -1442,7 +1442,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:167
+#: src/settings/ai/stt/select.tsx:169
 msgid "Select a provider"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr "Bonisa ibha entantayo"
 
-#: src/settings/ai/stt/select.tsx:726
+#: src/settings/ai/stt/select.tsx:728
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1832,11 +1832,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:200
+#: src/settings/ai/stt/select.tsx:202
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:637
+#: src/settings/ai/stt/select.tsx:639
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -84,7 +84,9 @@ export function SelectProviderAndModel() {
   const displayedSttModel =
     selectedProvider === "custom"
       ? selectedSttModel
-      : getPreferredProviderModel(selectedSttModel, selectedModels);
+      : getPreferredProviderModel(selectedSttModel, selectedModels, {
+          keepUnavailableSavedModel: true,
+        });
   const selectedModel = selectedModels.find(
     (model) => model.id === displayedSttModel,
   );

--- a/apps/desktop/src/settings/ai/stt/selection.test.ts
+++ b/apps/desktop/src/settings/ai/stt/selection.test.ts
@@ -39,6 +39,19 @@ describe("getPreferredProviderModel", () => {
     ).toBe("soniqo-qwen3-small");
   });
 
+  test("can keep a saved model visible even when it is not selectable", () => {
+    expect(
+      getPreferredProviderModel(
+        "cloud",
+        [
+          { id: "cloud", isDownloaded: false },
+          { id: "soniqo-parakeet-streaming", isDownloaded: true },
+        ],
+        { keepUnavailableSavedModel: true },
+      ),
+    ).toBe("cloud");
+  });
+
   test("clears the selection when a provider has no selectable models", () => {
     expect(
       getPreferredProviderModel("cloud", [

--- a/apps/desktop/src/stt/model-selection.ts
+++ b/apps/desktop/src/stt/model-selection.ts
@@ -5,6 +5,7 @@ type ModelEntry = {
 
 type PreferredProviderModelOptions = {
   allowSavedModelWithoutChoices?: boolean;
+  keepUnavailableSavedModel?: boolean;
 };
 
 export function normalizeStoredSttModel(
@@ -62,6 +63,14 @@ export function getPreferredProviderModel(
 ) {
   const normalizedSavedModel = normalizeSavedModel(savedModel, models);
   const selectableModels = models.filter((model) => model.isDownloaded ?? true);
+
+  if (
+    options?.keepUnavailableSavedModel &&
+    normalizedSavedModel &&
+    models.some((model) => model.id === normalizedSavedModel)
+  ) {
+    return normalizedSavedModel;
+  }
 
   if (
     normalizedSavedModel &&


### PR DESCRIPTION
## Summary
- Keep unavailable saved STT models visible in settings.
- Prevent settings from appearing to select a different local model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized settings display/selection helper change with unit tests; no auth or data-path changes.
> 
> **Overview**
> Fixes a **display mismatch** in AI transcription settings where the saved local/cloud model could differ from what the model dropdown showed (often the first downloaded model) even though the stored preference was unchanged.
> 
> The settings UI now derives **`displayedSttModel`** via `getPreferredProviderModel` with **`keepUnavailableSavedModel: true`**, so a saved model that is still known to the provider but not currently selectable (e.g. not downloaded) stays visible in the selector instead of being replaced silently. **`getPreferredProviderModel`** gains that option path; behavior without the flag is unchanged (still falls back to the first selectable model or clears).
> 
> Locale **`messages.po`** files were refreshed so Lingui source references track the small line shifts in `stt/select.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d665c16561e60980a38eb493351a5cf9ed7c44e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->