### PR TITLE
fix: hide title format toolbar

### DIFF
--- a/packages/editor/src/widgets/format-toolbar.test.ts
+++ b/packages/editor/src/widgets/format-toolbar.test.ts
@@ -1,0 +1,43 @@
+import { EditorState, TextSelection } from "prosemirror-state";
+import { describe, expect, it } from "vitest";
+
+import { schema } from "../note/schema";
+import { selectionTouchesTitleHeading } from "./format-toolbar";
+
+function createState(from: number, to: number) {
+  const doc = schema.node("doc", null, [
+    schema.node("heading", { level: 1 }, [schema.text("Design sync")]),
+    schema.node("paragraph", null, [schema.text("Follow up")]),
+  ]);
+
+  return EditorState.create({
+    doc,
+    selection: TextSelection.create(doc, from, to),
+  });
+}
+
+describe("selectionTouchesTitleHeading", () => {
+  it("returns true for selections inside the title heading", () => {
+    expect(selectionTouchesTitleHeading(createState(1, 12))).toBe(true);
+  });
+
+  it("returns true for selections spanning the title heading", () => {
+    expect(selectionTouchesTitleHeading(createState(6, 18))).toBe(true);
+  });
+
+  it("returns false for body selections", () => {
+    expect(selectionTouchesTitleHeading(createState(14, 20))).toBe(false);
+  });
+
+  it("returns false when the first block is not a title heading", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("Body")]),
+    ]);
+    const state = EditorState.create({
+      doc,
+      selection: TextSelection.create(doc, 1, 3),
+    });
+
+    expect(selectionTouchesTitleHeading(state)).toBe(false);
+  });
+});

--- a/packages/editor/src/widgets/format-toolbar.tsx
+++ b/packages/editor/src/widgets/format-toolbar.tsx
@@ -28,6 +28,24 @@ import { cn } from "@hypr/utils";
 
 import { schema } from "../note/schema";
 
+export function selectionTouchesTitleHeading(state: EditorState): boolean {
+  const firstNode = state.doc.firstChild;
+  if (
+    !firstNode ||
+    firstNode.type !== state.schema.nodes.heading ||
+    firstNode.attrs.level !== 1 ||
+    state.selection.empty
+  ) {
+    return false;
+  }
+
+  const titleStart = 1;
+  const titleEnd = firstNode.nodeSize - 1;
+  const { from, to } = state.selection;
+
+  return from < titleEnd && to > titleStart;
+}
+
 function isMarkActive(state: EditorState, type: MarkType): boolean {
   const { from, $from, to, empty } = state.selection;
   if (empty) {
@@ -53,7 +71,9 @@ export function FormatToolbar() {
   const cleanupRef = useRef<(() => void) | null>(null);
 
   const editorState = useEditorState();
-  const hasSelection = editorState ? !editorState.selection.empty : false;
+  const shouldShowToolbar = editorState
+    ? !editorState.selection.empty && !selectionTouchesTitleHeading(editorState)
+    : false;
 
   const toggle = useEditorEventCallback((view, markType: MarkType) => {
     if (!view) return;
@@ -62,7 +82,7 @@ export function FormatToolbar() {
   });
 
   useEditorEffect((view) => {
-    if (!view || !hasSelection) {
+    if (!view || !shouldShowToolbar) {
       cleanupRef.current?.();
       cleanupRef.current = null;
       return;
@@ -103,7 +123,7 @@ export function FormatToolbar() {
     update();
   });
 
-  if (!hasSelection || !editorState) return null;
+  if (!shouldShowToolbar || !editorState) return null;
 
   return createPortal(
     <div


### PR DESCRIPTION
Summary:
- skip the format toolbar when selections touch the enforced title heading
- add coverage for title and body selection behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor UI-only gating with a small exported helper and tests; no auth, data, or schema changes.
> 
> **Overview**
> **Hides the floating format toolbar when the user’s selection overlaps the enforced note title** (first level-1 heading), so inline marks aren’t offered on title text.
> 
> Adds exported helper `selectionTouchesTitleHeading` and gates `FormatToolbar` visibility/positioning on `shouldShowToolbar` (non-empty selection **and** not touching the title). **Vitest coverage** exercises title-only, title+body span, body-only, and docs without an h1 first block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e65fba1607699f2e055584e0289a4edf79c3de5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->