### PR TITLE
Keep sidebar collapse from restoring window width

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -412,6 +412,20 @@ describe("ClassicMainBody", () => {
     expect(panels[1]?.dataset.minWidth).toBe("500");
   });
 
+  it("keeps the empty content panel at least 500px wide", () => {
+    mocks.currentTab = {
+      active: true,
+      pinned: false,
+      slotId: "slot-home",
+      type: "empty",
+    };
+
+    render(<ClassicMainBody />);
+
+    const panels = screen.getAllByTestId("panel");
+    expect(panels[1]?.dataset.minWidth).toBe("500");
+  });
+
   it("collapses the sidebar panel without unmounting the animated shell", () => {
     mocks.leftsidebar.expanded = false;
 

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -43,7 +43,10 @@ import { useClassicMainTabsShortcuts } from "./useTabsShortcuts";
 import { useShell } from "~/contexts/shell";
 import { scrollElementByWheel } from "~/shared/dom/scroll-wheel";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
-import { NOTE_SURFACE_MIN_WIDTH_PX } from "~/shared/main/layout-widths";
+import {
+  NOTE_SURFACE_MIN_WIDTH_PX,
+  usesNoteSurfaceMinWidth,
+} from "~/shared/main/layout-widths";
 import { useOpenNoteDialog } from "~/shared/open-note-dialog";
 import { useNewNote } from "~/shared/useNewNote";
 import { useSidebarUpcomingMeetingStatus } from "~/sidebar/timeline/upcoming-meeting";
@@ -141,7 +144,7 @@ export function ClassicMainBody() {
   });
 
   const isOnboarding = currentTab?.type === "onboarding";
-  const isSessionTab = currentTab?.type === "sessions";
+  const reserveNoteSurfaceMinWidth = usesNoteSurfaceMinWidth(currentTab);
   const hasCustomSidebar = hasCustomSidebarTab(currentTab);
   const hasLeftSurfaceCustomSidebar =
     hasLeftSurfaceCustomSidebarTab(currentTab);
@@ -455,7 +458,9 @@ export function ClassicMainBody() {
           order={2}
           className="min-h-0 flex-1 overflow-hidden"
           style={{
-            minWidth: isSessionTab ? NOTE_SURFACE_MIN_WIDTH_PX : undefined,
+            minWidth: reserveNoteSurfaceMinWidth
+              ? NOTE_SURFACE_MIN_WIDTH_PX
+              : undefined,
           }}
         >
           <div

--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -216,6 +216,19 @@ describe("MainChatPanels", () => {
     expect(screen.getAllByTestId("panel")[0]?.dataset.minWidth).toBe("700");
   });
 
+  it("reserves enough main-body width for the empty surface beside the sidebar", () => {
+    mocks.currentTab = { type: "empty" };
+    mocks.leftSidebarExpanded = true;
+
+    render(
+      <MainChatPanels>
+        <div data-testid="main-content" />
+      </MainChatPanels>,
+    );
+
+    expect(screen.getAllByTestId("panel")[0]?.dataset.minWidth).toBe("700");
+  });
+
   it("expands left when opening the sidebar would make a note surface narrower than 500px", () => {
     mocks.currentTab = { type: "sessions" };
     mocks.leftSidebarExpanded = true;
@@ -229,6 +242,26 @@ describe("MainChatPanels", () => {
         <div data-left-sidebar-chrome />
         <div data-chat-floating-anchor>
           <div data-session-surface />
+        </div>
+      </MainChatPanels>,
+    );
+
+    expect(mocks.windowExpandWidth).toHaveBeenCalledWith(60, null, false, true);
+  });
+
+  it("expands left when opening the sidebar would make the empty surface narrower than 500px", () => {
+    mocks.currentTab = { type: "empty" };
+    mocks.leftSidebarExpanded = true;
+    mockPanelWidths({
+      bodyPanelWidth: 640,
+      leftSidebarWidth: 200,
+    });
+
+    render(
+      <MainChatPanels>
+        <div data-left-sidebar-chrome />
+        <div data-chat-floating-anchor>
+          <div data-testid="empty-surface" />
         </div>
       </MainChatPanels>,
     );

--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -246,7 +246,13 @@ describe("MainChatPanels", () => {
       </MainChatPanels>,
     );
 
-    expect(mocks.windowExpandWidth).toHaveBeenCalledWith(60, null, false, true);
+    expect(mocks.windowExpandWidth).toHaveBeenCalledWith(
+      60,
+      null,
+      false,
+      true,
+      false,
+    );
   });
 
   it("expands left when opening the sidebar would make the empty surface narrower than 500px", () => {
@@ -266,7 +272,13 @@ describe("MainChatPanels", () => {
       </MainChatPanels>,
     );
 
-    expect(mocks.windowExpandWidth).toHaveBeenCalledWith(60, null, false, true);
+    expect(mocks.windowExpandWidth).toHaveBeenCalledWith(
+      60,
+      null,
+      false,
+      true,
+      false,
+    );
   });
 
   it("expands right when docked chat would make a note surface narrower than 500px", () => {
@@ -292,6 +304,7 @@ describe("MainChatPanels", () => {
       null,
       false,
       false,
+      true,
     );
   });
 
@@ -342,7 +355,40 @@ describe("MainChatPanels", () => {
       null,
       false,
       false,
+      true,
     );
+  });
+
+  it("does not restore window width after closing a left-sidebar expansion", () => {
+    mocks.currentTab = { type: "sessions" };
+    mocks.leftSidebarExpanded = true;
+    mockPanelWidths({
+      bodyPanelWidth: 640,
+      leftSidebarWidth: 200,
+    });
+
+    const renderPanels = () => (
+      <MainChatPanels>
+        <div data-left-sidebar-chrome />
+        <div data-chat-floating-anchor>
+          <div data-session-surface />
+        </div>
+      </MainChatPanels>
+    );
+    const { rerender } = render(renderPanels());
+
+    expect(mocks.windowExpandWidth).toHaveBeenCalledWith(
+      60,
+      null,
+      false,
+      true,
+      false,
+    );
+
+    mocks.leftSidebarExpanded = false;
+    rerender(renderPanels());
+
+    expect(mocks.windowRestoreWidth).not.toHaveBeenCalled();
   });
 
   it("restores window width expansions after the side panels close", () => {
@@ -369,6 +415,7 @@ describe("MainChatPanels", () => {
       null,
       false,
       false,
+      true,
     );
 
     mocks.chatMode = "FloatingClosed";

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -129,7 +129,7 @@ function useNoteSurfaceWindowWidthGuard({
   leftPanelOpen: boolean;
   rightPanelOpen: boolean;
 }) {
-  const expansionCountRef = useRef(0);
+  const restorableExpansionCountRef = useRef(0);
   const lastVisibleBodyWidthRef = useRef<number | null>(null);
   const previousStateRef = useRef({
     enabled: false,
@@ -138,8 +138,8 @@ function useNoteSurfaceWindowWidthGuard({
   });
 
   const restoreWidthExpansions = useCallback(() => {
-    const restoreCount = expansionCountRef.current;
-    expansionCountRef.current = 0;
+    const restoreCount = restorableExpansionCountRef.current;
+    restorableExpansionCountRef.current = 0;
 
     for (let i = 0; i < restoreCount; i += 1) {
       void windowsCommands.windowRestoreWidth();
@@ -212,13 +212,18 @@ function useNoteSurfaceWindowWidthGuard({
     }
 
     const expandLeft = leftPanelJustOpened && !rightPanelJustOpened;
+    const restoreOnClose = !expandLeft;
 
-    expansionCountRef.current += 1;
+    if (restoreOnClose) {
+      restorableExpansionCountRef.current += 1;
+    }
+
     void windowsCommands.windowExpandWidth(
       widthDeficit,
       null,
       false,
       expandLeft,
+      restoreOnClose,
     );
   }, [
     bodyPanelContainerRef,

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -8,7 +8,10 @@ import {
   ResizablePanelGroup,
 } from "@hypr/ui/components/ui/resizable";
 
-import { NOTE_SURFACE_MIN_WIDTH_PX } from "./layout-widths";
+import {
+  NOTE_SURFACE_MIN_WIDTH_PX,
+  usesNoteSurfaceMinWidth,
+} from "./layout-widths";
 
 import { ChatPanelFrame, ChatSessionHost } from "~/chat/components/chat-panel";
 import { PersistentChatPanel } from "~/chat/components/persistent-chat";
@@ -23,7 +26,7 @@ export function MainChatPanels({ children }: { children: React.ReactNode }) {
   const currentTab = useTabs((state) => state.currentTab);
   const bodyPanelContainerRef = useRef<HTMLDivElement>(null);
   const isRightPanelOpen = chat.mode === "RightPanelOpen";
-  const isSessionTab = currentTab?.type === "sessions";
+  const reserveNoteSurfaceMinWidth = usesNoteSurfaceMinWidth(currentTab);
   const collapseLeftSidebar = useCallback(() => {
     leftsidebar.setExpanded(false);
   }, [leftsidebar.setExpanded]);
@@ -34,7 +37,7 @@ export function MainChatPanels({ children }: { children: React.ReactNode }) {
 
   useNoteSurfaceWindowWidthGuard({
     bodyPanelContainerRef,
-    enabled: isSessionTab,
+    enabled: reserveNoteSurfaceMinWidth,
     leftPanelOpen: leftsidebar.expanded,
     collapseLeftPanel: collapseLeftSidebar,
     rightPanelOpen: isRightPanelOpen,
@@ -103,7 +106,7 @@ function getMainBodyMinWidth({
   currentTab: Tab | null;
   leftSidebarExpanded: boolean;
 }) {
-  if (currentTab?.type !== "sessions") {
+  if (!usesNoteSurfaceMinWidth(currentTab)) {
     return undefined;
   }
 

--- a/apps/desktop/src/shared/main/layout-widths.ts
+++ b/apps/desktop/src/shared/main/layout-widths.ts
@@ -1,1 +1,7 @@
+import type { Tab } from "~/store/zustand/tabs";
+
 export const NOTE_SURFACE_MIN_WIDTH_PX = 500;
+
+export function usesNoteSurfaceMinWidth(tab: Pick<Tab, "type"> | null) {
+  return tab?.type === "sessions" || tab?.type === "empty";
+}

--- a/plugins/windows/js/bindings.gen.ts
+++ b/plugins/windows/js/bindings.gen.ts
@@ -150,6 +150,7 @@ export const commands = {
     maxCurrentWidth: number | null,
     checkMonitorSpace: boolean,
     expandLeft: boolean,
+    restoreOnClose: boolean,
   ): Promise<Result<null, string>> {
     try {
       return {
@@ -159,6 +160,7 @@ export const commands = {
           maxCurrentWidth,
           checkMonitorSpace,
           expandLeft,
+          restoreOnClose,
         }),
       };
     } catch (e) {

--- a/plugins/windows/src/commands.rs
+++ b/plugins/windows/src/commands.rs
@@ -197,6 +197,7 @@ pub async fn window_expand_width(
     max_current_width: Option<u32>,
     check_monitor_space: bool,
     expand_left: bool,
+    restore_on_close: bool,
 ) -> Result<(), String> {
     if check_monitor_space {
         let outer_size = window.outer_size().map_err(|e| e.to_string())?;
@@ -254,7 +255,7 @@ pub async fn window_expand_width(
         })
         .map_err(|e| e.to_string())?;
 
-        if let Some(entry) = pushed {
+        if restore_on_close && let Some(entry) = pushed {
             app.state::<crate::WindowExpansions>()
                 .0
                 .lock()
@@ -281,17 +282,19 @@ pub async fn window_expand_width(
             }))
             .map_err(|e| e.to_string())?;
 
-        app.state::<crate::WindowExpansions>()
-            .0
-            .lock()
-            .unwrap()
-            .entry(window.label().to_string())
-            .or_default()
-            .push((
-                f64::from(outer_size.width),
-                f64::from(new_width),
-                expand_left,
-            ));
+        if restore_on_close {
+            app.state::<crate::WindowExpansions>()
+                .0
+                .lock()
+                .unwrap()
+                .entry(window.label().to_string())
+                .or_default()
+                .push((
+                    f64::from(outer_size.width),
+                    f64::from(new_width),
+                    expand_left,
+                ));
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Prevent the main window from shrinking when the left sidebar collapses after a layout-driven width expansion.

**Stack**
- Base PR: #5840 `fix/empty-view-min-width`
- This PR builds on that shared note-surface window-width guard and narrows how native width restores are recorded.

**Changes**
- Add `restoreOnClose` to `windowExpandWidth` so the native plugin only records restorable expansions when requested.
- Keep right chat panel expansions restorable, while left-sidebar-only expansions stay expanded after the sidebar collapses.
- Add regression coverage for closing a sidebar-triggered expansion without calling `windowRestoreWidth`.

**Verification**
- `pnpm exec dprint fmt`
- `pnpm -F desktop exec vitest run src/shared/main/chat-panels.test.tsx`
- `pnpm -F desktop typecheck`
- `cargo check -p tauri-plugin-windows`