### PR TITLE
Darken floating bar hover surface

### DIFF
--- a/plugins/windows/swift-lib/src/FloatingBarView.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarView.swift
@@ -10,6 +10,7 @@ enum FloatingBarLayout {
   static let compactIconSize: CGFloat = 34
   static let compactGap: CGFloat = 4
   static let compactHorizontalPadding: CGFloat = 5
+  static let compactControlSurfaceInset: CGFloat = (compactHeight - compactIconSize) / 2
   static let compactCornerControlFactor: CGFloat = 0.55228475
   static let expandedWidth: CGFloat = 360
   static let expandedHeight: CGFloat = 430
@@ -90,8 +91,10 @@ struct FloatingBarView: View {
       FloatingBarLayout.compactHeight
       + (isBarHovered ? FloatingBarLayout.hoverHandleReservedHeight : 0)
     let width = FloatingBarLayout.compactWidth(showsExpand: model.liveCaptionToggleVisible)
-    let radius = FloatingBarLayout.compactHeight / 2
-    let pillShape = FloatingBarSurfaceShape(
+    let controlsWidth = FloatingBarLayout.compactControlsWidth(
+      showsExpand: model.liveCaptionToggleVisible)
+    let radius = isBarHovered ? height / 2 : FloatingBarLayout.compactHeight / 2
+    let surfaceShape = FloatingBarSurfaceShape(
       topRadius: radius,
       bottomRadius: radius,
       cornerControlFactor: FloatingBarLayout.compactCornerControlFactor
@@ -115,10 +118,20 @@ struct FloatingBarView: View {
         .transition(.opacity)
       }
 
+      if isBarHovered {
+        Capsule(style: .continuous)
+          .fill(compactControlSurfaceColor)
+          .frame(
+            width: controlsWidth,
+            height: FloatingBarLayout.compactIconSize
+          )
+          .padding(.bottom, FloatingBarLayout.compactControlSurfaceInset)
+          .transition(.opacity.combined(with: .scale(scale: 0.98)))
+      }
+
       floatingControls(isExpanded: false)
         .frame(
-          width: FloatingBarLayout.compactControlsWidth(
-            showsExpand: model.liveCaptionToggleVisible),
+          width: controlsWidth,
           height: FloatingBarLayout.compactHeight
         )
         .frame(
@@ -132,19 +145,19 @@ struct FloatingBarView: View {
       alignment: .bottom
     )
     .background(
-      pillShape
+      surfaceShape
         .fill(isBarHovered ? envelopeSurfaceColor : surfaceColor)
     )
     .overlay(
-      pillShape
+      surfaceShape
         .strokeBorder(outerStrokeColor, lineWidth: 0.5)
     )
     .overlay(
-      pillShape
+      surfaceShape
         .strokeBorder(innerStrokeColor, lineWidth: 0.5)
         .padding(1)
     )
-    .clipShape(pillShape)
+    .clipShape(surfaceShape)
     .animation(.easeOut(duration: 0.12), value: isBarHovered)
   }
 
@@ -347,26 +360,34 @@ struct FloatingBarView: View {
 
   private var surfaceColor: Color {
     if model.colorScheme == .dark {
-      return Color(red: 0.43, green: 0.44, blue: 0.40).opacity(primarySurfaceOpacity)
+      return Color(red: 0.36, green: 0.37, blue: 0.34).opacity(primarySurfaceOpacity)
     }
 
-    return Color(red: 0.86, green: 0.85, blue: 0.82).opacity(primarySurfaceOpacity)
+    return Color(red: 0.76, green: 0.75, blue: 0.71).opacity(primarySurfaceOpacity)
   }
 
   private var envelopeSurfaceColor: Color {
     if model.colorScheme == .dark {
-      return Color(red: 0.43, green: 0.44, blue: 0.40).opacity(envelopeSurfaceOpacity)
+      return Color(red: 0.36, green: 0.37, blue: 0.34).opacity(envelopeSurfaceOpacity)
     }
 
-    return Color(red: 0.86, green: 0.85, blue: 0.82).opacity(envelopeSurfaceOpacity)
+    return Color(red: 0.76, green: 0.75, blue: 0.71).opacity(envelopeSurfaceOpacity)
+  }
+
+  private var compactControlSurfaceColor: Color {
+    if model.colorScheme == .dark {
+      return Color(red: 0.49, green: 0.50, blue: 0.46).opacity(primarySurfaceOpacity)
+    }
+
+    return Color(red: 0.88, green: 0.87, blue: 0.83).opacity(primarySurfaceOpacity)
   }
 
   private var primarySurfaceOpacity: Double {
-    settings.floatingBarOpacity * 0.82
+    min(settings.floatingBarOpacity * 0.96, FloatingOverlayOpacity.maxFloatingBar)
   }
 
   private var envelopeSurfaceOpacity: Double {
-    min(settings.floatingBarOpacity * 1.08, FloatingOverlayOpacity.maxFloatingBar)
+    min(settings.floatingBarOpacity * 1.12, FloatingOverlayOpacity.maxFloatingBar)
   }
 
   private var primaryContentColor: Color {


### PR DESCRIPTION
Adds a separate compact hover control surface and darkens the native floating bar shell.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SwiftUI-only visual and hover styling in the Windows floating bar; no behavior, auth, or data changes.
> 
> **Overview**
> **Darkens** the native floating bar shell in light and dark mode by lowering the RGB values used for `surfaceColor` and `envelopeSurfaceOpacity`, and bumps opacity scaling (`primarySurfaceOpacity` and `envelopeSurfaceOpacity`) so the bar reads more solid while still respecting `FloatingOverlayOpacity.maxFloatingBar`.
> 
> On **compact hover**, the outer shape now uses a taller corner radius (`height / 2` instead of a fixed pill radius), and a **lighter capsule** (`compactControlSurfaceColor`) appears behind the stop/expand controls with a fade/scale transition. Layout adds `compactControlSurfaceInset` to align that capsule with the icon row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 795c0fdbba3d8cbb69ada18dfb10a6c6d9c38168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->