### PR TITLE
Show summary title generation placeholder

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Altyd gereed sonder om handmatig te begin."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "እራስዎ ሳይጀመር ሁልጊዜ ዝግጁ።"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "جاهز دائمًا بدون التشغيل يدويًا."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "হস্তচালিতভাৱে আৰম্ভ নকৰাকৈ সদায় সাজু।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Əl ilə işə salmadan həmişə hazırdır."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Ҡул менән эшләтеп ебәрмәйенсә һәр ваҡыт әҙер."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Заўсёды гатовы без ручнога запуску."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Винаги готов без ръчно стартиране."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ম্যানুয়ালি লঞ্চ না করে সর্বদা প্রস্তুত।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ལག་ཐོག་ནས་འགོ་མ་བཙུགས་པར་ག་དུས་ཡིན་ཡང་གྲ་སྒྲིག་ཡོད།"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Prest atav hep loc'hañ dre zorn."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Uvijek spreman bez ručnog pokretanja."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Sempre a punt sense iniciar-lo manualment."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Vždy připraven bez ručního spouštění."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Bob amser yn barod heb ei lansio â llaw."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Altid klar uden manuel lancering."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Immer bereit, ohne manuelles Starten."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Πάντα έτοιμο χωρίς μη αυτόματη εκκίνηση."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -147,7 +147,7 @@ msgstr "Allow system audio access"
 msgid "Always ready without manually launching."
 msgstr "Always ready without manually launching."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr "Analyzing structure..."
 
