### PR TITLE
Fix direct mic speaker labels

### DIFF
--- a/apps/desktop/src/meeting-float/host.test.ts
+++ b/apps/desktop/src/meeting-float/host.test.ts
@@ -253,6 +253,58 @@ describe("getFloatingTranscriptBubbles", () => {
       "segment-7",
     ]);
   });
+
+  it("labels diarized direct-mic bubbles as self", () => {
+    const bubbles = getFloatingTranscriptBubbles([
+      createSegment({
+        id: "local-mic",
+        key: {
+          channel: "DirectMic",
+          speaker_index: 2,
+          speaker_human_id: null,
+        },
+        start_ms: 0,
+        text: "hello",
+        words: [{ text: "hello" }],
+      }),
+    ]);
+
+    expect(bubbles).toEqual([
+      {
+        id: "local-mic",
+        speakerLabel: "You",
+        text: "hello",
+        isSelf: true,
+        isFinal: true,
+      },
+    ]);
+  });
+
+  it("labels assigned direct-mic bubbles as self", () => {
+    const bubbles = getFloatingTranscriptBubbles([
+      createSegment({
+        id: "assigned-mic",
+        key: {
+          channel: "DirectMic",
+          speaker_index: 1,
+          speaker_human_id: "participant-1",
+        },
+        start_ms: 0,
+        text: "hello",
+        words: [{ text: "hello" }],
+      }),
+    ]);
+
+    expect(bubbles).toEqual([
+      {
+        id: "assigned-mic",
+        speakerLabel: "You",
+        text: "hello",
+        isSelf: true,
+        isFinal: true,
+      },
+    ]);
+  });
 });
 
 describe("getCurrentFloatingBarColorScheme", () => {

--- a/apps/desktop/src/meeting-float/host.tsx
+++ b/apps/desktop/src/meeting-float/host.tsx
@@ -573,9 +573,7 @@ export function getFloatingTranscriptBubbles(
         id: segment.id,
         speakerLabel: getFloatingSpeakerLabel(segment.key),
         text,
-        isSelf:
-          segment.key.channel === "DirectMic" &&
-          segment.key.speaker_index == null,
+        isSelf: isFloatingSelfSpeaker(segment.key),
         isFinal: segment.words.every((word) => word.is_final),
       };
     })
