### PR TITLE
Update desktop 1.1.4 changelog

### DIFF
--- a/packages/changelog/content/1.1.4.md
+++ b/packages/changelog/content/1.1.4.md
@@ -1,6 +1,6 @@
 ---
 date: "2026-06-26"
-summary: "Anarlog chat can use meeting notes more reliably, transcription feels steadier, and personalization settings are easier to manage."
+summary: "Anarlog chat can use meeting notes more reliably, transcripts stay easier to follow while you work, and the website explains Anarlog more clearly."
 ---
 
 ## Chat
@@ -15,17 +15,35 @@ summary: "Anarlog chat can use meeting notes more reliably, transcription feels 
 ## Transcription
 
 - Long transcripts now render more smoothly during active recordings
+- Transcript jump controls now stay out of the way while floating chat is open
+- Live transcript tabs no longer show a spinner during active meetings
+- Transcript speaker headers now stay cleaner by hiding timestamp ranges
 - Live transcription now keeps Parakeet models in streaming mode instead of switching to a slower batch path
 - Soniqo batch transcripts now preserve chunk timing more accurately
 - STT model labels now match the selected model more reliably
+- iPhone call detection notifications now use a dedicated phone icon
+- On-device transcription options now use clearer model names
+- Speech-to-text warning banners now read more cleanly in dark mode
+- Speech-to-text row actions now stay steadier when you hover them
 - The live transcript panel now stays focused on the session transcript without an extra bottom accessory
 
 ## Notes
 
+- Insights and transcripts now live in editor tabs instead of a separate bottom panel
 - Session metadata now loads before note content so sidebar details are available more reliably after startup
 - Active session transcript state now restores correctly when returning to a live note
+- Contact suggestions can now use event titles to identify meeting contacts more accurately
+
+## Website
+
+- The homepage now gives a clearer view of Anarlog's privacy model, open-source project, and local meeting capture flow
+- The Char announcement now points to the Char waitlist and rotates between the new and original messaging more smoothly
 
 ## Settings
 
+- Trial-ended prompts now appear more reliably when a Pro trial expires
+- Integration sign-in windows now show the specific service name and icon for Google Calendar, Outlook, and GitHub
+- Pro model rows in transcription settings now use cleaner spacing around upgrade chips
+- Custom transcription providers now stay grouped after built-in providers
 - Personalization dictionary settings now make it easier to manage custom names and terms for transcription
 - LLM providers now require their configured API keys and base URLs before use, making provider setup clearer


### PR DESCRIPTION
Summarize the latest note surface and Pro menu polish in the 1.1.4 release notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no application or infrastructure changes.
> 
> **Overview**
> **Expands the desktop 1.1.4 release notes** in `packages/changelog/content/1.1.4.md` so they cover more of what shipped in this release, not only chat and core transcription fixes.
> 
> The **top-line summary** now mentions clearer transcripts while you work and a clearer website story, instead of only personalization settings.
> 
> **Transcription** gains bullets for jump controls with floating chat, no spinner on live tabs, cleaner speaker headers, phone icon for iPhone call detection, clearer on-device model names, dark-mode STT warnings, and steadier row hover behavior.
> 
> **Notes** adds that insights/transcripts moved into editor tabs (not a bottom panel) and that contact suggestions can use event titles.
> 
> A new **Website** section describes homepage privacy/open-source/local capture messaging and Char waitlist / rotating announcement copy.
> 
> **Settings** adds trial-ended prompts, branded integration sign-in (Google Calendar, Outlook, GitHub), Pro row spacing, and custom STT providers grouped after built-ins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0056e462db4800fd05cff4f83e6e1c60dbc496e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->