### PR TITLE
Detect Cal.com video links

### DIFF
--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -1316,7 +1316,73 @@ describe("ListenerProvider detect events", () => {
     );
   });
 
-  test("shows Cal Video for browser mic notifications with Cal video links", async () => {
+  test.each([
+    "https://app.cal.com/video/founder-call",
+    "https://cal.com/video/founder-call",
+  ])(
+    "shows Cal Video for browser mic notifications with %s",
+    async (meetingLink) => {
+      const store = createListenerStore();
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-06-24T02:09:00.000Z"));
+      (useStoreMock as any).mockReturnValue(
+        mockNearbyEventStore({
+          title: "Founder call",
+          started_at: "2026-06-24T02:09:00.000Z",
+          meeting_link: meetingLink,
+        }),
+      );
+
+      render(
+        <ListenerProvider store={store}>
+          <div>child</div>
+        </ListenerProvider>,
+      );
+
+      await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+      const handler = listenMock.mock.calls[0]?.[0];
+      expect(handler).toBeTypeOf("function");
+
+      handler({
+        payload: {
+          type: "micDetected",
+          key: "mic-1",
+          apps: [{ id: "at.studio.AsideBrowser", name: "Aside" }],
+          duration_secs: 15,
+        },
+      });
+
+      await vi.waitFor(() =>
+        expect(showNotificationMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: expect.objectContaining({
+              app_names: ["Cal Video"],
+              app_ids: ["at.studio.AsideBrowser"],
+              event_ids: ["event-1"],
+            }),
+            title: "Are you in Founder call right now?",
+            action_label: "Yes",
+            options: null,
+            footer: expect.objectContaining({
+              text: "Ignore Cal Video?",
+              icon: {
+                type: "path",
+                path: "/resources/notification-icons/cal-video.png",
+              },
+            }),
+            icon: {
+              type: "path",
+              path: "/resources/notification-icons/cal-video.png",
+            },
+          }),
+        ),
+      );
+    },
+  );
+
+  test("shows Cal Video for protocol-less Cal.com video text", async () => {
     const store = createListenerStore();
 
     vi.useFakeTimers();
@@ -1325,7 +1391,7 @@ describe("ListenerProvider detect events", () => {
       mockNearbyEventStore({
         title: "Founder call",
         started_at: "2026-06-24T02:09:00.000Z",
-        meeting_link: "https://app.cal.com/video/founder-call",
+        location: "cal.com/video/founder-call",
       }),
     );
 
@@ -1357,20 +1423,9 @@ describe("ListenerProvider detect events", () => {
             app_ids: ["at.studio.AsideBrowser"],
             event_ids: ["event-1"],
           }),
-          title: "Are you in Founder call right now?",
-          action_label: "Yes",
-          options: null,
           footer: expect.objectContaining({
             text: "Ignore Cal Video?",
-            icon: {
-              type: "path",
-              path: "/resources/notification-icons/cal-video.png",
-            },
           }),
-          icon: {
-            type: "path",
-            path: "/resources/notification-icons/cal-video.png",
-          },
         }),
       ),
     );

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -402,7 +402,8 @@ function detectMeetingPlatformFromUrl(value: string): MeetingPlatform | null {
       hostname === "app.cal.video" ||
       hostname === "cal.video" ||
       hostname.endsWith(".cal.video") ||
-      (hostname === "app.cal.com" && pathname.startsWith("/video/"))
+      ((hostname === "cal.com" || hostname === "app.cal.com") &&
+        pathname.startsWith("/video/"))
     ) {
       return MEETING_PLATFORMS.calVideo;
     }
@@ -503,7 +504,11 @@ function detectMeetingPlatformFromText(value: string): MeetingPlatform | null {
   if (/\bwebex\b/.test(normalized)) {
     return MEETING_PLATFORMS.webex;
   }
-  if (/\bcal video\b|(^|[^a-z0-9])cal\.video([^a-z0-9]|$)/.test(normalized)) {
+  if (
+    /\bcal video\b|(^|[^a-z0-9])cal\.video([^a-z0-9]|$)|(^|[^a-z0-9])cal\.com\/video\//.test(
+      normalized,
+    )
+  ) {
     return MEETING_PLATFORMS.calVideo;
   }
   if (/(^|[^a-z0-9])cal\.com([^a-z0-9]|$)/.test(normalized)) {


### PR DESCRIPTION
Treat cal.com video URLs and protocol-less cal.com/video text as Cal Video for browser mic prompts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to meeting-platform heuristics for mic-detected notifications, with added tests and no auth or data-path impact.
> 
> **Overview**
> **Cal Video** is now recognized when calendar events use `cal.com` or `app.cal.com` URLs with a `/video/` path, not only `app.cal.com`.
> 
> URL parsing treats both hostnames as Cal Video when the path starts with `/video/`. Plain-text detection (e.g. **location** without `https://`) also matches `cal.com/video/…`, so browser mic prompts show **Cal Video** branding instead of a generic browser label.
> 
> Tests cover `https://app.cal.com/video/…`, `https://cal.com/video/…`, and protocol-less `cal.com/video/…` in event location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0bd45470c22b2434603e0c013bd02828e0f801f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->