### PR TITLE
Keep Parakeet streaming in live mode

### DIFF
--- a/apps/desktop/src/stt/capabilities.test.ts
+++ b/apps/desktop/src/stt/capabilities.test.ts
@@ -53,10 +53,10 @@ describe("getOnDeviceTranscriptionMode", () => {
     ).toBe("live");
   });
 
-  test("falls back to batch for non-English Soniqo streaming languages", () => {
+  test("keeps European Soniqo streaming languages live", () => {
     expect(
       getOnDeviceTranscriptionMode("soniqo-parakeet-streaming", ["de"]),
-    ).toBe("batch");
+    ).toBe("live");
   });
 });
 
@@ -96,12 +96,12 @@ describe("getOnDeviceTranscriptionConfig", () => {
     });
   });
 
-  test("keeps German on batch even when English is an additional language", () => {
+  test("keeps German live even when English is an additional language", () => {
     expect(
       getOnDeviceTranscriptionConfig("soniqo-parakeet-streaming", ["de", "en"]),
     ).toEqual({
-      languages: ["de", "en"],
-      transcriptionMode: "batch",
+      languages: ["de"],
+      transcriptionMode: "live",
     });
   });
 

--- a/apps/desktop/src/stt/capabilities.ts
+++ b/apps/desktop/src/stt/capabilities.ts
@@ -9,7 +9,6 @@ type LiveTranscriptionConfig = {
   transcriptionMode?: TranscriptionMode;
 };
 
-const SONIQO_STREAMING_LANGUAGE_CODES = new Set(["en"]);
 const SONIQO_PARAKEET_BATCH_LANGUAGE_CODES = new Set([
   "bg",
   "cs",
@@ -37,6 +36,7 @@ const SONIQO_PARAKEET_BATCH_LANGUAGE_CODES = new Set([
   "sv",
   "uk",
 ]);
+const SONIQO_STREAMING_LANGUAGE_CODES = SONIQO_PARAKEET_BATCH_LANGUAGE_CODES;
 
 export function isSupportedLocalSttModel(
   model?: string | null,
@@ -149,23 +149,6 @@ export function getOnDeviceTranscriptionConfig(
   languages: readonly string[],
 ): LiveTranscriptionConfig {
   if (!isRealtimeLocalModel(model)) {
-    return {
-      languages: [...languages],
-      transcriptionMode: "batch",
-    };
-  }
-
-  const primaryLanguage = languages[0];
-  const primaryLanguageLiveSupported =
-    !primaryLanguage ||
-    SONIQO_STREAMING_LANGUAGE_CODES.has(baseLanguageCode(primaryLanguage));
-  const primaryLanguageBatchSupported =
-    !!primaryLanguage &&
-    SONIQO_PARAKEET_BATCH_LANGUAGE_CODES.has(baseLanguageCode(primaryLanguage));
-
-  // The Soniqo streaming session API does not accept a language hint, so keep
-  // non-English Parakeet languages on batch instead of relying on live auto-detect.
-  if (!primaryLanguageLiveSupported && primaryLanguageBatchSupported) {
     return {
       languages: [...languages],
       transcriptionMode: "batch",

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -440,6 +440,31 @@ describe("useStartListening", () => {
     });
   });
 
+  test("keeps supported non-English realtime local models live", async () => {
+    useConfigValueMock.mockImplementation((key) =>
+      key === "ai_language" ? "de" : ["en"],
+    );
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "hyprnote",
+        model: "soniqo-parakeet-streaming",
+        baseUrl: "http://localhost:8080",
+        apiKey: "",
+      },
+    });
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(startMock.mock.calls[0]?.[0]).toMatchObject({
+      languages: ["de"],
+      transcription_mode: "live",
+    });
+  });
+
   test("keeps realtime local transcription live by filtering unsupported extra spoken languages", async () => {
     useConfigValueMock.mockImplementation((key) =>
       key === "ai_language" ? "en" : ["ko"],


### PR DESCRIPTION
## Summary
- Align desktop Soniqo streaming language support with local model metadata.
- Cover capture payloads for supported non-English languages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live vs batch transcription for non-English local STT users, which affects capture behavior and transcript quality if streaming support does not match metadata assumptions.
> 
> **Overview**
> **Soniqo Parakeet streaming** no longer downgrades to **batch** when the user’s language is a supported European locale (e.g. German). Streaming language support is aligned with the existing Parakeet batch language list instead of treating only English as live-capable.
> 
> In `capabilities.ts`, `SONIQO_STREAMING_LANGUAGE_CODES` now mirrors `SONIQO_PARAKEET_BATCH_LANGUAGE_CODES`, and the branch that forced batch for non-English primary languages with batch support is removed. For `soniqo-parakeet-streaming`, config stays **`live`**, passes the first Soniqo-supported language hint (e.g. `["de"]` when German is primary), and still drops unsupported hints without switching modes.
> 
> Tests cover German live mode and a **`useStartListening`** case that asserts capture starts with `languages: ["de"]` and `transcription_mode: "live"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 871432ae916b9895eb00a1c8237fb56f5a2a574f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->