### PR TITLE
Stabilize summary finalization layout

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Altyd gereed sonder om handmatig te begin."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "እራስዎ ሳይጀመር ሁልጊዜ ዝግጁ።"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "جاهز دائمًا بدون التشغيل يدويًا."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "হস্তচালিতভাৱে আৰম্ভ নকৰাকৈ সদায় সাজু।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Əl ilə işə salmadan həmişə hazırdır."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Ҡул менән эшләтеп ебәрмәйенсә һәр ваҡыт әҙер."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Заўсёды гатовы без ручнога запуску."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Винаги готов без ръчно стартиране."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ম্যানুয়ালি লঞ্চ না করে সর্বদা প্রস্তুত।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ལག་ཐོག་ནས་འགོ་མ་བཙུགས་པར་ག་དུས་ཡིན་ཡང་གྲ་སྒྲིག་ཡོད།"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Prest atav hep loc'hañ dre zorn."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Uvijek spreman bez ručnog pokretanja."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Sempre a punt sense iniciar-lo manualment."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Vždy připraven bez ručního spouštění."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Bob amser yn barod heb ei lansio â llaw."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Altid klar uden manuel lancering."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Immer bereit, ohne manuelles Starten."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Πάντα έτοιμο χωρίς μη αυτόματη εκκίνηση."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -147,7 +147,7 @@ msgstr "Allow system audio access"
 msgid "Always ready without manually launching."
 msgstr "Always ready without manually launching."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr "Analyzing structure..."
 
@@ -723,7 +723,7 @@ msgstr "Free"
 msgid "General"
 msgstr "General"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr "Generating title..."