@@ -723,6 +723,7 @@ msgstr "Free"
 msgid "General"
 msgstr "General"
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr "Generating title..."
@@ -1776,7 +1777,7 @@ msgstr "Ticket"
 msgid "Timezone"
 msgstr "Timezone"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr "Tip: The Anarlog team loves our users!"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Siempre listo sin iniciarlo manualmente."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Alati valmis ilma käsitsi käivitamata."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Beti prest eskuz abiarazi gabe."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "همیشه بدون راه‌اندازی دستی آماده است."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Ko hesɗi sahaa kala tawa aɗa uddita e junngo."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Aina valmis ilman manuaalista käynnistämistä."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Altíð klárur uttan at seta í gongd manuelt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Toujours prêt sans lancement manuel."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Bí réidh i gcónaí gan é a sheoladh de láimh."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Sempre listo sen iniciar manualmente."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "મેન્યુઅલી લોન્ચ કર્યા વિના હંમેશા તૈયાર."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Koyaushe a shirye ba tare da ƙaddamar da hannu ba."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "תמיד מוכן ללא הפעלה ידנית."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "मैन्युअल रूप से लॉन्च किए बिना हमेशा तैयार।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Uvijek spreman bez ručnog pokretanja."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Toujou pare san yo pa lanse manyèlman."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Mindig készen áll kézi indítás nélkül."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Միշտ պատրաստ է առանց ձեռքով գործարկելու:"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Selalu siap tanpa meluncurkan secara manual."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Na-adị njikere mgbe niile na-ejighi aka malite."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Alltaf tilbúinn án þess að ræsa handvirkt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Sempre disponibile senza avvio manuale."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "手動で起動しなくても常に準備できます。"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Tansah siyap tanpa diluncurake kanthi manual."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ყოველთვის მზადაა ხელით გაშვების გარეშე."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Қолмен іске қоспай-ақ әрқашан дайын."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "រួចរាល់ជានិច្ច ដោយមិនចាំបាច់បើកដំណើរការដោយដៃ។"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ಹಸ್ತಚಾಲಿತವಾಗಿ ಪ್ರಾರಂಭಿಸದೆ ಯಾವಾಗಲೂ ಸಿದ್ಧವಾಗಿದೆ."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "수동으로 실행하지 않아도 항상 준비됩니다."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Bêyî destpêkirina bi destan her dem amade ye."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Кол менен ишке киргизбестен ар дайым даяр."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Semper sine manually deductis."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Immer prett ouni manuell ze starten."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Bulijjo mwetegefu nga totongozza mu ngalo."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Ezali ntango nyonso prêt sans lancement manuellement."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ພ້ອມສະເໝີໂດຍບໍ່ມີການເປີດດ້ວຍຕົນເອງ."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Visada paruoštas nepaleidus rankiniu būdu."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Vienmēr gatavs bez manuālas palaišanas."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Vonona foana nefa tsy alefa amin'ny tanana."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Kua reri tonu me te kore e whakarewa ringa."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Секогаш подготвен без рачно стартување."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "സ്വയം ലോഞ്ച് ചെയ്യാതെ എപ്പോഴും തയ്യാറാണ്."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Гараар эхлүүлэхгүйгээр үргэлж бэлэн байна."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "मॅन्युअली लॉन्च न करता नेहमी तयार."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Sentiasa bersedia tanpa melancarkan secara manual."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Dejjem lest mingħajr tnedija manwalment."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ကိုယ်တိုင်မဖွင့်ဘဲ အမြဲတမ်းအဆင်သင့်ဖြစ်နေပါပြီ။"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "मैन्युअल रूपमा सुरु नगरी सधैं तयार।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Altijd klaar zonder handmatig te starten."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Alltid klar uten å starte manuelt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Alltid klar uten å starte manuelt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Zimakhala zokonzeka nthawi zonse osatsegula pamanja."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Totjorn prèst sens lo lançament manualament."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ମାନୁଆଲ ଲଞ୍ଚ ନକରି ସର୍ବଦା ପ୍ରସ୍ତୁତ |"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ਹੱਥੀਂ ਲਾਂਚ ਕੀਤੇ ਬਿਨਾਂ ਹਮੇਸ਼ਾ ਤਿਆਰ।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Zawsze gotowy, bez ręcznego uruchamiania."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "د لاسي پیل کولو پرته تل چمتو وي."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Sempre pronto sem iniciar manualmente."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Întotdeauna gata fără lansare manuală."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Всегда готов без запуска вручную."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "हस्तेन प्रक्षेपणं विना सर्वदा सज्जम्।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "دستي طور تي لانچ ڪرڻ کان سواءِ هميشه تيار."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "අතින් දියත් නොකර සැම විටම සූදානම්."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Vždy pripravené bez manuálneho spúšťania."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Vedno pripravljen brez ročnega zagona."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Yagara yakagadzirira pasina kuvhura nemaoko."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Had iyo jeer diyaar adiga oo aan gacanta ku soo daacin."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Gjithmonë gati pa nisur manualisht."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Увек спреман без ручног покретања."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Salawasna siap tanpa diluncurkeun sacara manual."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Alltid redo utan att starta manuellt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Tayari kila wakati bila kuzindua wewe mwenyewe."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "கைமுறையாகத் தொடங்காமல் எப்போதும் தயார்."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "మాన్యువల్‌గా ప్రారంభించకుండానే ఎల్లప్పుడూ సిద్ధంగా ఉంటుంది."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Ҳамеша бидуни оғози дастӣ омода аст."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "พร้อมเสมอโดยไม่ต้องเปิดด้วยตนเอง"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "El bilen işlemezden elmydama taýýar."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Palaging handa nang hindi manu-manong inilulunsad."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Manuel olarak başlatmaya gerek kalmadan her zaman hazır."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Кул белән эшләтеп җибәрмичә һәрвакыт әзер."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Завжди готовий без запуску вручну."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "دستی طور پر لانچ کیے بغیر ہمیشہ تیار۔"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Qo'lda ishga tushirmasdan ham doim tayyor."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Luôn sẵn sàng mà không cần khởi chạy thủ công."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Dafay waajal saa yu nekk te doo tàmbali ko ak loxo."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Ihlala ilungile ngaphandle kokuyizisa ngesandla."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "שטענדיק גרייט אָן מאַניואַלי קאַטער."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Ṣetan nigbagbogbo lai ṣe ifilọlẹ pẹlu ọwọ."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "无需手动启动，随时就绪。"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Ihlala ilungile ngaphandle kokuyiqalisa mathupha."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:33
