### PR TITLE
fix: make mic prompt confirm likely event

### DIFF
--- a/apps/desktop/src/devtools-panel/host.tsx
+++ b/apps/desktop/src/devtools-panel/host.tsx
@@ -264,21 +264,21 @@ function useDevtoolsPanelActions() {
   const showMicOptionsNotification = useCallback(async () => {
     await notificationCommands.showNotification({
       key: `devtool-mic-options-${crypto.randomUUID()}`,
-      title: "Are you in a meeting?",
+      title: "Are you in Design sync right now?",
       message: "",
       timeout: { secs: 15, nanos: 0 },
       source: {
         type: "mic_detected",
         app_names: ["Zoom", "Google Chrome"],
         app_ids: ["us.zoom.xos", "com.google.Chrome"],
-        event_ids: [],
+        event_ids: ["devtool-event-1"],
       },
       start_time: null,
       participants: null,
       event_details: null,
-      action_label: null,
+      action_label: "Yes",
       action_variant: null,
-      options: ["Design sync", "Customer call"],
+      options: null,
       footer: {
         text: "Ignore Zoom and Chrome?",
         actionLabel: "Yes",

--- a/apps/desktop/src/services/event-listeners.test.tsx
+++ b/apps/desktop/src/services/event-listeners.test.tsx
@@ -325,7 +325,7 @@ describe("EventListeners notification events", () => {
     });
   });
 
-  test("notification_confirm with mic_detected source sets triggerAppIds (regression: #5120 confirm path)", async () => {
+  test("notification_confirm with mic_detected source opens detected event and sets triggerAppIds", async () => {
     useMainStoreMock.mockReturnValue({} as never);
 
     render(<EventListeners />);
@@ -344,13 +344,22 @@ describe("EventListeners notification events", () => {
           type: "mic_detected",
           app_names: ["Zoom"],
           app_ids: ["us.zoom.xos"],
-          event_ids: [],
+          event_ids: ["event-1"],
         },
       },
     });
 
+    expect(getOrCreateSessionForEventIdMock).toHaveBeenCalledWith(
+      {},
+      "event-1",
+    );
+    expect(createSessionMock).not.toHaveBeenCalled();
     expect(setTriggerAppIdsMock).toHaveBeenCalledWith(["us.zoom.xos"]);
-    expect(openNewMock).toHaveBeenCalledTimes(1);
+    expect(openNewMock).toHaveBeenCalledWith({
+      type: "sessions",
+      id: "session-event",
+      state: { view: null, autoStart: true },
+    });
   });
 
   test("notification_option_selected with mic_detected source sets triggerAppIds", async () => {

--- a/apps/desktop/src/services/event-listeners.tsx
+++ b/apps/desktop/src/services/event-listeners.tsx
@@ -376,7 +376,9 @@ function useNotificationEvents() {
           const eventId =
             payload.source?.type === "calendar_event"
               ? payload.source.event_id
-              : null;
+              : payload.source?.type === "mic_detected"
+                ? (payload.source.event_ids?.[0] ?? null)
+                : null;
           const sourceSessionId =
             payload.source?.type === "session"
               ? payload.source.session_id

--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -95,6 +95,7 @@ function mockNearbyEventStore(event: {
   meeting_link?: string;
   location?: string;
   description?: string;
+  participants_json?: string;
   is_all_day?: boolean;
 }) {
   return mockNearbyEventStoreMany([event]);
@@ -108,6 +109,7 @@ function mockNearbyEventStoreMany(
     meeting_link?: string;
     location?: string;
     description?: string;
+    participants_json?: string;
     is_all_day?: boolean;
   }>,
 ) {
@@ -126,6 +128,7 @@ function mockNearbyEventStoreMany(
         meeting_link: event.meeting_link,
         location: event.location,
         description: event.description,
+        participants_json: event.participants_json,
         is_all_day: event.is_all_day ?? false,
       };
     }),
@@ -784,7 +787,9 @@ describe("ListenerProvider detect events", () => {
             app_ids: ["at.studio.AsideBrowser"],
             event_ids: ["event-1"],
           },
-          options: ["Design sync"],
+          title: "Are you in Design sync right now?",
+          action_label: "Yes",
+          options: null,
           footer: {
             text: "Ignore Google Meet?",
             actionLabel: "Yes",
@@ -797,6 +802,108 @@ describe("ListenerProvider detect events", () => {
             type: "path",
             path: "/resources/notification-icons/google-meet.svg",
           },
+        }),
+      ),
+    );
+  });
+
+  test("uses event participants for nearby mic notification copy", async () => {
+    const store = createListenerStore();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-24T02:09:00.000Z"));
+    (useStoreMock as any).mockReturnValue(
+      mockNearbyEventStore({
+        title: "Design sync",
+        started_at: "2026-06-24T02:09:00.000Z",
+        participants_json: JSON.stringify([
+          { name: "John", email: "john@example.com", is_current_user: true },
+          { name: "Artem", email: "artem@example.com" },
+        ]),
+      }),
+    );
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "micDetected",
+        key: "mic-1",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
+        duration_secs: 15,
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(showNotificationMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Are you talking to Artem right now?",
+          source: expect.objectContaining({
+            event_ids: ["event-1"],
+          }),
+          action_label: "Yes",
+          options: null,
+        }),
+      ),
+    );
+  });
+
+  test("uses event title for nearby mic notification copy with several participants", async () => {
+    const store = createListenerStore();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-24T02:09:00.000Z"));
+    (useStoreMock as any).mockReturnValue(
+      mockNearbyEventStore({
+        title: "Design sync",
+        started_at: "2026-06-24T02:09:00.000Z",
+        participants_json: JSON.stringify([
+          { name: "John", email: "john@example.com", is_current_user: true },
+          { name: "Artem", email: "artem@example.com" },
+          { name: "Ananya", email: "ananya@example.com" },
+          { name: "Maria", email: "maria@example.com" },
+        ]),
+      }),
+    );
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "micDetected",
+        key: "mic-1",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
+        duration_secs: 15,
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(showNotificationMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Are you in Design sync right now?",
+          source: expect.objectContaining({
+            event_ids: ["event-1"],
+          }),
+          action_label: "Yes",
+          options: null,
         }),
       ),
     );
