### PR TITLE
Fix live meeting tab timing

### DIFF
--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -152,6 +152,8 @@ vi.mock("~/session/components/shared", () => ({
     (audioExists &&
       hoisted.sessionMode !== "active" &&
       hoisted.sessionMode !== "finalizing") ||
+    hoisted.sessionMode === "active" ||
+    hoisted.sessionMode === "finalizing" ||
     (hoisted.liveSessionId === sessionId && hoisted.liveSegments.length > 0) ||
     hoisted.sessionMode === "running_batch",
 }));
@@ -670,7 +672,7 @@ describe("Header", () => {
     ]);
   });
 
-  it("omits the transcript tab for active meetings without transcript evidence", () => {
+  it("includes the transcript tab for active meetings before transcript evidence arrives", () => {
     hoisted.hasTranscript = false;
     hoisted.sessionMode = "active";
     hoisted.liveSessionId = "session-1";
@@ -682,6 +684,7 @@ describe("Header", () => {
     expect(result.current).toEqual([
       { type: "enhanced", id: "note-1" },
       { type: "raw" },
+      { type: "transcript" },
     ]);
   });
 

--- a/apps/desktop/src/session/components/shared.test.ts
+++ b/apps/desktop/src/session/components/shared.test.ts
@@ -105,16 +105,16 @@ describe("useCurrentNoteTab", () => {
     expect(result.current).toEqual({ type: "raw" });
   });
 
-  it("normalizes active transcript view when no transcript evidence exists", () => {
+  it("keeps active transcript view when no transcript evidence exists", () => {
     hoisted.sessionMode = "active";
     hoisted.liveSessionId = "session-1";
 
     const { result } = renderHook(() => useCurrentNoteTab(tab));
 
-    expect(result.current).toEqual({ type: "raw" });
+    expect(result.current).toEqual({ type: "transcript" });
   });
 
-  it("normalizes active transcript view when only in-progress audio exists", () => {
+  it("keeps active transcript view when only in-progress audio exists", () => {
     hoisted.sessionMode = "active";
     hoisted.liveSessionId = "session-1";
 
@@ -122,7 +122,7 @@ describe("useCurrentNoteTab", () => {
       useCurrentNoteTab(tab, { audioExists: true }),
     );
 
-    expect(result.current).toEqual({ type: "raw" });
+    expect(result.current).toEqual({ type: "transcript" });
   });
 });
 
@@ -145,15 +145,22 @@ describe("useCanShowTranscript", () => {
     expect(result.current).toBe(true);
   });
 
-  it("ignores live segments from another active session while finalizing", () => {
+  it("shows the transcript while active before live segments arrive", () => {
+    hoisted.liveSessionId = "session-1";
+    hoisted.sessionMode = "active";
+
+    const { result } = renderHook(() => useCanShowTranscript("session-1"));
+
+    expect(result.current).toBe(true);
+  });
+
+  it("shows the transcript while finalizing", () => {
     hoisted.finalizingBySession = { "session-1": { startedAt: 1 } };
-    hoisted.liveSessionId = "session-2";
-    hoisted.liveSegments = [{ id: "segment-1" }];
     hoisted.sessionMode = "finalizing";
 
     const { result } = renderHook(() => useCanShowTranscript("session-1"));
 
-    expect(result.current).toBe(false);
+    expect(result.current).toBe(true);
   });
 });
 

--- a/apps/desktop/src/session/components/shared.tsx
+++ b/apps/desktop/src/session/components/shared.tsx
@@ -126,6 +126,7 @@ export function useCanShowTranscript(
   return (
     hasTranscript ||
     (audioExists && !isLiveCapture) ||
+    isLiveCapture ||
     hasLiveSegments ||
     sessionMode === "running_batch" ||
     Boolean(batchError)

--- a/apps/desktop/src/session/hooks/useEnhancedNotes.test.tsx
+++ b/apps/desktop/src/session/hooks/useEnhancedNotes.test.tsx
@@ -111,6 +111,26 @@ describe("useEnsureDefaultSummary", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("does not create the summary row during active recording", async () => {
+    hoisted.sessionMode = "active";
+
+    renderHook(() => useEnsureDefaultSummary("session-1"));
+
+    await waitFor(() => {
+      expect(hoisted.service.ensureNote).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not create the summary row while finalizing recording", async () => {
+    hoisted.sessionMode = "finalizing";
+
+    renderHook(() => useEnsureDefaultSummary("session-1"));
+
+    await waitFor(() => {
+      expect(hoisted.service.ensureNote).not.toHaveBeenCalled();
+    });
+  });
+
   it("creates the summary row while batch transcription is running", async () => {
     hoisted.hasTranscript = false;
     hoisted.sessionMode = "running_batch";

--- a/apps/desktop/src/session/hooks/useEnhancedNotes.ts
+++ b/apps/desktop/src/session/hooks/useEnhancedNotes.ts
@@ -67,11 +67,11 @@ export function useEnsureDefaultSummary(sessionId: string) {
 
     const hasEnhancedNotes = enhancedNoteIds && enhancedNoteIds.length > 0;
     const templateId = selectedTemplateId || undefined;
+    const isLiveCapture =
+      sessionMode === "active" || sessionMode === "finalizing";
     const canCreateSummary =
-      hasTranscript ||
-      sessionMode === "finalizing" ||
-      sessionMode === "running_batch" ||
-      Boolean(batchError);
+      !isLiveCapture &&
+      (hasTranscript || sessionMode === "running_batch" || Boolean(batchError));
 
     if (!hasEnhancedNotes && canCreateSummary) {
       service.ensureNote(sessionId, templateId);


### PR DESCRIPTION
Show transcript tabs immediately during recording and delay default summary tab creation until live capture is done.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI timing and tab visibility only; no auth, persistence, or transcription pipeline changes beyond when the summary row is created.
> 
> **Overview**
> **Transcript** is available as soon as a meeting is **active** or **finalizing**, even before stored transcript rows or live segments exist. `useCanShowTranscript` treats live capture like a first-class signal, so the transcript tab stays in the editor and the current tab is no longer forced back to **Memos** in that window.
> 
> **Default summary** creation is held until live capture finishes: `useEnsureDefaultSummary` skips `ensureNote` while `sessionMode` is **active** or **finalizing** (batch transcription and batch errors still allow creation as before).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86189d579905459742435e8688802d1a79e2d2dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->