### PR TITLE
Handle bidirectional AEC reference lag

### DIFF
--- a/crates/audio-actual/src/capture/stream.rs
+++ b/crates/audio-actual/src/capture/stream.rs
@@ -165,15 +165,25 @@ async fn run_dual_loop(
                 while let Some((raw_mic, raw_speaker)) = joiner.pop_pair() {
                     let raw_mic = Arc::<[f32]>::from(raw_mic);
                     let raw_speaker = Arc::<[f32]>::from(raw_speaker);
-                    let aec_reference_speaker = aec_reference
+                    let aligned = aec_reference
                         .as_mut()
                         .map(|aligner| aligner.align(&raw_speaker, &raw_mic))
-                        .unwrap_or_else(|| Arc::clone(&raw_speaker));
+                        .unwrap_or_else(|| AecAlignedPair {
+                            mic: Arc::clone(&raw_mic),
+                            speaker: Arc::clone(&raw_speaker),
+                            alignment_changed: false,
+                        });
+                    if aligned.alignment_changed {
+                        if let Some(processor) = aec.as_mut() {
+                            processor.reset();
+                        }
+                        linear_echo_gain = None;
+                    }
                     let aec_mic = process_aec(
                         &mut aec,
                         &mut linear_echo_gain,
-                        &raw_mic,
-                        &aec_reference_speaker,
+                        &aligned.mic,
+                        &aligned.speaker,
                     );
                     if tx
                         .send(Ok(CaptureFrame {
@@ -199,11 +209,49 @@ async fn run_dual_loop(
 
 struct AecReferenceAligner {
     probe: SyncProbe,
-    delay_line: SampleDelayLine,
-    last_delay_samples: usize,
+    mic_delay_line: SampleDelayLine,
+    speaker_delay_line: SampleDelayLine,
+    last_alignment: AecAlignment,
     last_logged_state: Option<SyncProbeState>,
     last_logged_stable_lag_samples: Option<isize>,
     log_probe_events: bool,
+}
+
+struct AecAlignedPair {
+    mic: Arc<[f32]>,
+    speaker: Arc<[f32]>,
+    alignment_changed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AecAlignment {
+    None,
+    DelayMic(usize),
+    DelaySpeaker(usize),
+}
+
+impl AecAlignment {
+    fn from_lag_samples(lag_samples: Option<isize>) -> Self {
+        match lag_samples {
+            Some(lag) if lag > 0 => Self::DelaySpeaker(lag as usize),
+            Some(lag) if lag < 0 => Self::DelayMic(lag.unsigned_abs()),
+            _ => Self::None,
+        }
+    }
+
+    fn mic_delay_samples(self) -> usize {
+        match self {
+            Self::DelayMic(samples) => samples,
+            Self::None | Self::DelaySpeaker(_) => 0,
+        }
+    }
+
+    fn speaker_delay_samples(self) -> usize {
+        match self {
+            Self::DelaySpeaker(samples) => samples,
+            Self::None | Self::DelayMic(_) => 0,
+        }
+    }
 }
 
 impl AecReferenceAligner {
@@ -215,15 +263,16 @@ impl AecReferenceAligner {
 
         Self {
             probe: SyncProbe::new(config),
-            delay_line: SampleDelayLine::new(max_delay_samples),
-            last_delay_samples: 0,
+            mic_delay_line: SampleDelayLine::new(max_delay_samples),
+            speaker_delay_line: SampleDelayLine::new(max_delay_samples),
+            last_alignment: AecAlignment::None,
             last_logged_state: None,
             last_logged_stable_lag_samples: None,
             log_probe_events: std::env::var(AUDIO_SYNC_PROBE_ENV).ok().as_deref() == Some("1"),
         }
     }
 
-    fn align(&mut self, raw_speaker: &[f32], raw_mic: &[f32]) -> Arc<[f32]> {
+    fn align(&mut self, raw_speaker: &[f32], raw_mic: &[f32]) -> AecAlignedPair {
         let observed = catch_unwind(AssertUnwindSafe(|| {
             self.probe.observe(raw_speaker, raw_mic)
         }));
@@ -235,44 +284,62 @@ impl AecReferenceAligner {
             }
         };
 
-        if let Some(event) = event {
-            self.update_delay(&event);
+        let alignment_changed = if let Some(event) = event {
+            let alignment_changed = self.update_alignment(&event);
             if self.log_probe_events {
                 self.log_probe_event(event);
             }
-        }
+            alignment_changed
+        } else {
+            false
+        };
 
-        Arc::<[f32]>::from(
-            self.delay_line
-                .process(raw_speaker, self.last_delay_samples),
-        )
+        let aligned_mic = self
+            .mic_delay_line
+            .process(raw_mic, self.last_alignment.mic_delay_samples());
+        let aligned_speaker = self
+            .speaker_delay_line
+            .process(raw_speaker, self.last_alignment.speaker_delay_samples());
+
+        AecAlignedPair {
+            mic: Arc::from(aligned_mic),
+            speaker: Arc::from(aligned_speaker),
+            alignment_changed,
+        }
     }
 
-    fn update_delay(&mut self, event: &SyncProbeEvent) {
+    fn update_alignment(&mut self, event: &SyncProbeEvent) -> bool {
         let snapshot = event.snapshot();
-        let next_delay = if matches!(
+        let next_alignment = if matches!(
             snapshot.state,
             SyncProbeState::Locked | SyncProbeState::Holdover
         ) {
-            snapshot
-                .stable_lag_samples
-                .filter(|lag| *lag > 0)
-                .map(|lag| lag as usize)
-                .unwrap_or(0)
+            AecAlignment::from_lag_samples(snapshot.stable_lag_samples)
         } else {
-            0
+            AecAlignment::None
         };
 
-        if next_delay != self.last_delay_samples {
+        if next_alignment != self.last_alignment {
             tracing::info!(
-                previous_delay_samples = self.last_delay_samples,
-                delay_samples = next_delay,
-                delay_ms = next_delay as f32 / self.probe.config().sample_rate as f32 * 1000.0,
+                previous_alignment = ?self.last_alignment,
+                alignment = ?next_alignment,
+                mic_delay_samples = next_alignment.mic_delay_samples(),
+                speaker_delay_samples = next_alignment.speaker_delay_samples(),
+                mic_delay_ms = next_alignment.mic_delay_samples() as f32
+                    / self.probe.config().sample_rate as f32
+                    * 1000.0,
+                speaker_delay_ms = next_alignment.speaker_delay_samples() as f32
+                    / self.probe.config().sample_rate as f32
+                    * 1000.0,
+                stable_lag_samples = snapshot.stable_lag_samples,
                 state = ?snapshot.state,
-                "aec_reference_delay_changed"
+                "aec_reference_alignment_changed"
             );
-            self.last_delay_samples = next_delay;
+            self.last_alignment = next_alignment;
+            return true;
         }
+
+        false
     }
 
     fn log_probe_event(&mut self, event: SyncProbeEvent) {
@@ -635,5 +702,23 @@ mod tests {
 
         assert_eq!(first, vec![0.0, 0.0, 1.0]);
         assert_eq!(second, vec![2.0]);
+    }
+
+    #[test]
+    fn aec_alignment_delays_speaker_for_positive_lag() {
+        let alignment = AecAlignment::from_lag_samples(Some(320));
+
+        assert_eq!(alignment, AecAlignment::DelaySpeaker(320));
+        assert_eq!(alignment.mic_delay_samples(), 0);
+        assert_eq!(alignment.speaker_delay_samples(), 320);
+    }
+
+    #[test]
+    fn aec_alignment_delays_mic_for_negative_lag() {
+        let alignment = AecAlignment::from_lag_samples(Some(-320));
+
+        assert_eq!(alignment, AecAlignment::DelayMic(320));
+        assert_eq!(alignment.mic_delay_samples(), 320);
+        assert_eq!(alignment.speaker_delay_samples(), 0);
     }
 }

--- a/crates/audio-sync/src/estimator.rs
+++ b/crates/audio-sync/src/estimator.rs
@@ -177,6 +177,14 @@ mod tests {
         out
     }
 
+    fn advance_signal(input: &[f32], advance_samples: usize) -> Vec<f32> {
+        let mut out = vec![0.0; input.len()];
+        for idx in 0..input.len().saturating_sub(advance_samples) {
+            out[idx] = input[idx + advance_samples];
+        }
+        out
+    }
+
     #[test]
     fn gcc_phat_estimates_positive_delay() {
         let window = 4096;
@@ -188,6 +196,20 @@ mod tests {
         let estimate = estimator.estimate(&reference, &observed).unwrap();
 
         assert_eq!(estimate.lag_samples, delay as isize);
+        assert!(estimate.peak_ratio > 1.0);
+    }
+
+    #[test]
+    fn gcc_phat_estimates_negative_delay() {
+        let window = 4096;
+        let delay = 192;
+        let reference = excitation(window);
+        let observed = advance_signal(&reference, delay);
+
+        let mut estimator = GccPhatLagEstimator::new(window, 512);
+        let estimate = estimator.estimate(&reference, &observed).unwrap();
+
+        assert_eq!(estimate.lag_samples, -(delay as isize));
         assert!(estimate.peak_ratio > 1.0);
     }
 }

--- a/crates/audio-sync/src/probe.rs
+++ b/crates/audio-sync/src/probe.rs
@@ -607,6 +607,14 @@ mod tests {
         out
     }
 
+    fn advance_signal(input: &[f32], advance_samples: usize) -> Vec<f32> {
+        let mut out = vec![0.0; input.len()];
+        for idx in 0..input.len().saturating_sub(advance_samples) {
+            out[idx] = input[idx + advance_samples];
+        }
+        out
+    }
+
     fn test_config(window_samples: usize) -> SyncProbeConfig {
         SyncProbeConfig {
             sample_rate: 16_000,
@@ -648,6 +656,26 @@ mod tests {
         assert_eq!(snapshot.state, SyncProbeState::Locked);
         assert_eq!(snapshot.stable_lag_samples, Some(delay as isize));
         assert_eq!(snapshot.accepted_window_count, 3);
+    }
+
+    #[test]
+    fn sync_probe_can_lock_negative_lag() {
+        let window = 4096;
+        let delay = 192;
+        let reference = excitation(window);
+        let observed = advance_signal(&reference, delay);
+        let mut probe = SyncProbe::new(test_config(window));
+
+        for _ in 0..2 {
+            let event = probe.observe(&reference, &observed).unwrap();
+            assert_eq!(event.snapshot().state, SyncProbeState::Acquiring);
+        }
+
+        let locked = probe.observe(&reference, &observed).unwrap();
+        let snapshot = locked.snapshot();
+
+        assert_eq!(snapshot.state, SyncProbeState::Locked);
+        assert_eq!(snapshot.stable_lag_samples, Some(-(delay as isize)));
     }
 
     #[test]

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -13,11 +13,16 @@ use owhisper_interface::stream::Extra;
 use owhisper_interface::{ControlMessage, MixedMessage};
 
 use super::stream::process_stream;
-use super::{
-    ChannelSender, DEVICE_FINGERPRINT_HEADER, ListenerArgs, ListenerMsg, SoniqoAudioMsg,
-    actor_error,
-};
+use super::{ChannelSender, DEVICE_FINGERPRINT_HEADER, ListenerArgs, ListenerMsg, actor_error};
 use crate::SessionErrorEvent;
+
+const SONIQO_ECHO_GATE_MIN_SAMPLES: usize = 512;
+const SONIQO_ECHO_GATE_MAX_LAG_SAMPLES: isize = 640;
+const SONIQO_ECHO_GATE_LAG_STEP_SAMPLES: isize = 160;
+const SONIQO_ECHO_GATE_MIN_MIC_RMS: f32 = 0.0025;
+const SONIQO_ECHO_GATE_MIN_SPEAKER_RMS: f32 = 0.01;
+const SONIQO_ECHO_GATE_MIN_CORRELATION: f32 = 0.55;
+const SONIQO_ECHO_GATE_MAX_RESIDUAL_RATIO: f32 = 0.45;
 
 pub(super) async fn spawn_rx_task(
     args: ListenerArgs,
@@ -139,16 +144,149 @@ async fn spawn_soniqo_rx_task(
     ),
     ActorProcessingErr,
 > {
+    if matches!(args.mode, crate::actors::ChannelMode::MicAndSpeaker) {
+        spawn_soniqo_rx_task_dual(model, args, myself).await
+    } else {
+        let source = if matches!(args.mode, crate::actors::ChannelMode::SpeakerOnly) {
+            hypr_transcribe_soniqo::TranscriptSource::System
+        } else {
+            hypr_transcribe_soniqo::TranscriptSource::Microphone
+        };
+
+        spawn_soniqo_rx_task_single(model, args, myself, source).await
+    }
+}
+
+async fn spawn_soniqo_rx_task_single(
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    args: ListenerArgs,
+    myself: ActorRef<ListenerMsg>,
+    source: hypr_transcribe_soniqo::TranscriptSource,
+) -> Result<
+    (
+        ChannelSender,
+        tokio::task::JoinHandle<()>,
+        tokio::sync::oneshot::Sender<()>,
+    ),
+    ActorProcessingErr,
+> {
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     let (session_offset_secs, extra) = build_extra(&args);
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<SoniqoAudioMsg>(32);
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<MixedMessage<Bytes, ControlMessage>>(32);
 
-    let session = tokio::task::spawn_blocking(move || {
-        hypr_transcribe_soniqo::LiveTranscriptionSession::start(model)
-    })
-    .await
-    .map_err(|e| actor_error(format!("soniqo_live_start_join_failed: {e}")))?
-    .map_err(|e| actor_error(format!("soniqo_live_start_failed: {e}")))?;
+    let session = start_soniqo_live_session(model).await?;
+
+    let rx_task = tokio::spawn(async move {
+        let mut session = session;
+        let mut buffer = Vec::<f32>::new();
+        let mut cursor = 0.0;
+        let mut interval = tokio::time::interval(Duration::from_millis(250));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                _ = &mut shutdown_rx => {
+                    break;
+                }
+                maybe_msg = rx.recv() => {
+                    let Some(msg) = maybe_msg else {
+                        break;
+                    };
+
+                    match msg {
+                        MixedMessage::Audio(audio) => {
+                            buffer.extend(i16_bytes_to_f32(&audio));
+                        }
+                        MixedMessage::Control(ControlMessage::CloseStream) => {
+                            break;
+                        }
+                        MixedMessage::Control(ControlMessage::Finalize | ControlMessage::KeepAlive) => {}
+                    }
+                }
+                _ = interval.tick() => {
+                    match flush_soniqo_buffer(
+                        session,
+                        model,
+                        source,
+                        &mut buffer,
+                        &mut cursor,
+                        &myself,
+                        session_offset_secs,
+                        &extra,
+                    )
+                    .await
+                    {
+                        Ok(next_session) => session = next_session,
+                        Err(error) => {
+                            let _ = myself.cast(ListenerMsg::StreamError(error));
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
+        match flush_soniqo_buffer(
+            session,
+            model,
+            source,
+            &mut buffer,
+            &mut cursor,
+            &myself,
+            session_offset_secs,
+            &extra,
+        )
+        .await
+        {
+            Ok(next_session) => session = next_session,
+            Err(error) => {
+                tracing::warn!(%error, "soniqo_final_flush_failed");
+                return;
+            }
+        }
+
+        match finalize_soniqo_source(
+            session,
+            model,
+            source,
+            cursor,
+            myself,
+            session_offset_secs,
+            extra,
+        )
+        .await
+        {
+            Ok(next_session) => session = next_session,
+            Err(error) => {
+                tracing::warn!(%error, "soniqo_final_finalize_failed");
+                return;
+            }
+        }
+
+        let _ = tokio::task::spawn_blocking(move || session.stop()).await;
+    });
+
+    Ok((ChannelSender::Single(tx), rx_task, shutdown_tx))
+}
+
+async fn spawn_soniqo_rx_task_dual(
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    args: ListenerArgs,
+    myself: ActorRef<ListenerMsg>,
+) -> Result<
+    (
+        ChannelSender,
+        tokio::task::JoinHandle<()>,
+        tokio::sync::oneshot::Sender<()>,
+    ),
+    ActorProcessingErr,
+> {
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let (session_offset_secs, extra) = build_extra(&args);
+    let (tx, mut rx) =
+        tokio::sync::mpsc::channel::<MixedMessage<(Bytes, Bytes), ControlMessage>>(32);
+
+    let session = start_soniqo_live_session(model).await?;
 
     let rx_task = tokio::spawn(async move {
         let mut session = session;
@@ -170,129 +308,101 @@ async fn spawn_soniqo_rx_task(
                     };
 
                     match msg {
-                        SoniqoAudioMsg::Single(source, audio) => {
-                            match source {
-                                hypr_transcribe_soniqo::TranscriptSource::Microphone => {
-                                    mic_buffer.extend(i16_bytes_to_f32(&audio));
-                                }
-                                hypr_transcribe_soniqo::TranscriptSource::System => {
-                                    spk_buffer.extend(i16_bytes_to_f32(&audio));
-                                }
+                        MixedMessage::Audio((mic, spk)) => {
+                            let mut mic_samples = i16_bytes_to_f32(&mic);
+                            let spk_samples = i16_bytes_to_f32(&spk);
+                            if suppress_soniqo_echo_dominant_mic(
+                                &mut mic_samples,
+                                &spk_samples,
+                            ) {
+                                tracing::debug!("soniqo_echo_dominant_mic_chunk_suppressed");
                             }
+                            mic_buffer.extend(mic_samples);
+                            spk_buffer.extend(spk_samples);
                         }
-                        SoniqoAudioMsg::Dual(mic, spk) => {
-                            mic_buffer.extend(i16_bytes_to_f32(&mic));
-                            spk_buffer.extend(i16_bytes_to_f32(&spk));
+                        MixedMessage::Control(ControlMessage::CloseStream) => {
+                            break;
                         }
+                        MixedMessage::Control(ControlMessage::Finalize | ControlMessage::KeepAlive) => {}
                     }
                 }
                 _ = interval.tick() => {
-                    if !mic_buffer.is_empty() {
-                        let samples = std::mem::take(&mut mic_buffer);
-                        let duration = samples.len() as f64 / super::super::SAMPLE_RATE as f64;
-                        let start = mic_cursor;
-                        mic_cursor += duration;
-
-                        match flush_soniqo_source(
-                            session,
-                            model,
-                            hypr_transcribe_soniqo::TranscriptSource::Microphone,
-                            samples,
-                            start,
-                            duration,
-                            myself.clone(),
-                            session_offset_secs,
-                            extra.clone(),
-                        )
-                        .await
-                        {
-                            Ok(next_session) => session = next_session,
-                            Err(error) => {
-                                let _ = myself.cast(ListenerMsg::StreamError(error));
-                                return;
-                            }
+                    match flush_soniqo_buffer(
+                        session,
+                        model,
+                        hypr_transcribe_soniqo::TranscriptSource::Microphone,
+                        &mut mic_buffer,
+                        &mut mic_cursor,
+                        &myself,
+                        session_offset_secs,
+                        &extra,
+                    )
+                    .await
+                    {
+                        Ok(next_session) => session = next_session,
+                        Err(error) => {
+                            let _ = myself.cast(ListenerMsg::StreamError(error));
+                            return;
                         }
                     }
 
-                    if !spk_buffer.is_empty() {
-                        let samples = std::mem::take(&mut spk_buffer);
-                        let duration = samples.len() as f64 / super::super::SAMPLE_RATE as f64;
-                        let start = spk_cursor;
-                        spk_cursor += duration;
-
-                        match flush_soniqo_source(
-                            session,
-                            model,
-                            hypr_transcribe_soniqo::TranscriptSource::System,
-                            samples,
-                            start,
-                            duration,
-                            myself.clone(),
-                            session_offset_secs,
-                            extra.clone(),
-                        )
-                        .await
-                        {
-                            Ok(next_session) => session = next_session,
-                            Err(error) => {
-                                let _ = myself.cast(ListenerMsg::StreamError(error));
-                                return;
-                            }
+                    match flush_soniqo_buffer(
+                        session,
+                        model,
+                        hypr_transcribe_soniqo::TranscriptSource::System,
+                        &mut spk_buffer,
+                        &mut spk_cursor,
+                        &myself,
+                        session_offset_secs,
+                        &extra,
+                    )
+                    .await
+                    {
+                        Ok(next_session) => session = next_session,
+                        Err(error) => {
+                            let _ = myself.cast(ListenerMsg::StreamError(error));
+                            return;
                         }
                     }
                 }
             }
         }
 
-        if !mic_buffer.is_empty() {
-            let samples = std::mem::take(&mut mic_buffer);
-            let duration = samples.len() as f64 / super::super::SAMPLE_RATE as f64;
-            let start = mic_cursor;
-            mic_cursor += duration;
-            match flush_soniqo_source(
-                session,
-                model,
-                hypr_transcribe_soniqo::TranscriptSource::Microphone,
-                samples,
-                start,
-                duration,
-                myself.clone(),
-                session_offset_secs,
-                extra.clone(),
-            )
-            .await
-            {
-                Ok(next_session) => session = next_session,
-                Err(error) => {
-                    tracing::warn!(%error, "soniqo_final_mic_flush_failed");
-                    return;
-                }
+        match flush_soniqo_buffer(
+            session,
+            model,
+            hypr_transcribe_soniqo::TranscriptSource::Microphone,
+            &mut mic_buffer,
+            &mut mic_cursor,
+            &myself,
+            session_offset_secs,
+            &extra,
+        )
+        .await
+        {
+            Ok(next_session) => session = next_session,
+            Err(error) => {
+                tracing::warn!(%error, "soniqo_final_mic_flush_failed");
+                return;
             }
         }
 
-        if !spk_buffer.is_empty() {
-            let samples = std::mem::take(&mut spk_buffer);
-            let duration = samples.len() as f64 / super::super::SAMPLE_RATE as f64;
-            let start = spk_cursor;
-            spk_cursor += duration;
-            match flush_soniqo_source(
-                session,
-                model,
-                hypr_transcribe_soniqo::TranscriptSource::System,
-                samples,
-                start,
-                duration,
-                myself.clone(),
-                session_offset_secs,
-                extra.clone(),
-            )
-            .await
-            {
-                Ok(next_session) => session = next_session,
-                Err(error) => {
-                    tracing::warn!(%error, "soniqo_final_system_flush_failed");
-                    return;
-                }
+        match flush_soniqo_buffer(
+            session,
+            model,
+            hypr_transcribe_soniqo::TranscriptSource::System,
+            &mut spk_buffer,
+            &mut spk_cursor,
+            &myself,
+            session_offset_secs,
+            &extra,
+        )
+        .await
+        {
+            Ok(next_session) => session = next_session,
+            Err(error) => {
+                tracing::warn!(%error, "soniqo_final_system_flush_failed");
+                return;
             }
         }
 
@@ -335,7 +445,51 @@ async fn spawn_soniqo_rx_task(
         let _ = tokio::task::spawn_blocking(move || session.stop()).await;
     });
 
-    Ok((ChannelSender::Soniqo(tx), rx_task, shutdown_tx))
+    Ok((ChannelSender::Dual(tx), rx_task, shutdown_tx))
+}
+
+async fn start_soniqo_live_session(
+    model: hypr_transcribe_soniqo::SoniqoModel,
+) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, ActorProcessingErr> {
+    tokio::task::spawn_blocking(move || {
+        hypr_transcribe_soniqo::LiveTranscriptionSession::start(model)
+    })
+    .await
+    .map_err(|e| actor_error(format!("soniqo_live_start_join_failed: {e}")))?
+    .map_err(|e| actor_error(format!("soniqo_live_start_failed: {e}")))
+}
+
+async fn flush_soniqo_buffer(
+    session: hypr_transcribe_soniqo::LiveTranscriptionSession,
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    source: hypr_transcribe_soniqo::TranscriptSource,
+    buffer: &mut Vec<f32>,
+    cursor: &mut f64,
+    myself: &ActorRef<ListenerMsg>,
+    session_offset_secs: f64,
+    extra: &Extra,
+) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, String> {
+    if buffer.is_empty() {
+        return Ok(session);
+    }
+
+    let samples = std::mem::take(buffer);
+    let duration = samples.len() as f64 / super::super::SAMPLE_RATE as f64;
+    let start = *cursor;
+    *cursor += duration;
+
+    flush_soniqo_source(
+        session,
+        model,
+        source,
+        samples,
+        start,
+        duration,
+        myself.clone(),
+        session_offset_secs,
+        extra.clone(),
+    )
+    .await
 }
 
 async fn flush_soniqo_source(
@@ -407,6 +561,102 @@ fn i16_bytes_to_f32(bytes: &Bytes) -> Vec<f32> {
         .chunks_exact(2)
         .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / i16::MAX as f32)
         .collect()
+}
+
+fn suppress_soniqo_echo_dominant_mic(mic: &mut [f32], speaker: &[f32]) -> bool {
+    let Some(score) = best_soniqo_echo_score(mic, speaker) else {
+        return false;
+    };
+
+    if score.correlation < SONIQO_ECHO_GATE_MIN_CORRELATION
+        || score.residual_ratio > SONIQO_ECHO_GATE_MAX_RESIDUAL_RATIO
+        || score.mic_rms < SONIQO_ECHO_GATE_MIN_MIC_RMS
+        || score.speaker_rms < SONIQO_ECHO_GATE_MIN_SPEAKER_RMS
+    {
+        return false;
+    }
+
+    mic.fill(0.0);
+    true
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SoniqoEchoScore {
+    correlation: f32,
+    residual_ratio: f32,
+    mic_rms: f32,
+    speaker_rms: f32,
+}
+
+fn best_soniqo_echo_score(mic: &[f32], speaker: &[f32]) -> Option<SoniqoEchoScore> {
+    let len = mic.len().min(speaker.len());
+    if len < SONIQO_ECHO_GATE_MIN_SAMPLES {
+        return None;
+    }
+
+    let max_lag =
+        SONIQO_ECHO_GATE_MAX_LAG_SAMPLES.min((len - SONIQO_ECHO_GATE_MIN_SAMPLES) as isize);
+    let mut best = soniqo_echo_score_at_lag(&mic[..len], &speaker[..len], 0);
+    let mut lag = SONIQO_ECHO_GATE_LAG_STEP_SAMPLES;
+
+    while lag <= max_lag {
+        for lag in [-lag, lag] {
+            if let Some(score) = soniqo_echo_score_at_lag(&mic[..len], &speaker[..len], lag) {
+                if best
+                    .map(|current| score.correlation > current.correlation)
+                    .unwrap_or(true)
+                {
+                    best = Some(score);
+                }
+            }
+        }
+        lag += SONIQO_ECHO_GATE_LAG_STEP_SAMPLES;
+    }
+
+    best
+}
+
+fn soniqo_echo_score_at_lag(mic: &[f32], speaker: &[f32], lag: isize) -> Option<SoniqoEchoScore> {
+    let len = mic.len().min(speaker.len());
+    let (mic_start, speaker_start) = if lag >= 0 {
+        (lag as usize, 0)
+    } else {
+        (0, lag.unsigned_abs())
+    };
+    let overlap = len.saturating_sub(mic_start.max(speaker_start));
+    if overlap < SONIQO_ECHO_GATE_MIN_SAMPLES {
+        return None;
+    }
+
+    let mut mic_energy = 0.0;
+    let mut speaker_energy = 0.0;
+    let mut cross_energy = 0.0;
+    for idx in 0..overlap {
+        let mic_sample = mic[mic_start + idx];
+        let speaker_sample = speaker[speaker_start + idx];
+        mic_energy += mic_sample * mic_sample;
+        speaker_energy += speaker_sample * speaker_sample;
+        cross_energy += mic_sample * speaker_sample;
+    }
+
+    if mic_energy <= f32::EPSILON || speaker_energy <= f32::EPSILON {
+        return None;
+    }
+
+    let overlap_f32 = overlap as f32;
+    let mic_rms = (mic_energy / overlap_f32).sqrt();
+    let speaker_rms = (speaker_energy / overlap_f32).sqrt();
+    let correlation = cross_energy.abs() / (mic_energy * speaker_energy).sqrt().max(1e-6);
+    let residual_energy =
+        (mic_energy - (cross_energy * cross_energy / speaker_energy.max(1e-6))).max(0.0);
+    let residual_ratio = residual_energy.sqrt() / mic_energy.sqrt().max(1e-6);
+
+    Some(SoniqoEchoScore {
+        correlation,
+        residual_ratio,
+        mic_rms,
+        speaker_rms,
+    })
 }
 
 fn build_listen_params(args: &ListenerArgs) -> owhisper_interface::ListenParams {
@@ -649,6 +899,80 @@ mod tests {
             participant_human_ids: vec![],
             self_human_id: None,
         }
+    }
+
+    fn test_signal(len: usize, seed: u32) -> Vec<f32> {
+        let mut state = seed;
+        (0..len)
+            .map(|idx| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                let noise = (state as f32 / u32::MAX as f32) * 2.0 - 1.0;
+                let pulse = if idx % 257 == 0 { 0.8 } else { 0.0 };
+                0.45 * noise + pulse
+            })
+            .collect()
+    }
+
+    fn delayed(input: &[f32], delay_samples: usize, gain: f32) -> Vec<f32> {
+        let mut out = vec![0.0; input.len()];
+        for idx in delay_samples..input.len() {
+            out[idx] = input[idx - delay_samples] * gain;
+        }
+        out
+    }
+
+    #[test]
+    fn suppresses_soniqo_mic_when_chunk_is_echo_dominant() {
+        let speaker = test_signal(1920, 0x1234_5678);
+        let mut mic = delayed(&speaker, 160, 0.35);
+
+        assert!(suppress_soniqo_echo_dominant_mic(&mut mic, &speaker));
+        assert!(mic.iter().all(|sample| *sample == 0.0));
+    }
+
+    #[test]
+    fn suppresses_soniqo_mic_when_minimum_chunk_matches_zero_lag() {
+        let speaker = test_signal(SONIQO_ECHO_GATE_MIN_SAMPLES, 0x1234_5678);
+        let mut mic: Vec<f32> = speaker.iter().map(|sample| sample * 0.35).collect();
+
+        assert!(suppress_soniqo_echo_dominant_mic(&mut mic, &speaker));
+        assert!(mic.iter().all(|sample| *sample == 0.0));
+    }
+
+    #[test]
+    fn best_soniqo_echo_score_considers_zero_lag_when_step_grid_skips_it() {
+        let speaker = test_signal(1024, 0x1234_5678);
+        let mic: Vec<f32> = speaker.iter().map(|sample| sample * 0.35).collect();
+
+        let score = best_soniqo_echo_score(&mic, &speaker).expect("echo score");
+
+        assert!(score.correlation > 0.99);
+    }
+
+    #[test]
+    fn keeps_soniqo_mic_when_independent_speech_dominates() {
+        let speaker = test_signal(1920, 0x1234_5678);
+        let local = test_signal(1920, 0x8765_4321);
+        let mut mic = delayed(&speaker, 160, 0.15);
+        for (mic_sample, local_sample) in mic.iter_mut().zip(local) {
+            *mic_sample += 0.45 * local_sample;
+        }
+        let original = mic.clone();
+
+        assert!(!suppress_soniqo_echo_dominant_mic(&mut mic, &speaker));
+        assert_eq!(mic, original);
+    }
+
+    #[test]
+    fn keeps_soniqo_mic_when_speaker_reference_is_quiet() {
+        let speaker = vec![0.001; 1920];
+        let mut mic = test_signal(1920, 0x1234_5678);
+        let original = mic.clone();
+
+        assert!(!suppress_soniqo_echo_dominant_mic(&mut mic, &speaker));
+        assert_eq!(mic, original);
     }
 
     #[test]

--- a/crates/listener-core/src/actors/listener/mod.rs
+++ b/crates/listener-core/src/actors/listener/mod.rs
@@ -71,12 +71,6 @@ pub struct ListenerState {
 pub(super) enum ChannelSender {
     Single(tokio::sync::mpsc::Sender<MixedMessage<Bytes, ControlMessage>>),
     Dual(tokio::sync::mpsc::Sender<MixedMessage<(Bytes, Bytes), ControlMessage>>),
-    Soniqo(tokio::sync::mpsc::Sender<SoniqoAudioMsg>),
-}
-
-pub(super) enum SoniqoAudioMsg {
-    Single(hypr_transcribe_soniqo::TranscriptSource, Bytes),
-    Dual(Bytes, Bytes),
 }
 
 pub struct ListenerActor;
@@ -198,24 +192,12 @@ impl Actor for ListenerActor {
                 ChannelSender::Single(tx) => {
                     let _ = tx.try_send(MixedMessage::Audio(audio));
                 }
-                ChannelSender::Soniqo(tx) => {
-                    let source =
-                        if matches!(state.args.mode, crate::actors::ChannelMode::SpeakerOnly) {
-                            hypr_transcribe_soniqo::TranscriptSource::System
-                        } else {
-                            hypr_transcribe_soniqo::TranscriptSource::Microphone
-                        };
-                    let _ = tx.try_send(SoniqoAudioMsg::Single(source, audio));
-                }
                 ChannelSender::Dual(_) => {}
             },
 
             ListenerMsg::AudioDual(mic, spk) => match &state.tx {
                 ChannelSender::Dual(tx) => {
                     let _ = tx.try_send(MixedMessage::Audio((mic, spk)));
-                }
-                ChannelSender::Soniqo(tx) => {
-                    let _ = tx.try_send(SoniqoAudioMsg::Dual(mic, spk));
                 }
                 ChannelSender::Single(_) => {}
             },


### PR DESCRIPTION
Delay either the speaker reference or mic input based on sync lag, reset AEC state on alignment changes, and cover negative-lag detection in audio sync tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live capture AEC alignment and Soniqo mic gating, which can affect echo cancellation quality and transcript content if thresholds are wrong; scope is audio pipeline only, not auth or data storage.
> 
> **Overview**
> **AEC capture** now aligns mic and speaker using sync lag in both directions: positive lag delays the speaker reference, negative lag delays the mic, and **AEC state resets** when that alignment changes. Processing uses the aligned pair instead of only shifting the speaker.
> 
> **audio-sync** gains regression tests that **negative lag** is estimated (GCC-PHAT) and that the sync probe can lock on it.
> 
> **Soniqo live transcription** is refactored onto the same `MixedMessage` single/dual channels as other adapters (dropping `SoniqoAudioMsg`). In **mic+speaker** mode, an **echo gate** zeros mic chunks that look like delayed, highly correlated speaker bleed before they are sent for transcription, with unit tests for suppress vs keep cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bca97d29cf6cc32a148af25a3d09d6d09647776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->