### PR TITLE
feat: add transcript and summary generation actions

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -817,7 +817,7 @@ msgstr "Insert above"
 msgid "Insert below"
 msgstr "Insert below"
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr "Insights"
 
@@ -1432,7 +1432,7 @@ msgstr "Search or type owner/repo"
 msgid "Search people"
 msgstr "Search people"
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr "Search templates..."
@@ -1450,7 +1450,7 @@ msgstr "Search..."
 msgid "Section actions"
 msgstr "Section actions"
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr "See all templates"
 
@@ -1508,7 +1508,7 @@ msgstr "Send email"
 msgid "Send message"
 msgstr "Send message"
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr "Session note tabs"
 
@@ -1783,7 +1783,7 @@ msgstr "Timezone"
 msgid "Tip: The Anarlog team loves our users!"
 msgstr "Tip: The Anarlog team loves our users!"
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:739
+#: src/session/components/note-input/header.tsx:769
 msgid "Insights"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1117
+#: src/session/components/note-input/header.tsx:1147
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1183
+#: src/session/components/note-input/header.tsx:1213
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1222
+#: src/session/components/note-input/header.tsx:1254
 msgid "Session note tabs"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:620
+#: src/session/components/note-input/header.tsx:633
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -27,7 +27,10 @@ const hoisted = vi.hoisted(() => ({
   sessionMode: "inactive",
   sendEvent: vi.fn(),
   enhance: vi.fn(),
+  regenerateSummary: vi.fn(),
+  cancelSummary: vi.fn(),
   regenerateTranscript: vi.fn(),
+  stopTranscription: vi.fn(),
   updateSessionTabState: vi.fn(),
 }));
 
