### PR TITLE
Adjust transcript scroll chip around floating chat

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -197,7 +197,7 @@ msgstr "Applying..."
 msgid "Ask & search about anything, or be creative!"
 msgstr "Ask & search about anything, or be creative!"
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr "Ask Anarlog anything"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:31
+#: src/shared/chat-cta.tsx:32
 msgid "Ask Anarlog anything"
 msgstr ""
 

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -13,6 +13,10 @@ const mocks = vi.hoisted(() => ({
     autoScrollEnabled: true,
     scrollTarget: null as "top" | "bottom" | null,
   },
+  chatMode: "FloatingClosed" as
+    | "FloatingClosed"
+    | "FloatingOpen"
+    | "RightPanelOpen",
 }));
 
 vi.mock("react-hotkeys-hook", () => ({
@@ -32,6 +36,14 @@ vi.mock("~/audio-player", () => ({
 
 vi.mock("~/audio-player/provider", () => ({
   useAudioTime: () => ({ current: 0 }),
+}));
+
+vi.mock("~/contexts/shell", () => ({
+  useShell: () => ({
+    chat: {
+      mode: mocks.chatMode,
+    },
+  }),
 }));
 
 vi.mock("./selection-menu", () => ({
@@ -66,6 +78,7 @@ describe("TranscriptViewer", () => {
     mocks.scrollDetection.isAtBottom = true;
     mocks.scrollDetection.autoScrollEnabled = true;
     mocks.scrollDetection.scrollTarget = null;
+    mocks.chatMode = "FloatingClosed";
   });
 
   it("does not pin inactive transcript sessions to the bottom on open", () => {
@@ -155,7 +168,27 @@ describe("TranscriptViewer", () => {
     const button = screen.getByRole("button", { name: "Go to top" });
     button.click();
 
+    expect(button.style.bottom).toBe(
+      "var(--transcript-scroll-chip-bottom, calc(3.75rem + env(safe-area-inset-bottom)))",
+    );
     expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
     expect(mocks.scrollToTop).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the scroll chip while floating chat is expanded", () => {
+    mocks.scrollDetection.isAtTop = false;
+    mocks.scrollDetection.scrollTarget = "top";
+    mocks.chatMode = "FloatingOpen";
+
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive
+        scrollRef={createRef()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
   });
 });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -20,6 +20,7 @@ import {
 
 import { useAudioPlayer } from "~/audio-player";
 import { useAudioTime } from "~/audio-player/provider";
+import { useShell } from "~/contexts/shell";
 import type { Segment } from "~/stt/live-segment";
 
 export function TranscriptViewer({
@@ -33,6 +34,7 @@ export function TranscriptViewer({
   currentActive: boolean;
   scrollRef: RefObject<HTMLDivElement | null>;
 }) {
+  const { chat } = useShell();
   const containerRef = useRef<HTMLDivElement>(null);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
     null,
@@ -92,17 +94,19 @@ export function TranscriptViewer({
   );
 
   const scrollChip =
-    currentActive && scrollTarget === "bottom" && !isAtBottom
-      ? {
-          label: "Go to bottom",
-          onClick: scrollToBottom,
-        }
-      : currentActive && scrollTarget === "top" && !isAtTop
+    chat.mode === "FloatingOpen"
+      ? null
+      : currentActive && scrollTarget === "bottom" && !isAtBottom
         ? {
-            label: "Go to top",
-            onClick: scrollToTop,
+            label: "Go to bottom",
+            onClick: scrollToBottom,
           }
-        : null;
+        : currentActive && scrollTarget === "top" && !isAtTop
+          ? {
+              label: "Go to top",
+              onClick: scrollToTop,
+            }
+          : null;
 
   const handleSelectionAction = (action: string, selectedText: string) => {
     if (action === "copy") {
@@ -151,14 +155,19 @@ export function TranscriptViewer({
 
       {scrollChip && (
         <button
+          data-transcript-scroll-chip
           onClick={scrollChip.onClick}
+          style={{
+            bottom:
+              "var(--transcript-scroll-chip-bottom, calc(3.75rem + env(safe-area-inset-bottom)))",
+          }}
           className={cn([
-            "absolute bottom-[calc(5rem+env(safe-area-inset-bottom))] left-1/2 z-30 -translate-x-1/2",
+            "absolute left-1/2 z-30 -translate-x-1/2",
             "rounded-full px-4 py-2",
             "from-muted to-accent text-foreground bg-linear-to-t",
             "shadow-xs hover:scale-[102%] hover:shadow-md active:scale-[98%]",
             "text-xs font-light",
-            "transition-opacity duration-150",
+            "transition-[bottom,opacity,transform,box-shadow] duration-150",
           ])}
         >
           {scrollChip.label}

--- a/apps/desktop/src/shared/chat-cta.test.tsx
+++ b/apps/desktop/src/shared/chat-cta.test.tsx
@@ -48,6 +48,7 @@ describe("ChatCTA", () => {
     const surface = button.querySelector("[data-chat-cta-surface]");
     const label = screen.getByText("Ask anything");
 
+    expect(button.hasAttribute("data-chat-cta-trigger")).toBe(true);
     expect(button.className).toContain("h-10");
     expect(button.className).toContain("w-40");
     expect(button.className).toContain("cursor-text");

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -28,6 +28,7 @@ export function ChatCTA({
   return (
     <button
       type="button"
+      data-chat-cta-trigger
       aria-label={ariaLabel ?? t`Ask Anarlog anything`}
       onClick={handleClick}
       className="group/anarlog-chat-cta relative h-10 w-40 max-w-full cursor-text focus-visible:outline-none"

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -240,6 +240,11 @@
   [data-settings-content] [data-slot="select-trigger"]:hover {
     box-shadow: none !important;
   }
+
+  [data-chat-floating-anchor]:has([data-chat-cta-trigger]:is(:hover, :focus-visible, :focus-within))
+    [data-transcript-scroll-chip] {
+    --transcript-scroll-chip-bottom: calc(5rem + env(safe-area-inset-bottom));
+  }
 }
 
 /* Search result highlighting styles — matches transcript's bg-yellow-200/50 and bg-yellow-500 */


### PR DESCRIPTION
Hide transcript scroll chip while floating chat is expanded and lower it near the collapsed CTA, with hover/focus offset styling for the default CTA state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and visibility in the transcript viewer; no auth, data, or API changes.
> 
> **Overview**
> The transcript **Go to top / Go to bottom** chip no longer shows while **floating chat is expanded** (`FloatingOpen`), so it does not sit on top of the chat UI.
> 
> When the chip is visible, its vertical position is driven by a **`--transcript-scroll-chip-bottom`** CSS variable (default sits closer to the collapsed chat area). **`globals.css`** nudges the chip upward when the collapsed chat CTA is hovered, focused, or focused-within, using **`data-chat-cta-trigger`** on the CTA and the existing **`data-chat-floating-anchor`** wrapper.
> 
> Locale **`.po`** files only refresh the source line reference for “Ask Anarlog anything” after a small change in **`chat-cta.tsx`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59e7a2a33efef90d17840666425d210aeed1822f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->