@@ -902,8 +1009,11 @@ describe("ListenerProvider detect events", () => {
         expect.objectContaining({
           source: expect.objectContaining({
             app_names: ["Google Meet"],
-            event_ids: ["event-1", "event-2"],
+            event_ids: ["event-2"],
           }),
+          title: "Are you in Design sync right now?",
+          action_label: "Yes",
+          options: null,
           footer: expect.objectContaining({
             text: "Ignore Google Meet?",
           }),
@@ -911,6 +1021,62 @@ describe("ListenerProvider detect events", () => {
             type: "path",
             path: "/resources/notification-icons/google-meet.svg",
           },
+        }),
+      ),
+    );
+  });
+
+  test("does not infer browser platform from a different nearby event", async () => {
+    const store = createListenerStore();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-24T02:09:00.000Z"));
+    (useStoreMock as any).mockReturnValue(
+      mockNearbyEventStoreMany([
+        {
+          title: "Sales sync",
+          started_at: "2026-06-24T02:09:00.000Z",
+        },
+        {
+          title: "Design sync",
+          started_at: "2026-06-24T02:10:00.000Z",
+          meeting_link: "https://meet.google.com/abc-defg-hij",
+        },
+      ]),
+    );
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "micDetected",
+        key: "mic-1",
+        apps: [{ id: "com.google.Chrome", name: "Google Chrome" }],
+        duration_secs: 15,
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(showNotificationMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: expect.objectContaining({
+            app_names: ["Google Chrome"],
+            event_ids: ["event-1"],
+          }),
+          title: "Are you in Sales sync right now?",
+          footer: expect.objectContaining({
+            text: "Ignore Google Chrome?",
+          }),
+          icon: { type: "bundle_id", bundle_id: "com.google.Chrome" },
         }),
       ),
     );
@@ -1092,7 +1258,7 @@ describe("ListenerProvider detect events", () => {
     );
   });
 
