### PR TITLE
Load session metadata before note content

### DIFF
--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -21,6 +21,7 @@ import { useAutoEnhance } from "./hooks/useAutoEnhance";
 import { shouldShowSessionTopAudioPlayer } from "./top-audio-player";
 
 import * as AudioPlayer from "~/audio-player";
+import { hydrateSessionContent } from "~/store/tinybase/persister/session/hydrate";
 import * as main from "~/store/tinybase/store/main";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
@@ -28,6 +29,8 @@ import { consumePendingUpload } from "~/stt/pending-upload";
 import { useStartListening } from "~/stt/useStartListening";
 import { useSTTConnection } from "~/stt/useSTTConnection";
 import { useUploadFile } from "~/stt/useUploadFile";
+
+const hydratedSessionIds = new Set<string>();
 
 export function TabContentNote({
   standaloneWindow = false,
@@ -123,6 +126,7 @@ function TabContentNoteInner({
   const { audioExists } = AudioPlayer.useAudioPlayer();
   const editorTabs = useEditorTabs({ sessionId: tab.id, audioExists });
   const currentView = useCurrentNoteTab(tab, { audioExists });
+  const contentHydrated = useHydrateSessionContent(tab.id);
   const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
   const hasTranscript = useHasTranscript(tab.id);
 
@@ -222,17 +226,76 @@ function TabContentNoteInner({
           </div>
         ) : null}
         <div className="min-h-0 flex-1">
-          <NoteInput
-            ref={noteInputRef}
-            tab={tab}
-            editorTabs={editorTabs}
-            currentTab={currentView}
-            handleTabChange={handleTabChange}
-            hideHeader
-          />
+          {contentHydrated ? (
+            <NoteInput
+              ref={noteInputRef}
+              tab={tab}
+              editorTabs={editorTabs}
+              currentTab={currentView}
+              handleTabChange={handleTabChange}
+              hideHeader
+            />
+          ) : (
+            <SessionContentLoading />
+          )}
         </div>
       </div>
     </SessionSurface>
+  );
+}
+
+function useHydrateSessionContent(sessionId: string): boolean {
+  const store = main.UI.useStore(main.STORE_ID);
+  const [retryAttempt, setRetryAttempt] = React.useState(0);
+  const [hydrated, setHydrated] = React.useState(() =>
+    hydratedSessionIds.has(sessionId),
+  );
+
+  useEffect(() => {
+    if (hydratedSessionIds.has(sessionId)) {
+      setHydrated(true);
+      return;
+    }
+
+    if (!store) {
+      setHydrated(false);
+      return;
+    }
+
+    let active = true;
+    setHydrated(false);
+
+    void hydrateSessionContent(store, sessionId).then((success) => {
+      if (success) {
+        hydratedSessionIds.add(sessionId);
+      }
+      if (active) {
+        setHydrated(success);
+        if (!success) {
+          window.setTimeout(() => {
+            if (active) {
+              setRetryAttempt((attempt) => attempt + 1);
+            }
+          }, 1000);
+        }
+      }
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [store, sessionId, retryAttempt]);
+
+  return hydrated;
+}
+
+function SessionContentLoading() {
+  return (
+    <div className="flex h-full flex-col gap-3 px-4 py-5">
+      <div className="bg-muted h-5 w-3/5 animate-pulse rounded-md" />
+      <div className="bg-muted/80 h-4 w-4/5 animate-pulse rounded-md" />
+      <div className="bg-muted/70 h-4 w-2/3 animate-pulse rounded-md" />
+    </div>
   );
 }
 

--- a/apps/desktop/src/store/tinybase/persister/session/hydrate.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/hydrate.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { hydrateSessionContent } from "./hydrate";
+import { loadSingleSession } from "./load";
+
+import { ok } from "~/store/tinybase/persister/shared";
+import { createTestMainStore } from "~/store/tinybase/persister/testing/mocks";
+
+vi.mock("./load", () => ({
+  loadSingleSession: vi.fn(),
+}));
+
+vi.mock("~/store/tinybase/persister/shared/paths", () => ({
+  getDataDir: vi.fn().mockResolvedValue("/data"),
+}));
+
+const loadSingleSessionMock = vi.mocked(loadSingleSession);
+
+describe("hydrateSessionContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("merges loaded session content without removing other sessions", async () => {
+    const store = createTestMainStore();
+    store.setRow("sessions", "session-1", {
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:00Z",
+      title: "First",
+      raw_md: "",
+    });
+    store.setRow("sessions", "session-2", {
+      user_id: "user-1",
+      created_at: "2024-01-02T00:00:00Z",
+      title: "Second",
+      raw_md: "",
+    });
+
+    loadSingleSessionMock.mockResolvedValue(
+      ok({
+        sessions: {
+          "session-1": {
+            user_id: "user-1",
+            created_at: "2024-01-01T00:00:00Z",
+            title: "First",
+            raw_md: '{"type":"doc"}',
+          },
+        },
+        mapping_session_participant: {},
+        tags: {},
+        mapping_tag_session: {},
+        transcripts: {},
+        enhanced_notes: {},
+        session_key_facts: {},
+      }),
+    );
+
+    await hydrateSessionContent(store, "session-1");
+
+    expect(store.getRowIds("sessions")).toEqual(["session-1", "session-2"]);
+    expect(store.getCell("sessions", "session-1", "raw_md")).toBe(
+      '{"type":"doc"}',
+    );
+    expect(store.getCell("sessions", "session-2", "title")).toBe("Second");
+  });
+});

--- a/apps/desktop/src/store/tinybase/persister/session/hydrate.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/hydrate.ts
@@ -1,0 +1,36 @@
+import type { Store } from "tinybase/with-schemas";
+
+import type { Schemas } from "@hypr/store";
+import { asTablesChanges } from "@hypr/tinybase-utils";
+
+import { loadSingleSession } from "./load";
+import type { LoadedSessionData } from "./load";
+
+import { getDataDir } from "~/store/tinybase/persister/shared/paths";
+
+function hasLoadedRows(data: LoadedSessionData): boolean {
+  return Object.values(data).some((table) => Object.keys(table).length > 0);
+}
+
+export async function hydrateSessionContent(
+  store: Store<Schemas>,
+  sessionId: string,
+): Promise<boolean> {
+  const dataDir = await getDataDir();
+  const loadResult = await loadSingleSession(dataDir, sessionId);
+
+  if (loadResult.status === "error") {
+    console.error(
+      `[SessionPersister] hydrate error for ${sessionId}:`,
+      loadResult.error,
+    );
+    return false;
+  }
+
+  if (!hasLoadedRows(loadResult.data)) {
+    return true;
+  }
+
+  store.applyChanges(asTablesChanges(loadResult.data));
+  return true;
+}

--- a/apps/desktop/src/store/tinybase/persister/session/load/index.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/load/index.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { loadAllSessionData } from "./index";
+
+const fsSyncMocks = vi.hoisted(() => ({
+  scanAndRead: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/path", () => ({
+  sep: () => "/",
+}));
+vi.mock("@hypr/plugin-fs-sync", () => ({ commands: fsSyncMocks }));
+
+describe("loadAllSessionData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsSyncMocks.scanAndRead.mockResolvedValue({
+      status: "ok",
+      data: { files: {}, dirs: [] },
+    });
+  });
+
+  test("scans only metadata when content is excluded", async () => {
+    await loadAllSessionData("/data", { includeContent: false });
+
+    expect(fsSyncMocks.scanAndRead).toHaveBeenCalledWith(
+      "/data/sessions",
+      ["_meta.json"],
+      true,
+      null,
+    );
+  });
+
+  test("scans metadata and content by default", async () => {
+    await loadAllSessionData("/data");
+
+    expect(fsSyncMocks.scanAndRead).toHaveBeenCalledWith(
+      "/data/sessions",
+      ["_meta.json", "transcript.json", "*.md"],
+      true,
+      null,
+    );
+  });
+});

