### PR TITLE
fix: update floating transcript controls

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -637,7 +637,7 @@ msgstr "Expire recordings after three days"
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr "Export"
 
@@ -1143,7 +1143,7 @@ msgstr "Open calendar"
 msgid "Open calendar account actions"
 msgstr "Open calendar account actions"
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr "Open floating panel"
 
@@ -1151,7 +1151,7 @@ msgstr "Open floating panel"
 msgid "Open in New Tab"
 msgstr "Open in New Tab"
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr "Open in New Window"
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr "Upgrade to use"
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr "Upload audio"
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr "Upload transcript"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:112
+#: src/session/components/outer-header/overflow/index.tsx:115
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:148
+#: src/session/components/outer-header/overflow/index.tsx:151
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:160
+#: src/session/components/outer-header/overflow/index.tsx:163
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:127
+#: src/session/components/outer-header/overflow/index.tsx:130
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:136
+#: src/session/components/outer-header/overflow/index.tsx:139
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/meeting-float/hooks.ts
+++ b/apps/desktop/src/meeting-float/hooks.ts
@@ -1,0 +1,7 @@
+import * as main from "~/store/tinybase/store/main";
+
+export type MeetingFloatMainStore = main.Store;
+
+export function useMeetingFloatMainStore() {
+  return main.UI.useStore(main.STORE_ID) as MeetingFloatMainStore | undefined;
+}

