### PR TITLE
Keep custom providers last

### DIFF
--- a/apps/desktop/src/settings/ai/shared/sort-providers.test.ts
+++ b/apps/desktop/src/settings/ai/shared/sort-providers.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+
+import { sortProviders } from "./sort-providers";
+
+describe("sortProviders", () => {
+  test("keeps Anarlog first and Custom last", () => {
+    const sorted = sortProviders([
+      { id: "custom", displayName: "Custom" },
+      { id: "fireworks", displayName: "Fireworks", disabled: true },
+      { id: "openai", displayName: "OpenAI" },
+      { id: "hyprnote", displayName: "Anarlog" },
+    ]);
+
+    expect(sorted.map((provider) => provider.id)).toEqual([
+      "hyprnote",
+      "openai",
+      "fireworks",
+      "custom",
+    ]);
+  });
+});

--- a/apps/desktop/src/settings/ai/shared/sort-providers.ts
+++ b/apps/desktop/src/settings/ai/shared/sort-providers.ts
@@ -11,11 +11,11 @@ export function sortProviders<T extends Sortable>(
     if (a.id === "hyprnote") return -1;
     if (b.id === "hyprnote") return 1;
 
-    if (a.disabled && !b.disabled) return 1;
-    if (!a.disabled && b.disabled) return -1;
-
     if (a.id === "custom") return 1;
     if (b.id === "custom") return -1;
+
+    if (a.disabled && !b.disabled) return 1;
+    if (!a.disabled && b.disabled) return -1;
 
     const localOnlyIds = ["ollama", "lmstudio"];
     const aIsLocalOnly = localOnlyIds.includes(a.id);


### PR DESCRIPTION
Move Custom provider ordering ahead of disabled-provider sorting and cover the shared sorter with a focused test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only ordering in shared AI settings lists; behavior change is intentional and covered by a unit test.
> 
> **Overview**
> **Custom** stays pinned to the end of AI provider pickers even when other entries are disabled.
> 
> `sortProviders` now applies the **hyprnote**-first and **custom**-last rules before pushing disabled providers down, so a disabled provider no longer sorts above **Custom**. A Vitest case locks in order: Anarlog first, enabled providers by name, disabled in the middle, **Custom** last.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb6aa3eee688595d24a74a040a824e662c418b8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->