### PR TITLE
Match empty view minimum width

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -412,6 +412,20 @@ describe("ClassicMainBody", () => {
     expect(panels[1]?.dataset.minWidth).toBe("500");
   });
 
+  it("keeps the empty content panel at least 500px wide", () => {
+    mocks.currentTab = {
+      active: true,
+      pinned: false,
+      slotId: "slot-home",
+      type: "empty",
+    };
+
+    render(<ClassicMainBody />);
+
+    const panels = screen.getAllByTestId("panel");
+    expect(panels[1]?.dataset.minWidth).toBe("500");
+  });
+
   it("collapses the sidebar panel without unmounting the animated shell", () => {
     mocks.leftsidebar.expanded = false;
 

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -43,7 +43,10 @@ import { useClassicMainTabsShortcuts } from "./useTabsShortcuts";
 import { useShell } from "~/contexts/shell";
 import { scrollElementByWheel } from "~/shared/dom/scroll-wheel";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
-import { NOTE_SURFACE_MIN_WIDTH_PX } from "~/shared/main/layout-widths";
+import {
+  NOTE_SURFACE_MIN_WIDTH_PX,
+  usesNoteSurfaceMinWidth,
+} from "~/shared/main/layout-widths";
 import { useOpenNoteDialog } from "~/shared/open-note-dialog";
 import { useNewNote } from "~/shared/useNewNote";
 import { useSidebarUpcomingMeetingStatus } from "~/sidebar/timeline/upcoming-meeting";
@@ -141,7 +144,7 @@ export function ClassicMainBody() {
   });
 
   const isOnboarding = currentTab?.type === "onboarding";
-  const isSessionTab = currentTab?.type === "sessions";
+  const reserveNoteSurfaceMinWidth = usesNoteSurfaceMinWidth(currentTab);
   const hasCustomSidebar = hasCustomSidebarTab(currentTab);
   const hasLeftSurfaceCustomSidebar =
     hasLeftSurfaceCustomSidebarTab(currentTab);
@@ -455,7 +458,9 @@ export function ClassicMainBody() {
           order={2}
           className="min-h-0 flex-1 overflow-hidden"
           style={{
-            minWidth: isSessionTab ? NOTE_SURFACE_MIN_WIDTH_PX : undefined,
+            minWidth: reserveNoteSurfaceMinWidth
+              ? NOTE_SURFACE_MIN_WIDTH_PX
+              : undefined,
           }}
         >
           <div

--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -216,6 +216,19 @@ describe("MainChatPanels", () => {
     expect(screen.getAllByTestId("panel")[0]?.dataset.minWidth).toBe("700");
   });
 
+  it("reserves enough main-body width for the empty surface beside the sidebar", () => {
+    mocks.currentTab = { type: "empty" };
+    mocks.leftSidebarExpanded = true;
+
+    render(
+      <MainChatPanels>
+        <div data-testid="main-content" />
+      </MainChatPanels>,
+    );
+
+    expect(screen.getAllByTestId("panel")[0]?.dataset.minWidth).toBe("700");
+  });
+
   it("expands left when opening the sidebar would make a note surface narrower than 500px", () => {
     mocks.currentTab = { type: "sessions" };
     mocks.leftSidebarExpanded = true;
@@ -229,6 +242,26 @@ describe("MainChatPanels", () => {
         <div data-left-sidebar-chrome />
         <div data-chat-floating-anchor>
           <div data-session-surface />
+        </div>
+      </MainChatPanels>,
+    );
+
+    expect(mocks.windowExpandWidth).toHaveBeenCalledWith(60, null, false, true);
+  });
+
+  it("expands left when opening the sidebar would make the empty surface narrower than 500px", () => {
+    mocks.currentTab = { type: "empty" };
+    mocks.leftSidebarExpanded = true;
+    mockPanelWidths({
+      bodyPanelWidth: 640,
+      leftSidebarWidth: 200,
+    });
+
+    render(
+      <MainChatPanels>
+        <div data-left-sidebar-chrome />
+        <div data-chat-floating-anchor>
+          <div data-testid="empty-surface" />
         </div>
       </MainChatPanels>,
     );

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -8,7 +8,10 @@ import {
   ResizablePanelGroup,
 } from "@hypr/ui/components/ui/resizable";
 
-import { NOTE_SURFACE_MIN_WIDTH_PX } from "./layout-widths";
+import {
+  NOTE_SURFACE_MIN_WIDTH_PX,
+  usesNoteSurfaceMinWidth,
+} from "./layout-widths";
 
 import { ChatPanelFrame, ChatSessionHost } from "~/chat/components/chat-panel";
 import { PersistentChatPanel } from "~/chat/components/persistent-chat";
@@ -23,7 +26,7 @@ export function MainChatPanels({ children }: { children: React.ReactNode }) {
   const currentTab = useTabs((state) => state.currentTab);
   const bodyPanelContainerRef = useRef<HTMLDivElement>(null);
   const isRightPanelOpen = chat.mode === "RightPanelOpen";
-  const isSessionTab = currentTab?.type === "sessions";
+  const reserveNoteSurfaceMinWidth = usesNoteSurfaceMinWidth(currentTab);
   const collapseLeftSidebar = useCallback(() => {
     leftsidebar.setExpanded(false);
   }, [leftsidebar.setExpanded]);
@@ -34,7 +37,7 @@ export function MainChatPanels({ children }: { children: React.ReactNode }) {
 
   useNoteSurfaceWindowWidthGuard({
     bodyPanelContainerRef,
-    enabled: isSessionTab,
+    enabled: reserveNoteSurfaceMinWidth,
     leftPanelOpen: leftsidebar.expanded,
     collapseLeftPanel: collapseLeftSidebar,
     rightPanelOpen: isRightPanelOpen,
@@ -103,7 +106,7 @@ function getMainBodyMinWidth({
   currentTab: Tab | null;
   leftSidebarExpanded: boolean;
 }) {
-  if (currentTab?.type !== "sessions") {
+  if (!usesNoteSurfaceMinWidth(currentTab)) {
     return undefined;
   }
 

--- a/apps/desktop/src/shared/main/layout-widths.ts
+++ b/apps/desktop/src/shared/main/layout-widths.ts
@@ -1,1 +1,7 @@
+import type { Tab } from "~/store/zustand/tabs";
+
 export const NOTE_SURFACE_MIN_WIDTH_PX = 500;
+
+export function usesNoteSurfaceMinWidth(tab: Pick<Tab, "type"> | null) {
+  return tab?.type === "sessions" || tab?.type === "empty";
+}


### PR DESCRIPTION
Apply the note surface minimum width rules to empty tabs and cover the body and window guard behavior with layout tests.

**Stack**
- Base: `main`
- Follow-up: #5843 `fix/sidebar-collapse-window-width` builds on this PR's shared window-width guard.

**Changes**
- Share the note-surface minimum width rule so empty and session tabs reserve the same 500px content surface.
- Apply that rule in the classic body panel and main chat panel window-width guard.
- Cover empty-tab body/chat panel layout behavior with regression tests.

**Verification**
- `pnpm -F desktop exec vitest run src/shared/main/chat-panels.test.tsx`
- `pnpm -F desktop typecheck`