### PR TITLE
Show devtools sidebar button in staging

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -8,6 +8,8 @@ import {
 } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { commands } from "~/types/tauri.gen";
+
 const mocks = vi.hoisted(() => ({
   currentTab: {
     active: true,
@@ -202,6 +204,8 @@ describe("ClassicMainBody", () => {
     mocks.devtoolsPanelActionListeners = [];
     mocks.windowsCommands.devtoolsPanelHide.mockClear();
     mocks.windowsCommands.devtoolsPanelShow.mockClear();
+    vi.mocked(commands.showDevtool).mockClear();
+    vi.mocked(commands.showDevtool).mockResolvedValue(true);
   });
 
   it("wraps the expanded left sidebar in a persistent resizable panel", () => {
@@ -396,7 +400,7 @@ describe("ClassicMainBody", () => {
 
     const searchButton = screen.getByRole("button", { name: "Search" });
     const newNoteButton = screen.getByRole("button", { name: "New note" });
-    const devtoolsButton = screen.getByRole("button", {
+    const devtoolsButton = await screen.findByRole("button", {
       name: "Show devtools panel",
     });
 
@@ -443,7 +447,7 @@ describe("ClassicMainBody", () => {
     render(<ClassicMainBody />);
 
     expect(
-      screen.getByRole("button", { name: "Show devtools panel" }),
+      await screen.findByRole("button", { name: "Show devtools panel" }),
     ).toBeTruthy();
 
     await waitFor(() => {
@@ -469,6 +473,20 @@ describe("ClassicMainBody", () => {
     expect(
       await screen.findByRole("button", { name: "Show devtools panel" }),
     ).toBeTruthy();
+  });
+
+  it("does not show the devtools button when devtools are disabled", async () => {
+    vi.mocked(commands.showDevtool).mockResolvedValue(false);
+
+    render(<ClassicMainBody />);
+
+    await waitFor(() => {
+      expect(commands.showDevtool).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      screen.queryByRole("button", { name: "Show devtools panel" }),
+    ).toBeNull();
+    expect(mocks.devtoolsPanelActionListeners).toHaveLength(0);
   });
 
   it("routes wheel gestures from sidebar chrome into the timeline scroller", () => {

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -51,6 +51,7 @@ import {
   hasLeftSurfaceCustomSidebarTab,
 } from "~/sidebar/use-custom-sidebar";
 import { type Tab, uniqueIdfromTab, useTabs } from "~/store/zustand/tabs";
+import { commands } from "~/types/tauri.gen";
 
 const MAIN_AREA_TOP_DRAG_HEIGHT_PX = 48;
 const MAIN_AREA_WINDOW_DRAG_THRESHOLD_PX = 5;
@@ -58,7 +59,6 @@ const LEFT_SIDEBAR_DEFAULT_WIDTH_PX = 200;
 const LEFT_SIDEBAR_MIN_WIDTH_PX = 200;
 const LEFT_SIDEBAR_MAX_WIDTH_PX = 360;
 const LEFT_SIDEBAR_FALLBACK_CONTAINER_WIDTH_PX = 1000;
-const showDevtoolsPanelButton = import.meta.env.DEV;
 
 type MainAreaWindowDragStart = {
   pointerId: number;
@@ -86,33 +86,49 @@ export function ClassicMainBody() {
   const leftSidebarResizeDraggingRef = useRef(false);
   const [showIgnoredTimelineEvents, setShowIgnoredTimelineEvents] =
     useState(false);
+  const [showDevtoolsPanelButton, setShowDevtoolsPanelButton] = useState(false);
   const [devtoolsPanelOpen, setDevtoolsPanelOpen] = useState(false);
 
   useMountEffect(() => {
-    if (!showDevtoolsPanelButton) {
-      return;
-    }
-
     let cancelled = false;
     let unlistenDevtoolsAction: (() => void) | undefined;
 
-    windowsEvents.devtoolsPanelAction
-      .listen(({ payload }) => {
-        if (payload.action === "panel:opened") {
-          setDevtoolsPanelOpen(true);
-        }
-        if (payload.action === "panel:closed") {
-          setDevtoolsPanelOpen(false);
-        }
-      })
-      .then((unlisten) => {
-        if (cancelled) {
-          unlisten();
-          return;
-        }
-
-        unlistenDevtoolsAction = unlisten;
+    const syncDevtoolsPanelButton = async () => {
+      const enabled = await commands.showDevtool().catch((error) => {
+        console.error("Failed to resolve devtools availability:", error);
+        return false;
       });
+
+      if (cancelled) {
+        return;
+      }
+
+      setShowDevtoolsPanelButton(enabled);
+
+      if (!enabled) {
+        return;
+      }
+
+      windowsEvents.devtoolsPanelAction
+        .listen(({ payload }) => {
+          if (payload.action === "panel:opened") {
+            setDevtoolsPanelOpen(true);
+          }
+          if (payload.action === "panel:closed") {
+            setDevtoolsPanelOpen(false);
+          }
+        })
+        .then((unlisten) => {
+          if (cancelled) {
+            unlisten();
+            return;
+          }
+
+          unlistenDevtoolsAction = unlisten;
+        });
+    };
+
+    void syncDevtoolsPanelButton();
 
     return () => {
       cancelled = true;
@@ -278,6 +294,7 @@ export function ClassicMainBody() {
           >
             <SidebarTimelineChrome
               sidebarExpanded={leftsidebar.expanded}
+              showDevtoolsPanelButton={showDevtoolsPanelButton}
               devtoolsPanelOpen={devtoolsPanelOpen}
               onNewNote={createNewNote}
               onSearch={handleOpenNoteDialog}
@@ -583,6 +600,7 @@ function SidebarTimelineChrome({
   onSearch,
   onToggleSidebar,
   sidebarExpanded,
+  showDevtoolsPanelButton,
   update,
 }: {
   devtoolsPanelOpen: boolean;
@@ -592,6 +610,7 @@ function SidebarTimelineChrome({
   onSearch: () => void;
   onToggleSidebar: () => void;
   sidebarExpanded: boolean;
+  showDevtoolsPanelButton: boolean;
   update: DesktopUpdateControl;
 }) {
   const updateVisible = Boolean(update.status && update.version);

--- a/apps/desktop/src/test-setup.ts
+++ b/apps/desktop/src/test-setup.ts
@@ -144,6 +144,7 @@ vi.mock("./types/tauri.gen", () => ({
     getOnboardingNeeded: vi
       .fn()
       .mockResolvedValue({ status: "ok", data: false }),
+    showDevtool: vi.fn().mockResolvedValue(true),
     getPinnedTabs: vi.fn().mockResolvedValue({ status: "ok", data: null }),
     setPinnedTabs: vi.fn().mockResolvedValue({ status: "ok", data: null }),
     getRecentlyOpenedSessions: vi


### PR DESCRIPTION
Resolve devtools button visibility from the existing runtime command so staging builds follow the staging bundle-id allowlist, and cover enabled/disabled sidebar behavior in tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI gating change aligned with existing devtools-panel logic; no auth or data-path changes.
> 
> **Overview**
> The left sidebar **Show devtools panel** control no longer follows `import.meta.env.DEV`. On mount, `ClassicMainBody` calls **`commands.showDevtool()`** (same runtime check as the devtools panel host, including the staging bundle-id allowlist) and drives visibility from that result.
> 
> When devtools are off, the wrench button stays hidden and the app does not register **`devtoolsPanelAction`** listeners. When they are on, open/close behavior is unchanged. Tests wait for the async button, mock **`showDevtool`** in shared setup, and add a case where **`showDevtool`** returns false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feedd0c56dfaba894dd4948dd00c5c7606703f81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->