### PR TITLE
Hide transcript header timestamps

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.test.tsx
@@ -29,7 +29,7 @@ beforeEach(() => {
 });
 
 describe("SegmentHeader", () => {
-  it("keeps the speaker label and timestamp visible", () => {
+  it("keeps the speaker label visible without exposing timestamps", () => {
     render(
       <SegmentHeader
         transcriptId="transcript-1"
@@ -68,6 +68,6 @@ describe("SegmentHeader", () => {
     );
 
     expect(screen.getByRole("button", { name: "Speaker 3" })).toBeTruthy();
-    expect(screen.getByText("00:12 - 00:18")).toBeTruthy();
+    expect(screen.queryByText("00:12 - 00:18")).toBeNull();
   });
 });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { cn } from "@hypr/utils";
 
 import { SpeakerAssignPopover } from "./speaker-assign";
-import { getTimestampRange, useSegmentColorVars } from "./utils";
+import { useSegmentColorVars } from "./utils";
 
 import * as main from "~/store/tinybase/store/main";
 import type { Segment } from "~/stt/live-segment";
@@ -21,7 +21,6 @@ export function SegmentHeader({
 }) {
   const colorVars = useSegmentColorVars(segment.key);
   const label = useSpeakerLabel(segment.key, speakerLabelManager);
-  const timestamp = getTimestampRange(segment);
   const headerClassName = cn([
     "bg-card sticky top-0 z-20",
     "-mx-3 px-3 py-1",
@@ -39,9 +38,6 @@ export function SegmentHeader({
         color="var(--segment-color)"
         label={label}
       />
-      <span className="text-muted-foreground ml-auto shrink-0 tabular-nums">
-        {timestamp}
-      </span>
     </div>
   );
 }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/utils.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/utils.ts
@@ -1,7 +1,7 @@
 import chroma from "chroma-js";
 import { type CSSProperties, useMemo } from "react";
 
-import type { Segment, SegmentKey, SegmentWord } from "~/stt/live-segment";
+import type { SegmentKey, SegmentWord } from "~/stt/live-segment";
 
 export type HighlightSegment = { text: string; isMatch: boolean };
 
@@ -80,29 +80,6 @@ export function getActiveLineIndex(
   }
 
   return null;
-}
-
-export function formatTimestamp(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
-
-  if (hours > 0) {
-    return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
-  }
-
-  return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
-}
-
-export function getTimestampRange(segment: Segment): string {
-  if (segment.words.length === 0) {
-    return "00:00 - 00:00";
-  }
-
-  const firstWord = segment.words[0]!;
-  const lastWord = segment.words[segment.words.length - 1]!;
-  return `${formatTimestamp(firstWord.start_ms)} - ${formatTimestamp(lastWord.end_ms)}`;
 }
 
 export function getSegmentColor(


### PR DESCRIPTION
Remove visible transcript segment time ranges while preserving word timing data for playback and highlighting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in the transcript note-input UI with no auth, data, or playback logic touched.
> 
> **Overview**
> **Transcript segment headers no longer show time ranges** (e.g. `00:12 - 00:18`). The sticky header now only renders the speaker assignment control; word-level `start_ms` / `end_ms` on segments and words are unchanged for playback and highlighting elsewhere.
> 
> Unused **`formatTimestamp`** and **`getTimestampRange`** helpers were removed from the transcript renderer `utils` module, and the **`SegmentHeader`** test was updated to assert timestamps are not in the DOM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e347d8937e44fc6a7b7fc25cfcc17a844ebf75cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->