### PR TITLE
Make sidebar collapsible by drag

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { forwardRef, useImperativeHandle } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -17,10 +18,21 @@ const mocks = vi.hoisted(() => ({
   } as ({ type: string } & Record<string, unknown>) | null,
   leftsidebar: {
     expanded: true,
+    setExpanded: vi.fn(),
     toggleExpanded: vi.fn(),
   },
+  onPanelCollapse: null as null | (() => void),
   onPanelLayout: null as null | ((sizes: number[]) => void),
   onResizeDragging: null as null | ((isDragging: boolean) => void),
+  leftSidebarPanelHandle: {
+    collapse: vi.fn(),
+    expand: vi.fn(),
+    getId: vi.fn(() => "classic-main-sidebar-left"),
+    getSize: vi.fn(() => 12.5),
+    isCollapsed: vi.fn(() => false),
+    isExpanded: vi.fn(() => true),
+    resize: vi.fn(),
+  },
   tabContentRenderCount: 0,
   devtoolsPanelActionListeners: [] as Array<
     (event: { payload: { action: string } }) => void
@@ -61,40 +73,61 @@ vi.mock("@hypr/ui/components/ui/resizable", () => ({
       </div>
     );
   },
-  ResizablePanel: ({
-    children,
-    className,
-    defaultSize,
-    id,
-    maxSize,
-    minSize,
-    order,
-    style,
-  }: {
-    children: React.ReactNode;
-    className?: string;
-    defaultSize?: number;
-    id?: string;
-    maxSize?: number;
-    minSize?: number;
-    order?: number;
-    style?: React.CSSProperties;
-  }) => (
-    <div
-      data-class-name={className}
-      data-default-size={defaultSize}
-      data-panel-id={id}
-      data-max-size={maxSize}
-      data-min-size={minSize}
-      data-flex-grow={style?.flexGrow}
-      data-max-width={style?.maxWidth}
-      data-min-width={style?.minWidth}
-      data-order={order}
-      data-transition={style?.transition}
-      data-testid="panel"
-    >
-      {children}
-    </div>
+  ResizablePanel: forwardRef(
+    (
+      {
+        children,
+        className,
+        collapsedSize,
+        collapsible,
+        defaultSize,
+        id,
+        maxSize,
+        minSize,
+        onCollapse,
+        order,
+        style,
+      }: {
+        children: React.ReactNode;
+        className?: string;
+        collapsedSize?: number;
+        collapsible?: boolean;
+        defaultSize?: number;
+        id?: string;
+        maxSize?: number;
+        minSize?: number;
+        onCollapse?: () => void;
+        order?: number;
+        style?: React.CSSProperties;
+      },
+      ref,
+    ) => {
+      useImperativeHandle(ref, () => mocks.leftSidebarPanelHandle);
+
+      if (id === "classic-main-sidebar-left") {
+        mocks.onPanelCollapse = onCollapse ?? null;
+      }
+
+      return (
+        <div
+          data-class-name={className}
+          data-collapsed-size={collapsedSize}
+          data-collapsible={collapsible}
+          data-default-size={defaultSize}
+          data-panel-id={id}
+          data-max-size={maxSize}
+          data-min-size={minSize}
+          data-flex-grow={style?.flexGrow}
+          data-max-width={style?.maxWidth}
+          data-min-width={style?.minWidth}
+          data-order={order}
+          data-transition={style?.transition}
+          data-testid="panel"
+        >
+          {children}
+        </div>
+      );
+    },
   ),
   ResizableHandle: ({
     className,
@@ -195,9 +228,18 @@ describe("ClassicMainBody", () => {
       type: "empty",
     };
     mocks.leftsidebar.expanded = true;
+    mocks.leftsidebar.setExpanded.mockClear();
     mocks.leftsidebar.toggleExpanded.mockClear();
+    mocks.onPanelCollapse = null;
     mocks.onPanelLayout = null;
     mocks.onResizeDragging = null;
+    mocks.leftSidebarPanelHandle.collapse.mockClear();
+    mocks.leftSidebarPanelHandle.expand.mockClear();
+    mocks.leftSidebarPanelHandle.getId.mockClear();
+    mocks.leftSidebarPanelHandle.getSize.mockClear();
+    mocks.leftSidebarPanelHandle.isCollapsed.mockClear();
+    mocks.leftSidebarPanelHandle.isExpanded.mockClear();
+    mocks.leftSidebarPanelHandle.resize.mockClear();
     mocks.tabContentRenderCount = 0;
     mocks.devtoolsPanelActionListeners = [];
     mocks.windowsCommands.devtoolsPanelHide.mockClear();
@@ -226,6 +268,8 @@ describe("ClassicMainBody", () => {
     expect(panels).toHaveLength(2);
     expect(panels[0]?.dataset.panelId).toBe("classic-main-sidebar-left");
     expect(panels[0]?.dataset.order).toBe("1");
+    expect(panels[0]?.dataset.collapsible).toBe("true");
+    expect(panels[0]?.dataset.collapsedSize).toBe("0");
     expect(panels[0]?.dataset.defaultSize).toBe("12.5");
     expect(panels[0]?.dataset.minSize).toBe("12.5");
     expect(panels[0]?.dataset.maxSize).toBe("22.5");
@@ -327,6 +371,28 @@ describe("ClassicMainBody", () => {
     );
   });
 
+  it("collapses the sidebar when the resize handle snaps below the threshold", () => {
+    render(<ClassicMainBody />);
+
+    const bodyRoot = screen.getByTestId("panel-group").parentElement;
+
+    act(() => {
+      mocks.onResizeDragging?.(true);
+      mocks.onPanelLayout?.([0, 100]);
+      mocks.onPanelCollapse?.();
+    });
+
+    expect(mocks.leftsidebar.setExpanded).toHaveBeenCalledWith(false);
+    expect(mocks.leftsidebar.toggleExpanded).not.toHaveBeenCalled();
+    expect(mocks.leftSidebarPanelHandle.resize).toHaveBeenCalledWith(12.5);
+    expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-size")).toBe(
+      "12.5",
+    );
+    expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-width")).toBe(
+      "12.5%",
+    );
+  });
+
   it("keeps the note content panel at least 500px wide", () => {
     mocks.currentTab = {
       active: true,
@@ -368,6 +434,18 @@ describe("ClassicMainBody", () => {
     expect(sidebarContent?.className).toContain("opacity-0");
     expect(sidebarContent?.getAttribute("aria-hidden")).toBe("true");
     expect(sidebarContent?.hasAttribute("inert")).toBe(true);
+  });
+
+  it("resizes the collapsed sidebar panel before reopening it", () => {
+    mocks.leftsidebar.expanded = false;
+
+    render(<ClassicMainBody />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Show sidebar" }));
+
+    expect(mocks.leftSidebarPanelHandle.resize).toHaveBeenCalledWith(12.5);
+    expect(mocks.leftSidebarPanelHandle.expand).not.toHaveBeenCalled();
+    expect(mocks.leftsidebar.toggleExpanded).toHaveBeenCalledTimes(1);
   });
 
   it("restores sidebar transitions when a resize is interrupted by collapse", () => {

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -24,6 +24,7 @@ import {
   events as windowsEvents,
 } from "@hypr/plugin-windows";
 import {
+  type ImperativePanelHandle,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
@@ -57,6 +58,7 @@ const MAIN_AREA_WINDOW_DRAG_THRESHOLD_PX = 5;
 const LEFT_SIDEBAR_DEFAULT_WIDTH_PX = 200;
 const LEFT_SIDEBAR_MIN_WIDTH_PX = 200;
 const LEFT_SIDEBAR_MAX_WIDTH_PX = 360;
+const LEFT_SIDEBAR_COLLAPSED_SIZE = 0;
 const LEFT_SIDEBAR_FALLBACK_CONTAINER_WIDTH_PX = 1000;
 const showDevtoolsPanelButton = import.meta.env.DEV;
 
@@ -82,7 +84,9 @@ export function ClassicMainBody() {
     leftSidebarPanelConstraints.defaultSize,
   );
   const bodyRootRef = useRef<HTMLDivElement>(null);
+  const leftSidebarPanelRef = useRef<ImperativePanelHandle>(null);
   const leftSidebarPanelSizeRef = useRef(leftSidebarPanelSize);
+  const lastExpandedLeftSidebarPanelSizeRef = useRef(leftSidebarPanelSize);
   const leftSidebarResizeDraggingRef = useRef(false);
   const [showIgnoredTimelineEvents, setShowIgnoredTimelineEvents] =
     useState(false);
@@ -177,8 +181,16 @@ export function ClassicMainBody() {
         leftSidebarPanelSizeRef.current = sidebarSize;
         applyLeftSidebarPanelSize(sidebarSize);
 
+        if (sidebarSize > LEFT_SIDEBAR_COLLAPSED_SIZE) {
+          lastExpandedLeftSidebarPanelSizeRef.current = sidebarSize;
+        }
+
         if (!leftSidebarResizeDraggingRef.current) {
-          commitLeftSidebarPanelSize(sidebarSize);
+          commitLeftSidebarPanelSize(
+            sidebarSize > LEFT_SIDEBAR_COLLAPSED_SIZE
+              ? sidebarSize
+              : lastExpandedLeftSidebarPanelSizeRef.current,
+          );
         }
       }
     },
@@ -194,17 +206,59 @@ export function ClassicMainBody() {
       setLeftSidebarResizing(isDragging);
 
       if (!isDragging) {
-        commitLeftSidebarPanelSize(leftSidebarPanelSizeRef.current);
+        commitLeftSidebarPanelSize(
+          leftSidebarPanelSizeRef.current > LEFT_SIDEBAR_COLLAPSED_SIZE
+            ? leftSidebarPanelSizeRef.current
+            : lastExpandedLeftSidebarPanelSizeRef.current,
+        );
       }
     },
     [commitLeftSidebarPanelSize],
   );
+  const restoreLeftSidebarPanelSize = useCallback(() => {
+    const restoredSize = Math.max(
+      lastExpandedLeftSidebarPanelSizeRef.current,
+      leftSidebarPanelConstraints.minSize,
+    );
+
+    leftSidebarPanelSizeRef.current = restoredSize;
+    lastExpandedLeftSidebarPanelSizeRef.current = restoredSize;
+    commitLeftSidebarPanelSize(restoredSize);
+    applyLeftSidebarPanelSize(restoredSize);
+    resizeLeftSidebarPanel(leftSidebarPanelRef.current, restoredSize);
+  }, [
+    applyLeftSidebarPanelSize,
+    commitLeftSidebarPanelSize,
+    leftSidebarPanelConstraints.minSize,
+  ]);
+  const handleLeftSidebarPanelCollapse = useCallback(() => {
+    leftSidebarResizeDraggingRef.current = false;
+    setLeftSidebarResizing(false);
+    restoreLeftSidebarPanelSize();
+    leftsidebar.setExpanded(false);
+  }, [leftsidebar.setExpanded, restoreLeftSidebarPanelSize]);
   const handleToggleLeftSidebar = useCallback(() => {
     leftSidebarResizeDraggingRef.current = false;
     setLeftSidebarResizing(false);
-    commitLeftSidebarPanelSize(leftSidebarPanelSizeRef.current);
+
+    if (!leftsidebar.expanded) {
+      restoreLeftSidebarPanelSize();
+      leftsidebar.toggleExpanded();
+      return;
+    }
+
+    commitLeftSidebarPanelSize(
+      leftSidebarPanelSizeRef.current > LEFT_SIDEBAR_COLLAPSED_SIZE
+        ? leftSidebarPanelSizeRef.current
+        : lastExpandedLeftSidebarPanelSizeRef.current,
+    );
     leftsidebar.toggleExpanded();
-  }, [commitLeftSidebarPanelSize, leftsidebar.toggleExpanded]);
+  }, [
+    commitLeftSidebarPanelSize,
+    leftsidebar.expanded,
+    leftsidebar.toggleExpanded,
+    restoreLeftSidebarPanelSize,
+  ]);
   const handleLeftSidebarChromeWheel = useCallback(
     (event: WheelEvent<HTMLDivElement>) => {
       if (!showSidebarTimeline) {
@@ -333,11 +387,15 @@ export function ClassicMainBody() {
         {mountLeftSidebarPanel ? (
           <>
             <ResizablePanel
+              ref={leftSidebarPanelRef}
               id="classic-main-sidebar-left"
               order={1}
+              collapsible
+              collapsedSize={LEFT_SIDEBAR_COLLAPSED_SIZE}
               defaultSize={leftSidebarPanelConstraints.defaultSize}
               minSize={leftSidebarPanelConstraints.minSize}
               maxSize={leftSidebarPanelConstraints.maxSize}
+              onCollapse={handleLeftSidebarPanelCollapse}
               className={cn([
                 "min-h-0 overflow-hidden",
                 !leftsidebar.expanded && "pointer-events-none",
@@ -442,6 +500,27 @@ function getInitialMainAreaWidthPx() {
 
 function percentageFromPixels(widthPx: number, containerWidthPx: number) {
   return Math.min((widthPx / containerWidthPx) * 100, 100);
+}
+
+function resizeLeftSidebarPanel(
+  panel: ImperativePanelHandle | null,
+  size: number,
+) {
+  if (!panel) {
+    return;
+  }
+
+  try {
+    panel.resize(size);
+  } catch {
+    window.requestAnimationFrame(() => {
+      try {
+        panel.resize(size);
+      } catch {
+        // The panel can be layoutless while hidden; the CSS variables still restore visual width on reopen.
+      }
+    });
+  }
 }
 
 function useMainAreaTopWindowDrag(enabled: boolean) {


### PR DESCRIPTION
Use the resizable panel collapse behavior and preserve the last expanded width when snapping closed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop main-layout UI only; behavior is covered by new unit tests with no auth, data, or backend changes.
> 
> **Overview**
> Users can **drag the left sidebar resize handle past the minimum** so the panel snaps closed, matching collapsible resizable-panel behavior instead of only using the chrome toggle.
> 
> **`ClassicMainBody`** wires the left panel as **`collapsible`** with **`collapsedSize` 0**, an imperative **`ref`**, and **`onCollapse`** that calls **`leftsidebar.setExpanded(false)`** after restoring the last expanded width via CSS variables and **`panel.resize`**. A **`lastExpandedLeftSidebarPanelSizeRef`** keeps the pre-collapse percentage so layout commits and reopening (Show sidebar) **resize back to that width** before **`toggleExpanded`**, without calling **`expand()`** on the handle.
> 
> Tests extend the resizable mock with **`forwardRef`**, **`onCollapse`**, and panel handle stubs, and add cases for drag-to-collapse and reopen resize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac2270bf3aace3dc2ad441c2ea757fb0a4b4d49a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->