--- a/apps/desktop/src/meeting-float/host.test.ts
+++ b/apps/desktop/src/meeting-float/host.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+import type { LiveTranscriptSegment } from "@hypr/plugin-transcription";
+
 import {
   getCurrentFloatingBarColorScheme,
   getFloatingRouteState,
+  getFloatingTranscriptBubbles,
   getLiveCaptionDisplayText,
   getLiveCaptionMinimizedForSessionDefault,
   getLiveCaptionRouteState,
@@ -14,6 +17,7 @@ import { createListenerStore } from "~/store/zustand/listener";
 type ListenerLiveState = ReturnType<
   ReturnType<typeof createListenerStore>["getState"]
 >["live"];
+type SegmentWord = LiveTranscriptSegment["words"][number];
 
 function createListenerState(live: Partial<ListenerLiveState>) {
   const store = createListenerStore();
@@ -41,6 +45,41 @@ function createListenerStateWithCaption(
   return store.getState();
 }
 
+function createListenerStateWithSegments(
+  live: Partial<ListenerLiveState>,
+  liveSegments: LiveTranscriptSegment[],
+) {
+  const store = createListenerStore();
+  store.setState({
+    live: {
+      ...store.getState().live,
+      ...live,
+    },
+    liveSegments,
+  });
+  return store.getState();
+}
+
+function createSegment(
+  segment: Omit<LiveTranscriptSegment, "end_ms" | "words"> & {
+    words: Array<Partial<SegmentWord> & Pick<SegmentWord, "text">>;
+    end_ms?: number;
+  },
+): LiveTranscriptSegment {
+  return {
+    ...segment,
+    end_ms: segment.end_ms ?? segment.start_ms + 100,
+    words: segment.words.map((word, index) => ({
+      start_ms: word.start_ms ?? segment.start_ms + index * 10,
+      end_ms: word.end_ms ?? segment.start_ms + index * 10 + 5,
+      channel: word.channel ?? segment.key.channel,
+      is_final: word.is_final ?? true,
+      text: word.text,
+      id: word.id,
+    })),
+  };
+}
+
 describe("getFloatingRouteState", () => {
   it("returns recording status for healthy live sessions", () => {
     expect(
@@ -53,6 +92,7 @@ describe("getFloatingRouteState", () => {
       ),
     ).toEqual({
       sessionId: "session-1",
+      title: "Live transcript",
       amplitude: 1,
       status: "recording",
       colorScheme: "dark",
@@ -63,7 +103,76 @@ describe("getFloatingRouteState", () => {
       liveCaptionPosition: "topCenter",
       liveCaptionMinimized: false,
       liveCaptionToggleVisible: false,
+      transcriptBubbles: [],
     });
+  });
+
+  it("uses the session title when provided", () => {
+    expect(
+      getFloatingRouteState(
+        createListenerState({
+          status: "active",
+          sessionId: "session-1",
+        }),
+        { sessionTitle: "  Weekly team sync  " },
+      )?.title,
+    ).toBe("Weekly team sync");
+  });
+
+  it("builds transcript bubbles from speaker segments", () => {
+    const segments = [
+      createSegment({
+        id: "remote-1",
+        key: {
+          channel: "RemoteParty",
+          speaker_index: 1,
+          speaker_human_id: null,
+        },
+        start_ms: 200,
+        text: "being bingo",
+        words: [{ text: "being", is_final: false }, { text: "bingo" }],
+      }),
+      createSegment({
+        id: "mic-1",
+        key: {
+          channel: "DirectMic",
+          speaker_index: null,
+          speaker_human_id: null,
+        },
+        start_ms: 100,
+        text: "summary yep",
+        words: [{ text: "summary" }, { text: "yep" }, { text: "." }],
+      }),
+    ];
+
+    expect(
+      getFloatingRouteState(
+        createListenerStateWithSegments(
+          {
+            status: "active",
+            sessionId: "session-1",
+            liveTranscriptionActive: true,
+          },
+          segments,
+        ),
+        { liveCaptionToggleVisible: true },
+      )?.transcriptBubbles,
+    ).toEqual([
+      {
+        id: "mic-1",
+        speakerLabel: "You",
+        text: "summary yep.",
+        isSelf: true,
+        isFinal: true,
+      },
+      {
+        id: "remote-1",
+        speakerLabel: "Speaker 2",
+        text: "being bingo",
+        isSelf: false,
+        isFinal: false,
+      },
+    ]);
   });
 
   it("marks the transcript toggle visible for cloud live transcription", () => {
@@ -114,6 +223,35 @@ describe("getFloatingRouteState", () => {
         }),
       ),
     ).toBeNull();
+  });
+});
+
+describe("getFloatingTranscriptBubbles", () => {
+  it("keeps only the most recent transcript bubbles", () => {
+    const bubbles = getFloatingTranscriptBubbles(
+      Array.from({ length: 8 }, (_, index) =>
+        createSegment({
+          id: `segment-${index}`,
+          key: {
+            channel: "RemoteParty",
+            speaker_index: index % 2,
+            speaker_human_id: null,
+          },
+          start_ms: index,
+          text: `segment ${index}`,
+          words: [{ text: `segment ${index}` }],
+        }),
+      ),
+    );
+
+    expect(bubbles.map((bubble) => bubble.id)).toEqual([
+      "segment-2",
+      "segment-3",
+      "segment-4",
+      "segment-5",
+      "segment-6",
+      "segment-7",
+    ]);
   });
 });
 

--- a/apps/desktop/src/meeting-float/host.tsx
+++ b/apps/desktop/src/meeting-float/host.tsx
@@ -5,6 +5,8 @@ import {
 } from "@hypr/plugin-windows";
 import type { GeneralStorage } from "@hypr/store";
 
+import { type MeetingFloatMainStore, useMeetingFloatMainStore } from "./hooks";
+
 import { useConfigValue } from "~/shared/config";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import * as settingsStore from "~/store/tinybase/store/settings";
@@ -42,8 +44,16 @@ type FloatingOverlaySettingsStorage = Pick<
   | "live_caption_minimized"
   | "live_caption_enabled"
 >;
+type FloatingTranscriptBubble = {
+  id: string;
+  speakerLabel: string;
+  text: string;
+  isSelf: boolean;
+  isFinal: boolean;
+};
 type FloatingRouteState = {
   sessionId: string;
+  title: string;
   amplitude: number;
   status: FloatingBarStatus;
   colorScheme: FloatingBarColorScheme;
@@ -54,6 +64,7 @@ type FloatingRouteState = {
   liveCaptionPosition: LiveCaptionPosition;
   liveCaptionMinimized: boolean;
   liveCaptionToggleVisible: boolean;
+  transcriptBubbles: FloatingTranscriptBubble[];
 };
 type LiveCaptionRouteState = {
   sessionId: string;
@@ -85,6 +96,7 @@ const LIVE_CAPTION_MIN_LINE_COUNT = 1;
 const LIVE_CAPTION_MAX_LINE_COUNT = 4;
 const LIVE_CAPTION_HORIZONTAL_PADDING_PX = 32;
 const LIVE_CAPTION_AVERAGE_CHARACTER_WIDTH_PX = 7.8;
+const FLOATING_TRANSCRIPT_BUBBLE_LIMIT = 6;
 
 const LIVE_CAPTION_POSITIONS: ReadonlySet<string> = new Set([
   "topCenter",
@@ -110,17 +122,22 @@ const FLOATING_OVERLAY_SETTING_KEYS = [
 export function FloatingMeetingWindowHost() {
   const floatingBarEnabled = useConfigValue("floating_bar_enabled");
   const store = settingsStore.UI.useStore(settingsStore.STORE_ID);
+  const main = useMeetingFloatMainStore();
 
   return (
     <>
       <FloatingOverlaySettingsEventSync />
       <LiveCaptionDefaultVisibilitySync store={store} />
       {floatingBarEnabled ? (
-        <FloatingMeetingWindowSync store={store} />
+        <FloatingMeetingWindowSync
+          key={main ? "main-store-ready" : "main-store-pending"}
+          store={store}
+          main={main}
+        />
       ) : (
         <FloatingMeetingWindowDisabled />
       )}
-      <LiveCaptionWindowSync store={store} />
+      <LiveCaptionWindowDisabled />
     </>
   );
 }
@@ -255,155 +272,19 @@ function FloatingMeetingWindowDisabled() {
   return null;
 }
 
-function LiveCaptionWindowSync({
-  store,
-}: {
-  store: SettingsStore | undefined;
-}) {
+function LiveCaptionWindowDisabled() {
   useMountEffect(() => {
-    let settings = getFloatingOverlaySettingsFromStore(store);
-    let routeState = getCurrentLiveCaptionRouteState(
-      listenerStore.getState(),
-      settings,
-    );
-    let syncQueued = false;
-    let syncRunning = false;
-    let syncRequested = false;
-    let cancelled = false;
-    let shownSessionId: string | null = null;
-    const unlisteners: Array<() => void> = [];
-
-    const shouldContinue = () => !cancelled;
-    const updateSettings = (nextSettings: FloatingOverlaySettings) => {
-      const nextRouteState = getLiveCaptionRouteState(
-        listenerStore.getState(),
-        nextSettings,
-      );
-
-      settings = nextSettings;
-      if (isSameLiveCaptionRouteState(nextRouteState, routeState)) {
-        return;
-      }
-
-      routeState = nextRouteState;
-      scheduleSync();
-    };
-
-    const sync = async () => {
-      if (!shouldContinue()) {
-        return;
-      }
-
-      const nextShownSessionId = await syncLiveCaptionWindow(
-        routeState,
-        shownSessionId,
-        shouldContinue,
-      );
-      if (!shouldContinue()) {
-        await hideLiveCaptionPanel();
-        return;
-      }
-
-      if (nextShownSessionId === "unavailable") {
-        return;
-      }
-
-      shownSessionId = nextShownSessionId;
-    };
-
-    const runQueuedSync = async () => {
-      if (syncRunning) {
-        syncRequested = true;
-        return;
-      }
-
-      syncRunning = true;
-      try {
-        do {
-          syncRequested = false;
-          await sync();
-        } while (syncRequested && !cancelled);
-      } finally {
-        syncRunning = false;
-      }
-    };
-
-    const scheduleSync = () => {
-      if (syncQueued) {
-        return;
-      }
-
-      syncQueued = true;
-      queueMicrotask(() => {
-        syncQueued = false;
-        if (cancelled) {
-          return;
-        }
-
-        void runQueuedSync();
-      });
-    };
-
-    scheduleSync();
-
-    const unsubscribe = listenerStore.subscribe((state, previousState) => {
-      const nextRouteState = getLiveCaptionRouteState(state, settings);
-      const previousRouteState = getLiveCaptionRouteState(
-        previousState,
-        settings,
-      );
-
-      if (isSameLiveCaptionRouteState(nextRouteState, previousRouteState)) {
-        return;
-      }
-
-      routeState = nextRouteState;
-      scheduleSync();
-    });
-
-    const settingsListenerIds = addFloatingOverlaySettingsListeners(
-      store,
-      () => {
-        updateSettings(getFloatingOverlaySettingsFromStore(store));
-      },
-    );
-    windowsEvents.floatingBarSettingsChange
-      .listen((event) => {
-        if (cancelled) {
-          return;
-        }
-
-        updateSettings(
-          mergeFloatingOverlaySettings(
-            settings,
-            getSettingsValuesFromNativeChange(event.payload),
-          ),
-        );
-      })
-      .then((unlisten) => {
-        if (cancelled) {
-          unlisten();
-          return;
-        }
-
-        unlisteners.push(unlisten);
-      });
-
-    return () => {
-      cancelled = true;
-      unsubscribe();
-      removeSettingsListeners(store, settingsListenerIds);
-      unlisteners.forEach((unlisten) => unlisten());
-      void hideLiveCaptionPanel();
-    };
+    void hideLiveCaptionPanel();
   });
 
   return null;
 }
 
 function FloatingMeetingWindowSync({
+  main,
   store,
 }: {
+  main: MeetingFloatMainStore | undefined;
   store: SettingsStore | undefined;
 }) {
   useMountEffect(() => {
@@ -413,6 +294,7 @@ function FloatingMeetingWindowSync({
       undefined,
       settings,
       getFloatingLiveCaptionToggleVisible(listenerStore.getState(), store),
+      main,
     );
     let syncQueued = false;
     let cancelled = false;
@@ -421,6 +303,14 @@ function FloatingMeetingWindowSync({
     const unlisteners: Array<() => void> = [];
 
     const shouldContinue = () => !cancelled;
+    const updateRouteState = (nextRouteState: FloatingRouteState | null) => {
+      if (isSameFloatingRouteState(nextRouteState, routeState)) {
+        return;
+      }
+
+      routeState = nextRouteState;
+      scheduleSync();
+    };
 
     const sync = async () => {
       if (!shouldContinue()) {
@@ -503,6 +393,7 @@ function FloatingMeetingWindowSync({
           state,
           store,
         ),
+        sessionTitle: getFloatingSessionTitle(state, main),
       });
       const previousRouteState = getFloatingRouteState(previousState, {
         colorScheme,
@@ -511,14 +402,12 @@ function FloatingMeetingWindowSync({
           previousState,
           store,
         ),
+        sessionTitle: getFloatingSessionTitle(previousState, main),
       });
 
-      if (isSameFloatingRouteState(nextRouteState, previousRouteState)) {
-        return;
+      if (!isSameFloatingRouteState(nextRouteState, previousRouteState)) {
+        updateRouteState(nextRouteState);
       }
-
-      routeState = nextRouteState;
-      scheduleSync();
     });
 
     const settingsListenerIds = addFloatingOverlaySettingsListeners(
@@ -530,15 +419,31 @@ function FloatingMeetingWindowSync({
           undefined,
           nextSettings,
           getFloatingLiveCaptionToggleVisible(listenerStore.getState(), store),
+          main,
         );
 
         settings = nextSettings;
-        if (isSameFloatingRouteState(nextRouteState, routeState)) {
-          return;
-        }
+        updateRouteState(nextRouteState);
+      },
+    );
 
-        routeState = nextRouteState;
-        scheduleSync();
+    const sessionTitleListenerId = main?.addCellListener(
+      "sessions",
+      null,
+      "title",
+      () => {
+        updateRouteState(
+          getCurrentFloatingRouteState(
+            listenerStore.getState(),
+            undefined,
+            settings,
+            getFloatingLiveCaptionToggleVisible(
+              listenerStore.getState(),
+              store,
+            ),
+            main,
+          ),
+        );
       },
     );
 
@@ -548,14 +453,10 @@ function FloatingMeetingWindowSync({
         undefined,
         settings,
         getFloatingLiveCaptionToggleVisible(listenerStore.getState(), store),
+        main,
       );
 
-      if (isSameFloatingRouteState(nextRouteState, routeState)) {
-        return;
-      }
-
-      routeState = nextRouteState;
-      scheduleSync();
+      updateRouteState(nextRouteState);
     });
 
     return () => {
@@ -563,6 +464,9 @@ function FloatingMeetingWindowSync({
       unsubscribe();
       unsubscribeAppliedTheme();
       removeSettingsListeners(store, settingsListenerIds);
+      if (sessionTitleListenerId) {
+        main?.delListener(sessionTitleListenerId);
+      }
       unlisteners.forEach((unlisten) => unlisten());
       void hideFloatingMeetingPanel();
     };
@@ -578,11 +482,13 @@ export function getFloatingRouteState(
     colorScheme = "dark",
     settings = DEFAULT_FLOATING_OVERLAY_SETTINGS,
     liveCaptionToggleVisible = false,
+    sessionTitle,
   }: {
     sessionId?: string;
     colorScheme?: FloatingBarColorScheme;
     settings?: FloatingOverlaySettings;
     liveCaptionToggleVisible?: boolean;
+    sessionTitle?: string | null;
   } = {},
 ): FloatingRouteState | null {
   if (state.live.status !== "active") {
@@ -599,6 +505,7 @@ export function getFloatingRouteState(
 
   return {
     sessionId: state.live.sessionId,
+    title: getFloatingTitle(sessionTitle),
     amplitude: Math.min(
       Math.hypot(state.live.amplitude.mic, state.live.amplitude.speaker),
       1,
@@ -612,6 +519,7 @@ export function getFloatingRouteState(
     liveCaptionPosition: settings.liveCaptionPosition,
     liveCaptionMinimized: settings.liveCaptionMinimized,
     liveCaptionToggleVisible,
+    transcriptBubbles: getFloatingTranscriptBubbles(state.liveSegments),
   };
 }
 
@@ -620,13 +528,89 @@ function getCurrentFloatingRouteState(
   sessionId?: string,
   settings: FloatingOverlaySettings = DEFAULT_FLOATING_OVERLAY_SETTINGS,
   liveCaptionToggleVisible = false,
+  main?: MeetingFloatMainStore,
 ): FloatingRouteState | null {
   return getFloatingRouteState(state, {
     sessionId,
     colorScheme: getCurrentFloatingBarColorScheme(),
     settings,
     liveCaptionToggleVisible,
+    sessionTitle: getFloatingSessionTitle(state, main),
   });
+}
+
+function getFloatingSessionTitle(
+  state: ListenerState,
+  main: MeetingFloatMainStore | undefined,
+) {
+  const sessionId = state.live.sessionId;
+  if (!sessionId) {
+    return null;
+  }
+
+  const title = main?.getCell("sessions", sessionId, "title");
+  return typeof title === "string" ? title : null;
+}
+
+function getFloatingTitle(title: string | null | undefined) {
+  const normalized = title?.trim();
+  return normalized || "Live transcript";
+}
+
+export function getFloatingTranscriptBubbles(
+  segments: ListenerState["liveSegments"],
+): FloatingTranscriptBubble[] {
+  return segments
+    .slice()
+    .sort((a, b) => a.start_ms - b.start_ms)
+    .map((segment) => {
+      const text = getFloatingSegmentText(segment);
+      if (!text) {
+        return null;
+      }
+
+      return {
+        id: segment.id,
+        speakerLabel: getFloatingSpeakerLabel(segment.key),
+        text,
+        isSelf:
+          segment.key.channel === "DirectMic" &&
+          segment.key.speaker_index == null,
+        isFinal: segment.words.every((word) => word.is_final),
+      };
+    })
+    .filter((bubble): bubble is FloatingTranscriptBubble => bubble !== null)
+    .slice(-FLOATING_TRANSCRIPT_BUBBLE_LIMIT);
+}
+
+function getFloatingSegmentText(
+  segment: ListenerState["liveSegments"][number],
+) {
+  const wordText = segment.words
+    .map((word) => word.text.trim())
+    .filter(Boolean)
+    .join(" ")
+    .replace(/\s+([,.?!;:])/g, "$1");
+
+  return (wordText || segment.text).trim().replace(/\s+/g, " ");
+}
+
+function getFloatingSpeakerLabel(
+  key: ListenerState["liveSegments"][number]["key"],
+) {
+  if (key.channel === "DirectMic" && key.speaker_index == null) {
+    return "You";
+  }
+
+  if (key.speaker_index != null) {
+    return `Speaker ${key.speaker_index + 1}`;
+  }
+
+  if (key.channel === "RemoteParty") {
+    return "Speaker";
+  }
+
+  return "Audio";
 }
 
 export function shouldShowFloatingLiveCaptionToggle({
@@ -694,13 +678,6 @@ export function getLiveCaptionRouteState(
   };
 }
 
-function getCurrentLiveCaptionRouteState(
-  state: ListenerState,
-  settings: FloatingOverlaySettings = DEFAULT_FLOATING_OVERLAY_SETTINGS,
-): LiveCaptionRouteState | null {
-  return getLiveCaptionRouteState(state, settings);
-}
-
 function subscribeToAppliedTheme(onStoreChange: () => void) {
   if (
     typeof document === "undefined" ||
@@ -766,23 +743,38 @@ function isSameFloatingRouteState(
     left?.liveCaptionLineCount === right?.liveCaptionLineCount &&
     left?.liveCaptionPosition === right?.liveCaptionPosition &&
     left?.liveCaptionMinimized === right?.liveCaptionMinimized &&
-    left?.liveCaptionToggleVisible === right?.liveCaptionToggleVisible
+    left?.liveCaptionToggleVisible === right?.liveCaptionToggleVisible &&
+    left?.title === right?.title &&
+    isSameFloatingTranscriptBubbles(
+      left?.transcriptBubbles,
+      right?.transcriptBubbles,
+    )
   );
 }
 
-function isSameLiveCaptionRouteState(
-  left: LiveCaptionRouteState | null,
-  right: LiveCaptionRouteState | null,
+function isSameFloatingTranscriptBubbles(
+  left: FloatingTranscriptBubble[] | undefined,
+  right: FloatingTranscriptBubble[] | undefined,
 ) {
-  return (
-    left?.sessionId === right?.sessionId &&
-    left?.text === right?.text &&
-    left?.opacity === right?.opacity &&
-    left?.width === right?.width &&
-    left?.lineCount === right?.lineCount &&
-    left?.position === right?.position &&
-    left?.minimized === right?.minimized
-  );
+  if (left === right) {
+    return true;
+  }
+
+  if (!left || !right || left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((bubble, index) => {
+    const other = right[index];
+    return (
+      other &&
+      bubble.id === other.id &&
+      bubble.speakerLabel === other.speakerLabel &&
+      bubble.text === other.text &&
+      bubble.isSelf === other.isSelf &&
+      bubble.isFinal === other.isFinal
+    );
+  });
 }
 
 async function syncFloatingMeetingWindow(
@@ -806,33 +798,6 @@ async function syncFloatingMeetingWindow(
   );
   if (!shouldContinue()) {
     await hideFloatingMeetingPanel();
-    return null;
-  }
-
-  return ready ? routeState.sessionId : "unavailable";
-}
-
-async function syncLiveCaptionWindow(
-  routeState: LiveCaptionRouteState | null,
-  shownSessionId: string | null,
-  shouldContinue: () => boolean,
-): Promise<string | null | "unavailable"> {
-  if (!shouldContinue()) {
-    return null;
-  }
-
-  if (!routeState) {
-    await hideLiveCaptionPanel();
-    return null;
-  }
-
-  const ready = await showLiveCaptionWindow(
-    routeState,
-    shownSessionId !== routeState.sessionId,
-    shouldContinue,
-  );
-  if (!shouldContinue()) {
-    await hideLiveCaptionPanel();
     return null;
   }
 
@@ -863,6 +828,7 @@ async function showFloatingMeetingWindow(
 
   const updateResult = await windowsCommands.floatingBarUpdate({
     amplitude: routeState.amplitude,
+    title: routeState.title,
     status: routeState.status,
     colorScheme: routeState.colorScheme,
     opacity: routeState.opacity,
@@ -872,6 +838,7 @@ async function showFloatingMeetingWindow(
     liveCaptionPosition: routeState.liveCaptionPosition,
     liveCaptionMinimized: routeState.liveCaptionMinimized,
     liveCaptionToggleVisible: routeState.liveCaptionToggleVisible,
+    transcriptBubbles: routeState.transcriptBubbles,
   });
   if (!shouldContinue()) {
     await hideFloatingMeetingPanel();
@@ -883,49 +850,6 @@ async function showFloatingMeetingWindow(
       "Failed to update floating meeting panel:",
       updateResult.error,
     );
-    return false;
-  }
-
-  return true;
-}
-
-async function showLiveCaptionWindow(
-  routeState: LiveCaptionRouteState,
-  shouldShow: boolean,
-  shouldContinue: () => boolean = () => true,
-): Promise<boolean> {
-  if (!shouldContinue()) {
-    return false;
-  }
-
-  if (shouldShow) {
-    const showResult = await windowsCommands.liveCaptionShow();
-    if (!shouldContinue()) {
-      await hideLiveCaptionPanel();
-      return false;
-    }
-
-    if (showResult.status === "error") {
-      console.error("Failed to show live caption panel:", showResult.error);
-      return false;
-    }
-  }
-
-  const updateResult = await windowsCommands.liveCaptionUpdate({
-    text: routeState.text,
-    opacity: routeState.opacity,
-    width: routeState.width,
-    lineCount: routeState.lineCount,
-    position: routeState.position,
-    minimized: routeState.minimized,
-  });
-  if (!shouldContinue()) {
-    await hideLiveCaptionPanel();
-    return false;
-  }
-
-  if (updateResult.status === "error") {
-    console.error("Failed to update live caption panel:", updateResult.error);
     return false;
   }
 
@@ -1082,35 +1006,15 @@ function getSettingsValuesFromNativeChange(change: FloatingBarSettingsChange) {
   return values;
 }
 
-function mergeFloatingOverlaySettings(
-  settings: FloatingOverlaySettings,
-  values: Partial<FloatingOverlaySettingsStorage>,
-): FloatingOverlaySettings {
-  return {
-    ...settings,
-    floatingBarOpacity:
-      values.floating_bar_opacity ?? settings.floatingBarOpacity,
-    liveCaptionOpacity:
-      values.live_caption_opacity ?? settings.liveCaptionOpacity,
-    liveCaptionWidth: values.live_caption_width ?? settings.liveCaptionWidth,
-    liveCaptionLineCount:
-      values.live_caption_line_count ?? settings.liveCaptionLineCount,
-    liveCaptionPosition:
-      values.live_caption_position === undefined
-        ? settings.liveCaptionPosition
-        : normalizeLiveCaptionPosition(values.live_caption_position),
-    liveCaptionMinimized:
-      values.live_caption_minimized ?? settings.liveCaptionMinimized,
-  };
-}
-
 export async function openFloatingMeetingPanel({
   sessionId,
   enabled,
+  main,
   store,
 }: {
   sessionId?: string;
   enabled: boolean;
+  main?: MeetingFloatMainStore;
   store?: SettingsStore;
 }) {
   if (!enabled) {
@@ -1124,6 +1028,7 @@ export async function openFloatingMeetingPanel({
     sessionId,
     getFloatingOverlaySettingsFromStore(store),
     getFloatingLiveCaptionToggleVisible(state, store),
+    main,
   );
 
   if (!routeState) {

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -13,6 +13,8 @@ const {
   useHasTranscriptMock,
   useListenerMock,
   useConfigValueMock,
+  useMeetingFloatMainStoreMock,
+  mainStoreMock,
   windowShowMock,
 } = vi.hoisted(() => ({
   uploadAudioMock: vi.fn(),
@@ -21,6 +23,8 @@ const {
   useHasTranscriptMock: vi.fn(),
   useListenerMock: vi.fn(),
   useConfigValueMock: vi.fn(),
+  useMeetingFloatMainStoreMock: vi.fn(),
+  mainStoreMock: { getCell: vi.fn() },
   windowShowMock: vi.fn(() => Promise.resolve({ status: "ok", data: null })),
 }));
 
@@ -77,6 +81,10 @@ vi.mock("~/meeting-float/host", () => ({
   openFloatingMeetingPanel: vi.fn(),
 }));
 
+vi.mock("~/meeting-float/hooks", () => ({
+  useMeetingFloatMainStore: useMeetingFloatMainStoreMock,
+}));
+
 vi.mock("@hypr/plugin-windows", () => ({
   commands: {
     windowShow: windowShowMock,
@@ -113,6 +121,7 @@ describe("OverflowButton", () => {
     useCurrentNoteHasContentMock.mockReturnValue(false);
     useHasTranscriptMock.mockReturnValue(true);
     useConfigValueMock.mockReturnValue(false);
+    useMeetingFloatMainStoreMock.mockReturnValue(mainStoreMock);
     useListenerMock.mockImplementation((selector) =>
       selector({
         getSessionMode: () => "inactive",
@@ -205,10 +214,13 @@ describe("OverflowButton", () => {
       screen.getByRole("button", { name: "Open floating panel" }),
     );
 
-    expect(openFloatingMeetingPanel).toHaveBeenCalledWith({
-      sessionId: "session-1",
-      enabled: true,
-    });
+    expect(openFloatingMeetingPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session-1",
+        enabled: true,
+        main: mainStoreMock,
+      }),
+    );
   });
 
   it("opens the current note in a standalone window", () => {

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -24,6 +24,7 @@ import { ExportModal } from "./export-modal";
 import { Listening } from "./listening";
 import { ShowInFinder } from "./misc";
 
+import { useMeetingFloatMainStore } from "~/meeting-float/hooks";
 import { openFloatingMeetingPanel } from "~/meeting-float/host";
 import {
   useCurrentNoteHasContent,
@@ -57,6 +58,7 @@ export function OverflowButton({
   const { uploadAudio, uploadTranscript } = useUploadFile(sessionId);
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const floatingBarEnabled = useConfigValue("floating_bar_enabled");
+  const main = useMeetingFloatMainStore();
   const settings = settingsStore.UI.useStore(settingsStore.STORE_ID);
   const isMeetingInProgress =
     sessionMode === "active" || sessionMode === "finalizing";
@@ -80,6 +82,7 @@ export function OverflowButton({
     void openFloatingMeetingPanel({
       sessionId,
       enabled: floatingBarEnabled,
+      main,
       store: settings,
     });
   };

--- a/plugins/windows/js/bindings.gen.ts
+++ b/plugins/windows/js/bindings.gen.ts
@@ -349,6 +349,7 @@ export type FloatingBarSettingsChange = {
 };
 export type FloatingBarState = {
   amplitude: number;
+  title: string;
   status: FloatingBarStatus;
   colorScheme: FloatingBarColorScheme;
   opacity: number;
@@ -358,9 +359,17 @@ export type FloatingBarState = {
   liveCaptionPosition: LiveCaptionPosition;
   liveCaptionMinimized: boolean;
   liveCaptionToggleVisible: boolean;
+  transcriptBubbles: FloatingTranscriptBubble[];
 };
 export type FloatingBarStatus = "recording" | "error";
 export type FloatingBarStop = Record<string, never>;
+export type FloatingTranscriptBubble = {
+  id: string;
+  speakerLabel: string;
+  text: string;
+  isSelf: boolean;
+  isFinal: boolean;
+};
 export type JsonValue =
   | null
   | boolean

--- a/plugins/windows/src/window/floating_bar.rs
+++ b/plugins/windows/src/window/floating_bar.rs
@@ -17,10 +17,21 @@ pub enum FloatingBarColorScheme {
     Dark,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, specta::Type)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct FloatingTranscriptBubble {
+    pub id: String,
+    pub speaker_label: String,
+    pub text: String,
+    pub is_self: bool,
+    pub is_final: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct FloatingBarState {
     pub amplitude: f64,
+    pub title: String,
     pub status: FloatingBarStatus,
     pub color_scheme: FloatingBarColorScheme,
     pub opacity: f64,
@@ -30,6 +41,7 @@ pub struct FloatingBarState {
     pub live_caption_position: LiveCaptionPosition,
     pub live_caption_minimized: bool,
     pub live_caption_toggle_visible: bool,
+    pub transcript_bubbles: Vec<FloatingTranscriptBubble>,
 }
 
 #[cfg(target_os = "macos")]

--- a/plugins/windows/swift-lib/src/FloatingBarManager.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarManager.swift
@@ -126,7 +126,7 @@ final class FloatingBarManager {
     ) { screen, size in
       let frame = screen.visibleFrame
       let x = frame.maxX - size.width - FloatingBarLayout.screenMargin
-      let y = frame.midY - size.height / 2 - FloatingBarLayout.visualCenterOffset
+      let y = frame.maxY - size.height - FloatingBarLayout.screenMargin
       return NSPoint(x: x, y: y)
     }
   }
@@ -135,13 +135,12 @@ final class FloatingBarManager {
     let size = currentSize
     guard panel.frame.size != size else { return }
 
-    panel.setFrame(
-      NSRect(
-        x: panel.frame.minX,
-        y: panel.frame.midY - size.height / 2,
-        width: size.width,
-        height: size.height),
-      display: true)
+    let frame = NSRect(
+      x: panel.frame.maxX - size.width,
+      y: panel.frame.maxY - size.height,
+      width: size.width,
+      height: size.height)
+    placement.setFrame(panel, to: frame, display: true, animate: false)
     panel.contentView?.frame = NSRect(origin: .zero, size: size)
   }
 

--- a/plugins/windows/swift-lib/src/FloatingBarManager.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarManager.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import Combine
 import SwiftUI
 
 final class FloatingBarManager {
@@ -10,8 +11,18 @@ final class FloatingBarManager {
   private let placement = FloatingPanelPositionController()
   private var displayChangeObserver: Any?
   private var followActiveScreenTimer: Timer?
+  private var cancellables = Set<AnyCancellable>()
 
-  private init() {}
+  private init() {
+    model.$isExpanded
+      .removeDuplicates()
+      .sink { [weak self] _ in
+        guard let self, let panel = self.panel else { return }
+        self.resize(panel)
+        self.position(panel, force: true)
+      }
+      .store(in: &cancellables)
+  }
 
   func show() {
     DispatchQueue.main.async { [weak self] in
@@ -68,8 +79,12 @@ final class FloatingBarManager {
       self.model.status = state.status
       self.model.amplitude = min(max(state.amplitude, 0), 1)
       self.model.colorScheme = state.colorScheme
+      self.model.title = state.title
       self.model.liveCaptionToggleVisible = state.liveCaptionToggleVisible
+      self.model.transcriptBubbles = state.transcriptBubbles
       self.settingsModel.apply(floatingBarState: state)
+      self.model.isExpanded =
+        state.liveCaptionToggleVisible && !self.settingsModel.liveCaptionMinimized
       if let panel = self.panel {
         self.resize(panel)
         self.position(panel, force: true)
@@ -82,7 +97,7 @@ final class FloatingBarManager {
       contentRect: NSRect(
         x: 0,
         y: 0,
-        width: FloatingBarLayout.containerWidth,
+        width: currentSize.width,
         height: currentSize.height),
       styleMask: [.borderless, .nonactivatingPanel],
       backing: .buffered,
@@ -131,10 +146,10 @@ final class FloatingBarManager {
   }
 
   private var currentSize: NSSize {
-    let controlCount: CGFloat = model.liveCaptionToggleVisible ? 3 : 2
-    return NSSize(
-      width: FloatingBarLayout.containerWidth,
-      height: FloatingBarLayout.containerHeight(forControlCount: controlCount))
+    FloatingBarLayout.containerSize(
+      isExpanded: model.isExpanded,
+      showsExpand: model.liveCaptionToggleVisible
+    )
   }
 
   private func startFollowingActiveScreen() {

--- a/plugins/windows/swift-lib/src/FloatingBarModels.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarModels.swift
@@ -10,8 +10,17 @@ enum FloatingBarColorScheme: String, Codable {
   case dark
 }
 
+struct FloatingTranscriptBubblePayload: Codable, Identifiable {
+  let id: String
+  let speakerLabel: String
+  let text: String
+  let isSelf: Bool
+  let isFinal: Bool
+}
+
 struct FloatingBarStatePayload: Codable {
   let amplitude: Double
+  let title: String
   let status: FloatingBarStatus
   let colorScheme: FloatingBarColorScheme
   let opacity: Double
@@ -21,4 +30,5 @@ struct FloatingBarStatePayload: Codable {
   let liveCaptionPosition: LiveCaptionPosition
   let liveCaptionMinimized: Bool
   let liveCaptionToggleVisible: Bool
+  let transcriptBubbles: [FloatingTranscriptBubblePayload]
 }

--- a/plugins/windows/swift-lib/src/FloatingBarView.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarView.swift
@@ -13,20 +13,21 @@ enum FloatingBarLayout {
   static let expandedHeight: CGFloat = 430
   static let expandedCornerRadius: CGFloat = 20
   static let expandedPadding: CGFloat = 12
-  static let headerHeight: CGFloat = 32
-  static let headerIconSize: CGFloat = 30
   static let waveformWidth: CGFloat = 26
   static let waveformHeight: CGFloat = 14
   static let stopSquareSize: CGFloat = 9
   static let dragClickThreshold: CGFloat = 4
-  static let visualCenterOffset: CGFloat = 0
 
-  static func compactWidth(showsExpand: Bool) -> CGFloat {
+  static func compactControlsWidth(showsExpand: Bool) -> CGFloat {
     if showsExpand {
-      return compactStopWidth + compactGap + compactIconSize + inset * 2
+      return compactStopWidth + compactGap + compactIconSize
     }
 
-    return compactSoloStopWidth + inset * 2
+    return compactSoloStopWidth
+  }
+
+  static func compactWidth(showsExpand: Bool) -> CGFloat {
+    compactControlsWidth(showsExpand: showsExpand) + inset * 2
   }
 
   static func containerSize(isExpanded: Bool, showsExpand: Bool) -> NSSize {
@@ -63,103 +64,92 @@ struct FloatingBarView: View {
     .frame(
       width: containerSize.width,
       height: containerSize.height,
-      alignment: .top
+      alignment: .topTrailing
     )
     .contentShape(Rectangle())
     .simultaneousGesture(dragClickSuppressor)
   }
 
   private var compactPill: some View {
-    HStack(spacing: FloatingBarLayout.compactGap) {
-      audioControl(
-        width: model.liveCaptionToggleVisible
-          ? FloatingBarLayout.compactStopWidth : FloatingBarLayout.compactSoloStopWidth,
-        height: FloatingBarLayout.compactIconSize
+    floatingControls(isExpanded: false)
+      .frame(
+        width: FloatingBarLayout.compactControlsWidth(showsExpand: model.liveCaptionToggleVisible),
+        height: FloatingBarLayout.compactHeight
       )
-
-      if model.liveCaptionToggleVisible {
-        FloatingIconButton(
-          systemName: "arrow.up.left.and.arrow.down.right",
-          accessibilityLabel: "Expand live transcript",
-          color: primaryContentColor,
-          hoverFill: controlHoverFill,
-          size: FloatingBarLayout.compactIconSize,
-          action: { performClick { setExpanded(true) } }
-        )
-      }
-    }
-    .frame(
-      width: FloatingBarLayout.compactWidth(showsExpand: model.liveCaptionToggleVisible)
-        - FloatingBarLayout.inset * 2,
-      height: FloatingBarLayout.compactHeight
-    )
-    .background(
-      Capsule(style: .continuous)
-        .fill(surfaceColor)
-    )
-    .overlay(
-      Capsule(style: .continuous)
-        .strokeBorder(outerStrokeColor, lineWidth: 0.5)
-    )
-    .overlay(
-      Capsule(style: .continuous)
-        .strokeBorder(innerStrokeColor, lineWidth: 0.5)
-        .padding(1.5)
-    )
+      .background(
+        Capsule(style: .continuous)
+          .fill(surfaceColor)
+      )
+      .overlay(
+        Capsule(style: .continuous)
+          .strokeBorder(outerStrokeColor, lineWidth: 0.5)
+      )
+      .overlay(
+        Capsule(style: .continuous)
+          .strokeBorder(innerStrokeColor, lineWidth: 0.5)
+          .padding(1.5)
+      )
   }
 
   private var expandedPanel: some View {
-    VStack(spacing: 12) {
-      HStack(spacing: 8) {
-        Text(model.title)
-          .font(.system(size: 13, weight: .semibold))
-          .foregroundStyle(primaryContentColor)
-          .lineLimit(1)
-          .truncationMode(.tail)
+    ZStack(alignment: .topTrailing) {
+      VStack(spacing: 12) {
+        HStack {
+          Text(model.title)
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(primaryContentColor)
+            .lineLimit(1)
+            .truncationMode(.tail)
 
-        Spacer(minLength: 12)
-
-        audioControl(
-          width: 46,
-          height: FloatingBarLayout.headerIconSize
+          Spacer(minLength: 12)
+        }
+        .padding(.leading, FloatingBarLayout.expandedPadding)
+        .padding(
+          .trailing,
+          FloatingBarLayout.compactControlsWidth(showsExpand: model.liveCaptionToggleVisible)
+            + 12
         )
+        .frame(height: FloatingBarLayout.compactHeight)
 
-        FloatingIconButton(
-          systemName: "arrow.down.right.and.arrow.up.left",
-          accessibilityLabel: "Collapse live transcript",
-          color: primaryContentColor,
-          hoverFill: controlHoverFill,
-          size: FloatingBarLayout.headerIconSize,
-          action: { performClick { setExpanded(false) } }
-        )
-      }
-      .frame(height: FloatingBarLayout.headerHeight)
-
-      ScrollViewReader { proxy in
-        ScrollView(.vertical, showsIndicators: false) {
-          VStack(spacing: 8) {
-            ForEach(model.transcriptBubbles) { bubble in
-              TranscriptBubbleView(
-                bubble: bubble,
-                accentColor: accentColor,
-                primaryContentColor: primaryContentColor,
-                secondaryContentColor: secondaryContentColor,
-                colorScheme: model.colorScheme
-              )
-              .id(bubble.id)
+        ScrollViewReader { proxy in
+          ScrollView(.vertical, showsIndicators: false) {
+            VStack(spacing: 8) {
+              ForEach(model.transcriptBubbles) { bubble in
+                TranscriptBubbleView(
+                  bubble: bubble,
+                  accentColor: accentColor,
+                  primaryContentColor: primaryContentColor,
+                  secondaryContentColor: secondaryContentColor,
+                  colorScheme: model.colorScheme
+                )
+                .id(bubble.id)
+              }
+            }
+            .frame(maxWidth: .infinity, alignment: .bottom)
+          }
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .onChange(of: model.transcriptBubbles.last?.id) { _, bubbleId in
+            if let bubbleId {
+              proxy.scrollTo(bubbleId, anchor: .bottom)
             }
           }
-          .frame(maxWidth: .infinity, alignment: .bottom)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onChange(of: model.transcriptBubbles.last?.id) { _, bubbleId in
-          if let bubbleId {
-            proxy.scrollTo(bubbleId, anchor: .bottom)
-          }
-        }
+        .padding(.horizontal, FloatingBarLayout.expandedPadding)
+        .padding(.bottom, FloatingBarLayout.expandedPadding)
       }
+      .frame(
+        width: FloatingBarLayout.expandedWidth,
+        height: FloatingBarLayout.expandedHeight,
+        alignment: .top
+      )
+
+      floatingControls(isExpanded: true)
+        .frame(
+          width: FloatingBarLayout.compactControlsWidth(
+            showsExpand: model.liveCaptionToggleVisible),
+          height: FloatingBarLayout.compactHeight
+        )
     }
-    .padding(FloatingBarLayout.expandedPadding)
     .frame(
       width: FloatingBarLayout.expandedWidth,
       height: FloatingBarLayout.expandedHeight,
@@ -187,6 +177,28 @@ struct FloatingBarView: View {
       .strokeBorder(innerStrokeColor, lineWidth: 0.5)
       .padding(1.5)
     )
+  }
+
+  private func floatingControls(isExpanded: Bool) -> some View {
+    HStack(spacing: FloatingBarLayout.compactGap) {
+      audioControl(
+        width: model.liveCaptionToggleVisible
+          ? FloatingBarLayout.compactStopWidth : FloatingBarLayout.compactSoloStopWidth,
+        height: FloatingBarLayout.compactIconSize
+      )
+
+      if model.liveCaptionToggleVisible {
+        FloatingIconButton(
+          systemName: isExpanded
+            ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right",
+          accessibilityLabel: isExpanded ? "Collapse live transcript" : "Expand live transcript",
+          color: primaryContentColor,
+          hoverFill: controlHoverFill,
+          size: FloatingBarLayout.compactIconSize,
+          action: { performClick { setExpanded(!isExpanded) } }
+        )
+      }
+    }
   }
 
   private func audioControl(width: CGFloat, height: CGFloat) -> some View {

--- a/plugins/windows/swift-lib/src/FloatingBarView.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarView.swift
@@ -4,32 +4,41 @@ import SwiftUI
 enum FloatingBarLayout {
   static let inset: CGFloat = 4
   static let screenMargin: CGFloat = 8
-  static let markSize: CGFloat = 20
-  static let waveformWidth: CGFloat = 18
-  static let waveformHeight: CGFloat = 13
+  static let compactHeight: CGFloat = 42
+  static let compactStopWidth: CGFloat = 72
+  static let compactSoloStopWidth: CGFloat = 78
+  static let compactIconSize: CGFloat = 34
+  static let compactGap: CGFloat = 4
+  static let expandedWidth: CGFloat = 360
+  static let expandedHeight: CGFloat = 430
+  static let expandedCornerRadius: CGFloat = 20
+  static let expandedPadding: CGFloat = 12
+  static let headerHeight: CGFloat = 32
+  static let headerIconSize: CGFloat = 30
+  static let waveformWidth: CGFloat = 26
+  static let waveformHeight: CGFloat = 14
   static let stopSquareSize: CGFloat = 9
-  static let clickAreaSize: CGFloat = 28
-  static let clickAreaGap: CGFloat = 0
-  static let pillPadding: CGFloat = 2
-  static let pillWidth: CGFloat = clickAreaSize + pillPadding * 2
-  static let hoverHandleGap: CGFloat = 3
-  static let hoverHandleWidth: CGFloat = 13
-  static let hoverHandleHeight: CGFloat = 8
-  static let hoverHandleBottomPadding: CGFloat = 4
-  static let hoverHandleReservedHeight: CGFloat =
-    hoverHandleGap + hoverHandleHeight + hoverHandleBottomPadding
-  static let hoverHandleDotSize: CGFloat = 1.6
-  static let hoverHandleDotGap: CGFloat = 2.4
-  static let containerWidth: CGFloat = pillWidth + inset * 2
-  static let visualCenterOffset: CGFloat = hoverHandleReservedHeight / 2
   static let dragClickThreshold: CGFloat = 4
+  static let visualCenterOffset: CGFloat = 0
 
-  static func pillHeight(forControlCount controlCount: CGFloat) -> CGFloat {
-    clickAreaSize * controlCount + clickAreaGap * (controlCount - 1) + pillPadding * 2
+  static func compactWidth(showsExpand: Bool) -> CGFloat {
+    if showsExpand {
+      return compactStopWidth + compactGap + compactIconSize + inset * 2
+    }
+
+    return compactSoloStopWidth + inset * 2
   }
 
-  static func containerHeight(forControlCount controlCount: CGFloat) -> CGFloat {
-    pillHeight(forControlCount: controlCount) + hoverHandleReservedHeight + inset * 2
+  static func containerSize(isExpanded: Bool, showsExpand: Bool) -> NSSize {
+    if isExpanded {
+      return NSSize(
+        width: expandedWidth + inset * 2,
+        height: expandedHeight + inset * 2)
+    }
+
+    return NSSize(
+      width: compactWidth(showsExpand: showsExpand),
+      height: compactHeight + inset * 2)
   }
 }
 
@@ -38,30 +47,52 @@ struct FloatingBarView: View {
   @ObservedObject var settings: FloatingOverlaySettingsModel
   let panelOrigin: () -> NSPoint?
   let movePanel: (NSPoint) -> Void
-  @State private var isBarHovered = false
-  @State private var isBarsHovered = false
+  @State private var isStopHovered = false
   @State private var suppressNextClick = false
   @State private var dragStart: FloatingBarDragStart?
 
   var body: some View {
-    VStack(spacing: FloatingBarLayout.hoverHandleGap) {
-      controls
-
-      FloatingBarHoverHandle(color: secondaryContentColor)
-        .opacity(isBarHovered ? 1 : 0)
-        .scaleEffect(isBarHovered ? 1 : 0.92)
-        .accessibilityHidden(true)
+    Group {
+      if model.isExpanded {
+        expandedPanel
+      } else {
+        compactPill
+      }
     }
-    .padding(.bottom, FloatingBarLayout.hoverHandleBottomPadding)
+    .padding(FloatingBarLayout.inset)
     .frame(
-      width: FloatingBarLayout.pillWidth,
-      height: isBarHovered
-        ? pillHeight + FloatingBarLayout.hoverHandleReservedHeight
-        : pillHeight,
+      width: containerSize.width,
+      height: containerSize.height,
       alignment: .top
     )
-    .contentShape(Capsule(style: .continuous))
+    .contentShape(Rectangle())
     .simultaneousGesture(dragClickSuppressor)
+  }
+
+  private var compactPill: some View {
+    HStack(spacing: FloatingBarLayout.compactGap) {
+      audioControl(
+        width: model.liveCaptionToggleVisible
+          ? FloatingBarLayout.compactStopWidth : FloatingBarLayout.compactSoloStopWidth,
+        height: FloatingBarLayout.compactIconSize
+      )
+
+      if model.liveCaptionToggleVisible {
+        FloatingIconButton(
+          systemName: "arrow.up.left.and.arrow.down.right",
+          accessibilityLabel: "Expand live transcript",
+          color: primaryContentColor,
+          hoverFill: controlHoverFill,
+          size: FloatingBarLayout.compactIconSize,
+          action: { performClick { setExpanded(true) } }
+        )
+      }
+    }
+    .frame(
+      width: FloatingBarLayout.compactWidth(showsExpand: model.liveCaptionToggleVisible)
+        - FloatingBarLayout.inset * 2,
+      height: FloatingBarLayout.compactHeight
+    )
     .background(
       Capsule(style: .continuous)
         .fill(surfaceColor)
@@ -75,93 +106,126 @@ struct FloatingBarView: View {
         .strokeBorder(innerStrokeColor, lineWidth: 0.5)
         .padding(1.5)
     )
-    .clipShape(Capsule(style: .continuous))
-    .animation(.easeOut(duration: 0.12), value: isBarHovered)
-    .padding(FloatingBarLayout.inset)
+  }
+
+  private var expandedPanel: some View {
+    VStack(spacing: 12) {
+      HStack(spacing: 8) {
+        Text(model.title)
+          .font(.system(size: 13, weight: .semibold))
+          .foregroundStyle(primaryContentColor)
+          .lineLimit(1)
+          .truncationMode(.tail)
+
+        Spacer(minLength: 12)
+
+        audioControl(
+          width: 46,
+          height: FloatingBarLayout.headerIconSize
+        )
+
+        FloatingIconButton(
+          systemName: "arrow.down.right.and.arrow.up.left",
+          accessibilityLabel: "Collapse live transcript",
+          color: primaryContentColor,
+          hoverFill: controlHoverFill,
+          size: FloatingBarLayout.headerIconSize,
+          action: { performClick { setExpanded(false) } }
+        )
+      }
+      .frame(height: FloatingBarLayout.headerHeight)
+
+      ScrollViewReader { proxy in
+        ScrollView(.vertical, showsIndicators: false) {
+          VStack(spacing: 8) {
+            ForEach(model.transcriptBubbles) { bubble in
+              TranscriptBubbleView(
+                bubble: bubble,
+                accentColor: accentColor,
+                primaryContentColor: primaryContentColor,
+                secondaryContentColor: secondaryContentColor,
+                colorScheme: model.colorScheme
+              )
+              .id(bubble.id)
+            }
+          }
+          .frame(maxWidth: .infinity, alignment: .bottom)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onChange(of: model.transcriptBubbles.last?.id) { _, bubbleId in
+          if let bubbleId {
+            proxy.scrollTo(bubbleId, anchor: .bottom)
+          }
+        }
+      }
+    }
+    .padding(FloatingBarLayout.expandedPadding)
     .frame(
-      width: FloatingBarLayout.containerWidth,
-      height: containerHeight,
+      width: FloatingBarLayout.expandedWidth,
+      height: FloatingBarLayout.expandedHeight,
       alignment: .top
     )
-    .contentShape(Rectangle())
-    .onHover { isBarHovered = $0 }
+    .background(
+      RoundedRectangle(
+        cornerRadius: FloatingBarLayout.expandedCornerRadius,
+        style: .continuous
+      )
+      .fill(surfaceColor)
+    )
+    .overlay(
+      RoundedRectangle(
+        cornerRadius: FloatingBarLayout.expandedCornerRadius,
+        style: .continuous
+      )
+      .strokeBorder(outerStrokeColor, lineWidth: 0.5)
+    )
+    .overlay(
+      RoundedRectangle(
+        cornerRadius: FloatingBarLayout.expandedCornerRadius,
+        style: .continuous
+      )
+      .strokeBorder(innerStrokeColor, lineWidth: 0.5)
+      .padding(1.5)
+    )
   }
 
-  private var controls: some View {
-    VStack(spacing: FloatingBarLayout.clickAreaGap) {
-      Button(action: { performClick(RustBridge.openMainWindow) }) {
-        CircularClickArea(hoverFill: controlHoverFill) {
-          Text("a")
-            .font(.custom(FloatingBarFonts.cabinSketchName, size: FloatingBarLayout.markSize))
-            .foregroundStyle(primaryContentColor)
-            .offset(y: -1)
-        }
-      }
-      .buttonStyle(.plain)
-
-      if model.liveCaptionToggleVisible {
-        Button(action: { performClick(toggleLiveCaption) }) {
-          CircularClickArea(
-            hoverFill: controlHoverFill
-          ) {
-            Image(systemName: settings.liveCaptionMinimized ? "eye.slash" : "eye")
-              .font(.system(size: 12, weight: .semibold))
-              .foregroundStyle(
-                settings.liveCaptionMinimized ? secondaryContentColor : primaryContentColor
-              )
-          }
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(
-          settings.liveCaptionMinimized ? "Show live transcript" : "Hide live transcript"
-        )
-      }
-
-      audioControl
-    }
-    .padding(FloatingBarLayout.pillPadding)
-    .frame(width: FloatingBarLayout.pillWidth, height: pillHeight)
-  }
-
-  private var audioControl: some View {
+  private func audioControl(width: CGFloat, height: CGFloat) -> some View {
     Button(action: { performClick(RustBridge.stopListening) }) {
-      CircularClickArea(
-        hoverFill: accentColor.opacity(0.16),
-        onHoverChange: { isBarsHovered = $0 }
-      ) {
-        Group {
-          if isBarsHovered {
-            Rectangle()
-              .fill(stopColor)
-              .frame(
-                width: FloatingBarLayout.stopSquareSize,
-                height: FloatingBarLayout.stopSquareSize
-              )
-          } else if model.status == .error {
-            ErrorMark(color: errorAccentColor)
-          } else {
-            DancingBars(color: accentColor, amplitude: model.amplitude)
-          }
+      Group {
+        if isStopHovered {
+          Rectangle()
+            .fill(stopColor)
+            .frame(
+              width: FloatingBarLayout.stopSquareSize,
+              height: FloatingBarLayout.stopSquareSize
+            )
+        } else if model.status == .error {
+          ErrorMark(color: errorAccentColor)
+        } else {
+          DancingBars(color: accentColor, amplitude: model.amplitude)
         }
-        .frame(
-          width: FloatingBarLayout.waveformWidth,
-          height: FloatingBarLayout.waveformHeight
-        )
       }
+      .frame(
+        width: FloatingBarLayout.waveformWidth,
+        height: FloatingBarLayout.waveformHeight
+      )
+      .frame(width: width, height: height)
+      .background(
+        Capsule(style: .continuous)
+          .fill(isStopHovered ? accentColor.opacity(0.16) : controlHoverFill)
+      )
+      .contentShape(Capsule(style: .continuous))
     }
     .buttonStyle(.plain)
+    .accessibilityLabel("Stop listening")
+    .onHover { isStopHovered = $0 }
   }
 
-  private var controlCount: CGFloat {
-    model.liveCaptionToggleVisible ? 3 : 2
-  }
-
-  private var pillHeight: CGFloat {
-    FloatingBarLayout.pillHeight(forControlCount: controlCount)
-  }
-
-  private var containerHeight: CGFloat {
-    FloatingBarLayout.containerHeight(forControlCount: controlCount)
+  private var containerSize: NSSize {
+    FloatingBarLayout.containerSize(
+      isExpanded: model.isExpanded,
+      showsExpand: model.liveCaptionToggleVisible
+    )
   }
 
   private var accentColor: Color {
@@ -254,13 +318,11 @@ struct FloatingBarView: View {
     action()
   }
 
-  private func toggleLiveCaption() {
-    let shouldHide = !settings.liveCaptionMinimized
-    settings.setLiveCaptionMinimized(shouldHide)
-    if shouldHide {
+  private func setExpanded(_ expanded: Bool) {
+    model.isExpanded = expanded
+    settings.setLiveCaptionMinimized(!expanded)
+    if !expanded {
       LiveCaptionManager.shared.hide(clearText: false)
-    } else {
-      LiveCaptionManager.shared.show()
     }
   }
 }
@@ -270,63 +332,76 @@ private struct FloatingBarDragStart {
   let mouseLocation: NSPoint
 }
 
-private struct FloatingBarHoverHandle: View {
+private struct FloatingIconButton: View {
+  let systemName: String
+  let accessibilityLabel: String
   let color: Color
-  private let columns = Array(
-    repeating: GridItem(
-      .fixed(FloatingBarLayout.hoverHandleDotSize), spacing: FloatingBarLayout.hoverHandleDotGap),
-    count: 3
-  )
+  let hoverFill: Color
+  let size: CGFloat
+  let action: () -> Void
+  @State private var isHovered = false
 
   var body: some View {
-    LazyVGrid(columns: columns, spacing: FloatingBarLayout.hoverHandleDotGap) {
-      ForEach(0..<6, id: \.self) { _ in
-        Circle()
-          .fill(color)
-          .frame(
-            width: FloatingBarLayout.hoverHandleDotSize,
-            height: FloatingBarLayout.hoverHandleDotSize
-          )
-      }
+    Button(action: action) {
+      Image(systemName: systemName)
+        .font(.system(size: 12, weight: .semibold))
+        .foregroundStyle(color)
+        .frame(width: size, height: size)
+        .background(
+          Circle()
+            .fill(isHovered ? hoverFill : Color.clear)
+        )
+        .contentShape(Circle())
     }
-    .frame(
-      width: FloatingBarLayout.hoverHandleWidth,
-      height: FloatingBarLayout.hoverHandleHeight
-    )
+    .buttonStyle(.plain)
+    .accessibilityLabel(accessibilityLabel)
+    .onHover { isHovered = $0 }
   }
 }
 
-private struct CircularClickArea<Content: View>: View {
-  private let content: () -> Content
-  private let hoverFill: Color
-  private let onHoverChange: (Bool) -> Void
-  @State private var isHovered = false
-
-  init(
-    hoverFill: Color = Color.white.opacity(0.08),
-    onHoverChange: @escaping (Bool) -> Void = { _ in },
-    @ViewBuilder content: @escaping () -> Content
-  ) {
-    self.content = content
-    self.hoverFill = hoverFill
-    self.onHoverChange = onHoverChange
-  }
+private struct TranscriptBubbleView: View {
+  let bubble: FloatingTranscriptBubblePayload
+  let accentColor: Color
+  let primaryContentColor: Color
+  let secondaryContentColor: Color
+  let colorScheme: FloatingBarColorScheme
 
   var body: some View {
-    content()
-      .frame(
-        width: FloatingBarLayout.clickAreaSize,
-        height: FloatingBarLayout.clickAreaSize
-      )
-      .contentShape(Circle())
-      .background(
-        Circle()
-          .fill(isHovered ? hoverFill : Color.clear)
-      )
-      .onHover { hovered in
-        isHovered = hovered
-        onHoverChange(hovered)
+    HStack {
+      if bubble.isSelf {
+        Spacer(minLength: 40)
       }
+
+      VStack(alignment: bubble.isSelf ? .trailing : .leading, spacing: 3) {
+        Text(bubble.speakerLabel)
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(secondaryContentColor)
+          .lineLimit(1)
+
+        Text(bubble.text)
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(primaryContentColor)
+          .multilineTextAlignment(bubble.isSelf ? .trailing : .leading)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      .padding(.horizontal, 11)
+      .padding(.vertical, 8)
+      .background(bubbleBackground)
+      .clipShape(RoundedRectangle(cornerRadius: 11, style: .continuous))
+      .opacity(bubble.isFinal ? 1 : 0.68)
+
+      if !bubble.isSelf {
+        Spacer(minLength: 40)
+      }
+    }
+  }
+
+  private var bubbleBackground: Color {
+    if bubble.isSelf {
+      return accentColor.opacity(colorScheme == .dark ? 0.28 : 0.2)
+    }
+
+    return primaryContentColor.opacity(colorScheme == .dark ? 0.1 : 0.08)
   }
 }
 
@@ -349,11 +424,11 @@ private struct DancingBars: View {
   let color: Color
   let amplitude: Double
 
-  private let barCount = 3
-  private let barWidth: CGFloat = 4
+  private let barCount = 5
+  private let barWidth: CGFloat = 3
   private let barSpacing: CGFloat = 2
   private let minHeight: CGFloat = 2
-  private let maxHeight: CGFloat = 13
+  private let maxHeight: CGFloat = 14
 
   var body: some View {
     TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: false)) { timeline in

--- a/plugins/windows/swift-lib/src/FloatingBarViewModel.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarViewModel.swift
@@ -5,5 +5,8 @@ final class FloatingBarViewModel: ObservableObject {
   @Published var amplitude: Double = 0
   @Published var status: FloatingBarStatus = .recording
   @Published var colorScheme: FloatingBarColorScheme = .dark
+  @Published var isExpanded: Bool = false
   @Published var liveCaptionToggleVisible: Bool = false
+  @Published var title: String = "Live transcript"
+  @Published var transcriptBubbles: [FloatingTranscriptBubblePayload] = []
 }


### PR DESCRIPTION
Summary:
- Render the floating bar as compact stop and expand controls.
- Add an expanded speaker-bubble transcript panel.
- Update desktop, Rust, and Swift floating bar wiring for the new panel behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Locale catalog reference updates only; no runtime logic in the provided diff.
> 
> **Overview**
> The diff **only** refreshes Lingui `messages.po` catalogs across locales. It does not include application source in this snapshot.
> 
> **Source line references** for several session header overflow strings were bumped (for example `overflow/index.tsx` lines **112→115**, **148→151**, **160→163**, **127→130**, **136→139**) for **Export**, **Open floating panel**, **Open in New Window**, **Upload audio**, and **Upload transcript**. That pattern usually means **`outer-header/overflow/index.tsx` was edited** (extra lines or reordering above those `Trans` calls) and catalogs were re-extracted. **`msgid` / `msgstr` text is unchanged** in the snippets shown.
> 
> If the branch also changes floating transcript UI (per the PR title), those changes are **not visible in this diff**—reviewers should confirm the full branch diff includes the intended UI/native work, not only locale files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd9e46e5d33c9937f0715ffd23b69c38fe4acbe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->