### PR TITLE
Keep meeting chip active until event end

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Kennisgewings"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "ማሳወቂያዎች"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "الإشعارات"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "জাননীসমূহ"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Bildirişlər"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Хәбәр итеүҙәр"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Апавяшчэнні"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Известия"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "বিজ্ঞপ্তি"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "བརྡ་ཐོ"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Kemennadennoù"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Obaveštenja"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificacions"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Oznámení"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Hysbysiadau"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Underretninger"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Benachrichtigungen"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ειδοποιήσεις"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -500,7 +500,7 @@ msgstr "Delete Note"
 msgid "Delete recording"
 msgstr "Delete recording"
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr "Delete Selected ({sessionCount})"
 
@@ -739,7 +739,7 @@ msgstr "Get started"
 msgid "Get started for free"
 msgstr "Get started for free"
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr "Go back to now"
 
@@ -772,7 +772,7 @@ msgstr "Help Anarlog listen to others"
 msgid "Help Anarlog listen to you"
 msgstr "Help Anarlog listen to you"
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr "Hide Deleted Events"
 
@@ -788,19 +788,19 @@ msgstr "Human"
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr "In {minutes} minute"
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr "In {minutes} minutes"
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr "In {totalSeconds} second"
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr "In {totalSeconds} seconds"
 
@@ -911,7 +911,7 @@ msgstr "Match case"
 msgid "Match whole word"
 msgstr "Match whole word"
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr "Meeting"
 
@@ -1038,7 +1038,7 @@ msgstr "No content."
 msgid "No description provided."
 msgstr "No description provided."
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr "No items today"
 
@@ -1101,7 +1101,9 @@ msgstr "Notes"
 msgid "Notifications"
 msgstr "Notifications"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr "Now"
 
@@ -1131,8 +1133,8 @@ msgstr "Open {0} settings"
 msgid "Open Anarlog"
 msgstr "Open Anarlog"
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr "Open calendar"
 
@@ -1538,7 +1540,7 @@ msgstr "Show Anarlog in the Dock and app switcher."
 msgid "Show app in Dock"
 msgstr "Show app in Dock"
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr "Show Deleted Events"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificaciones"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Märguanded"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Jakinarazpenak"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "اعلان‌ها"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Noddaango"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ilmoitukset"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Fráboðanir"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifications"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Fógraí"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificacións"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "સૂચના"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Sanarwa"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "התראות"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "सूचनाएँ"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Obavijesti"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifikasyon"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Értesítések"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ծանուցումներ"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Pemberitahuan"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ọkwa"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Tilkynningar"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifiche"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "通知"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Kabar"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "შეტყობინებები"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Хабарландырулар"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "ការជូនដំណឹង"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "ಅಧಿಸೂಚನೆಗಳು"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "알림"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Agahdar"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Эскертмелер"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificationes"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifikatiounen"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ebimanyisibwa"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Mayebisi"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "ການແຈ້ງເຕືອນ"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Pranešimai"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Paziņojumi"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Fampandrenesana"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Whakamōhiotanga"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Известувања"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "അറിയിപ്പുകൾ"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Мэдэгдэл"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "सूचना"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Pemberitahuan"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notifiki"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "သတိပေးချက်များ"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "सूचनाहरू"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Meldingen"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Varsler"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Varsler"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Zidziwitso"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificacions"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "ବିଜ୍ଞପ୍ତିଗୁଡିକ"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "ਸੂਚਨਾਵਾਂ"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Powiadomienia"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "اطلاعات"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificações"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Notificări"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Уведомления"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "सूचना"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "اطلاعات"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "දැනුම්දීම්"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Upozornenia"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Obvestila"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Zviziviso"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Ogaysiisyo"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Njoftimet"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Обавештења"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Bewara"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Aviseringar"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Arifa"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "அறிவிப்புகள்"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "నోటిఫికేషన్‌లు"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Огоҳиҳо"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "การแจ้งเตือน"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Duýduryşlar"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Mga Notification"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Bildirimler"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Хәбәрләр"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Сповіщення"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "اطلاعات"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Bildirishnomalar"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Thông báo"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Yégle yi"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Izaziso"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "נאָטיפיקאַטיאָנס"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Awọn iwifunni"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "通知"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:401
+#: src/sidebar/timeline/index.tsx:402
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:798
+#: src/sidebar/timeline/index.tsx:799
 msgid "Go back to now"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:410