@@ -1779,7 +1779,7 @@ msgstr "Ticket"
 msgid "Timezone"
 msgstr "Timezone"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr "Tip: The Anarlog team loves our users!"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Siempre listo sin iniciarlo manualmente."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Alati valmis ilma käsitsi käivitamata."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Beti prest eskuz abiarazi gabe."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "همیشه بدون راه‌اندازی دستی آماده است."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Ko hesɗi sahaa kala tawa aɗa uddita e junngo."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Aina valmis ilman manuaalista käynnistämistä."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Altíð klárur uttan at seta í gongd manuelt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Toujours prêt sans lancement manuel."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Bí réidh i gcónaí gan é a sheoladh de láimh."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Sempre listo sen iniciar manualmente."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "મેન્યુઅલી લોન્ચ કર્યા વિના હંમેશા તૈયાર."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Koyaushe a shirye ba tare da ƙaddamar da hannu ba."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "תמיד מוכן ללא הפעלה ידנית."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "मैन्युअल रूप से लॉन्च किए बिना हमेशा तैयार।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Uvijek spreman bez ručnog pokretanja."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Toujou pare san yo pa lanse manyèlman."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Mindig készen áll kézi indítás nélkül."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Միշտ պատրաստ է առանց ձեռքով գործարկելու:"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Selalu siap tanpa meluncurkan secara manual."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Na-adị njikere mgbe niile na-ejighi aka malite."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Alltaf tilbúinn án þess að ræsa handvirkt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Sempre disponibile senza avvio manuale."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "手動で起動しなくても常に準備できます。"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Tansah siyap tanpa diluncurake kanthi manual."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ყოველთვის მზადაა ხელით გაშვების გარეშე."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Қолмен іске қоспай-ақ әрқашан дайын."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "រួចរាល់ជានិច្ច ដោយមិនចាំបាច់បើកដំណើរការដោយដៃ។"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ಹಸ್ತಚಾಲಿತವಾಗಿ ಪ್ರಾರಂಭಿಸದೆ ಯಾವಾಗಲೂ ಸಿದ್ಧವಾಗಿದೆ."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "수동으로 실행하지 않아도 항상 준비됩니다."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Bêyî destpêkirina bi destan her dem amade ye."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Кол менен ишке киргизбестен ар дайым даяр."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Semper sine manually deductis."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Immer prett ouni manuell ze starten."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Bulijjo mwetegefu nga totongozza mu ngalo."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Ezali ntango nyonso prêt sans lancement manuellement."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ພ້ອມສະເໝີໂດຍບໍ່ມີການເປີດດ້ວຍຕົນເອງ."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Visada paruoštas nepaleidus rankiniu būdu."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Vienmēr gatavs bez manuālas palaišanas."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Vonona foana nefa tsy alefa amin'ny tanana."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Kua reri tonu me te kore e whakarewa ringa."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Секогаш подготвен без рачно стартување."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "സ്വയം ലോഞ്ച് ചെയ്യാതെ എപ്പോഴും തയ്യാറാണ്."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Гараар эхлүүлэхгүйгээр үргэлж бэлэн байна."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "मॅन्युअली लॉन्च न करता नेहमी तयार."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Sentiasa bersedia tanpa melancarkan secara manual."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Dejjem lest mingħajr tnedija manwalment."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ကိုယ်တိုင်မဖွင့်ဘဲ အမြဲတမ်းအဆင်သင့်ဖြစ်နေပါပြီ။"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "मैन्युअल रूपमा सुरु नगरी सधैं तयार।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Altijd klaar zonder handmatig te starten."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Alltid klar uten å starte manuelt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Alltid klar uten å starte manuelt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Zimakhala zokonzeka nthawi zonse osatsegula pamanja."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Totjorn prèst sens lo lançament manualament."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ମାନୁଆଲ ଲଞ୍ଚ ନକରି ସର୍ବଦା ପ୍ରସ୍ତୁତ |"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "ਹੱਥੀਂ ਲਾਂਚ ਕੀਤੇ ਬਿਨਾਂ ਹਮੇਸ਼ਾ ਤਿਆਰ।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Zawsze gotowy, bez ręcznego uruchamiania."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "د لاسي پیل کولو پرته تل چمتو وي."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Sempre pronto sem iniciar manualmente."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Întotdeauna gata fără lansare manuală."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Всегда готов без запуска вручную."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "हस्तेन प्रक्षेपणं विना सर्वदा सज्जम्।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "دستي طور تي لانچ ڪرڻ کان سواءِ هميشه تيار."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "අතින් දියත් නොකර සැම විටම සූදානම්."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Vždy pripravené bez manuálneho spúšťania."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Vedno pripravljen brez ročnega zagona."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Yagara yakagadzirira pasina kuvhura nemaoko."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Had iyo jeer diyaar adiga oo aan gacanta ku soo daacin."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Gjithmonë gati pa nisur manualisht."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Увек спреман без ручног покретања."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Salawasna siap tanpa diluncurkeun sacara manual."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Alltid redo utan att starta manuellt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Tayari kila wakati bila kuzindua wewe mwenyewe."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "கைமுறையாகத் தொடங்காமல் எப்போதும் தயார்."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "మాన్యువల్‌గా ప్రారంభించకుండానే ఎల్లప్పుడూ సిద్ధంగా ఉంటుంది."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Ҳамеша бидуни оғози дастӣ омода аст."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "พร้อมเสมอโดยไม่ต้องเปิดด้วยตนเอง"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "El bilen işlemezden elmydama taýýar."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Palaging handa nang hindi manu-manong inilulunsad."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Manuel olarak başlatmaya gerek kalmadan her zaman hazır."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Кул белән эшләтеп җибәрмичә һәрвакыт әзер."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Завжди готовий без запуску вручну."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "دستی طور پر لانچ کیے بغیر ہمیشہ تیار۔"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Qo'lda ishga tushirmasdan ham doim tayyor."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Luôn sẵn sàng mà không cần khởi chạy thủ công."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Dafay waajal saa yu nekk te doo tàmbali ko ak loxo."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Ihlala ilungile ngaphandle kokuyizisa ngesandla."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "שטענדיק גרייט אָן מאַניואַלי קאַטער."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Ṣetan nigbagbogbo lai ṣe ifilọlẹ pẹlu ọwọ."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "无需手动启动，随时就绪。"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Always ready without manually launching."
 msgstr "Ihlala ilungile ngaphandle kokuyiqalisa mathupha."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:54
+#: src/session/components/note-input/enhanced/streaming.tsx:64
 msgid "Analyzing structure..."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:22
+#: src/session/components/note-input/enhanced/streaming.tsx:28
 #: src/session/components/title-input.tsx:97
 msgid "Generating title..."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:62
+#: src/session/components/note-input/enhanced/streaming.tsx:72
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 

