### PR TITLE
fix: preserve live transcript word spacing

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment.test.tsx
@@ -38,6 +38,24 @@ describe("SegmentRenderer", () => {
     mocks.wordSpan.mockClear();
   });
 
+  it("keeps spaces between rendered words and lines", () => {
+    const segment = createSegment();
+    const seekAndPlay = vi.fn();
+    const view = render(
+      <SegmentRenderer
+        segment={segment}
+        offsetMs={0}
+        transcriptId="transcript-1"
+        currentMs={0}
+        seekAndPlay={seekAndPlay}
+        audioExists
+        search={EMPTY_TRANSCRIPT_SEARCH}
+      />,
+    );
+
+    expect(view.container.textContent).toBe("First line. Second line.");
+  });
+
   it("skips playback rerenders while the active line is unchanged", () => {
     const segment = createSegment();
     const seekAndPlay = vi.fn();

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from "react";
+import { Fragment, memo, useMemo } from "react";
 
 import { cn } from "@hypr/utils";
 
@@ -71,10 +71,11 @@ export const SegmentRenderer = memo(
 
       const highlights = new Map<SegmentWord, HighlightSegment[]>();
       for (const word of segment.words) {
+        const displayText = getWordDisplayText(word);
         highlights.set(
           word,
           createHighlightSegments(
-            word.text,
+            displayText,
             search.query,
             search.caseSensitive,
             search.wholeWord,
@@ -116,20 +117,23 @@ export const SegmentRenderer = memo(
                   isCurrentLine && "bg-yellow-100/50 dark:bg-yellow-900/30",
                 ])}
               >
+                {lineIdx > 0 ? " " : null}
                 {line.words.map((word, idx) => (
-                  <WordSpan
-                    key={word.id ?? `${word.start_ms}-${idx}`}
-                    word={word}
-                    displayText={word.text}
-                    audioExists={audioExists}
-                    onClickWord={seekAndPlay}
-                    highlightSegments={
-                      highlightSegmentsByWord?.get(word) ?? undefined
-                    }
-                    isActiveMatch={
-                      Boolean(word.id) && word.id === search.activeMatchId
-                    }
-                  />
+                  <Fragment key={word.id ?? `${word.start_ms}-${idx}`}>
+                    {idx > 0 ? " " : null}
+                    <WordSpan
+                      word={word}
+                      displayText={getWordDisplayText(word)}
+                      audioExists={audioExists}
+                      onClickWord={seekAndPlay}
+                      highlightSegments={
+                        highlightSegmentsByWord?.get(word) ?? undefined
+                      }
+                      isActiveMatch={
+                        Boolean(word.id) && word.id === search.activeMatchId
+                      }
+                    />
+                  </Fragment>
                 ))}
               </span>
             );
@@ -205,4 +209,8 @@ function segmentContainsWordId(segment: Segment, wordId: string | null) {
   }
 
   return segment.words.some((word) => word.id === wordId);
+}
+
+function getWordDisplayText(word: SegmentWord) {
+  return word.text.trim();
 }


### PR DESCRIPTION
Summary:
- Render live transcript words with explicit separators.
- Cover line-boundary spacing behavior in the transcript renderer test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized transcript UI rendering and search-highlight alignment; no auth, data, or backend changes.
> 
> **Overview**
> Fixes **live transcript** text running together by inserting explicit space separators between words and between grouped lines in `SegmentRenderer`, instead of relying on adjacent inline elements to preserve whitespace.
> 
> **Display and search** now use trimmed word text via `getWordDisplayText`, so highlights and rendered labels stay aligned with the visible tokens.
> 
> Adds a renderer test asserting the combined text is `First line. Second line.` with spaces at word and line boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4638b8d6d59e1a49be0853e591671df59d09f62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->