### PR TITLE
Keep devtools panel closed by default

### DIFF
--- a/apps/desktop/src/devtools-panel/host.tsx
+++ b/apps/desktop/src/devtools-panel/host.tsx
@@ -104,8 +104,6 @@ function DevtoolsFloatingPanelSync() {
     let cancelled = false;
     let unlistenAction: (() => void) | undefined;
 
-    void showDevtoolsPanel();
-
     windowsEvents.devtoolsPanelAction
       .listen(({ payload }) => {
         actionHandlerRef.current(payload.action);
@@ -472,13 +470,6 @@ function useDevtoolsPanelActions() {
     handleAction,
     shouldThrow,
   };
-}
-
-async function showDevtoolsPanel() {
-  const result = await windowsCommands.devtoolsPanelShow();
-  if (result.status === "error") {
-    console.error("Failed to show Devtools panel:", result.error);
-  }
 }
 
 async function hideDevtoolsPanel() {


### PR DESCRIPTION
Remove the mount-time native devtools panel open call while keeping the panel event listener and explicit open button behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dev-only UX change with no auth, data, or production feature-path impact; explicit open and hide paths are unchanged.
> 
> **Overview**
> The native devtools panel **no longer opens automatically** when `DevtoolsFloatingPanelSync` mounts in the main window. The mount effect now only wires up `devtoolsPanelAction` events and still **hides the panel on cleanup**; the removed `showDevtoolsPanel` helper and its `devtoolsPanelShow` call are gone.
> 
> **Unchanged behavior:** when devtools are disabled, the host still hides the panel on mount; opening the panel remains tied to the explicit UI control (e.g. “Show devtools panel”), not startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f62da63216793fde776f354020e88f8b63706c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->