--- a/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
@@ -6,7 +6,16 @@ import { Enhanced } from "./index";
 import type { LLMConnectionStatus } from "~/ai/hooks";
 
 const hoisted = vi.hoisted(() => ({
-  task: undefined as
+  enhanceTask: undefined as
+    | {
+        status: string;
+        error: Error | undefined;
+        streamedText: string;
+        currentStep: unknown;
+        isGenerating: boolean;
+      }
+    | undefined,
+  titleTask: undefined as
     | {
         status: string;
         error: Error | undefined;
@@ -33,14 +42,18 @@ vi.mock("streamdown", () => ({
 }));
 
 vi.mock("~/ai/hooks", () => ({
-  useAITaskTask: () => ({
-    status: hoisted.task?.status ?? "idle",
-    error: hoisted.task?.error,
-    streamedText: hoisted.task?.streamedText ?? "",
-    currentStep: hoisted.task?.currentStep,
-    hasTask: !!hoisted.task,
-    isGenerating: hoisted.task?.isGenerating ?? false,
-  }),
+  useAITaskTask: (_taskId: string, taskType: "enhance" | "title") => {
+    const task = taskType === "title" ? hoisted.titleTask : hoisted.enhanceTask;
+
+    return {
+      status: task?.status ?? "idle",
+      error: task?.error,
+      streamedText: task?.streamedText ?? "",
+      currentStep: task?.currentStep,
+      hasTask: !!task,
+      isGenerating: task?.isGenerating ?? false,
+    };
+  },
   useLLMConnectionStatus: () => hoisted.llmStatus,
 }));
 
@@ -99,7 +112,8 @@ describe("Enhanced", () => {
   });
 
   beforeEach(() => {
-    hoisted.task = undefined;
+    hoisted.enhanceTask = undefined;
+    hoisted.titleTask = undefined;
     hoisted.llmStatus = {
       status: "success",
       providerId: "hyprnote",
@@ -119,7 +133,7 @@ describe("Enhanced", () => {
   });
 
   it("shows a generating status before streamed text arrives", () => {
-    hoisted.task = {
+    hoisted.enhanceTask = {
       status: "generating",
       error: undefined,
       streamedText: "",
@@ -138,7 +152,7 @@ describe("Enhanced", () => {
   });
 
   it("renders streamed summary in the generating view", () => {
-    hoisted.task = {
+    hoisted.enhanceTask = {
       status: "generating",
       error: undefined,
       streamedText: "Streaming summary",
@@ -155,9 +169,9 @@ describe("Enhanced", () => {
     expect(screen.queryByRole("status")).toBeNull();
   });
 
-  it("does not show the title placeholder while streaming for an already titled session", () => {
+  it("keeps the title row while streaming for an already titled session", () => {
     hoisted.sessionTitle = "Existing title";
-    hoisted.task = {
+    hoisted.enhanceTask = {
       status: "generating",
       error: undefined,
       streamedText: "Streaming summary",
@@ -168,12 +182,36 @@ describe("Enhanced", () => {
     render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
 
     expect(screen.getByText("Streaming summary")).not.toBeNull();
-    expect(screen.queryByTestId("summary-title-space")).toBeNull();
+    expect(screen.getByTestId("summary-title-space")).not.toBeNull();
+    expect(screen.getByText("Existing title")).not.toBeNull();
+    expect(screen.queryByText("Generating title...")).toBeNull();
+  });
+
+  it("shows the generated title while the summary is still streaming", () => {
+    hoisted.enhanceTask = {
+      status: "generating",
+      error: undefined,
+      streamedText: "Streaming summary",
+      currentStep: undefined,
+      isGenerating: true,
+    };
+    hoisted.titleTask = {
+      status: "success",
+      error: undefined,
+      streamedText: "Generated Session Title",
+      currentStep: undefined,
+      isGenerating: false,
+    };
+
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.getByTestId("summary-title-space")).not.toBeNull();
+    expect(screen.getByText("Generated Session Title")).not.toBeNull();
     expect(screen.queryByText("Generating title...")).toBeNull();
   });
 
   it("renders the editor after an empty enhance task returns idle", () => {
-    hoisted.task = {
+    hoisted.enhanceTask = {
       status: "idle",
       error: undefined,
       streamedText: "",

--- a/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
@@ -8,19 +8,26 @@ import { streamdownComponents } from "../../streamdown";
 import { useAITaskTask } from "~/ai/hooks";
 import * as main from "~/store/tinybase/store/main";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
+import { getPersistableGeneratedTitle } from "~/store/zustand/ai-task/task-configs/title-success";
 
-function SummaryTitleSpace() {
+function SummaryTitleSpace({ title }: { title: string }) {
   return (
     <div
       data-testid="summary-title-space"
-      className="pointer-events-none mb-3 flex h-[1.875rem] items-center"
+      className="pointer-events-none mb-4 flex min-h-[1.875rem] items-start"
     >
-      <span
-        aria-hidden="true"
-        className="text-muted-foreground animate-pulse text-[1.5rem] leading-[1.875rem] font-semibold opacity-60"
-      >
-        <Trans>Generating title...</Trans>
-      </span>
+      {title ? (
+        <h1 className="text-foreground text-[1.5rem] leading-[1.875rem] font-semibold">
+          {title}
+        </h1>
+      ) : (
+        <span
+          aria-hidden="true"
+          className="text-muted-foreground animate-pulse text-[1.5rem] leading-[1.875rem] font-semibold opacity-60"
+        >
+          <Trans>Generating title...</Trans>
+        </span>
+      )}
     </div>
   );
 }
@@ -34,14 +41,17 @@ export function StreamingView({
 }) {
   const taskId = createTaskId(enhancedNoteId, "enhance");
   const { streamedText, isGenerating } = useAITaskTask(taskId, "enhance");
+  const titleTaskId = createTaskId(sessionId, "title");
+  const { streamedText: streamedTitle } = useAITaskTask(titleTaskId, "title");
   const sessionTitle = main.UI.useCell(
     "sessions",
     sessionId,
     "title",
     main.STORE_ID,
   );
-  const shouldGenerateTitle =
-    typeof sessionTitle !== "string" || sessionTitle.trim().length === 0;
+  const title = typeof sessionTitle === "string" ? sessionTitle.trim() : "";
+  const generatedTitle = getPersistableGeneratedTitle(streamedTitle);
+  const visibleTitle = title || generatedTitle;
 
   if (streamedText.trim().length === 0) {
     return (
@@ -69,7 +79,7 @@ export function StreamingView({
   return (
     <div className="pb-2">
       <div className="flex flex-col gap-1">
-        {shouldGenerateTitle ? <SummaryTitleSpace /> : null}
+        <SummaryTitleSpace title={visibleTitle} />
         <Streamdown
           components={streamdownComponents}
           className={cn(["flex flex-col"])}

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
@@ -385,6 +385,38 @@ describe("enhanceSuccess.onSuccess", () => {
     expect(startTask).not.toHaveBeenCalled();
   });
 
+  it("uses the in-flight title text when summary finalizes first", async () => {
+    const store = {
+      setPartialRow: vi.fn(),
+      getCell: vi.fn().mockReturnValue(""),
+      getValue: vi.fn().mockReturnValue("user-1"),
+      setRow: vi.fn(),
+      forEachRow: vi.fn(),
+    } as unknown as EnhanceSuccessParams["store"];
+    const params = createParams({
+      store,
+      getTaskState: vi.fn().mockReturnValue({
+        taskType: "title",
+        status: "generating",
+        streamedText: "Visible Streaming Title",
+        abortController: null,
+        currentStep: undefined,
+      }),
+    });
+
+    await enhanceSuccess.onSuccess?.(params);
+
+    expect(params.startTask).not.toHaveBeenCalled();
+    const persisted = (store.setPartialRow as ReturnType<typeof vi.fn>).mock
+      .calls[0][2].content;
+    expect(json2md(JSON.parse(persisted)).trim()).toBe(
+      "# Visible Streaming Title\n\n# Summary\n\n- Point",
+    );
+    expect(store.setPartialRow).toHaveBeenCalledWith("sessions", "session-1", {
+      title: "Visible Streaming Title",
+    });
+  });
+
   it("does not start title generation when title task is already running", async () => {
     const params = createParams({
       getTaskState: vi.fn().mockReturnValue({

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
@@ -44,9 +44,9 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = async ({
     const titleTaskId = createTaskId(args.sessionId, "title");
     const titleTask = getTaskState(titleTaskId);
 
-    if (titleTask?.status === "success") {
+    if (titleTask?.status === "success" || titleTask?.status === "generating") {
       generatedTitle = getPersistableGeneratedTitle(titleTask.streamedText);
-    } else if (titleTask?.status !== "generating") {
+    } else {
       await startTask(titleTaskId, {
         model,
         taskType: "title",


### PR DESCRIPTION
Keep the streaming summary title row aligned with the finalized editor and cover the generated-title transition in tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are UI layout and i18n catalog reference updates in the session summary flow, with no auth, data, or API impact.
> 
> **Overview**
> The pull request’s **visible diff** refreshes Lingui `messages.po` catalogs across all desktop locales: source-location comments for three strings tied to `streaming.tsx` (`Analyzing structure...`, `Generating title...`, and the Anarlog tip) are updated because those `Trans` markers moved to new line numbers after the streaming summary UI was reworked. No `msgstr` translation text changes appear in the diff.
> 
> Per the PR intent, that rework adds a reserved **summary title row** (`summary-title-space`) during enhance streaming so typography matches the finalized editor—showing a persisted session title, streamed generated title, or a pulsing “Generating title...” placeholder—and **tests** in the enhanced note flow now cover titled sessions and generated-title-while-streaming cases. Locale files are the mechanical follow-on from those `streaming.tsx` edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 715de82b0bc1bf120f6641aa8cc140e7f0642b21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->