### PR TITLE
Constrain landing meeting asset width

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -343,7 +343,7 @@ function Component() {
 
       <div className="mx-auto w-full max-w-[700px] px-5 pt-4 pb-8 md:px-8 md:pt-4 md:pb-12">
         <div className="min-w-0 text-center">
-          <section className="pt-10 pb-20 md:pt-12 md:pb-24">
+          <section className="pt-10 pb-2 md:pt-12 md:pb-4">
             <h1 className="font-hand mx-auto max-w-3xl text-5xl leading-[0.98] font-semibold tracking-normal text-balance md:text-7xl">
               AI notepad for private meetings.
             </h1>
@@ -556,10 +556,13 @@ function OpenSourceSection({
 
 function CredibilityLogoMarquee() {
   return (
-    <section className="py-12 md:py-14" aria-labelledby="credibility-heading">
+    <section
+      className="pt-0 pb-6 md:pb-8"
+      aria-labelledby="credibility-heading"
+    >
       <h2
         id="credibility-heading"
-        className="font-hand text-3xl leading-none font-semibold text-[#756b5d]"
+        className="font-hand text-base leading-none font-semibold text-[#756b5d] md:text-lg"
       >
         Trusted by people in
       </h2>
@@ -567,7 +570,7 @@ function CredibilityLogoMarquee() {
         {credibilityLogos.map((logo) => logo.name).join(", ")}
       </p>
 
-      <div className="relative left-1/2 mt-6 w-screen -translate-x-1/2 overflow-hidden bg-white py-4 motion-reduce:overflow-visible">
+      <div className="relative left-1/2 mt-3 w-screen -translate-x-1/2 overflow-hidden bg-white py-4 motion-reduce:overflow-visible">
         <div
           className="pointer-events-none absolute inset-y-0 left-0 z-10 w-16 bg-linear-to-r from-white to-transparent motion-reduce:hidden md:w-32"
           aria-hidden="true"
@@ -849,7 +852,7 @@ function PrivacyVisual({
 
   return (
     <div className="flex h-20 items-center justify-center select-none md:h-28 md:w-full">
-      <div className="flex items-center gap-3 rounded-2xl border border-neutral-200 bg-white py-2 pr-3 pl-4 text-left shadow-[0_3px_10px_rgba(24,22,19,0.04)] md:w-full">
+      <div className="flex w-full max-w-[260px] items-center gap-3 rounded-2xl border border-neutral-200 bg-white py-2 pr-3 pl-4 text-left shadow-[0_3px_10px_rgba(24,22,19,0.04)]">
         <img
           src="/icons/google-meet.svg"
           alt=""
@@ -958,7 +961,7 @@ function HeroWorkflowDemo() {
   const isGeneratingSummary = enhancedLines > 0 && enhancedLines < 6;
 
   return (
-    <div className="relative left-1/2 mt-10 w-screen max-w-[500px] -translate-x-1/2 px-8 pb-16 sm:px-10">
+    <div className="relative left-1/2 mt-10 w-screen max-w-[500px] -translate-x-1/2 px-8 pb-8 sm:px-10">
       <div
         className="pointer-events-none absolute top-10 bottom-24 left-8 z-0 w-12 rounded-full bg-neutral-950/10 blur-2xl sm:left-10"
         aria-hidden="true"


### PR DESCRIPTION
Cap the meeting capture visual at 260px so the asset renders smaller in the privacy section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Tailwind class changes on the marketing landing route; no logic, data, or auth impact.
> 
> **Overview**
> Tightens vertical rhythm on the home page so the hero, workflow demo, and credibility marquee sit closer together.
> 
> The hero section and `HeroWorkflowDemo` lose large bottom padding (`pb-20`/`pb-24` → `pb-2`/`pb-4`, and `pb-16` → `pb-8`). The **Trusted by people in** block is de-emphasized with smaller heading text (`text-3xl` → `text-base`/`md:text-lg`), less section padding, and a tighter gap above the logo marquee.
> 
> In the privacy **meeting** visual, the Google Meet–style capture card is capped at **`max-w-[260px]`** instead of stretching full width on desktop (`md:w-full` removed), so the asset reads smaller in that column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 205ad94b5919b642838ab446a093261cef054899. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->