### PR TITLE
Update desktop 1.1.4 changelog

### DIFF
--- a/packages/changelog/content/1.1.4.md
+++ b/packages/changelog/content/1.1.4.md
@@ -14,7 +14,14 @@ summary: "Anarlog chat can use meeting notes more reliably, transcripts stay eas
 
 ## Transcription
 
+- Meeting detection now recognizes Cal.com video links more reliably
+- Microphone prompts now ask you to confirm the likely calendar event before starting capture
+- Meeting chips now stay active until the calendar event ends, instead of dropping early
+- Live meeting tabs now keep their timing in sync more reliably
 - Long transcripts now render more smoothly during active recordings
+- Live transcripts now appear correctly when you open standalone notes
+- Floating transcript controls now take up less space and stay easier to use during meetings
+- Transcript word spacing now stays more natural while live text updates
 - Transcript jump controls now stay out of the way while floating chat is open
 - Live transcript tabs no longer show a spinner during active meetings
 - Transcript speaker headers now stay cleaner by hiding timestamp ranges
@@ -29,14 +36,23 @@ summary: "Anarlog chat can use meeting notes more reliably, transcripts stay eas
 
 ## Notes
 
+- Transcript and summary generation actions are now easier to reach from the note header
+- Auto summaries can now use a selected template, making generated notes easier to standardize
+- Summary title generation now shows a clearer placeholder while Anarlog is working
 - Insights and transcripts now live in editor tabs instead of a separate bottom panel
 - Session metadata now loads before note content so sidebar details are available more reliably after startup
 - Active session transcript state now restores correctly when returning to a live note
 - Contact suggestions can now use event titles to identify meeting contacts more accurately
+- Title formatting controls no longer appear in places where title styling does not apply
+
+## Sidebar
+
+- The sidebar can now be resized by dragging, making it easier to balance navigation and note space
 
 ## Website
 
 - The homepage now gives a clearer view of Anarlog's privacy model, open-source project, and local meeting capture flow
+- The landing page hero now has cleaner spacing, logo alignment, and responsive layout
 - The Char announcement now points to the Char waitlist and rotates between the new and original messaging more smoothly
 
 ## Settings


### PR DESCRIPTION
Refresh the stable release notes with the latest user-facing desktop changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no application or infrastructure code changes.
> 
> **Overview**
> **Expands the desktop 1.1.4 changelog** in `packages/changelog/content/1.1.4.md` with user-facing bullets that were missing from the prior draft.
> 
> **Transcription** gains notes on Cal.com link detection, calendar confirmation before mic capture, meeting chips lasting until event end, live tab timing, standalone-note live transcripts, smaller floating controls, and improved live word spacing.
> 
> **Notes** documents easier transcript/summary actions in the header, template-based auto summaries, a clearer title-generation placeholder, and hiding title formatting where it does not apply.
> 
> A new **Sidebar** section calls out drag-to-resize. **Website** adds a landing-page hero layout/spacing item alongside the existing homepage copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e4865904988f239331f24af8fe437ca3f045be0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->