### PR TITLE
Hide transcript spinner during live meetings

### DIFF
--- a/apps/desktop/src/session/components/note-input/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/index.test.tsx
@@ -196,4 +196,12 @@ describe("NoteInput tab selection", () => {
 
     expect(screen.getByTestId("is-transcribing").textContent).toBe("true");
   });
+
+  it("keeps the transcript spinner while batch transcription is running", () => {
+    hoisted.sessionMode = "running_batch";
+
+    renderNoteInput();
+
+    expect(screen.getByTestId("is-transcribing").textContent).toBe("true");
+  });
 });

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -25,6 +25,7 @@ import { Transcript } from "./transcript";
 import { useCaretNearBottom } from "~/session/components/caret-position-context";
 import { useCurrentNoteTab } from "~/session/components/shared";
 import { useScrollPreservation } from "~/shared/hooks/useScrollPreservation";
+import type { SessionMode } from "~/store/zustand/listener/general";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { type EditorView as TabEditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
@@ -35,6 +36,10 @@ export interface NoteInputHandle {
   focusAtPixelWidth: (pixelWidth: number) => void;
   insertAtStartAndFocus: (content: string) => void;
   prepareForTabChange: () => void;
+}
+
+export function shouldShowTranscriptTabSpinner(sessionMode: SessionMode) {
+  return sessionMode === "finalizing" || sessionMode === "running_batch";
 }
 
 export const NoteInput = forwardRef<
@@ -90,7 +95,7 @@ export const NoteInput = forwardRef<
       sessionMode === "finalizing" ||
       sessionMode === "running_batch";
     const shouldShowTranscriptSpinner =
-      sessionMode === "finalizing" || sessionMode === "running_batch";
+      shouldShowTranscriptTabSpinner(sessionMode);
 
     const { scrollRef, onBeforeTabChange } = useScrollPreservation(
       renderedCurrentTab.type === "enhanced"

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -6,7 +6,11 @@ import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 
 import { CaretPositionProvider } from "./components/caret-position-context";
 import { FloatingActionButton } from "./components/floating";
-import { NoteInput, type NoteInputHandle } from "./components/note-input";
+import {
+  NoteInput,
+  shouldShowTranscriptTabSpinner,
+  type NoteInputHandle,
+} from "./components/note-input";
 import {
   Header as NoteInputHeader,
   useEditorTabs,
@@ -130,10 +134,7 @@ function TabContentNoteInner({
   const sessionId = tab.id;
   const { skipReason } = useAutoEnhance(tab);
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
-  const isTranscribing =
-    sessionMode === "active" ||
-    sessionMode === "finalizing" ||
-    sessionMode === "running_batch";
+  const isTranscribing = shouldShowTranscriptTabSpinner(sessionMode);
   useAutoFocusTitle({ sessionId, noteInputRef });
   usePendingUpload(sessionId);
 


### PR DESCRIPTION
Share the transcript tab spinner rule between session headers so active listening keeps the transcript tab idle while finalizing and batch transcription still show progress.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to when a header spinner displays; no auth, data, or transcription pipeline logic touched.
> 
> **Overview**
> **Aligns the outer session header with the note editor** so the Transcript tab spinner no longer appears while a meeting is in **`active`** (live listening) mode.
> 
> Introduces shared helper **`shouldShowTranscriptTabSpinner`**, which only returns true for **`finalizing`** and **`running_batch`**. `NoteInput` uses it for its header prop, and **`session/index.tsx`** replaces the broader `isTranscribing` check (which previously included **`active`**) when driving **`NoteInputHeader`** in the outer chrome.
> 
> Tests cover that **`active`** keeps the spinner off and that **`finalizing`** / **`running_batch`** still show it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fccff22edd90c7654b377f7abb1815a22827a000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->