### PR TITLE
Use Sonnet 5 for hosted text routing

### DIFF
--- a/crates/llm-proxy/src/model.rs
+++ b/crates/llm-proxy/src/model.rs
@@ -6,7 +6,7 @@ use utoipa::ToSchema;
 pub const MODEL_KEY_DEFAULT: &str = "default";
 pub const MODEL_KEY_TOOL_CALLING: &str = "tool_calling";
 pub const MODEL_KEY_AUDIO: &str = "audio";
-const MODEL_LATEST_SONNET: &str = "~anthropic/claude-sonnet-latest";
+const MODEL_SONNET_5: &str = "anthropic/claude-sonnet-5";
 
 #[derive(
     Debug,
@@ -48,23 +48,14 @@ impl Default for StaticModelResolver {
     fn default() -> Self {
         let mut models = HashMap::new();
 
-        models.insert(CharTask::Chat.to_string(), vec![MODEL_LATEST_SONNET.into()]);
-        models.insert(
-            CharTask::Title.to_string(),
-            vec![MODEL_LATEST_SONNET.into()],
-        );
-        models.insert(
-            CharTask::Enhance.to_string(),
-            vec![MODEL_LATEST_SONNET.into()],
-        );
+        models.insert(CharTask::Chat.to_string(), vec![MODEL_SONNET_5.into()]);
+        models.insert(CharTask::Title.to_string(), vec![MODEL_SONNET_5.into()]);
+        models.insert(CharTask::Enhance.to_string(), vec![MODEL_SONNET_5.into()]);
         models.insert(
             MODEL_KEY_TOOL_CALLING.to_owned(),
-            vec![MODEL_LATEST_SONNET.into()],
+            vec![MODEL_SONNET_5.into()],
         );
-        models.insert(
-            MODEL_KEY_DEFAULT.to_owned(),
-            vec![MODEL_LATEST_SONNET.into()],
-        );
+        models.insert(MODEL_KEY_DEFAULT.to_owned(), vec![MODEL_SONNET_5.into()]);
         models.insert(
             MODEL_KEY_AUDIO.to_owned(),
             vec![
@@ -139,7 +130,7 @@ mod tests {
                 false,
                 false,
                 None,
-                &[MODEL_LATEST_SONNET],
+                &[MODEL_SONNET_5],
             ),
             (
                 "by_tool_calling",
@@ -147,16 +138,16 @@ mod tests {
                 true,
                 false,
                 None,
-                &[MODEL_LATEST_SONNET],
+                &[MODEL_SONNET_5],
             ),
-            ("default", None, false, false, None, &[MODEL_LATEST_SONNET]),
+            ("default", None, false, false, None, &[MODEL_SONNET_5]),
             (
                 "task_overrides_tool_calling",
                 Some(CharTask::Chat),
                 true,
                 false,
                 None,
-                &[MODEL_LATEST_SONNET],
+                &[MODEL_SONNET_5],
             ),
             (
                 "with_models_custom_key",
@@ -172,7 +163,7 @@ mod tests {
                 false,
                 false,
                 None,
-                &[MODEL_LATEST_SONNET],
+                &[MODEL_SONNET_5],
             ),
             (
                 "audio_overrides_task",


### PR DESCRIPTION
Summary:
- Pin hosted llm-proxy text routes to anthropic/claude-sonnet-5.
- Leave audio model routing unchanged.

Validation:
- pnpm exec dprint fmt crates/llm-proxy/src/model.rs
- cargo test -p llm-proxy
- cargo check -p llm-proxy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which model all hosted text LLM traffic uses, affecting cost, latency, and behavior for every chat/title/enhance request without a custom override.
> 
> **Overview**
> Hosted **llm-proxy** text routing no longer uses the rolling `~anthropic/claude-sonnet-latest` alias. **Chat**, **Title**, **Enhance**, **tool_calling**, and **default** paths now resolve to **`anthropic/claude-sonnet-5`**.
> 
> **Audio** routing is unchanged (Gemini and Voxtral models). Resolver tests were updated to expect Sonnet 5.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7217dde5448731c2ff5c31f5851d16e60787e84b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->