@@ -598,7 +596,7 @@ function getFloatingSegmentText(
 function getFloatingSpeakerLabel(
   key: ListenerState["liveSegments"][number]["key"],
 ) {
-  if (key.channel === "DirectMic" && key.speaker_index == null) {
+  if (isFloatingSelfSpeaker(key)) {
     return "You";
   }
 
@@ -611,6 +609,12 @@ function getFloatingSpeakerLabel(
   }
 
   return "Audio";
+}
+
+function isFloatingSelfSpeaker(
+  key: ListenerState["liveSegments"][number]["key"],
+) {
+  return key.channel === "DirectMic";
 }
 
 export function shouldShowFloatingLiveCaptionToggle({

--- a/apps/desktop/src/stt/live-segment.test.ts
+++ b/apps/desktop/src/stt/live-segment.test.ts
@@ -14,15 +14,25 @@ const ctx: RenderLabelContext = {
 };
 
 describe("SegmentKeyUtils", () => {
-  it("does not treat diarized direct-mic segments as self", () => {
+  it("treats diarized direct-mic segments as self", () => {
     const key: Parameters<typeof SegmentKeyUtils.isKnownSpeaker>[0] = {
       channel: "DirectMic",
       speaker_index: 2,
       speaker_human_id: null,
     };
 
-    expect(SegmentKeyUtils.isKnownSpeaker(key, ctx)).toBe(false);
-    expect(SegmentKeyUtils.renderLabel(key, ctx)).toBe("Speaker 3");
+    expect(SegmentKeyUtils.isKnownSpeaker(key, ctx)).toBe(true);
+    expect(SegmentKeyUtils.renderLabel(key, ctx)).toBe("Me");
+  });
+
+  it("does not label assigned direct-mic segments as self when the name is unavailable", () => {
+    const key: Parameters<typeof SegmentKeyUtils.renderLabel>[0] = {
+      channel: "DirectMic",
+      speaker_index: 1,
+      speaker_human_id: "remote",
+    };
+
+    expect(SegmentKeyUtils.renderLabel(key, ctx)).toBe("Speaker 2");
   });
 
   it("caps unknown speaker labels when a participant max is provided", () => {

--- a/apps/desktop/src/stt/live-segment.ts
+++ b/apps/desktop/src/stt/live-segment.ts
@@ -109,7 +109,7 @@ export const SegmentKeyUtils = {
       return true;
     }
 
-    if (ctx && key.channel === "DirectMic" && key.speaker_index == null) {
+    if (ctx && key.channel === "DirectMic") {
       return Boolean(ctx.getSelfHumanId());
     }
 
@@ -121,14 +121,16 @@ export const SegmentKeyUtils = {
     ctx?: RenderLabelContext,
     manager?: SpeakerLabelManager,
   ): string => {
-    if (ctx && key.speaker_human_id) {
-      const human = ctx.getHumanName(key.speaker_human_id);
+    const assignedHumanId = key.speaker_human_id;
+
+    if (ctx && assignedHumanId != null) {
+      const human = ctx.getHumanName(assignedHumanId);
       if (human) {
         return human;
       }
     }
 
-    if (ctx && key.channel === "DirectMic" && key.speaker_index == null) {
+    if (ctx && key.channel === "DirectMic" && assignedHumanId == null) {
       const selfHumanId = ctx.getSelfHumanId();
       if (selfHumanId) {
         const selfHuman = ctx.getHumanName(selfHumanId);

--- a/crates/transcript/src/label.rs
+++ b/crates/transcript/src/label.rs
@@ -73,7 +73,7 @@ impl SegmentKey {
             Some(SpeakerLabelContext {
                 self_human_id: Some(_),
                 ..
-            }) if self.channel == ChannelProfile::DirectMic && self.speaker_index.is_none()
+            }) if self.channel == ChannelProfile::DirectMic
         )
     }
 }
@@ -92,7 +92,6 @@ pub fn render_speaker_label(
         }
 
         if key.channel == ChannelProfile::DirectMic
-            && key.speaker_index.is_none()
             && let Some(self_human_id) = ctx.self_human_id.as_ref()
         {
             if let Some(name) = ctx.human_name_by_id.get(self_human_id) {
@@ -190,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn does_not_treat_direct_mic_with_provider_speaker_as_self() {
+    fn treats_direct_mic_with_provider_speaker_as_self() {
         let ctx = SpeakerLabelContext {
             self_human_id: Some("self".to_string()),
             human_name_by_id: HashMap::new(),
@@ -201,7 +200,7 @@ mod tests {
             speaker_human_id: None,
         };
 
-        assert!(!key.is_known_speaker(Some(&ctx)));
-        assert_eq!(render_speaker_label(&key, Some(&ctx), None), "Speaker 3");
+        assert!(key.is_known_speaker(Some(&ctx)));
+        assert_eq!(render_speaker_label(&key, Some(&ctx), None), "You");
     }
 }

--- a/crates/transcript/src/render.rs
+++ b/crates/transcript/src/render.rs
@@ -349,6 +349,28 @@ mod tests {
     }
 
     #[test]
+    fn labels_diarized_direct_mic_as_self_without_remote_participant() {
+        let segments = render_transcript_segments(RenderTranscriptRequest {
+            transcripts: vec![RenderTranscriptInput {
+                started_at: Some(0),
+                words: vec![word_si("w1", " hello", 0, 100, 0, 2)],
+                assignments: vec![],
+            }],
+            participant_human_ids: vec![],
+            self_human_id: Some("self".to_string()),
+            humans: vec![RenderTranscriptHuman {
+                human_id: "self".to_string(),
+                name: "Me".to_string(),
+            }],
+        });
+
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].speaker_label, "Me");
+        assert_eq!(segments[0].key.speaker_index, Some(2));
+        assert_eq!(segments[0].key.speaker_human_id.as_deref(), Some("self"));
+    }
+
+    #[test]
     fn normalizes_word_spacing_for_rendered_segments() {
         let words = normalize_rendered_segment_words(vec![
             SegmentWord {

--- a/crates/transcript/src/segments/tests.rs
+++ b/crates/transcript/src/segments/tests.rs
@@ -434,6 +434,21 @@ fn propagates_direct_mic_channel_identity_forward() {
 }
 
 #[test]
+fn applies_direct_mic_channel_identity_to_provider_speakers() {
+    let finals = vec![fw_si("0", 0, 100, 0, 2)];
+    let assignments = vec![channel_human("self", ChannelProfile::DirectMic)];
+    let opts = SegmentBuilderOptions {
+        complete_channels: Some(vec![ChannelProfile::DirectMic]),
+        ..Default::default()
+    };
+
+    let result = build_segments(&finals, &[], &assignments, Some(&opts));
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].key, key_speaker_human(0, 2, "self"));
+}
+
+#[test]
 fn propagates_remote_party_identity_when_channel_marked_complete() {
     let finals = vec![fw("0", 0, 100, 1), fw("1", 200, 300, 1)];
     let assignments = vec![channel_human("remote", ChannelProfile::RemoteParty)];

--- a/crates/transcript/src/types/speaker.rs
+++ b/crates/transcript/src/types/speaker.rs
@@ -32,26 +32,23 @@ pub fn channel_assignments_for_participants(
         _ => return vec![],
     };
 
-    let remote_id = unique_other_participant(participant_human_ids, self_id);
-    let remote_id = match remote_id {
-        Some(id) => id,
-        None => return vec![],
-    };
-
-    vec![
-        IdentityAssignment {
-            human_id: self_id.to_string(),
-            scope: IdentityScope::Channel {
-                channel: ChannelProfile::DirectMic,
-            },
+    let mut assignments = vec![IdentityAssignment {
+        human_id: self_id.to_string(),
+        scope: IdentityScope::Channel {
+            channel: ChannelProfile::DirectMic,
         },
-        IdentityAssignment {
+    }];
+
+    if let Some(remote_id) = unique_other_participant(participant_human_ids, self_id) {
+        assignments.push(IdentityAssignment {
             human_id: remote_id.to_string(),
             scope: IdentityScope::Channel {
                 channel: ChannelProfile::RemoteParty,
             },
-        },
-    ]
+        });
+    }
+
+    assignments
 }
 
 pub fn segment_options_for_participants(
@@ -95,5 +92,69 @@ fn unique_other_participant<'a>(
         Some(others[0])
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn assigns_self_to_direct_mic_without_unique_remote() {
+        let assignments = channel_assignments_for_participants(&[], Some("self"));
+
+        assert_eq!(
+            assignments,
+            vec![IdentityAssignment {
+                human_id: "self".to_string(),
+                scope: IdentityScope::Channel {
+                    channel: ChannelProfile::DirectMic,
+                },
+            }]
+        );
+    }
+
+    #[test]
+    fn assigns_unique_remote_to_remote_party() {
+        let assignments = channel_assignments_for_participants(
+            &["self".to_string(), "remote".to_string()],
+            Some("self"),
+        );
+
+        assert_eq!(
+            assignments,
+            vec![
+                IdentityAssignment {
+                    human_id: "self".to_string(),
+                    scope: IdentityScope::Channel {
+                        channel: ChannelProfile::DirectMic,
+                    },
+                },
+                IdentityAssignment {
+                    human_id: "remote".to_string(),
+                    scope: IdentityScope::Channel {
+                        channel: ChannelProfile::RemoteParty,
+                    },
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn skips_remote_assignment_when_remote_is_ambiguous() {
+        let assignments = channel_assignments_for_participants(
+            &["remote-a".to_string(), "remote-b".to_string()],
+            Some("self"),
+        );
+
+        assert_eq!(
+            assignments,
+            vec![IdentityAssignment {
+                human_id: "self".to_string(),
+                scope: IdentityScope::Channel {
+                    channel: ChannelProfile::DirectMic,
+                },
+            }]
+        );
     }
 }


### PR DESCRIPTION
Keep DirectMic mapped to self when provider diarization adds speaker indexes, and cover the live and floating transcript labels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes speaker attribution and participant channel defaults across live UI and transcript rendering; wrong assumptions about DirectMic vs remote could mislabel speakers in edge cases (e.g. assigned non-self human on mic).
> 
> **Overview**
> **DirectMic is always treated as the local user** for speaker identity and labels, even when the STT provider attaches diarization `speaker_index` values to mic segments.
> 
> On the **desktop**, live segment helpers and the **floating meeting transcript** now mark any `DirectMic` segment as self/“You” (via `isFloatingSelfSpeaker`) instead of only when `speaker_index` is null. Assigned humans on mic still resolve to a display name when known; otherwise live labels can fall back to numbered speakers.
> 
> On the **Rust transcript pipeline**, `is_known_speaker` and `render_speaker_label` apply the same rule. **`channel_assignments_for_participants`** always assigns self to `DirectMic` and only adds a `RemoteParty` mapping when there is exactly one other participant (solo or ambiguous multi-remote no longer drops self assignment). Segment building propagates channel identity onto provider speaker indexes on completed DirectMic channels, and rendered transcripts label diarized solo-mic speech as the self display name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a0d4efc71ed21a3b67a48c343dd1e8c8fc00a31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->