### PR TITLE
Expose legal pages in footer

### DIFF
--- a/apps/web/content/legal/terms.mdx
+++ b/apps/web/content/legal/terms.mdx
@@ -74,7 +74,7 @@ You may opt out of marketing communications at any time by clicking the "unsubsc
 
 ## 9. Privacy and Third-Party Services
 
-Your use of the Service is also governed by our [Privacy Policy](/legal/privacy). Please review it to understand our practices.
+Your use of the Service is also governed by our [Privacy Policy](/privacy). Please review it to understand our practices.
 
 The Service may integrate with third-party services to provide certain features, including cloud-based transcription, AI-powered summarization, payment processing, and analytics. When you enable cloud-based features, your data may be processed by our sub-processors. You acknowledge and agree that your use of these features is subject to the terms and privacy practices of such third-party services.
 

--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -66,7 +66,7 @@ force = true
 
 [[redirects]]
 from = "https://hyprnote.com/legal/*"
-to = "https://char.com/legal/:splat"
+to = "https://anarlog.so/:splat"
 status = 301
 force = true
 
@@ -203,7 +203,7 @@ status = 301
 force = true
 
 # Domain migration: char.com -> anarlog.so (301 for SEO)
-# Char is shut down except for /blog/* and /legal/* which redirect to anarlog.so
+# Char is shut down except for /blog/* and root legal pages which redirect to anarlog.so
 
 [[redirects]]
 from = "https://char.com/blog/*"
@@ -218,13 +218,43 @@ status = 301
 force = true
 
 [[redirects]]
+from = "/legal/*"
+to = "/:splat"
+status = 301
+force = true
+
+[[redirects]]
 from = "https://char.com/legal/*"
-to = "https://anarlog.so/legal/:splat"
+to = "https://anarlog.so/:splat"
 status = 301
 force = true
 
 [[redirects]]
 from = "https://www.char.com/legal/*"
-to = "https://anarlog.so/legal/:splat"
+to = "https://anarlog.so/:splat"
+status = 301
+force = true
+
+[[redirects]]
+from = "https://char.com/privacy"
+to = "https://anarlog.so/privacy"
+status = 301
+force = true
+
+[[redirects]]
+from = "https://www.char.com/privacy"
+to = "https://anarlog.so/privacy"
+status = 301
+force = true
+
+[[redirects]]
+from = "https://char.com/terms"
+to = "https://anarlog.so/terms"
+status = 301
+force = true
+
+[[redirects]]
+from = "https://www.char.com/terms"
+to = "https://anarlog.so/terms"
 status = 301
 force = true

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -24,7 +24,8 @@ Allow: /docs
 Allow: /changelog
 Allow: /pricing
 Allow: /enterprise
-Allow: /legal/
+Allow: /privacy
+Allow: /terms
 Allow: /download
 Allow: /faq
 Allow: /about

--- a/apps/web/src/components/legal-document.tsx
+++ b/apps/web/src/components/legal-document.tsx
@@ -1,39 +1,27 @@
 import { MDXContent } from "@content-collections/mdx/react";
-import { createFileRoute, Link, notFound } from "@tanstack/react-router";
-import { allLegals } from "content-collections";
+import { Link } from "@tanstack/react-router";
+import type { Legal } from "content-collections";
 
-import { mdxComponents } from "@/components/mdx-components";
 import { ANARLOG_SITE_URL } from "@/lib/seo";
 
-export const Route = createFileRoute("/legal/$slug")({
-  component: Component,
-  loader: async ({ params }) => {
-    const doc = allLegals.find((d) => d.slug === params.slug);
-    if (!doc) {
-      throw notFound();
-    }
-    return { doc };
-  },
-  head: ({ loaderData }) => {
-    const doc = loaderData?.doc;
-    if (!doc) return {};
-    const url = `${ANARLOG_SITE_URL}/legal/${doc.slug}`;
-    return {
-      links: [{ rel: "canonical", href: url }],
-      meta: [
-        { title: `${doc.title} — Anarlog` },
-        { name: "description", content: doc.summary || doc.title },
-        { property: "og:title", content: doc.title },
-        { property: "og:description", content: doc.summary || doc.title },
-        { property: "og:url", content: url },
-      ],
-    };
-  },
-});
+import { mdxComponents } from "./mdx-components";
 