--- a/apps/desktop/src/store/tinybase/persister/session/load/index.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/load/index.ts
@@ -24,15 +24,24 @@ export { createEmptyLoadedSessionData, type LoadedSessionData } from "./types";
 
 const LABEL = "SessionPersister";
 
+type LoadSessionDataOptions = {
+  includeContent?: boolean;
+};
+
 async function processFiles(
   files: Partial<Record<string, string>>,
   result: LoadedSessionData,
+  { includeContent = true }: LoadSessionDataOptions = {},
 ): Promise<void> {
   for (const [path, content] of Object.entries(files)) {
     if (!content) continue;
     if (path.endsWith(SESSION_META_FILE)) {
       processMetaFile(path, content, result);
     }
+  }
+
+  if (!includeContent) {
+    return;
   }
 
   for (const [path, content] of Object.entries(files)) {
@@ -54,13 +63,21 @@ async function processFiles(
 
 export async function loadAllSessionData(
   dataDir: string,
+  options: LoadSessionDataOptions = {},
 ): Promise<LoadResult<LoadedSessionData>> {
   const result = createEmptyLoadedSessionData();
   const sessionsDir = [dataDir, "sessions"].join(sep());
+  const includeContent = options.includeContent ?? true;
 
   const scanResult = await fsSyncCommands.scanAndRead(
     sessionsDir,
-    [SESSION_META_FILE, SESSION_TRANSCRIPT_FILE, `*${SESSION_NOTE_EXTENSION}`],
+    includeContent
+      ? [
+          SESSION_META_FILE,
+          SESSION_TRANSCRIPT_FILE,
+          `*${SESSION_NOTE_EXTENSION}`,
+        ]
+      : [SESSION_META_FILE],
     true,
     null,
   );
@@ -73,7 +90,7 @@ export async function loadAllSessionData(
     return err(scanResult.error);
   }
 
-  await processFiles(scanResult.data.files, result);
+  await processFiles(scanResult.data.files, result, { includeContent });
   return ok(result);
 }
 

--- a/apps/desktop/src/store/tinybase/persister/session/persister.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/persister.ts
@@ -33,7 +33,8 @@ export function createSessionPersister(store: Store) {
       { tableName: "enhanced_notes", foreignKey: "session_id" },
       { tableName: "session_key_facts", foreignKey: "session_id" },
     ],
-    loadAll: loadAllSessionData,
+    loadAll: (dataDir) =>
+      loadAllSessionData(dataDir, { includeContent: false }),
     loadSingle: loadSingleSession,
     save: (store, tables, dataDir, changedTables) => {
       let changedSessionIds: Set<string> | undefined;
@@ -58,13 +59,40 @@ export function createSessionPersister(store: Store) {
       const transcriptOps = saveScope.transcript
         ? buildTranscriptSaveOps(tables, dataDir, changedSessionIds)
         : [];
+      const deleteEmptyMemos =
+        !changedTables || hasSessionRawContentChange(changedTables);
       const noteOps = saveScope.note
-        ? buildNoteSaveOps(store, tables, dataDir, changedSessionIds)
+        ? buildNoteSaveOps(store, tables, dataDir, changedSessionIds, {
+            deleteEmptyMemos,
+          })
         : [];
 
       return {
         operations: [...sessionOps, ...transcriptOps, ...noteOps],
       };
     },
+  });
+}
+
+function hasSessionRawContentChange(
+  changedTables: Parameters<typeof getChangedSessionIds>[1],
+) {
+  const changedSessions = changedTables.sessions;
+  if (!changedSessions) {
+    return false;
+  }
+
+  return Object.values(changedSessions).some((rowChange) => {
+    const row =
+      Array.isArray(rowChange) && rowChange.length > 0
+        ? rowChange[0]
+        : rowChange;
+
+    return (
+      !!row &&
+      typeof row === "object" &&
+      !Array.isArray(row) &&
+      Object.prototype.hasOwnProperty.call(row, "raw_md")
+    );
   });
 }

--- a/apps/desktop/src/store/tinybase/persister/session/save/note.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/save/note.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { buildNoteSaveOps } from "./note";
+
+import { createTestMainStore } from "~/store/tinybase/persister/testing/mocks";
+
+vi.mock("@tauri-apps/api/path", () => ({
+  sep: () => "/",
+}));
+
+describe("buildNoteSaveOps", () => {
+  test("does not delete empty memos when folder-only changes are saved", () => {
+    const store = createTestMainStore();
+    store.setRow("sessions", "session-1", {
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:00Z",
+      title: "Test Session",
+      folder_id: "work",
+      event_json: "",
+      raw_md: "",
+    });
+
+    const ops = buildNoteSaveOps(
+      store,
+      store.getTables(),
+      "/data",
+      new Set(["session-1"]),
+      { deleteEmptyMemos: false },
+    );
+
+    expect(ops).toEqual([]);
+  });
+
+  test("deletes empty memos when note content is cleared", () => {
+    const store = createTestMainStore();
+    store.setRow("sessions", "session-1", {
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:00Z",
+      title: "Test Session",
+      folder_id: "work",
+      event_json: "",
+      raw_md: "",
+    });
+
+    const ops = buildNoteSaveOps(
+      store,
+      store.getTables(),
+      "/data",
+      new Set(["session-1"]),
+      { deleteEmptyMemos: true },
+    );
+
+    expect(ops).toEqual([
+      {
+        type: "delete",
+        paths: ["/data/sessions/work/session-1/_memo.md"],
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/store/tinybase/persister/session/save/note.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/save/note.ts
@@ -21,6 +21,7 @@ type BuildContext = {
   tables: TablesContent;
   dataDir: string;
   changedSessionIds?: Set<string>;
+  deleteEmptyMemos: boolean;
 };
 
 export function buildNoteSaveOps(
@@ -28,8 +29,15 @@ export function buildNoteSaveOps(
   tables: TablesContent,
   dataDir: string,
   changedSessionIds?: Set<string>,
+  options: { deleteEmptyMemos?: boolean } = {},
 ): WriteOperation[] {
-  const ctx: BuildContext = { store, tables, dataDir, changedSessionIds };
+  const ctx: BuildContext = {
+    store,
+    tables,
+    dataDir,
+    changedSessionIds,
+    deleteEmptyMemos: options.deleteEmptyMemos ?? true,
+  };
 
   const enhancedNoteItems = collectEnhancedNotes(ctx);
   const { items: memoItems, deletePaths: memoDeletePaths } = collectMemos(ctx);
@@ -74,7 +82,7 @@ function collectMemos(ctx: BuildContext): {
   items: DocumentItem[];
   deletePaths: string[];
 } {
-  const { tables, dataDir, changedSessionIds } = ctx;
+  const { tables, dataDir, changedSessionIds, deleteEmptyMemos } = ctx;
   const items: DocumentItem[] = [];
   const deletePaths: string[] = [];
 
@@ -92,7 +100,9 @@ function collectMemos(ctx: BuildContext): {
       ? tryParseAndConvertToMarkdown(session.raw_md)
       : null;
     if (!markdown) {
-      deletePaths.push(memoPath);
+      if (deleteEmptyMemos) {
+        deletePaths.push(memoPath);
+      }
       continue;
     }
 


### PR DESCRIPTION
## Summary
- Start session persistence with metadata-only scans.
- Hydrate full session content lazily when a note opens.
- Add focused hydration and load coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session load/save timing and memo deletion rules; wrong hydration or `deleteEmptyMemos` logic could cause missing notes or stale content, though behavior is covered by new tests.
> 
> **Overview**
> **Startup and persistence** now load only session `_meta.json` into TinyBase; transcripts and markdown are no longer scanned on initial `loadAll`.
> 
> **Opening a session** triggers `hydrateSessionContent`, which loads that session’s files via `loadSingleSession` and merges them into the store without dropping other sessions. The note UI stays on a skeleton until hydration succeeds, with a 1s retry on failure and an in-memory cache so repeat opens skip reload.
> 
> **Saves** only delete `_memo.md` when `raw_md` actually changed (or on full saves), so metadata-only updates (e.g. folder moves) no longer wipe memo files while `raw_md` is still empty in the metadata-only store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d5b805f7bdcb568d5c820b1c743fb41bb8291ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->