### PR TITLE
Hide upload actions after transcript exists

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -637,7 +637,7 @@ msgstr "Expire recordings after three days"
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr "Export"
 
@@ -1143,7 +1143,7 @@ msgstr "Open calendar"
 msgid "Open calendar account actions"
 msgstr "Open calendar account actions"
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr "Open floating panel"
 
@@ -1151,7 +1151,7 @@ msgstr "Open floating panel"
 msgid "Open in New Tab"
 msgstr "Open in New Tab"
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr "Open in New Window"
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr "Upgrade to use"
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr "Upload audio"
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr "Upload transcript"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -637,7 +637,7 @@ msgstr ""
 
 #: src/session/components/outer-header/overflow/export-modal.tsx:467
 #: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:115
+#: src/session/components/outer-header/overflow/index.tsx:116
 msgid "Export"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:151
+#: src/session/components/outer-header/overflow/index.tsx:152
 msgid "Open floating panel"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:163
+#: src/session/components/outer-header/overflow/index.tsx:164
 #: src/sidebar/timeline/item.tsx:600
 msgid "Open in New Window"
 msgstr ""
@@ -1867,12 +1867,12 @@ msgid "Upgrade to use"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:130
+#: src/session/components/outer-header/overflow/index.tsx:131
 msgid "Upload audio"
 msgstr ""
 
 #: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:139
+#: src/session/components/outer-header/overflow/index.tsx:140
 msgid "Upload transcript"
 msgstr ""
 

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -130,6 +130,8 @@ describe("OverflowButton", () => {
   });
 
   it("keeps upload actions available when the current note is empty", () => {
+    useHasTranscriptMock.mockReturnValue(false);
+
     render(
       <OverflowButton
         sessionId="session-1"
@@ -142,6 +144,20 @@ describe("OverflowButton", () => {
 
     expect(uploadAudioMock).toHaveBeenCalledTimes(1);
     expect(uploadTranscriptMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides upload actions when the session already has a transcript", () => {
+    render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Upload audio" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Upload transcript" }),
+    ).toBeNull();
   });
 
   it("keeps the overflow trigger out of the header drag region", () => {
@@ -160,6 +176,7 @@ describe("OverflowButton", () => {
   });
 
   it("hides upload actions when the current note has content", () => {
+    useHasTranscriptMock.mockReturnValue(false);
     useCurrentNoteHasContentMock.mockReturnValue(true);
 
     render(
@@ -176,6 +193,7 @@ describe("OverflowButton", () => {
   });
 
   it("hides upload actions while a meeting is in progress", () => {
+    useHasTranscriptMock.mockReturnValue(false);
     useListenerMock.mockImplementation((selector) =>
       selector({
         getSessionMode: () => "active",

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -62,7 +62,8 @@ export function OverflowButton({
   const settings = settingsStore.UI.useStore(settingsStore.STORE_ID);
   const isMeetingInProgress =
     sessionMode === "active" || sessionMode === "finalizing";
-  const showUploadActions = !currentNoteHasContent && !isMeetingInProgress;
+  const showUploadActions =
+    !hasTranscript && !currentNoteHasContent && !isMeetingInProgress;
   const canOpenFloatingPanel =
     allowListening && floatingBarEnabled && sessionMode === "active";
   const openExportModal = () => {


### PR DESCRIPTION
Guard the note overflow upload actions with transcript availability and cover the existing-transcript case in tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Menu visibility change only; upload paths unchanged when actions are shown.
> 
> **Overview**
> The session note **overflow menu** no longer shows **Upload audio** and **Upload transcript** once the session already has a transcript (`useHasTranscript`). Those entries still only appear when the note is empty, nothing is being recorded/finalized, and upload is otherwise allowed.
> 
> **Tests** in `overflow/index.test.tsx` assert that upload actions are absent when a transcript is present (and when the note has content or a meeting is active).
> 
> The large **`.po` locale diff** only updates Lingui source line numbers after edits in `overflow/index.tsx`; no new user-facing strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc34134c4cd836eb60fb502d35f8059d143dc8e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->