### PR TITLE
Fix expired trial modal detection

### DIFF
--- a/apps/desktop/src/auth/billing.test.tsx
+++ b/apps/desktop/src/auth/billing.test.tsx
@@ -1,0 +1,138 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { canStartTrial as canStartTrialApi } from "@hypr/api-client";
+import { commands as authCommands } from "@hypr/plugin-auth";
+
+import { BillingProvider } from "./billing";
+
+const refreshSession = vi.fn();
+const setValue = vi.fn();
+
+vi.mock("./context", () => ({
+  useAuth: () => ({
+    session: {
+      access_token: "stale-token",
+      user: { id: "user-1", email: "test@example.com" },
+    },
+    getHeaders: () => ({ Authorization: "Bearer stale-token" }),
+    refreshSession,
+  }),
+}));
+
+vi.mock("@hypr/api-client", () => ({
+  canStartTrial: vi.fn(),
+}));
+
+vi.mock("@hypr/api-client/client", () => ({
+  createClient: vi.fn(() => ({})),
+}));
+
+vi.mock("@hypr/plugin-auth", () => ({
+  commands: {
+    decodeClaims: vi.fn(),
+  },
+}));
+
+vi.mock("@hypr/plugin-opener2", () => ({
+  commands: {
+    openUrl: vi.fn(),
+  },
+}));
+
+vi.mock("@hypr/plugin-windows", () => ({
+  openUrlWithInstruction: vi.fn(),
+}));
+
+vi.mock("~/store/tinybase/store/settings", () => ({
+  STORE_ID: "settings",
+  UI: {
+    useStore: () => ({ setValue }),
+    useValues: () => ({ current_llm_provider: "" }),
+  },
+}));
+
+vi.mock("../billing/trial-ended-dialog", () => ({
+  TrialEndedDialog: ({ open }: { open: boolean }) => (
+    <div data-open={open ? "true" : "false"} data-testid="trial-ended-dialog" />
+  ),
+}));
+
+vi.mock("../billing/trial-started-dialog", () => ({
+  TrialStartedDialog: ({ open }: { open: boolean }) => (
+    <div
+      data-open={open ? "true" : "false"}
+      data-testid="trial-started-dialog"
+    />
+  ),
+}));
+
+function renderBillingProvider() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BillingProvider>
+        <div>content</div>
+      </BillingProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("BillingProvider", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+    });
+
+    refreshSession.mockReset();
+    setValue.mockReset();
+
+    vi.mocked(authCommands.decodeClaims).mockResolvedValue({
+      status: "ok",
+      data: {
+        sub: "user-1",
+        email: "test@example.com",
+        entitlements: [],
+        subscription_status: null,
+        trial_end: null,
+      },
+    });
+
+    vi.mocked(canStartTrialApi).mockResolvedValue({
+      data: { canStartTrial: false, reason: "not_eligible" as const },
+      error: undefined,
+      request: new Request("https://api.example.test/can-start-trial"),
+      response: new Response(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("opens the trial-ended modal after a failed eligibility refresh", async () => {
+    refreshSession.mockResolvedValue(null);
+
+    renderBillingProvider();
+
+    await waitFor(() => {
+      expect(refreshSession).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("trial-ended-dialog").getAttribute("data-open"),
+      ).toBe("true");
+    });
+  });
+});

