### PR TITLE
Skip empty API secret imports

### DIFF
--- a/.github/workflows/api_cd.yaml
+++ b/.github/workflows/api_cd.yaml
@@ -61,7 +61,11 @@ jobs:
                   target.write(f"{key}={value}\n")
           PY
 
-          flyctl secrets import --app hyprnote-ai --stage < "$secrets_file"
+          if [ -s "$secrets_file" ]; then
+            flyctl secrets import --app hyprnote-ai --stage < "$secrets_file"
+          else
+            echo "No Infisical secrets exported; skipping Fly secret import."
+          fi
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           INFISICAL_TOKEN: ${{ secrets.INFISICAL_TOKEN }}


### PR DESCRIPTION
Summary:
- Skip Fly secret import when Infisical exports no production secrets.
- Preserve the existing Fly app secret set instead of failing before deploy.

Validation:
- pnpm exec dprint fmt .github/workflows/api_cd.yaml
- Reproduced api_cd failure on empty Infisical export before this guard

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only guard around secret import; no application runtime or auth logic changes.
> 
> **Overview**
> **API CD** no longer always runs `flyctl secrets import` after building the secrets file from Infisical.
> 
> When the exported secrets file is **empty** (`-s` check), the workflow **skips** import and logs that there were no secrets, then continues to **deploy**. That avoids a CD failure when Infisical returns no production secrets and leaves the app’s existing Fly secrets unchanged instead of erroring before deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c15b50b6f66a6647d14d7ae2b61c62eb510d40f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->