### PR TITLE
Remove footer contact link

### DIFF
--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -17,9 +17,20 @@ export function SiteFooter() {
         <Link to="/changelog/" className="hover:text-[#181613]">
           Changelog
         </Link>
-        <a href="mailto:founders@fastrepl.com" className="hover:text-[#181613]">
-          Contact
-        </a>
+        <Link
+          to="/legal/$slug/"
+          params={{ slug: "privacy" }}
+          className="hover:text-[#181613]"
+        >
+          Privacy
+        </Link>
+        <Link
+          to="/legal/$slug/"
+          params={{ slug: "terms" }}
+          className="hover:text-[#181613]"
+        >
+          Terms
+        </Link>
       </nav>
     </footer>
   );


### PR DESCRIPTION
Removes the Contact mailto link from the shared web footer navigation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only change in the footer with no auth, data, or API impact.
> 
> **Overview**
> Updates the shared site footer nav by **removing** the `mailto:founders@fastrepl.com` **Contact** link and **adding** in-app **Privacy** and **Terms** links that route to `/legal/$slug/` with slugs `privacy` and `terms`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f394ca977104c594e9fe8ae4fec0cf21f0a5073a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->