--- a/apps/desktop/src/auth/billing.tsx
+++ b/apps/desktop/src/auth/billing.tsx
@@ -95,23 +95,32 @@ export function BillingProvider({ children }: { children: ReactNode }) {
     queryFn: async () => {
       const headers = auth?.getHeaders();
       if (!headers) {
-        return false;
+        return { canStartTrial: false, reason: "error" as const };
       }
       const client = createClient({ baseUrl: env.VITE_API_URL, headers });
       const { data, error } = await canStartTrialApi({ client });
       if (error) {
-        return false;
+        return { canStartTrial: false, reason: "error" as const };
       }
-      return data?.canStartTrial ?? false;
+      return {
+        canStartTrial: data?.canStartTrial ?? false,
+        reason: data?.reason ?? null,
+      };
     },
   });
 
   const canStartTrial = useMemo(
     () => ({
-      data: billing.isPaid ? false : (canTrialQuery.data ?? false),
+      data: billing.isPaid
+        ? false
+        : (canTrialQuery.data?.canStartTrial ?? false),
       isPending: canTrialQuery.isPending,
     }),
-    [billing.isPaid, canTrialQuery.data, canTrialQuery.isPending],
+    [
+      billing.isPaid,
+      canTrialQuery.data?.canStartTrial,
+      canTrialQuery.isPending,
+    ],
   );
 
   const upgradeToPro = useCallback(async () => {
@@ -152,6 +161,9 @@ export function BillingProvider({ children }: { children: ReactNode }) {
 
   const [trialStartedOpen, setTrialStartedOpen] = useState(false);
   const [trialEndedOpen, setTrialEndedOpen] = useState(false);
+  const [trialEligibilityRefreshedUserId, setTrialEligibilityRefreshedUserId] =
+    useState<string | null>(null);
+  const trialEligibilityRefreshPendingRef = useRef<string | null>(null);
   const hasTrial = billing.trialEnd !== null;
 
   useEffect(() => {
@@ -169,7 +181,36 @@ export function BillingProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    if (hasTrial && !billing.isPaid) {
+    const isTrialIneligible =
+      !canTrialQuery.isPending && canTrialQuery.data?.reason === "not_eligible";
+
+    if (
+      isTrialIneligible &&
+      !hasTrial &&
+      !billing.isPaid &&
+      trialEligibilityRefreshedUserId !== userId
+    ) {
+      if (trialEligibilityRefreshPendingRef.current !== userId) {
+        trialEligibilityRefreshPendingRef.current = userId;
+        void auth
+          .refreshSession()
+          .then((session) => {
+            if (session) {
+              setTrialEligibilityRefreshedUserId(userId);
+            }
+          })
+          .finally(() => {
+            trialEligibilityRefreshPendingRef.current = null;
+          });
+      }
+      return;
+    }
+
+    const hasRecentTrial =
+      hasTrial ||
+      (isTrialIneligible && trialEligibilityRefreshedUserId === userId);
+
+    if (hasRecentTrial && !billing.isPaid) {
       const key = TRIAL_ENDED_SEEN_PREFIX + userId;
       if (!readSeen(key)) {
         setTrialEndedOpen(true);
@@ -182,6 +223,10 @@ export function BillingProvider({ children }: { children: ReactNode }) {
     hasTrial,
     billing.isPaid,
     isReady,
+    canTrialQuery.data?.reason,
+    canTrialQuery.isPending,
+    trialEligibilityRefreshedUserId,
+    auth.refreshSession,
   ]);
 
   const value = useMemo<BillingContextValue>(

--- a/apps/desktop/src/auth/billing.tsx
+++ b/apps/desktop/src/auth/billing.tsx
@@ -194,12 +194,9 @@ export function BillingProvider({ children }: { children: ReactNode }) {
         trialEligibilityRefreshPendingRef.current = userId;
         void auth
           .refreshSession()
-          .then((session) => {
-            if (session) {
-              setTrialEligibilityRefreshedUserId(userId);
-            }
-          })
+          .catch(() => null)
           .finally(() => {
+            setTrialEligibilityRefreshedUserId(userId);
             trialEligibilityRefreshPendingRef.current = null;
           });
       }


### PR DESCRIPTION
Use trial eligibility state to show the ended modal after Stripe cancels trial subscriptions and JWT trial_end disappears.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes billing UX and session refresh timing around trial expiry; limited to desktop auth/billing but affects when users see paywall modals.
> 
> **Overview**
> Fixes **trial-ended** modal not appearing when Stripe cancels an expired trial and the JWT no longer includes `trial_end`, while the user is still trial-ineligible on the API.
> 
> `BillingProvider` now keeps the full **`canStartTrial`** response (including **`reason`**) instead of a boolean. When **`reason === "not_eligible"`**, the user is unpaid, and claims show no trial, it **refreshes the session once** per user, then treats that state as a recent trial for the ended-modal path (same localStorage “seen” keys as before).
> 
> Adds **`billing.test.tsx`** covering the case where eligibility refresh fails but the trial-ended dialog still opens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69b65d121f66662f3527d5b4efc26b20ffce3333. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->