### PR TITLE
Show devtools in staging

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1,5 +1,7 @@
 use crate::AppExt;
 
+const STAGING_BUNDLE_ID: &str = "com.hyprnote.staging";
+
 #[tauri::command]
 #[specta::specta]
 pub async fn get_onboarding_needed<R: tauri::Runtime>(
@@ -40,10 +42,15 @@ pub async fn get_env<R: tauri::Runtime>(_app: tauri::AppHandle<R>, key: String) 
     std::env::var(&key).unwrap_or_default()
 }
 
+fn should_show_devtool(identifier: &str) -> bool {
+    cfg!(any(debug_assertions, feature = "dev", feature = "devtools"))
+        || identifier == STAGING_BUNDLE_ID
+}
+
 #[tauri::command]
 #[specta::specta]
-pub fn show_devtool() -> bool {
-    cfg!(any(debug_assertions, feature = "dev", feature = "devtools"))
+pub fn show_devtool<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> bool {
+    should_show_devtool(&app.config().identifier)
 }
 
 #[tauri::command]
@@ -95,4 +102,14 @@ pub async fn set_recently_opened_sessions<R: tauri::Runtime>(
     v: String,
 ) -> Result<(), String> {
     app.set_recently_opened_sessions(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shows_devtools_for_staging_bundle() {
+        assert!(should_show_devtool(STAGING_BUNDLE_ID));
+    }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -375,7 +375,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::get_dismissed_toasts::<tauri::Wry>,
             commands::set_dismissed_toasts::<tauri::Wry>,
             commands::get_env::<tauri::Wry>,
-            commands::show_devtool,
+            commands::show_devtool::<tauri::Wry>,
             commands::get_tinybase_values::<tauri::Wry>,
             commands::set_tinybase_values::<tauri::Wry>,
             commands::get_pinned_tabs::<tauri::Wry>,


### PR DESCRIPTION
Allow the staging bundle id to enable the devtools panel visibility gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small visibility-gating change for an internal staging bundle; production bundle behavior is unchanged aside from the command now requiring `AppHandle`.
> 
> **Overview**
> **Staging builds** (`com.hyprnote.staging`) can now pass the frontend devtools visibility check, not only debug/`dev`/`devtools` compile-time builds.
> 
> `show_devtool` takes `AppHandle` and reads `app.config().identifier` via a new `should_show_devtool` helper (with `STAGING_BUNDLE_ID`). Specta registration is updated for the generic command signature, and a unit test asserts staging returns true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caec0c98c8e7b5f8dabdfcbe4e47afd1f3e77685. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->