### PR TITLE
Disable testimonial text selection

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -195,7 +195,7 @@ function TestimonialTweetCard({
         onMoveToSide();
       }}
       className={cn([
-        "border-color-subtle absolute rounded-lg border bg-white p-5 transition-[transform,box-shadow,opacity] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none sm:p-5",
+        "border-color-subtle absolute rounded-lg border bg-white p-5 text-left transition-[transform,box-shadow,opacity] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] select-none motion-reduce:transition-none sm:p-5",
         className,
       ])}
       style={style}


### PR DESCRIPTION
Adds a non-selectable style to testimonial tweet cards so dragging the card does not highlight text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on marketing UI; no auth, data, or API impact.
> 
> **Overview**
> **Testimonial tweet cards** on the landing page now use **`select-none`** so dragging or clicking to move a card in the deck does not highlight quote and author text.
> 
> Also adds **`text-left`** on the same card container for consistent alignment with the interactive card layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23819ab68b9820b8b6ac5ea66e382690e67f8011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->