### PR TITLE
feat: add auto summary template option

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -1432,7 +1432,7 @@ msgstr "Search or type owner/repo"
 msgid "Search people"
 msgstr "Search people"
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr "Search templates..."
@@ -1450,7 +1450,7 @@ msgstr "Search..."
 msgid "Section actions"
 msgstr "Section actions"
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr "See all templates"
 
@@ -1508,7 +1508,7 @@ msgstr "Send email"
 msgid "Send message"
 msgstr "Send message"
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr "Session note tabs"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1092
+#: src/session/components/note-input/header.tsx:1117
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1158
+#: src/session/components/note-input/header.tsx:1183
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1197
+#: src/session/components/note-input/header.tsx:1222
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -323,6 +323,108 @@ describe("EnhancerService", () => {
         },
       });
     });
+
+    it("can replace a target note with no template when a default template is selected", () => {
+      const tables = createTables({
+        enhanced_notes: {
+          "note-1": {
+            session_id: "session-1",
+            template_id: "template-1",
+            title: "Customer Call",
+            content: "Generated summary",
+          },
+        },
+      });
+      const store = createMockStore(tables);
+      const generate = vi.fn().mockResolvedValue(undefined);
+      const aiTaskStore = createMockAITaskStore();
+      aiTaskStore.getState.mockReturnValue({
+        generate,
+        getState: vi.fn().mockReturnValue({ status: "success" }),
+      });
+      const deps = createDeps({
+        mainStore: store,
+        indexes: createMockIndexes(tables),
+        aiTaskStore,
+        getSelectedTemplateId: () => "template-default",
+      });
+      const service = new EnhancerService(deps);
+
+      const result = service.enhance("session-1", {
+        templateId: null,
+        targetNoteId: "note-1",
+      });
+
+      expect(result).toEqual({ type: "started", noteId: "note-1" });
+      expect(store.setPartialRow).toHaveBeenCalledWith(
+        "enhanced_notes",
+        "note-1",
+        {
+          content: "",
+          title: "Summary",
+          template_id: undefined,
+        },
+      );
+      expect(generate).toHaveBeenCalledWith("note-1-enhance", {
+        model: expect.anything(),
+        taskType: "enhance",
+        args: {
+          sessionId: "session-1",
+          enhancedNoteId: "note-1",
+          templateId: undefined,
+        },
+      });
+    });
+
+    it("uses the default template when a target note receives an undefined template", () => {
+      const tables = createTables({
+        enhanced_notes: {
+          "note-1": {
+            session_id: "session-1",
+            template_id: "template-1",
+            title: "Customer Call",
+            content: "Generated summary",
+          },
+        },
+      });
+      const store = createMockStore(tables);
+      const generate = vi.fn().mockResolvedValue(undefined);
+      const aiTaskStore = createMockAITaskStore();
+      aiTaskStore.getState.mockReturnValue({
+        generate,
+        getState: vi.fn().mockReturnValue({ status: "success" }),
+      });
+      const deps = createDeps({
+        mainStore: store,
+        indexes: createMockIndexes(tables),
+        aiTaskStore,
+        getSelectedTemplateId: () => "template-default",
+      });
+      const service = new EnhancerService(deps);
+
+      const result = service.enhance("session-1", {
+        templateId: undefined,
+        targetNoteId: "note-1",
+      });
+
+      expect(result).toEqual({ type: "started", noteId: "note-1" });
+      expect(store.setPartialRow).toHaveBeenCalledWith(
+        "enhanced_notes",
+        "note-1",
+        expect.objectContaining({
+          template_id: "template-default",
+        }),
+      );
+      expect(generate).toHaveBeenCalledWith("note-1-enhance", {
+        model: expect.anything(),
+        taskType: "enhance",
+        args: {
+          sessionId: "session-1",
+          enhancedNoteId: "note-1",
+          templateId: "template-default",
+        },
+      });
+    });
   });
 
   describe("queueAutoEnhanceIfSummaryEmpty()", () => {

--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -22,7 +22,7 @@ type QueueEmptySummaryResult =
 
 type EnhanceOpts = {
   isAuto?: boolean;
-  templateId?: string;
+  templateId?: string | null;
   targetNoteId?: string;
   templateTitle?: string;
 };
@@ -104,6 +104,21 @@ function shouldHydrateTemplateTitle(
     UUID_TITLE_RE.test(title) ||
     ISO_TITLE_RE.test(title)
   );
+}
+
+function resolveTemplateId(
+  opts: EnhanceOpts | undefined,
+  getSelectedTemplateId: () => string | undefined,
+) {
+  if (opts?.templateId === null) {
+    return undefined;
+  }
+
+  if (opts?.templateId) {
+    return opts.templateId || undefined;
+  }
+
+  return getSelectedTemplateId();
 }
 
 let instance: EnhancerService | null = null;
@@ -256,7 +271,7 @@ export class EnhancerService {
     const model = getModel();
     if (!model) return { type: "no_model" };
 
-    const templateId = opts?.templateId || getSelectedTemplateId();
+    const templateId = resolveTemplateId(opts, getSelectedTemplateId);
     const targetNoteId = opts?.targetNoteId
       ? this.getSessionEnhancedNoteId(sessionId, opts.targetNoteId)
       : undefined;

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -596,6 +596,44 @@ describe("Header", () => {
     });
   });
 