+#: src/sidebar/timeline/index.tsx:411
 msgid "Hide Deleted Events"
 msgstr ""
 
@@ -788,19 +788,19 @@ msgstr ""
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:127
+#: src/sidebar/timeline/upcoming-meeting.ts:164
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:123
+#: src/sidebar/timeline/upcoming-meeting.ts:160
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:124
+#: src/sidebar/timeline/upcoming-meeting.ts:161
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:634
+#: src/sidebar/timeline/index.tsx:635
 msgid "Meeting"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:899
+#: src/sidebar/timeline/index.tsx:900
 msgid "No items today"
 msgstr ""
 
@@ -1101,7 +1101,9 @@ msgstr ""
 msgid "Notifications"
 msgstr "Izaziso"
 
-#: src/sidebar/timeline/index.tsx:810
+#: src/sidebar/timeline/index.tsx:108
+#: src/sidebar/timeline/index.tsx:811
+#: src/sidebar/timeline/upcoming-meeting.ts:62
 msgid "Now"
 msgstr ""
 
@@ -1131,8 +1133,8 @@ msgstr ""
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:587
-#: src/sidebar/timeline/index.tsx:591
+#: src/sidebar/timeline/index.tsx:588
+#: src/sidebar/timeline/index.tsx:592
 msgid "Open calendar"
 msgstr ""
 
@@ -1538,7 +1540,7 @@ msgstr ""
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx:412
 msgid "Show Deleted Events"
 msgstr ""
 