-function Component() {
-  const { doc } = Route.useLoaderData();
+export function legalHead(doc: Legal, path: "/privacy" | "/terms") {
+  const url = `${ANARLOG_SITE_URL}${path}`;
 
+  return {
+    links: [{ rel: "canonical", href: url }],
+    meta: [
+      { title: `${doc.title} — Anarlog` },
+      { name: "description", content: doc.summary || doc.title },
+      { property: "og:title", content: doc.title },
+      { property: "og:description", content: doc.summary || doc.title },
+      { property: "og:url", content: url },
+    ],
+  };
+}
+
+export function LegalDocument({ doc }: { doc: Legal }) {
   return (
     <main className="mx-auto max-w-3xl px-6 py-16">
       <Link

--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -17,18 +17,10 @@ export function SiteFooter() {
         <Link to="/changelog/" className="hover:text-[#181613]">
           Changelog
         </Link>
-        <Link
-          to="/legal/$slug/"
-          params={{ slug: "privacy" }}
-          className="hover:text-[#181613]"
-        >
+        <Link to="/privacy/" className="hover:text-[#181613]">
           Privacy
         </Link>
-        <Link
-          to="/legal/$slug/"
-          params={{ slug: "terms" }}
-          className="hover:text-[#181613]"
-        >
+        <Link to="/terms/" className="hover:text-[#181613]">
           Terms
         </Link>
       </nav>

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -10,14 +10,15 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as UpdatePasswordRouteImport } from './routes/update-password'
+import { Route as TermsRouteImport } from './routes/terms'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as FoundersRouteImport } from './routes/founders'
 import { Route as AuthRouteImport } from './routes/auth'
 import { Route as ViewRouteRouteImport } from './routes/_view/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ChangelogIndexRouteImport } from './routes/changelog/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
-import { Route as LegalSlugRouteImport } from './routes/legal/$slug'
 import { Route as ChangelogVersionRouteImport } from './routes/changelog/$version'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as ApiTemplatesRouteImport } from './routes/api/templates'
@@ -80,9 +81,19 @@ const UpdatePasswordRoute = UpdatePasswordRouteImport.update({
   path: '/update-password',
   getParentRoute: () => rootRouteImport,
 } as any)
+const TermsRoute = TermsRouteImport.update({
+  id: '/terms',
+  path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
   id: '/reset-password',
   path: '/reset-password',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
   getParentRoute: () => rootRouteImport,
 } as any)
 const FoundersRoute = FoundersRouteImport.update({
@@ -112,11 +123,6 @@ const ChangelogIndexRoute = ChangelogIndexRouteImport.update({
 const BlogIndexRoute = BlogIndexRouteImport.update({
   id: '/blog/',
   path: '/blog/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const LegalSlugRoute = LegalSlugRouteImport.update({
-  id: '/legal/$slug',
-  path: '/legal/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ChangelogVersionRoute = ChangelogVersionRouteImport.update({
@@ -412,7 +418,9 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
   '/founders': typeof FoundersRoute
+  '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/terms': typeof TermsRoute
   '/update-password': typeof UpdatePasswordRoute
   '/app': typeof ViewAppRouteRouteWithChildren
   '/pricing': typeof ViewPricingRoute
@@ -421,7 +429,6 @@ export interface FileRoutesByFullPath {
   '/api/templates': typeof ApiTemplatesRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/changelog/$version': typeof ChangelogVersionRoute
-  '/legal/$slug': typeof LegalSlugRoute
   '/blog/': typeof BlogIndexRoute
   '/changelog/': typeof ChangelogIndexRoute
   '/app/account': typeof ViewAppAccountRoute
@@ -478,7 +485,9 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
   '/founders': typeof FoundersRoute
+  '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/terms': typeof TermsRoute
   '/update-password': typeof UpdatePasswordRoute
   '/pricing': typeof ViewPricingRoute
   '/api/media-upload': typeof ApiMediaUploadRoute
@@ -486,7 +495,6 @@ export interface FileRoutesByTo {
   '/api/templates': typeof ApiTemplatesRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/changelog/$version': typeof ChangelogVersionRoute
-  '/legal/$slug': typeof LegalSlugRoute
   '/blog': typeof BlogIndexRoute
   '/changelog': typeof ChangelogIndexRoute
   '/app/account': typeof ViewAppAccountRoute
@@ -545,7 +553,9 @@ export interface FileRoutesById {
   '/_view': typeof ViewRouteRouteWithChildren
   '/auth': typeof AuthRoute
   '/founders': typeof FoundersRoute
+  '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/terms': typeof TermsRoute
   '/update-password': typeof UpdatePasswordRoute
   '/_view/app': typeof ViewAppRouteRouteWithChildren
   '/_view/pricing': typeof ViewPricingRoute
@@ -554,7 +564,6 @@ export interface FileRoutesById {
   '/api/templates': typeof ApiTemplatesRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/changelog/$version': typeof ChangelogVersionRoute
-  '/legal/$slug': typeof LegalSlugRoute
   '/blog/': typeof BlogIndexRoute
   '/changelog/': typeof ChangelogIndexRoute
   '/_view/app/account': typeof ViewAppAccountRoute
@@ -613,7 +622,9 @@ export interface FileRouteTypes {
     | '/'
     | '/auth'
     | '/founders'
+    | '/privacy'
     | '/reset-password'
+    | '/terms'
     | '/update-password'
     | '/app'
     | '/pricing'
@@ -622,7 +633,6 @@ export interface FileRouteTypes {
     | '/api/templates'
     | '/blog/$slug'
     | '/changelog/$version'
-    | '/legal/$slug'
     | '/blog/'
     | '/changelog/'
     | '/app/account'
@@ -679,7 +689,9 @@ export interface FileRouteTypes {
     | '/'
     | '/auth'
     | '/founders'
+    | '/privacy'
     | '/reset-password'
+    | '/terms'
     | '/update-password'
     | '/pricing'
     | '/api/media-upload'
@@ -687,7 +699,6 @@ export interface FileRouteTypes {
     | '/api/templates'
     | '/blog/$slug'
     | '/changelog/$version'
-    | '/legal/$slug'
     | '/blog'
     | '/changelog'
     | '/app/account'
@@ -745,7 +756,9 @@ export interface FileRouteTypes {
     | '/_view'
     | '/auth'
     | '/founders'
+    | '/privacy'
     | '/reset-password'
+    | '/terms'
     | '/update-password'
     | '/_view/app'
     | '/_view/pricing'
@@ -754,7 +767,6 @@ export interface FileRouteTypes {
     | '/api/templates'
     | '/blog/$slug'
     | '/changelog/$version'
-    | '/legal/$slug'
     | '/blog/'
     | '/changelog/'
     | '/_view/app/account'
@@ -813,14 +825,15 @@ export interface RootRouteChildren {
   ViewRouteRoute: typeof ViewRouteRouteWithChildren
   AuthRoute: typeof AuthRoute
   FoundersRoute: typeof FoundersRoute
+  PrivacyRoute: typeof PrivacyRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
+  TermsRoute: typeof TermsRoute
   UpdatePasswordRoute: typeof UpdatePasswordRoute
   ApiMediaUploadRoute: typeof ApiMediaUploadRoute
   ApiShortcutsRoute: typeof ApiShortcutsRoute
   ApiTemplatesRoute: typeof ApiTemplatesRoute
   BlogSlugRoute: typeof BlogSlugRoute
   ChangelogVersionRoute: typeof ChangelogVersionRoute
-  LegalSlugRoute: typeof LegalSlugRoute
   BlogIndexRoute: typeof BlogIndexRoute
   ChangelogIndexRoute: typeof ChangelogIndexRoute
   ApiAssetsSplatRoute: typeof ApiAssetsSplatRoute
@@ -867,11 +880,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UpdatePasswordRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/terms': {
+      id: '/terms'
+      path: '/terms'
+      fullPath: '/terms'
+      preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/reset-password': {
       id: '/reset-password'
       path: '/reset-password'
       fullPath: '/reset-password'
       preLoaderRoute: typeof ResetPasswordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/founders': {
@@ -914,13 +941,6 @@ declare module '@tanstack/react-router' {
       path: '/blog'
       fullPath: '/blog/'
       preLoaderRoute: typeof BlogIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/legal/$slug': {
-      id: '/legal/$slug'
-      path: '/legal/$slug'
-      fullPath: '/legal/$slug'
-      preLoaderRoute: typeof LegalSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/changelog/$version': {
@@ -1379,14 +1399,15 @@ const rootRouteChildren: RootRouteChildren = {
   ViewRouteRoute: ViewRouteRouteWithChildren,
   AuthRoute: AuthRoute,
   FoundersRoute: FoundersRoute,
+  PrivacyRoute: PrivacyRoute,
   ResetPasswordRoute: ResetPasswordRoute,
+  TermsRoute: TermsRoute,
   UpdatePasswordRoute: UpdatePasswordRoute,
   ApiMediaUploadRoute: ApiMediaUploadRoute,
   ApiShortcutsRoute: ApiShortcutsRoute,
   ApiTemplatesRoute: ApiTemplatesRoute,
   BlogSlugRoute: BlogSlugRoute,
   ChangelogVersionRoute: ChangelogVersionRoute,
-  LegalSlugRoute: LegalSlugRoute,
   BlogIndexRoute: BlogIndexRoute,
   ChangelogIndexRoute: ChangelogIndexRoute,
   ApiAssetsSplatRoute: ApiAssetsSplatRoute,

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -276,14 +276,14 @@ function LegalText() {
     <p className="mt-4 px-8 pb-8 text-center text-xs text-neutral-500">
       By signing up, you agree to our{" "}
       <a
-        href="https://anarlog.so/legal/terms"
+        href="https://anarlog.so/terms"
         className="underline hover:text-neutral-700"
       >
         Terms of Service
       </a>{" "}
       and{" "}
       <a
-        href="https://anarlog.so/legal/privacy"
+        href="https://anarlog.so/privacy"
         className="underline hover:text-neutral-700"
       >
         Privacy Policy

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { allLegals } from "content-collections";
+
+import { LegalDocument, legalHead } from "@/components/legal-document";
+
+export const Route = createFileRoute("/privacy")({
+  component: Component,
+  loader: async () => {
+    const doc = allLegals.find((legal) => legal.slug === "privacy");
+    if (!doc) {
+      throw notFound();
+    }
+    return { doc };
+  },
+  head: ({ loaderData }) => {
+    const doc = loaderData?.doc;
+    if (!doc) return {};
+    return legalHead(doc, "/privacy");
+  },
+});
+
+function Component() {
+  const { doc } = Route.useLoaderData();
+
+  return <LegalDocument doc={doc} />;
+}

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { allLegals } from "content-collections";
+
+import { LegalDocument, legalHead } from "@/components/legal-document";
+
+export const Route = createFileRoute("/terms")({
+  component: Component,
+  loader: async () => {
+    const doc = allLegals.find((legal) => legal.slug === "terms");
+    if (!doc) {
+      throw notFound();
+    }
+    return { doc };
+  },
+  head: ({ loaderData }) => {
+    const doc = loaderData?.doc;
+    if (!doc) return {};
+    return legalHead(doc, "/terms");
+  },
+});
+
+function Component() {
+  const { doc } = Route.useLoaderData();
+
+  return <LegalDocument doc={doc} />;
+}


### PR DESCRIPTION
Add root-level privacy and terms routes, reuse the existing legal document renderer, and update public legal links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routing and redirect-only changes for public legal content; no auth or data-handling logic touched.
> 
> **Overview**
> Legal pages move from **`/legal/{slug}`** to top-level **`/privacy`** and **`/terms`**, with dedicated TanStack routes that load the same MDX from content collections via a shared **`LegalDocument`** renderer and **`legalHead`** helper (the old **`/legal/$slug`** route is removed).
> 
> **Footer**, **auth** signup copy, and **Terms** MDX now link to the new paths. **`robots.txt`** allows **`/privacy`** and **`/terms`** instead of **`/legal/`**.
> 
> **Netlify** adds 301s: site **`/legal/*` → `/:splat`**, legacy **hyprnote/char** legal URLs to **anarlog.so** without the **`/legal`** prefix, plus explicit **char.com/privacy** and **char.com/terms** → **anarlog.so**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bd993139ece94c29fefc36d9b6ae4ae981c5f1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->