+  it("replaces the current enhanced note with auto generation", () => {
+    hoisted.userTemplates = [
+      {
+        id: "template-2",
+        title: "Decision Log",
+        description: "",
+        pinned: false,
+        sections: [],
+      },
+    ];
+    hoisted.enhance.mockReturnValue({
+      type: "started",
+      noteId: "note-1",
+    });
+    const editorTabs: EditorView[] = [
+      { type: "enhanced", id: "note-1" },
+      { type: "raw" },
+    ];
+
+    render(
+      <Header
+        sessionId="session-1"
+        editorTabs={editorTabs}
+        currentTab={{ type: "enhanced", id: "note-1" }}
+        handleTabChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Customer Call" }));
+    fireEvent.click(screen.getByRole("button", { name: "Auto" }));
+
+    expect(hoisted.enhance).toHaveBeenCalledWith("session-1", {
+      templateId: null,
+      targetNoteId: "note-1",
+      templateTitle: undefined,
+    });
+  });
+
   it("shows a spinner in the active enhanced tab while generating", () => {
     hoisted.isGenerating = true;
     const editorTabs: EditorView[] = [

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -214,7 +214,7 @@ async function copyTextToClipboard(
 }
 
 type TemplateSelection = {
-  templateId: string;
+  templateId: string | null;
   title: string;
 };
 
@@ -468,7 +468,7 @@ function HeaderTabEnhancedActive({
       const result = getEnhancerService()?.enhance(sessionId, {
         templateId: selection.templateId,
         targetNoteId: enhancedNoteId,
-        templateTitle: selection.title,
+        templateTitle: selection.templateId ? selection.title : undefined,
       });
 
       if (
@@ -984,8 +984,26 @@ function TemplatePickerPopover({
       }>;
     }>
   >(() => {
+    const autoSection = {
+      key: "auto",
+      title: "Auto",
+      showHeader: false,
+      items: [
+        {
+          key: "auto",
+          title: "Auto",
+          onClick: () =>
+            handleUseTemplate({
+              templateId: null,
+              title: "Auto",
+            }),
+        },
+      ],
+    };
+
     if (!hasSearch) {
       return [
+        autoSection,
         {
           key: "templates",
           title: "Templates",
@@ -997,6 +1015,7 @@ function TemplatePickerPopover({
     }
 
     return [
+      autoSection,
       {
         key: "create",
         title: "Create new template",
@@ -1021,7 +1040,13 @@ function TemplatePickerPopover({
           ]
         : []),
     ];
-  }, [handleCreateTemplate, hasSearch, templateItems, trimmedSearch]);
+  }, [
+    handleCreateTemplate,
+    handleUseTemplate,
+    hasSearch,
+    templateItems,
+    trimmedSearch,
+  ]);
   const navigableResults = useMemo(
     () => resultSections.flatMap((section) => section.items),
     [resultSections],


### PR DESCRIPTION
Summary:
- add an Auto template item that regenerates summaries without a template
- preserve default-template enhancement behavior for existing calls

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Session UI and enhancer option parsing only; covered by new unit tests and no auth or data-migration changes.
> 
> **Overview**
> Adds an **Auto** choice at the top of the session note template picker so users can regenerate the current enhanced note **without** applying a template.
> 
> Enhancement routing now treats `templateId: null` as an explicit “no template” run (clears `template_id`, uses generic “Summary” titling). Omitting `templateId` or passing `undefined` still falls back to the user’s **default selected template**, so existing enhance flows stay the same.
> 
> Locale `.po` files only update source line references for strings moved in `header.tsx` after the new UI block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19e94fe5070123fe64024a6b8b059c912d5e1222. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->