--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -37,11 +37,13 @@ const lingui = vi.hoisted(() => {
     ...values: unknown[]
   ) => {
     if (Array.isArray(input)) {
-      return input.reduce(
+      const message = input.reduce(
         (message, part, index) =>
           `${message}${part}${index < values.length ? String(values[index]) : ""}`,
         "",
       );
+
+      return message === "Now" ? "Localized now" : message;
     }
 
     if (typeof input === "string") {
@@ -49,6 +51,10 @@ const lingui = vi.hoisted(() => {
     }
 
     if ("message" in input) {
+      if (input.message === "Now") {
+        return "Localized now";
+      }
+
       return (input.message ?? "").replace(
         /\{(\w+)\}/g,
         (_match: string, key: string) =>
@@ -815,7 +821,7 @@ describe("TimelineView", () => {
     ).toBe("In 1 minute");
   });
 
-  it("hides the imminent meeting chip outside the start window", () => {
+  it("keeps the meeting chip visible until the scheduled end time", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
     mocks.currentTimeMs = Date.now();
@@ -846,6 +852,15 @@ describe("TimelineView", () => {
     ).toBe("In 5 minutes");
 
     vi.setSystemTime(new Date("2024-01-15T12:06:01.000Z"));
+    mocks.currentTimeMs = Date.now();
+    rerender(<TimelineView topChromeInset />);
+
+    expect(
+      container.querySelector("[data-sidebar-upcoming-meeting-status]")
+        ?.textContent,
+    ).toBe("Localized now");
+
+    vi.setSystemTime(new Date("2024-01-15T12:30:01.000Z"));
     mocks.currentTimeMs = Date.now();
     rerender(<TimelineView topChromeInset />);
 

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -105,8 +105,9 @@ export function TimelineView({
         buckets,
         currentTimeMs,
         formatUpcomingMeetingLabel,
+        t`Now`,
       ),
-    [buckets, currentTimeMs, formatUpcomingMeetingLabel],
+    [buckets, currentTimeMs, formatUpcomingMeetingLabel, t],
   );
   const [isUpcomingMeetingVisible, setIsUpcomingMeetingVisible] =
     useState(false);

--- a/apps/desktop/src/sidebar/timeline/upcoming-meeting.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/upcoming-meeting.test.tsx
@@ -130,4 +130,29 @@ describe("useSidebarUpcomingMeetingStatus", () => {
       title: "Deleted standup",
     });
   });
+
+  it("keeps the meeting status active until the scheduled end time", () => {
+    mocks.timelineEventsTable = {
+      standup: {
+        title: "Team standup",
+        started_at: "2024-01-15T11:55:00.000Z",
+        ended_at: "2024-01-15T12:30:00.000Z",
+        tracking_id_event: "event-standup",
+        has_recurrence_rules: false,
+      },
+    };
+
+    const active = renderHook(() => useSidebarUpcomingMeetingStatus());
+
+    expect(active.result.current).toMatchObject({
+      itemKey: "event-standup",
+      label: "Now",
+      title: "Team standup",
+    });
+
+    mocks.currentTimeMs = Date.parse("2024-01-15T12:30:01.000Z");
+    active.rerender();
+
+    expect(active.result.current).toBeNull();
+  });
 });

--- a/apps/desktop/src/sidebar/timeline/upcoming-meeting.ts
+++ b/apps/desktop/src/sidebar/timeline/upcoming-meeting.ts
@@ -5,7 +5,7 @@ import { useCurrentTimeMs } from "./realtime";
 import {
   buildTimelineBuckets,
   deriveTimelineWindowData,
-  getItemTimestamp,
+  getItemTimeRange,
   type TimelineBucket,
 } from "./utils";
 
@@ -28,6 +28,7 @@ export function useSidebarUpcomingMeetingStatus({
   showIgnored?: boolean;
 } = {}): SidebarUpcomingMeetingStatus | null {
   const timezone = useConfigValue("timezone") || undefined;
+  const { t } = useLingui();
   const { isIgnored } = useIgnoredEvents();
   const formatLabel = useUpcomingMeetingLabelFormatter();
   const timelineEventsTable = main.UI.useResultTable(
@@ -54,7 +55,12 @@ export function useSidebarUpcomingMeetingStatus({
       timezone,
     });
 
-    return getUpcomingMeetingStatus(buckets, currentTimeMs, formatLabel);
+    return getUpcomingMeetingStatus(
+      buckets,
+      currentTimeMs,
+      formatLabel,
+      t`Now`,
+    );
   }, [
     currentTimeMs,
     formatLabel,
@@ -62,6 +68,7 @@ export function useSidebarUpcomingMeetingStatus({
     showIgnored,
     timelineEventsTable,
     timelineSessionsTable,
+    t,
     timezone,
   ]);
 }
@@ -70,7 +77,10 @@ export function getUpcomingMeetingStatus(
   buckets: TimelineBucket[],
   currentTimeMs: number,
   formatLabel: (diffMs: number) => string = formatUpcomingMeetingLabelEnglish,
+  activeLabel = "Now",
 ): SidebarUpcomingMeetingStatus | null {
+  let active: { itemKey: string; title: string; endsAtMs: number } | null =
+    null;
   let nearest: { itemKey: string; title: string; diffMs: number } | null = null;
 
   for (const bucket of buckets) {
@@ -79,12 +89,31 @@ export function getUpcomingMeetingStatus(
         continue;
       }
 
-      const timestamp = getItemTimestamp(item);
-      if (!timestamp) {
+      const { start, end } = getItemTimeRange(item);
+      if (!start) {
         continue;
       }
 
-      const diffMs = timestamp.getTime() - currentTimeMs;
+      const startsAtMs = start.getTime();
+      const endsAtMs = end?.getTime();
+      if (
+        typeof endsAtMs === "number" &&
+        endsAtMs > startsAtMs &&
+        startsAtMs <= currentTimeMs &&
+        currentTimeMs <= endsAtMs
+      ) {
+        if (!active || endsAtMs < active.endsAtMs) {
+          active = {
+            itemKey: `${item.type}-${item.id}`,
+            title: item.data.title || "Untitled",
+            endsAtMs,
+          };
+        }
+
+        continue;
+      }
+
+      const diffMs = startsAtMs - currentTimeMs;
       if (diffMs <= 0 || diffMs > UPCOMING_MEETING_VISIBLE_WINDOW_MS) {
         continue;
       }
@@ -97,6 +126,14 @@ export function getUpcomingMeetingStatus(
         };
       }
     }
+  }
+
+  if (active) {
+    return {
+      itemKey: active.itemKey,
+      label: activeLabel,
+      title: active.title,
+    };
   }
 
   if (!nearest) {


### PR DESCRIPTION
Treat scheduled meetings as active through their ended_at timestamp so the sidebar jump chip remains available after start.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar UI and meeting status timing only; covered by a focused timeline test.
> 
> **Overview**
> The sidebar **upcoming meeting** chip now treats a scheduled event as in progress from `started_at` through **`ended_at`**, not only before start. While the clock is inside that window, the chip shows **Now** and still jumps to the meeting row; after end it falls back to the next imminent event or hides.
> 
> Selection logic lives in `getUpcomingMeetingStatus` (`upcoming-meeting.ts`), with the timeline wired to pass the localized **Now** label. A test asserts the chip stays through the scheduled end time. Locale `.po` files only pick up updated source line references from the refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d7ea55b8fa1234947abe3ac6d8e0db58f70502c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->