### PR TITLE
Increase hero top spacing

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1140,7 +1140,7 @@ function HeroWorkflowDemo() {
 
 function AnnouncementBanner() {
   return (
-    <div className="flex justify-center px-5 pt-6 md:pt-8">
+    <div className="flex justify-center px-5 pt-10 md:pt-12">
       <a
         href="https://char.com"
         className="char-announcement group relative inline-flex h-8 w-[15.25rem] max-w-full items-center justify-center text-center text-sm font-medium text-[#181613] opacity-75 transition-opacity hover:opacity-100"


### PR DESCRIPTION
Bump the landing announcement padding so the hero has more breathing room above the headline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic spacing-only change on the home route with no logic or data impact.
> 
> **Overview**
> Adds more vertical space above the Char waitlist **announcement banner** on the landing page by increasing top padding from `pt-6` / `md:pt-8` to **`pt-10` / `md:pt-12`** in `AnnouncementBanner`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5ebe0358e7d597db8eadf5af386c29966d1662a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->