@@ -65,6 +68,17 @@ vi.mock("~/ai/contexts", () => ({
 
 vi.mock("~/ai/hooks", () => ({
   useLLMConnectionStatus: () => hoisted.llmStatus,
+  useLanguageModel: () => "model",
+  useAITaskTask: () => ({
+    isIdle:
+      hoisted.enhanceTaskStatus === undefined ||
+      hoisted.enhanceTaskStatus === "idle",
+    isGenerating: hoisted.enhanceTaskStatus === "generating",
+    isError: hoisted.enhanceTaskStatus === "error",
+    error: null,
+    start: hoisted.regenerateSummary,
+    cancel: hoisted.cancelSummary,
+  }),
 }));
 
 vi.mock("~/store/tinybase/store/main", () => ({
@@ -107,10 +121,14 @@ vi.mock("../caret-position-context", () => ({
 
 vi.mock("~/stt/contexts", () => ({
   useListener: (
-    selector: (state: { getSessionMode: () => string }) => unknown,
+    selector: (state: {
+      getSessionMode: () => string;
+      stopTranscription: (sessionId: string) => void;
+    }) => unknown,
   ) =>
     selector({
       getSessionMode: () => hoisted.sessionMode,
+      stopTranscription: hoisted.stopTranscription,
     }),
 }));
 
@@ -139,7 +157,10 @@ describe("FloatingActionButton", () => {
     hoisted.sessionMode = "inactive";
     hoisted.sendEvent.mockClear();
     hoisted.enhance.mockReset();
+    hoisted.regenerateSummary.mockReset();
+    hoisted.cancelSummary.mockReset();
     hoisted.regenerateTranscript.mockReset();
+    hoisted.stopTranscription.mockReset();
     hoisted.updateSessionTabState.mockClear();
   });
 
@@ -155,14 +176,25 @@ describe("FloatingActionButton", () => {
     ).not.toBeNull();
   });
 
-  it("shows the chat FAB on enhanced summary views", () => {
+  it("shows a regenerate summary FAB on enhanced summary views", () => {
     hoisted.currentTab = { type: "enhanced", id: "note-1" };
 
     render(<FloatingActionButton tab={tab} />);
 
     expect(
       screen.queryByRole("button", { name: "Ask Anarlog anything" }),
-    ).not.toBeNull();
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Regenerate summary" }));
+
+    expect(hoisted.regenerateSummary).toHaveBeenCalledWith({
+      model: "model",
+      args: {
+        sessionId: "session-1",
+        enhancedNoteId: "note-1",
+        templateId: undefined,
+      },
+    });
   });
 
   it("shows a generate summary FAB instead of chat for empty transcript-backed summaries", () => {
@@ -230,7 +262,7 @@ describe("FloatingActionButton", () => {
     ).toBeNull();
   });
 
-  it("shows the chat FAB while an empty enhanced summary is still generating", () => {
+  it("shows a stop summary FAB while an enhanced summary is generating", () => {
     hoisted.currentTab = { type: "enhanced", id: "note-1" };
     hoisted.enhanceTaskStatus = "generating";
     hoisted.enhancedContent = "";
@@ -240,7 +272,11 @@ describe("FloatingActionButton", () => {
 
     expect(
       screen.queryByRole("button", { name: "Ask Anarlog anything" }),
-    ).not.toBeNull();
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop summary" }));
+
+    expect(hoisted.cancelSummary).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the chat FAB visible near the editor caret", () => {
@@ -356,6 +392,34 @@ describe("FloatingActionButton", () => {
     );
 
     expect(hoisted.regenerateTranscript).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a regenerate transcript FAB on existing transcript views backed by audio", () => {
+    hoisted.currentTab = { type: "transcript" };
+    hoisted.hasTranscript = true;
+
+    render(<FloatingActionButton audioExists tab={tab} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Ask Anarlog anything" }),
+    ).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Regenerate transcript" }),
+    );
+
+    expect(hoisted.regenerateTranscript).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a stop transcript FAB while batch transcription is running", () => {
+    hoisted.currentTab = { type: "transcript" };
+    hoisted.sessionMode = "running_batch";
+
+    render(<FloatingActionButton audioExists tab={tab} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop transcription" }));
+
+    expect(hoisted.stopTranscription).toHaveBeenCalledWith("session-1");
   });
 
   it("hides the regenerate transcript FAB when audio is missing", () => {

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -1,4 +1,4 @@
-import { RefreshCwIcon } from "lucide-react";
+import { RefreshCwIcon, SquareIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import type { CSSProperties } from "react";
 import { useCallback } from "react";
@@ -12,6 +12,7 @@ import { FloatingButton } from "./shared";
 import { useAITask } from "~/ai/contexts";
 import { type LLMConnectionStatus, useLLMConnectionStatus } from "~/ai/hooks";
 import { getEnhancerService } from "~/services/enhancer";
+import { useEnhancedNoteActions } from "~/session/components/note-input/enhanced-actions";
 import { useRegenerateTranscript } from "~/session/components/note-input/transcript/actions";
 import {
   useCurrentNoteTab,
@@ -43,11 +44,12 @@ export function FloatingActionButton({
     audioExists,
   );
   const shouldShowListen = allowListening && canShowListen;
-  const shouldShowRegenerateTranscript = useShouldShowRegenerateTranscriptFab(
+  const transcriptAction = useTranscriptFloatingAction(
     tab,
     sessionMode,
     audioExists,
   );
+  const summaryAction = useSummaryFloatingAction(tab, sessionMode, audioExists);
   const shouldShowChat = useShouldShowChatFab(tab, sessionMode, audioExists);
   const generateSummaryNoteId = useGenerateSummaryNoteId(
     tab,
@@ -55,12 +57,15 @@ export function FloatingActionButton({
     audioExists,
   );
   const shouldShowGenerateSummary = generateSummaryNoteId !== null;
+  const shouldShowTranscriptAction = transcriptAction !== null;
+  const shouldShowSummaryAction = summaryAction !== null;
   const isCaretNearBottom = useCaretPosition()?.isCaretNearBottom ?? false;
   const showSkipReason = !!skipReason;
   const useChatHoverArea =
     !showSkipReason &&
+    !shouldShowTranscriptAction &&
+    !shouldShowSummaryAction &&
     !shouldShowGenerateSummary &&
-    !shouldShowRegenerateTranscript &&
     shouldShowChat;
   const tuckListenAction =
     !showSkipReason && shouldShowListen && isCaretNearBottom;
@@ -68,8 +73,9 @@ export function FloatingActionButton({
   if (
     !showSkipReason &&
     !shouldShowListen &&
+    !shouldShowTranscriptAction &&
+    !shouldShowSummaryAction &&
     !shouldShowGenerateSummary &&
-    !shouldShowRegenerateTranscript &&
     !shouldShowChat
   ) {
     return null;
@@ -107,11 +113,13 @@ export function FloatingActionButton({
             key={
               shouldShowListen
                 ? "listen"
-                : shouldShowGenerateSummary
-                  ? "generate-summary"
-                  : shouldShowRegenerateTranscript
-                    ? "regenerate-transcript"
-                    : "chat"
+                : shouldShowTranscriptAction
+                  ? `transcript-${transcriptAction.type}`
+                  : shouldShowSummaryAction
+                    ? `summary-${summaryAction.type}`
+                    : shouldShowGenerateSummary
+                      ? "generate-summary"
+                      : "chat"
             }
             aria-hidden={tuckListenAction}
             initial={{ opacity: 0 }}
@@ -134,13 +142,21 @@ export function FloatingActionButton({
           >
             {shouldShowListen ? (
               <ListenButton tab={tab} />
+            ) : transcriptAction ? (
+              <TranscriptActionButton
+                action={transcriptAction.type}
+                onClick={transcriptAction.onClick}
+              />
+            ) : summaryAction ? (
+              <SummaryActionButton
+                action={summaryAction.type}
+                onClick={summaryAction.onClick}
+              />
             ) : shouldShowGenerateSummary ? (
               <GenerateSummaryButton
                 tab={tab}
                 enhancedNoteId={generateSummaryNoteId}
               />
-            ) : shouldShowRegenerateTranscript ? (
-              <RegenerateTranscriptButton sessionId={tab.id} />
             ) : (
               <ChatCTA />
             )}
@@ -151,16 +167,58 @@ export function FloatingActionButton({
   );
 }
 
-function RegenerateTranscriptButton({ sessionId }: { sessionId: string }) {
-  const regenerateTranscript = useRegenerateTranscript(sessionId);
+function TranscriptActionButton({
+  action,
+  onClick,
+}: {
+  action: "regenerate" | "stop";
+  onClick: () => void;
+}) {
+  const label =
+    action === "stop" ? "Stop transcription" : "Regenerate transcript";
+  const Icon = action === "stop" ? SquareIcon : RefreshCwIcon;
 
   return (
     <FloatingButton
-      onClick={regenerateTranscript}
+      onClick={onClick}
       className="w-fit gap-2 px-4 whitespace-nowrap"
     >
       <span className="flex items-center gap-1.5">
-        <RefreshCwIcon className="size-3.5" /> Regenerate transcript
+        <Icon
+          className={cn([
+            "size-3.5",
+            action === "stop" ? "fill-current" : null,
+          ])}
+        />{" "}
+        {label}
+      </span>
+    </FloatingButton>
+  );
+}
+
+function SummaryActionButton({
+  action,
+  onClick,
+}: {
+  action: "regenerate" | "stop";
+  onClick: () => void;
+}) {
+  const label = action === "stop" ? "Stop summary" : "Regenerate summary";
+  const Icon = action === "stop" ? SquareIcon : RefreshCwIcon;
+
+  return (
+    <FloatingButton
+      onClick={onClick}
+      className="w-fit gap-2 px-4 whitespace-nowrap"
+    >
+      <span className="flex items-center gap-1.5">
+        <Icon
+          className={cn([
+            "size-3.5",
+            action === "stop" ? "fill-current" : null,
+          ])}
+        />{" "}
+        {label}
       </span>
     </FloatingButton>
   );
@@ -209,20 +267,87 @@ function GenerateSummaryButton({
   );
 }
 
-function useShouldShowRegenerateTranscriptFab(
+function useTranscriptFloatingAction(
   tab: Extract<Tab, { type: "sessions" }>,
   sessionMode: string,
   audioExists: boolean,
 ) {
   const currentTab = useCurrentNoteTab(tab, { audioExists });
-  const hasTranscript = useHasTranscript(tab.id);
+  const regenerateTranscript = useRegenerateTranscript(tab.id);
+  const stopTranscription = useListener((state) => state.stopTranscription);
 
-  return (
-    sessionMode === "inactive" &&
-    currentTab.type === "transcript" &&
-    audioExists &&
-    !hasTranscript
+  const handleStopTranscription = useCallback(() => {
+    void stopTranscription(tab.id);
+  }, [stopTranscription, tab.id]);
+
+  if (currentTab.type !== "transcript") {
+    return null;
+  }
+
+  if (sessionMode === "running_batch") {
+    return {
+      type: "stop" as const,
+      onClick: handleStopTranscription,
+    };
+  }
+
+  if (sessionMode === "inactive" && audioExists) {
+    return {
+      type: "regenerate" as const,
+      onClick: regenerateTranscript,
+    };
+  }
+
+  return null;
+}
+
+function useSummaryFloatingAction(
+  tab: Extract<Tab, { type: "sessions" }>,
+  sessionMode: string,
+  audioExists: boolean,
+) {
+  const currentTab = useCurrentNoteTab(tab, { audioExists });
+  const enhancedNoteId = currentTab.type === "enhanced" ? currentTab.id : null;
+  const { isGenerating, onCancel, onRegenerate } = useEnhancedNoteActions({
+    sessionId: tab.id,
+    enhancedNoteId,
+  });
+  const content = main.UI.useCell(
+    "enhanced_notes",
+    enhancedNoteId ?? "",
+    "content",
+    main.STORE_ID,
   );
+  const llmStatus = useLLMConnectionStatus();
+  const hasContent = hasStoredNoteContent(content);
+
+  const handleRegenerateSummary = useCallback(() => {
+    void onRegenerate(null);
+  }, [onRegenerate]);
+
+  if (!enhancedNoteId) {
+    return null;
+  }
+
+  if (isGenerating) {
+    return {
+      type: "stop" as const,
+      onClick: onCancel,
+    };
+  }
+
+  if (
+    sessionMode === "inactive" &&
+    hasContent &&
+    !isBlockingLLMStatus(llmStatus)
+  ) {
+    return {
+      type: "regenerate" as const,
+      onClick: handleRegenerateSummary,
+    };
+  }
+
+  return null;
 }
 
 function useShouldShowListeningFab(

--- a/apps/desktop/src/session/components/note-input/enhanced-actions.ts
+++ b/apps/desktop/src/session/components/note-input/enhanced-actions.ts
@@ -1,0 +1,81 @@
+import { useCallback, useState } from "react";
+
+import { commands as analyticsCommands } from "@hypr/plugin-analytics";
+
+import { useAITaskTask } from "~/ai/hooks";
+import { useLanguageModel, useLLMConnectionStatus } from "~/ai/hooks";
+import { shouldShowEmptySummaryConfigError } from "~/session/enhance-config";
+import * as main from "~/store/tinybase/store/main";
+import { createTaskId } from "~/store/zustand/ai-task/task-configs";
+
+export function useEnhancedNoteActions({
+  enhancedNoteId,
+  sessionId,
+}: {
+  enhancedNoteId: string | null;
+  sessionId: string;
+}) {
+  const model = useLanguageModel("enhance");
+  const llmStatus = useLLMConnectionStatus();
+  const taskId = enhancedNoteId
+    ? createTaskId(enhancedNoteId, "enhance")
+    : null;
+  const [missingModelError, setMissingModelError] = useState<Error | null>(
+    null,
+  );
+
+  const noteTemplateId =
+    (main.UI.useCell(
+      "enhanced_notes",
+      enhancedNoteId ?? "",
+      "template_id",
+      main.STORE_ID,
+    ) as string | undefined) || undefined;
+
+  const enhanceTask = useAITaskTask(taskId, "enhance");
+
+  const onRegenerate = useCallback(
+    async (templateId: string | null) => {
+      if (!enhancedNoteId) {
+        return;
+      }
+
+      if (!model) {
+        setMissingModelError(
+          new Error("Intelligence provider not configured."),
+        );
+        return;
+      }
+
+      setMissingModelError(null);
+
+      void analyticsCommands.event({
+        event: "note_enhanced",
+        is_auto: false,
+      });
+
+      await enhanceTask.start({
+        model,
+        args: {
+          sessionId,
+          enhancedNoteId,
+          templateId: templateId ?? noteTemplateId,
+        },
+      });
+    },
+    [enhancedNoteId, model, enhanceTask.start, sessionId, noteTemplateId],
+  );
+
+  const isConfigError = shouldShowEmptySummaryConfigError(llmStatus);
+  const isIdleWithConfigError = enhanceTask.isIdle && isConfigError;
+  const error = model ? enhanceTask.error : missingModelError;
+  const isError = !!error || enhanceTask.isError || isIdleWithConfigError;
+
+  return {
+    isGenerating: enhanceTask.isGenerating,
+    isError,
+    error,
+    onRegenerate,
+    onCancel: enhanceTask.cancel,
+  };
+}

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -21,6 +21,7 @@ type CapturedMenuItem =
 const hoisted = vi.hoisted(() => ({
   enhance: vi.fn(),
   regenerateTranscript: vi.fn(),
+  stopTranscription: vi.fn(),
   deleteRecording: vi.fn(),
   activeTemplateTitle: "Customer Call",
   audioExists: true,
@@ -263,6 +264,7 @@ vi.mock("~/stt/contexts", () => ({
       };
       liveSegments: unknown[];
       getSessionMode: () => string;
+      stopTranscription: (sessionId: string) => void;
     }) => unknown,
   ) =>
     selector({
@@ -273,6 +275,7 @@ vi.mock("~/stt/contexts", () => ({
       },
       liveSegments: hoisted.liveSegments,
       getSessionMode: () => hoisted.sessionMode,
+      stopTranscription: hoisted.stopTranscription,
     }),
 }));
 
@@ -292,6 +295,7 @@ describe("Header", () => {
   beforeEach(() => {
     hoisted.enhance.mockReset();
     hoisted.regenerateTranscript.mockReset();
+    hoisted.stopTranscription.mockReset();
     hoisted.deleteRecording.mockReset();
     hoisted.activeTemplateTitle = "Customer Call";
     hoisted.audioExists = true;
@@ -679,6 +683,53 @@ describe("Header", () => {
       transcriptTab.querySelector("[data-testid='tab-spinner']"),
     ).not.toBeNull();
     expect(transcriptTab.querySelector("svg")).toBeNull();
+  });
+
+  it("stops transcription from the active transcript tab spinner", () => {
+    const editorTabs: EditorView[] = [
+      { type: "enhanced", id: "note-1" },
+      { type: "raw" },
+      { type: "transcript" },
+    ];
+
+    render(
+      <Header
+        sessionId="session-1"
+        editorTabs={editorTabs}
+        currentTab={{ type: "transcript" }}
+        handleTabChange={vi.fn()}
+        isTranscribing
+        canStopTranscription
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Transcript" }));
+
+    expect(hoisted.stopTranscription).toHaveBeenCalledWith("session-1");
+  });
+
+  it("does not stop transcription from the active transcript tab while finalizing", () => {
+    const handleTabChange = vi.fn();
+    const editorTabs: EditorView[] = [
+      { type: "enhanced", id: "note-1" },
+      { type: "raw" },
+      { type: "transcript" },
+    ];
+
+    render(
+      <Header
+        sessionId="session-1"
+        editorTabs={editorTabs}
+        currentTab={{ type: "transcript" }}
+        handleTabChange={handleTabChange}
+        isTranscribing
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Transcript" }));
+
+    expect(hoisted.stopTranscription).not.toHaveBeenCalled();
+    expect(handleTabChange).toHaveBeenCalledWith({ type: "transcript" });
   });
 
   it("includes the transcript tab when saved audio exists without transcript rows", () => {

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -8,13 +8,13 @@ import {
   PlusIcon,
   SearchIcon,
   SparklesIcon,
+  SquareIcon,
   XIcon,
 } from "lucide-react";
 import { LightbulbIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import { json2md, parseJsonContent } from "@hypr/editor/markdown";
-import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 import {
   AppFloatingPanel,
   Popover,
@@ -26,9 +26,9 @@ import { sonnerToast } from "@hypr/ui/components/ui/toast";
 import { cn } from "@hypr/utils";
 
 import { useAITaskTask } from "~/ai/hooks";
-import { useLanguageModel, useLLMConnectionStatus } from "~/ai/hooks";
 import * as AudioPlayer from "~/audio-player";
 import { getEnhancerService } from "~/services/enhancer";
+import { useEnhancedNoteActions } from "~/session/components/note-input/enhanced-actions";
 import { useRegenerateTranscript } from "~/session/components/note-input/transcript/actions";
 import {
   buildTranscriptExportSegments,
@@ -36,7 +36,6 @@ import {
 } from "~/session/components/note-input/transcript/export-data";
 import { useSessionTranscriptRenderData } from "~/session/components/note-input/transcript/render-request-hooks";
 import { useCanShowTranscript } from "~/session/components/shared";
-import { shouldShowEmptySummaryConfigError } from "~/session/enhance-config";
 import { useEnsureDefaultSummary } from "~/session/hooks/useEnhancedNotes";
 import { useCanShowInsights } from "~/session/insights/past-notes";
 import {
@@ -48,6 +47,7 @@ import * as main from "~/store/tinybase/store/main";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { type EditorView } from "~/store/zustand/tabs/schema";
+import { useListener } from "~/stt/contexts";
 import {
   filterWebTemplatesAgainstUserTemplates,
   parseWebTemplates,
@@ -573,11 +573,13 @@ function HeaderTabEnhancedActive({
 function HeaderTabTranscript({
   isActive,
   isTranscribing,
+  canStopTranscription,
   onClick = () => {},
   sessionId,
 }: {
   isActive: boolean;
   isTranscribing: boolean;
+  canStopTranscription: boolean;
   onClick?: () => void;
   sessionId: string;
 }) {
@@ -595,6 +597,7 @@ function HeaderTabTranscript({
     <HeaderTabTranscriptActive
       isActive={isActive}
       isTranscribing={isTranscribing}
+      canStopTranscription={canStopTranscription}
       onClick={onClick}
       sessionId={sessionId}
     />
@@ -606,27 +609,45 @@ function HeaderTabTranscriptButton({
   isTranscribing,
   onClick,
   onContextMenu,
+  onStopTranscription,
 }: {
   isActive: boolean;
   isTranscribing: boolean;
   onClick?: () => void;
   onContextMenu?: React.MouseEventHandler<HTMLButtonElement>;
+  onStopTranscription?: () => void;
 }) {
   const { t } = useLingui();
+  const handleClick = useCallback(() => {
+    if (isTranscribing && onStopTranscription) {
+      onStopTranscription();
+      return;
+    }
+
+    onClick?.();
+  }, [isTranscribing, onClick, onStopTranscription]);
 
   return (
     <IconHeaderTab
       isActive={isActive}
       label={t`Transcript`}
       icon={
-        isTranscribing ? (
+        isTranscribing && onStopTranscription ? (
+          <span className="group/stop relative flex size-4 items-center justify-center">
+            <Spinner size={16} className="shrink-0 group-hover/stop:hidden" />
+            <SquareIcon className="hidden size-3 fill-current group-hover/stop:block" />
+          </span>
+        ) : isTranscribing ? (
           <Spinner size={16} className="shrink-0" />
         ) : (
           <AudioLinesIcon className="size-4" />
         )
       }
-      onClick={onClick}
+      onClick={handleClick}
       onContextMenu={onContextMenu}
+      title={
+        isTranscribing && onStopTranscription ? "Stop transcription" : undefined
+      }
     />
   );
 }
@@ -634,15 +655,18 @@ function HeaderTabTranscriptButton({
 function HeaderTabTranscriptActive({
   isActive,
   isTranscribing,
+  canStopTranscription,
   onClick,
   sessionId,
 }: {
   isActive: boolean;
   isTranscribing: boolean;
+  canStopTranscription: boolean;
   onClick?: () => void;
   sessionId: string;
 }) {
   const regenerate = useRegenerateTranscript(sessionId);
+  const stopTranscription = useListener((state) => state.stopTranscription);
   const { request: transcriptExportRequest } =
     useSessionTranscriptRenderData(sessionId);
   const { audioExists, deleteRecording, isDeletingRecording } =
@@ -674,6 +698,9 @@ function HeaderTabTranscriptActive({
   const handleDeleteRecording = useCallback(() => {
     void deleteRecording();
   }, [deleteRecording]);
+  const handleStopTranscription = useCallback(() => {
+    void stopTranscription(sessionId);
+  }, [sessionId, stopTranscription]);
   const contextMenu = useMemo<MenuItemDef[]>(() => {
     const items: MenuItemDef[] = [
       {
@@ -720,6 +747,9 @@ function HeaderTabTranscriptActive({
       isTranscribing={isTranscribing}
       onClick={onClick}
       onContextMenu={showContextMenu}
+      onStopTranscription={
+        canStopTranscription ? handleStopTranscription : undefined
+      }
     />
   );
 }
@@ -1195,12 +1225,14 @@ export function Header({
   currentTab,
   handleTabChange,
   isTranscribing = false,
+  canStopTranscription = false,
 }: {
   sessionId: string;
   editorTabs: EditorView[];
   currentTab: EditorView;
   handleTabChange: (view: EditorView) => void;
   isTranscribing?: boolean;
+  canStopTranscription?: boolean;
 }) {
   const { t } = useLingui();
   const store = main.UI.useStore(main.STORE_ID);
@@ -1293,6 +1325,7 @@ export function Header({
                     sessionId={sessionId}
                     isActive={currentTab.type === view.type}
                     isTranscribing={isTranscribing}
+                    canStopTranscription={canStopTranscription}
                     onClick={() => handleTabChange(view)}
                   />
                 );
@@ -1353,74 +1386,8 @@ function createEditorTabs({
   ];
 }
 
-function useEnhanceLogic(sessionId: string, enhancedNoteId: string) {
-  const model = useLanguageModel("enhance");
-  const llmStatus = useLLMConnectionStatus();
-  const taskId = createTaskId(enhancedNoteId, "enhance");
-  const [missingModelError, setMissingModelError] = useState<Error | null>(
-    null,
-  );
-
-  const noteTemplateId =
-    (main.UI.useCell(
-      "enhanced_notes",
-      enhancedNoteId,
-      "template_id",
-      main.STORE_ID,
-    ) as string | undefined) || undefined;
-
-  const enhanceTask = useAITaskTask(taskId, "enhance");
-
-  const onRegenerate = useCallback(
-    async (templateId: string | null) => {
-      if (!model) {
-        setMissingModelError(
-          new Error("Intelligence provider not configured."),
-        );
-        return;
-      }
-
-      setMissingModelError(null);
-
-      void analyticsCommands.event({
-        event: "note_enhanced",
-        is_auto: false,
-      });
-
-      await enhanceTask.start({
-        model,
-        args: {
-          sessionId,
-          enhancedNoteId,
-          templateId: templateId ?? noteTemplateId,
-        },
-      });
-    },
-    [model, enhanceTask.start, sessionId, enhancedNoteId, noteTemplateId],
-  );
-
-  useEffect(() => {
-    if (model && missingModelError) {
-      setMissingModelError(null);
-    }
-  }, [model, missingModelError]);
-
-  const isConfigError = shouldShowEmptySummaryConfigError(llmStatus);
-
-  const isIdleWithConfigError = enhanceTask.isIdle && isConfigError;
-
-  const error = missingModelError ?? enhanceTask.error;
-  const isError =
-    !!missingModelError || enhanceTask.isError || isIdleWithConfigError;
-
-  return {
-    isGenerating: enhanceTask.isGenerating,
-    isError,
-    error,
-    onRegenerate,
-    onCancel: enhanceTask.cancel,
-  };
-}
+const useEnhanceLogic = (sessionId: string, enhancedNoteId: string) =>
+  useEnhancedNoteActions({ sessionId, enhancedNoteId });
 
 function matchesTemplateSearch(
   template: {

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -203,6 +203,7 @@ export const NoteInput = forwardRef<
               currentTab={renderedCurrentTab}
               handleTabChange={handleTabChange}
               isTranscribing={shouldShowTranscriptSpinner}
+              canStopTranscription={sessionMode === "running_batch"}
             />
           </div>
         )}


### PR DESCRIPTION
Summary:
- add floating stop and regenerate controls for transcript and summary tabs
- share enhanced-note action logic across note input controls
- let the active transcript tab spinner stop batch transcription

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live transcription stop, AI enhance cancel/regenerate, and session tab UX; wrong wiring could interrupt batch jobs or duplicate generation, but scope is session UI and existing task APIs.
> 
> **Overview**
> Adds **contextual floating actions** on session note tabs so users can **stop** in-flight work or **regenerate** when idle: on the transcript tab, stop during batch transcription and regenerate when audio exists; on the summary (enhanced) tab, stop while the enhance task runs and regenerate when there is stored content and LLM is available.
> 
> **Shared `useEnhancedNoteActions`** centralizes summary generate/cancel/regenerate logic so the note header and floating controls stay in sync. The **transcript tab header** can surface stop while batch transcription is active (spinner tied to `canStopTranscription` / `stopTranscription`).
> 
> The diff also **refreshes Lingui `.po` source line references** for strings moved in `note-input/header.tsx` across locales (no copy changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e71669084f9b0b3b301fd6ca53dab73937f89941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->