### PR TITLE
Adjust STT warning banner for dark mode

### DIFF
--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -286,8 +286,8 @@ export function TranscriptionLanguageWarningBanner() {
   }
 
   return (
-    <div className="-mx-6 -mt-6 mb-6 border-b border-amber-200 bg-amber-50 px-6 py-3">
-      <span className="flex items-center justify-center gap-2 text-center text-sm text-amber-600">
+    <div className="-mx-6 -mt-6 mb-6 border-b border-amber-200 bg-amber-50 px-6 py-3 dark:border-amber-900/60 dark:bg-amber-950/30">
+      <span className="flex items-center justify-center gap-2 text-center text-sm text-amber-600 dark:text-amber-200">
         <AlertTriangle className="size-4 shrink-0" />
         Selected model may not support all your spoken languages.
       </span>


### PR DESCRIPTION
Add dark-mode border, background, and text colors while preserving the light-mode banner styling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind-only change to a conditional settings banner with no logic or data impact.
> 
> **Overview**
> Adds **dark mode** Tailwind classes to `TranscriptionLanguageWarningBanner` on the STT settings page so the amber warning strip stays readable when the app theme is dark.
> 
> The banner container gets `dark:border-amber-900/60` and `dark:bg-amber-950/30`; the message text gets `dark:text-amber-200`. Light-mode `border-amber-200`, `bg-amber-50`, and `text-amber-600` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79f4560bad0b7d9a9f4ea38c6d14e6ee9727527e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->