### PR TITLE
Fix tray visibility toggle crash

### DIFF
--- a/plugins/tray/src/ext.rs
+++ b/plugins/tray/src/ext.rs
@@ -136,7 +136,11 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
         let app = self.manager.app_handle();
 
         if visible {
-            self.create_tray_menu()?;
+            if let Some(tray) = app.tray_by_id(TRAY_ID) {
+                tray.set_visible(true)?;
+            } else {
+                self.create_tray_menu()?;
+            }
             Self::refresh_icon(app)?;
         } else {
             if let Ok(mut task) = ANIMATION_TASK.lock()
@@ -144,7 +148,10 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
             {
                 handle.abort();
             }
-            let _ = app.remove_tray_by_id(TRAY_ID);
+
+            if let Some(tray) = app.tray_by_id(TRAY_ID) {
+                tray.set_visible(false)?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Use Tauri tray visibility APIs instead of removing the tray icon from the IPC worker thread.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized tray plugin behavior change with no auth, data, or security impact; reduces risk of thread-related crashes compared to remove/recreate.
> 
> **Overview**
> **Fixes a crash when toggling tray visibility** from the IPC path by keeping the tray icon registered and using Tauri’s visibility APIs instead of tearing it down.
> 
> When showing the tray, **`set_visible` now reuses an existing icon** (`tray.set_visible(true)`) and only calls `create_tray_menu()` if none exists. When hiding, it **stops the recording animation** as before, then **hides** via `tray.set_visible(false)` rather than `remove_tray_by_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 069378db5be0d1c9d10a7cc8c3d937c806ac01b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->