### PR TITLE
Fix left sidebar default width

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -216,6 +216,20 @@ vi.mock("~/sidebar/timeline/upcoming-meeting", () => ({
 
 import { ClassicMainBody } from "./body";
 
+function rectWithWidth(width: number) {
+  return {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: width,
+    toJSON: () => ({}),
+    top: 0,
+    width,
+    x: 0,
+    y: 0,
+  } as DOMRect;
+}
+
 describe("ClassicMainBody", () => {
   beforeEach(() => {
     cleanup();
@@ -313,6 +327,141 @@ describe("ClassicMainBody", () => {
     expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-width")).toBe(
       "24%",
     );
+  });
+
+  it("settles the startup left sidebar default against the rendered body width", async () => {
+    let bodyWidth = 1000;
+    const requestAnimationFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        callback(0);
+        return 1;
+      });
+    const cancelAnimationFrame = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation(() => {});
+    const getBoundingClientRect = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
+        if (this.querySelector("[data-testid='panel-group']")) {
+          return rectWithWidth(bodyWidth);
+        }
+
+        return rectWithWidth(0);
+      });
+
+    try {
+      render(<ClassicMainBody />);
+
+      await waitFor(() => {
+        expect(mocks.leftSidebarPanelHandle.resize).toHaveBeenCalledWith(20);
+      });
+
+      const panels = screen.getAllByTestId("panel");
+      expect(panels[0]?.dataset.defaultSize).toBe("20");
+      expect(panels[0]?.dataset.minSize).toBe("20");
+      expect(panels[0]?.dataset.maxSize).toBe("36");
+
+      const bodyRoot = screen.getByTestId("panel-group").parentElement;
+      expect(
+        bodyRoot?.style.getPropertyValue("--left-sidebar-panel-size"),
+      ).toBe("20");
+      expect(
+        bodyRoot?.style.getPropertyValue("--left-sidebar-panel-width"),
+      ).toBe("20%");
+
+      act(() => {
+        mocks.onPanelLayout?.([12.5, 87.5]);
+      });
+
+      expect(
+        bodyRoot?.style.getPropertyValue("--left-sidebar-panel-size"),
+      ).toBe("20");
+      expect(
+        bodyRoot?.style.getPropertyValue("--left-sidebar-panel-width"),
+      ).toBe("20%");
+
+      bodyWidth = 800;
+      fireEvent.resize(window);
+
+      await waitFor(() => {
+        expect(mocks.leftSidebarPanelHandle.resize).toHaveBeenCalledWith(25);
+      });
+
+      const resizedPanels = screen.getAllByTestId("panel");
+      expect(resizedPanels[0]?.dataset.defaultSize).toBe("25");
+      expect(resizedPanels[0]?.dataset.minSize).toBe("25");
+      expect(resizedPanels[0]?.dataset.maxSize).toBe("45");
+      expect(
+        bodyRoot?.style.getPropertyValue("--left-sidebar-panel-size"),
+      ).toBe("25");
+      expect(
+        bodyRoot?.style.getPropertyValue("--left-sidebar-panel-width"),
+      ).toBe("25%");
+    } finally {
+      requestAnimationFrame.mockRestore();
+      cancelAnimationFrame.mockRestore();
+      getBoundingClientRect.mockRestore();
+    }
+  });
+
+  it("syncs the default left sidebar width after the panel mounts", async () => {
+    let bodyWidth = 1000;
+    const requestAnimationFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        callback(0);
+        return 1;
+      });
+    const cancelAnimationFrame = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation(() => {});
+    const getBoundingClientRect = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
+        if (this.querySelector("[data-testid='panel-group']")) {
+          return rectWithWidth(bodyWidth);
+        }
+
+        return rectWithWidth(0);
+      });
+
+    try {
+      mocks.currentTab = {
+        active: true,
+        pinned: false,
+        slotId: "slot-onboarding",
+        type: "onboarding",
+      };
+
+      const { rerender } = render(<ClassicMainBody />);
+      expect(
+        screen
+          .getAllByTestId("panel")
+          .some(
+            (panel) => panel.dataset.panelId === "classic-main-sidebar-left",
+          ),
+      ).toBe(false);
+
+      mocks.currentTab = {
+        active: true,
+        pinned: false,
+        slotId: "slot-home",
+        type: "empty",
+      };
+
+      rerender(<ClassicMainBody />);
+      bodyWidth = 1000;
+      fireEvent.resize(window);
+
+      await waitFor(() => {
+        expect(mocks.leftSidebarPanelHandle.resize).toHaveBeenCalledWith(20);
+      });
+    } finally {
+      requestAnimationFrame.mockRestore();
+      cancelAnimationFrame.mockRestore();
+      getBoundingClientRect.mockRestore();
+    }
   });
 
   it("updates sidebar sizing during drag without rerendering tab content", () => {

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -61,6 +61,7 @@ const LEFT_SIDEBAR_MIN_WIDTH_PX = 200;
 const LEFT_SIDEBAR_MAX_WIDTH_PX = 360;
 const LEFT_SIDEBAR_COLLAPSED_SIZE = 0;
 const LEFT_SIDEBAR_FALLBACK_CONTAINER_WIDTH_PX = 1000;
+const LEFT_SIDEBAR_PANEL_SIZE_EPSILON = 0.01;
 
 type MainAreaWindowDragStart = {
   pointerId: number;
@@ -77,21 +78,25 @@ export function ClassicMainBody() {
   const { leftsidebar } = useShell();
   const currentTab = useTabs((state) => state.currentTab);
   const { runEscapeShortcut } = useClassicMainTabsShortcuts();
-  const [leftSidebarPanelConstraints] = useState(
-    createLeftSidebarPanelConstraints,
-  );
+  const [leftSidebarPanelConstraints, setLeftSidebarPanelConstraints] =
+    useState(createLeftSidebarPanelConstraints);
   const [leftSidebarPanelSize, setLeftSidebarPanelSize] = useState(
     leftSidebarPanelConstraints.defaultSize,
   );
   const bodyRootRef = useRef<HTMLDivElement>(null);
   const leftSidebarPanelRef = useRef<ImperativePanelHandle>(null);
+  const leftSidebarPanelConstraintsRef = useRef(leftSidebarPanelConstraints);
   const leftSidebarPanelSizeRef = useRef(leftSidebarPanelSize);
   const lastExpandedLeftSidebarPanelSizeRef = useRef(leftSidebarPanelSize);
   const leftSidebarResizeDraggingRef = useRef(false);
+  const leftSidebarDefaultSizeTrackingRef = useRef(true);
+  const pendingLeftSidebarDefaultSizeRef = useRef<number | null>(null);
+  const syncDefaultLeftSidebarPanelSizeRef = useRef<() => void>(() => {});
   const [showIgnoredTimelineEvents, setShowIgnoredTimelineEvents] =
     useState(false);
   const [showDevtoolsPanelButton, setShowDevtoolsPanelButton] = useState(false);
   const [devtoolsPanelOpen, setDevtoolsPanelOpen] = useState(false);
+  leftSidebarPanelConstraintsRef.current = leftSidebarPanelConstraints;
 
   useMountEffect(() => {
     let cancelled = false;
@@ -194,6 +199,28 @@ export function ClassicMainBody() {
 
       const sidebarSize = sizes[0];
       if (typeof sidebarSize === "number") {
+        const pendingDefaultSize = pendingLeftSidebarDefaultSizeRef.current;
+        if (
+          pendingDefaultSize !== null &&
+          !leftSidebarResizeDraggingRef.current
+        ) {
+          if (!panelSizesAreEqual(sidebarSize, pendingDefaultSize)) {
+            return;
+          }
+
+          pendingLeftSidebarDefaultSizeRef.current = null;
+        }
+
+        if (
+          !leftSidebarResizeDraggingRef.current &&
+          !panelSizesAreEqual(
+            sidebarSize,
+            leftSidebarPanelConstraintsRef.current.defaultSize,
+          )
+        ) {
+          leftSidebarDefaultSizeTrackingRef.current = false;
+        }
+
         leftSidebarPanelSizeRef.current = sidebarSize;
         applyLeftSidebarPanelSize(sidebarSize);
 
@@ -220,6 +247,11 @@ export function ClassicMainBody() {
     (isDragging: boolean) => {
       leftSidebarResizeDraggingRef.current = isDragging;
       setLeftSidebarResizing(isDragging);
+
+      if (isDragging) {
+        leftSidebarDefaultSizeTrackingRef.current = false;
+        pendingLeftSidebarDefaultSizeRef.current = null;
+      }
 
       if (!isDragging) {
         commitLeftSidebarPanelSize(
@@ -275,6 +307,95 @@ export function ClassicMainBody() {
     leftsidebar.toggleExpanded,
     restoreLeftSidebarPanelSize,
   ]);
+  const syncDefaultLeftSidebarPanelSize = useCallback(() => {
+    if (
+      !mountLeftSidebarPanel ||
+      leftSidebarResizeDraggingRef.current ||
+      !leftSidebarDefaultSizeTrackingRef.current
+    ) {
+      return;
+    }
+
+    const currentConstraints = leftSidebarPanelConstraintsRef.current;
+
+    if (
+      !panelSizesAreEqual(
+        leftSidebarPanelSizeRef.current,
+        currentConstraints.defaultSize,
+      )
+    ) {
+      leftSidebarDefaultSizeTrackingRef.current = false;
+      return;
+    }
+
+    const measuredWidth = getMeasuredMainAreaWidthPx(bodyRootRef.current);
+    const nextConstraints = createLeftSidebarPanelConstraints(measuredWidth);
+
+    if (
+      panelSizesAreEqual(
+        nextConstraints.defaultSize,
+        currentConstraints.defaultSize,
+      ) &&
+      panelSizesAreEqual(nextConstraints.minSize, currentConstraints.minSize) &&
+      panelSizesAreEqual(nextConstraints.maxSize, currentConstraints.maxSize)
+    ) {
+      return;
+    }
+
+    leftSidebarPanelConstraintsRef.current = nextConstraints;
+    setLeftSidebarPanelConstraints(nextConstraints);
+    leftSidebarPanelSizeRef.current = nextConstraints.defaultSize;
+    lastExpandedLeftSidebarPanelSizeRef.current = nextConstraints.defaultSize;
+    pendingLeftSidebarDefaultSizeRef.current = nextConstraints.defaultSize;
+    commitLeftSidebarPanelSize(nextConstraints.defaultSize);
+    applyLeftSidebarPanelSize(nextConstraints.defaultSize);
+
+    window.requestAnimationFrame(() => {
+      resizeLeftSidebarPanel(
+        leftSidebarPanelRef.current,
+        nextConstraints.defaultSize,
+      );
+    });
+  }, [
+    applyLeftSidebarPanelSize,
+    commitLeftSidebarPanelSize,
+    mountLeftSidebarPanel,
+  ]);
+  syncDefaultLeftSidebarPanelSizeRef.current = syncDefaultLeftSidebarPanelSize;
+  useMountEffect(() => {
+    const bodyRoot = bodyRootRef.current;
+    let syncFrame: number | null = null;
+
+    const scheduleDefaultSizeSync = () => {
+      if (syncFrame !== null) {
+        window.cancelAnimationFrame(syncFrame);
+      }
+
+      syncFrame = window.requestAnimationFrame(() => {
+        syncFrame = null;
+        syncDefaultLeftSidebarPanelSizeRef.current();
+      });
+    };
+
+    scheduleDefaultSizeSync();
+    window.addEventListener("resize", scheduleDefaultSizeSync);
+
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined" && bodyRoot
+        ? new ResizeObserver(scheduleDefaultSizeSync)
+        : null;
+    if (resizeObserver && bodyRoot) {
+      resizeObserver.observe(bodyRoot);
+    }
+
+    return () => {
+      if (syncFrame !== null) {
+        window.cancelAnimationFrame(syncFrame);
+      }
+      window.removeEventListener("resize", scheduleDefaultSizeSync);
+      resizeObserver?.disconnect();
+    };
+  });
   const handleLeftSidebarChromeWheel = useCallback(
     (event: WheelEvent<HTMLDivElement>) => {
       if (!showSidebarTimeline) {
@@ -480,9 +601,9 @@ export function ClassicMainBody() {
   );
 }
 
-function createLeftSidebarPanelConstraints() {
+function createLeftSidebarPanelConstraints(widthPx?: number) {
   const containerWidthPx = Math.max(
-    getInitialMainAreaWidthPx(),
+    widthPx ?? getInitialMainAreaWidthPx(),
     LEFT_SIDEBAR_DEFAULT_WIDTH_PX,
   );
   const minSize = percentageFromPixels(
@@ -503,6 +624,12 @@ function createLeftSidebarPanelConstraints() {
   };
 }
 
+function getMeasuredMainAreaWidthPx(element: HTMLElement | null) {
+  const measuredWidth = element?.getBoundingClientRect().width ?? 0;
+
+  return measuredWidth > 0 ? measuredWidth : getInitialMainAreaWidthPx();
+}
+
 function getInitialMainAreaWidthPx() {
   if (typeof window === "undefined") {
     return LEFT_SIDEBAR_FALLBACK_CONTAINER_WIDTH_PX;
@@ -517,6 +644,10 @@ function getInitialMainAreaWidthPx() {
 
 function percentageFromPixels(widthPx: number, containerWidthPx: number) {
   return Math.min((widthPx / containerWidthPx) * 100, 100);
+}
+
+function panelSizesAreEqual(left: number, right: number) {
+  return Math.abs(left - right) < LEFT_SIDEBAR_PANEL_SIZE_EPSILON;
 }
 
 function resizeLeftSidebarPanel(


### PR DESCRIPTION
Keep the untouched left sidebar default tied to the rendered body width and cover startup resize behavior with a regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop shell layout logic with guarded default-size tracking; no auth, data, or API changes.
> 
> **Overview**
> **Fixes the classic main left sidebar** so its default/min/max panel percentages stay tied to the **rendered body width** (via `getBoundingClientRect`), not just `window.innerWidth` on first paint.
> 
> On mount and when the body resizes (`resize` + `ResizeObserver`), **`syncDefaultLeftSidebarPanelSize`** recomputes constraints from ~200px defaults and calls `panel.resize` only while the user is still at the untouched default. Manual resize or drag turns off that tracking; **`handlePanelLayout`** also ignores intermediate layouts until a pending programmatic resize settles (epsilon compare).
> 
> **Tests** mock body width and rAF to cover startup settle, window resize, ignoring stale `onLayout` values, and syncing after the sidebar panel appears when leaving onboarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c0e3ec0002dcf7a4f756450d4ff5b2c80d40d2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->