+#: src/session/components/note-input/enhanced/streaming.tsx:54
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,6 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: src/session/components/note-input/enhanced/streaming.tsx:22
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1776,7 +1777,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:41
+#: src/session/components/note-input/enhanced/streaming.tsx:62
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
@@ -21,6 +21,7 @@ const hoisted = vi.hoisted(() => ({
     isHosted: true,
   } as LLMConnectionStatus,
   content: "",
+  sessionTitle: "",
 }));
 
 vi.mock("@hypr/ui/components/ui/spinner", () => ({
@@ -46,7 +47,10 @@ vi.mock("~/ai/hooks", () => ({
 vi.mock("~/store/tinybase/store/main", () => ({
   STORE_ID: "main",
   UI: {
-    useCell: () => hoisted.content,
+    useCell: (table: string, _id: string, cell: string) =>
+      table === "sessions" && cell === "title"
+        ? hoisted.sessionTitle
+        : hoisted.content,
   },
 }));
 
@@ -102,6 +106,7 @@ describe("Enhanced", () => {
       isHosted: true,
     };
     hoisted.content = "";
+    hoisted.sessionTitle = "";
   });
 
   it("renders an empty editor before the auto-enhance task is visible", () => {
@@ -146,7 +151,25 @@ describe("Enhanced", () => {
     expect(screen.queryByText("Enhanced editor")).toBeNull();
     expect(screen.getByText("Streaming summary")).not.toBeNull();
     expect(screen.getByTestId("summary-title-space")).not.toBeNull();
+    expect(screen.getByText("Generating title...")).not.toBeNull();
     expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("does not show the title placeholder while streaming for an already titled session", () => {
+    hoisted.sessionTitle = "Existing title";
+    hoisted.task = {
+      status: "generating",
+      error: undefined,
+      streamedText: "Streaming summary",
+      currentStep: undefined,
+      isGenerating: true,
+    };
+
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.getByText("Streaming summary")).not.toBeNull();
+    expect(screen.queryByTestId("summary-title-space")).toBeNull();
+    expect(screen.queryByText("Generating title...")).toBeNull();
   });
 
   it("renders the editor after an empty enhance task returns idle", () => {

--- a/apps/desktop/src/session/components/note-input/enhanced/index.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.tsx
@@ -63,7 +63,9 @@ export const Enhanced = forwardRef<
     }
 
     if (status === "generating") {
-      return <StreamingView enhancedNoteId={enhancedNoteId} />;
+      return (
+        <StreamingView sessionId={sessionId} enhancedNoteId={enhancedNoteId} />
+      );
     }
 
     return (

--- a/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
@@ -6,21 +6,42 @@ import { cn } from "@hypr/utils";
 import { streamdownComponents } from "../../streamdown";
 
 import { useAITaskTask } from "~/ai/hooks";
+import * as main from "~/store/tinybase/store/main";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 
 function SummaryTitleSpace() {
   return (
     <div
-      aria-hidden="true"
       data-testid="summary-title-space"
-      className="pointer-events-none mb-4 h-[1.875rem]"
-    />
+      className="pointer-events-none mb-3 flex h-[1.875rem] items-center"
+    >
+      <span
+        aria-hidden="true"
+        className="text-muted-foreground animate-pulse text-[1.5rem] leading-[1.875rem] font-semibold opacity-60"
+      >
+        <Trans>Generating title...</Trans>
+      </span>
+    </div>
   );
 }
 
-export function StreamingView({ enhancedNoteId }: { enhancedNoteId: string }) {
+export function StreamingView({
+  sessionId,
+  enhancedNoteId,
+}: {
+  sessionId: string;
+  enhancedNoteId: string;
+}) {
   const taskId = createTaskId(enhancedNoteId, "enhance");
   const { streamedText, isGenerating } = useAITaskTask(taskId, "enhance");
+  const sessionTitle = main.UI.useCell(
+    "sessions",
+    sessionId,
+    "title",
+    main.STORE_ID,
+  );
+  const shouldGenerateTitle =
+    typeof sessionTitle !== "string" || sessionTitle.trim().length === 0;
 
   if (streamedText.trim().length === 0) {
     return (
@@ -48,7 +69,7 @@ export function StreamingView({ enhancedNoteId }: { enhancedNoteId: string }) {
   return (
     <div className="pb-2">
       <div className="flex flex-col gap-1">
-        <SummaryTitleSpace />
+        {shouldGenerateTitle ? <SummaryTitleSpace /> : null}
         <Streamdown
           components={streamdownComponents}
           className={cn(["flex flex-col"])}


### PR DESCRIPTION
Render a muted title placeholder in the streamed summary title space and cover it in the enhanced summary test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change in the enhanced note streaming path with no auth or data-model impact.
> 
> **Overview**
> While an **enhanced note** is streaming and the session has **no title yet**, the streaming view now reserves title space above the summary and shows a muted, pulsing **"Generating title..."** placeholder (hidden when the session already has a title).
> 
> **Tests** assert the placeholder appears only for untitled sessions during streaming. Locale catalogs were refreshed so the new copy in `streaming.tsx` is wired for i18n (same string as the existing title input).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb56e20867aed415bc635e8fd833452e40caae96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->