-  test("keeps main and footer icons aligned for mixed native and browser mic notifications", async () => {
+  test("does not let calendar video links override detected native meeting apps", async () => {
     const store = createListenerStore();
 
     vi.useFakeTimers();
@@ -1121,30 +1287,30 @@ describe("ListenerProvider detect events", () => {
         type: "micDetected",
         key: "mic-1",
         apps: [
-          { id: "us.zoom.xos", name: "Zoom" },
+          { id: "com.tinyspeck.slackmacgap", name: "Slack" },
           { id: "com.google.Chrome", name: "Google Chrome" },
         ],
         duration_secs: 15,
       },
     });
 
-    const zoomIcon = {
+    const slackIcon = {
       type: "path",
-      path: "/resources/notification-icons/zoom.svg",
+      path: "/resources/notification-icons/slack.svg",
     };
 
     await vi.waitFor(() =>
       expect(showNotificationMock).toHaveBeenCalledWith(
         expect.objectContaining({
           source: expect.objectContaining({
-            app_names: ["Zoom", "Google Meet"],
-            app_ids: ["us.zoom.xos", "com.google.Chrome"],
+            app_names: ["Slack", "Google Chrome"],
+            app_ids: ["com.tinyspeck.slackmacgap", "com.google.Chrome"],
           }),
           footer: expect.objectContaining({
-            text: "Ignore Zoom and Google Meet?",
-            icon: zoomIcon,
+            text: "Ignore Slack and Google Chrome?",
+            icon: slackIcon,
           }),
-          icon: zoomIcon,
+          icon: slackIcon,
         }),
       ),
     );
@@ -1191,6 +1357,9 @@ describe("ListenerProvider detect events", () => {
             app_ids: ["at.studio.AsideBrowser"],
             event_ids: ["event-1"],
           }),
+          title: "Are you in Founder call right now?",
+          action_label: "Yes",
+          options: null,
           footer: expect.objectContaining({
             text: "Ignore Cal Video?",
             icon: {

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -75,6 +75,7 @@ type NearbyEvent = {
   meetingLink?: string;
   location?: string;
   description?: string;
+  participantNames: string[];
 };
 type MeetingPlatform = {
   displayName: string;
@@ -194,6 +195,7 @@ type MicAppNotificationOverride = {
   ids: Set<string>;
   names: Set<string>;
   displayName: string;
+  meetingPlatform?: MeetingPlatform;
   icon?: NotificationIcon;
   iconResource?: NotificationIconResource;
 };
@@ -223,6 +225,7 @@ const MIC_APP_NOTIFICATION_OVERRIDES = [
     ids: new Set(["us.zoom.xos"]),
     names: new Set(["zoom", "zoom helper", "zoom workplace"]),
     displayName: "Zoom",
+    meetingPlatform: MEETING_PLATFORMS.zoom,
     iconResource: "zoom",
   },
   {
@@ -234,6 +237,7 @@ const MIC_APP_NOTIFICATION_OVERRIDES = [
       "teams helper",
     ]),
     displayName: "Microsoft Teams",
+    meetingPlatform: MEETING_PLATFORMS.teams,
     iconResource: "microsoftTeams",
   },
   {
@@ -244,54 +248,63 @@ const MIC_APP_NOTIFICATION_OVERRIDES = [
     ]),
     names: new Set(["cisco webex", "webex", "webex helper", "webex meetings"]),
     displayName: "Webex",
+    meetingPlatform: MEETING_PLATFORMS.webex,
     iconResource: "webex",
   },
   {
     ids: new Set(["com.slack.Slack", "com.tinyspeck.slackmacgap"]),
     names: new Set(["slack", "slack helper"]),
     displayName: "Slack",
+    meetingPlatform: MEETING_PLATFORMS.slack,
     iconResource: "slack",
   },
   {
     ids: new Set(["com.kakao.KakaoTalkMac"]),
     names: new Set(["kakaotalk", "kakaotalk helper"]),
     displayName: "KakaoTalk",
+    meetingPlatform: MEETING_PLATFORMS.kakaotalk,
     iconResource: "kakaotalk",
   },
   {
     ids: new Set(["net.whatsapp.WhatsApp"]),
     names: new Set(["whatsapp", "whatsapp helper"]),
     displayName: "WhatsApp",
+    meetingPlatform: MEETING_PLATFORMS.whatsapp,
     iconResource: "whatsapp",
   },
   {
     ids: new Set(["com.hnc.Discord", "com.discordapp.Discord"]),
     names: new Set(["discord", "discord helper"]),
     displayName: "Discord",
+    meetingPlatform: MEETING_PLATFORMS.discord,
     iconResource: "discord",
   },
   {
     ids: new Set(["org.whispersystems.signal-desktop"]),
     names: new Set(["signal", "signal helper"]),
     displayName: "Signal",
+    meetingPlatform: MEETING_PLATFORMS.signal,
     iconResource: "signal",
   },
   {
     ids: new Set(["ru.keepcoder.Telegram", "ru.keepcoder.TelegramLite"]),
     names: new Set(["telegram", "telegram helper", "telegram lite"]),
     displayName: "Telegram",
+    meetingPlatform: MEETING_PLATFORMS.telegram,
     iconResource: "telegram",
   },
   {
     ids: new Set(["jp.naver.line.mac"]),
     names: new Set(["line", "line helper"]),
     displayName: "LINE",
+    meetingPlatform: MEETING_PLATFORMS.line,
     iconResource: "line",
   },
   {
     ids: new Set(["com.facebook.archon"]),
     names: new Set(["messenger", "messenger helper"]),
     displayName: "Messenger",
+    meetingPlatform: MEETING_PLATFORMS.messenger,
     iconResource: "messenger",
   },
 ] satisfies MicAppNotificationOverride[];
@@ -541,9 +554,19 @@ function detectMeetingPlatformFromText(value: string): MeetingPlatform | null {
 
 function getBrowserMeetingPlatform(
   apps: MicApp[],
-  nearbyEvents: NearbyEvent[],
+  event: NearbyEvent | null,
 ): MeetingPlatform | null {
-  if (!apps.some(isBrowserApp)) {
+  if (!apps.some(isBrowserApp) || !event) {
+    return null;
+  }
+
+  if (
+    apps.some(
+      (app) =>
+        !isBrowserApp(app) &&
+        getMicAppNotificationOverride(app)?.meetingPlatform,
+    )
+  ) {
     return null;
   }
 
@@ -553,18 +576,16 @@ function getBrowserMeetingPlatform(
     "description",
     "title",
   ] satisfies Array<keyof NearbyEvent>) {
-    for (const event of nearbyEvents) {
-      const value = event[field];
-      if (!value) {
-        continue;
-      }
+    const value = event[field];
+    if (!value) {
+      continue;
+    }
 
-      const platform = value.startsWith("http")
-        ? detectMeetingPlatformFromUrl(value)
-        : detectMeetingPlatformFromText(value);
-      if (platform) {
-        return platform;
-      }
+    const platform = value.startsWith("http")
+      ? detectMeetingPlatformFromUrl(value)
+      : detectMeetingPlatformFromText(value);
+    if (platform) {
+      return platform;
     }
   }
 
@@ -826,19 +847,71 @@ function getNearbyEvents(
           typeof event.location === "string" ? event.location : undefined,
         description:
           typeof event.description === "string" ? event.description : undefined,
+        participantNames: getEventParticipantNames(event.participants_json),
         startedAt: startTime,
       });
     }
   });
 
-  results.sort((a, b) => a.startedAt - b.startedAt);
-  return results.map(({ id, title, meetingLink, location, description }) => ({
-    id,
-    title,
-    meetingLink,
-    location,
-    description,
-  }));
+  results.sort(
+    (a, b) =>
+      Math.abs(a.startedAt - now) - Math.abs(b.startedAt - now) ||
+      a.startedAt - b.startedAt,
+  );
+  return results.map(
+    ({ id, title, meetingLink, location, description, participantNames }) => ({
+      id,
+      title,
+      meetingLink,
+      location,
+      description,
+      participantNames,
+    }),
+  );
+}
+
+function getEventParticipantNames(participantsJson: unknown): string[] {
+  if (typeof participantsJson !== "string" || !participantsJson) {
+    return [];
+  }
+
+  try {
+    const participants = JSON.parse(participantsJson);
+    if (!Array.isArray(participants)) {
+      return [];
+    }
+
+    return [
+      ...new Set(
+        participants
+          .filter((participant) => participant?.is_current_user !== true)
+          .map((participant) =>
+            typeof participant?.name === "string"
+              ? participant.name.trim()
+              : "",
+          )
+          .filter(Boolean),
+      ),
+    ];
+  } catch {
+    return [];
+  }
+}
+
+function getMicDetectedNotificationTitle(event: NearbyEvent | null): string {
+  if (!event) {
+    return "Are you in a meeting?";
+  }
+
+  if (event.participantNames.length === 1) {
+    return `Are you talking to ${event.participantNames[0]} right now?`;
+  }
+
+  if (event.participantNames.length === 2) {
+    return `Are you talking to ${event.participantNames[0]} and ${event.participantNames[1]} right now?`;
+  }
+
+  return `Are you in ${event.title} right now?`;
 }
 
 const useHandleDetectEvents = (store: ListenerStore) => {
@@ -968,9 +1041,10 @@ const useHandleDetectEvents = (store: ListenerStore) => {
               const nearbyEvents = currentTinybaseStore
                 ? getNearbyEvents(currentTinybaseStore)
                 : [];
+              const nearbyEvent = nearbyEvents[0] ?? null;
               const browserMeetingPlatform = getBrowserMeetingPlatform(
                 payload.apps,
-                nearbyEvents,
+                nearbyEvent,
               );
               const displayApps = getNotificationDisplayApps(
                 payload.apps,
@@ -991,10 +1065,6 @@ const useHandleDetectEvents = (store: ListenerStore) => {
                 payload.apps,
                 browserMeetingPlatform,
               );
-              const options =
-                nearbyEvents.length > 0
-                  ? nearbyEvents.map((e) => e.title)
-                  : null;
               const footer =
                 displayIgnorableApps.length > 0
                   ? {
@@ -1011,7 +1081,7 @@ const useHandleDetectEvents = (store: ListenerStore) => {
 
               void notificationCommands.showNotification({
                 key: payload.key,
-                title: "Are you in a meeting?",
+                title: getMicDetectedNotificationTitle(nearbyEvent),
                 message: "",
                 timeout: { secs: 15, nanos: 0 },
                 source: {
@@ -1020,14 +1090,14 @@ const useHandleDetectEvents = (store: ListenerStore) => {
                     getNotificationAppName(app),
                   ),
                   app_ids: appIds,
-                  event_ids: nearbyEvents.map((e) => e.id),
+                  event_ids: nearbyEvent ? [nearbyEvent.id] : [],
                 },
                 start_time: null,
                 participants: null,
                 event_details: null,
-                action_label: null,
+                action_label: "Yes",
                 action_variant: null,
-                options,
+                options: null,
                 footer,
                 icon: notificationIcon,
               });


### PR DESCRIPTION
Summary:
- use nearby calendar context to ask a direct meeting confirmation question
- remove the options-menu flow for likely detected events

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mic-notification UX and confirm→session routing (auto-start, event binding); behavior is covered by expanded tests but affects a sensitive onboarding path.
> 
> **Overview**
> Mic-detected prompts now anchor on the **single nearest calendar event** and ask a direct yes/no question instead of showing a generic title and event options menu.
> 
> **Notification copy and payload:** Titles are built from calendar context (`getMicDetectedNotificationTitle`)—one other participant, two names, or the event title—and notifications use `action_label: "Yes"` with `options: null`. `event_ids` carries only that likely event, not every nearby event.
> 
> **Event matching:** `getNearbyEvents` picks the event closest in time to now and parses `participants_json` for display names. Browser meeting-platform labeling runs only against that event, and calendar video links no longer relabel the prompt when a native meeting app (e.g. Slack) is already detected.
> 
> **Confirm handling:** `notification_confirm` for `mic_detected` treats `event_ids[0]` like a calendar event—opens or creates the session for that event and auto-starts when appropriate—so confirming "Yes" starts listening for the inferred meeting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ac7309064738bf1c2bad3c8e0808843db8a1c22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->