### PR TITLE
Split desktop CI checks

### DIFF
--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -42,7 +42,6 @@ jobs:
       - run: pnpm -F ui build
       - run: pnpm -F desktop typecheck
       - run: pnpm -F desktop test
-      - run: pnpm -F desktop i18n:check
       - uses: ./.github/actions/install_desktop_deps
         with:
           target: ${{ matrix.platform }}
@@ -140,9 +139,33 @@ jobs:
             --exclude activity-capture-macos \
             --exclude tauri-plugin-activity-capture
 
+  desktop_i18n:
+    if: ${{ !startsWith(github.head_ref || '', 'blog/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: ./.github/actions/pnpm_install
+      - run: pnpm -F desktop i18n:check
+
+  desktop_swift:
+    if: ${{ !startsWith(github.head_ref || '', 'blog/') }}
+    runs-on: depot-macos-15
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - run: swift build --package-path plugins/windows/swift-lib
+
   ci:
     if: always()
-    needs: [desktop_ci]
+    needs: [desktop_ci, desktop_i18n, desktop_swift]
     runs-on: ubuntu-latest
     steps:
       - run: exit 1


### PR DESCRIPTION
Run Lingui catalog drift and the Windows Swift package as separate desktop CI jobs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; same checks run in parallel jobs with no application code touched.
> 
> **Overview**
> Desktop CI is split so the main **`desktop_ci`** macOS job no longer runs Lingui drift or Swift builds inline.
> 
> **`desktop_i18n`** runs on **ubuntu-latest** with checkout, pnpm install, and **`pnpm -F desktop i18n:check`** (extract/compile + fail on locale git diff). **`desktop_swift`** runs on **depot-macos-15** with **`swift build --package-path plugins/windows/swift-lib`**. The gate **`ci`** job now **`needs`** **`desktop_ci`**, **`desktop_i18n`**, and **`desktop_swift`** and still fails on any failure or cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 314002bdd80f7d3a7d2f59c4e218a22c9300b80d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->