### PR TITLE
Improve fs-sync write errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18240,6 +18240,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-settings",
  "tauri-specta",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/fs-sync-core/src/path.rs
+++ b/crates/fs-sync-core/src/path.rs
@@ -74,6 +74,10 @@ pub fn resolve_path_inside_base(base: &Path, path: &Path) -> Result<PathBuf> {
     let suffix = candidate
         .strip_prefix(existing)
         .map_err(|_| crate::Error::Path("path_outside_base".into()))?;
+    if suffix.as_os_str().is_empty() {
+        return Ok(existing_canonical);
+    }
+
     let resolved = existing_canonical.join(suffix);
     if !resolved.starts_with(&base) {
         return Err(crate::Error::Path("path_outside_base".into()));
@@ -179,6 +183,18 @@ mod tests {
         let result = resolve_path_inside_base(base, &base.join("note.txt")).unwrap();
 
         assert_eq!(result, base.canonicalize().unwrap().join("note.txt"));
+    }
+
+    #[test]
+    fn resolve_path_inside_base_existing_file_is_writable() {
+        let temp = assert_fs::TempDir::new().unwrap();
+        let base = temp.path();
+        temp.child("note.txt").write_str("hello").unwrap();
+
+        let result = resolve_path_inside_base(base, Path::new("note.txt")).unwrap();
+
+        std::fs::write(&result, "updated").unwrap();
+        assert_eq!(std::fs::read_to_string(&result).unwrap(), "updated");
     }
 
     #[test]

--- a/plugins/fs-sync/Cargo.toml
+++ b/plugins/fs-sync/Cargo.toml
@@ -12,6 +12,7 @@ tauri-plugin = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
 specta-typescript = { workspace = true }
+tempfile = { workspace = true }
 
 [dependencies]
 hypr-fs-sync-core = { workspace = true, features = ["tauri-event"] }

--- a/plugins/fs-sync/src/commands.rs
+++ b/plugins/fs-sync/src/commands.rs
@@ -56,7 +56,11 @@ pub(crate) async fn write_json_batch<R: tauri::Runtime>(
         .map_err(|e| e.to_string())?;
     let items: Vec<(Value, PathBuf)> = items
         .into_iter()
-        .map(|(json, path)| resolve_vault_path(&base_path, &path).map(|path| (json, path)))
+        .map(|(json, path)| {
+            resolve_vault_path(&base_path, &path)
+                .map(|resolved_path| (json, resolved_path))
+                .map_err(|e| format!("failed to resolve json path {path}: {e}"))
+        })
         .collect::<Result<_, _>>()?;
 
     let relative_paths: Vec<String> = items
@@ -73,11 +77,10 @@ pub(crate) async fn write_json_batch<R: tauri::Runtime>(
 
     spawn_blocking!({
         items.into_par_iter().try_for_each(|(json, path)| {
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-            }
-            let content = crate::json::serialize(json)?;
-            std::fs::write(path, content).map_err(|e| e.to_string())
+            create_parent_dir_for_write(&path)?;
+            let content = crate::json::serialize(json)
+                .map_err(|e| format!("failed to serialize json for {}: {e}", path.display()))?;
+            write_file_with_context(&path, content)
         })
     })
 }
@@ -95,7 +98,11 @@ pub(crate) async fn write_document_batch<R: tauri::Runtime>(
         .map_err(|e| e.to_string())?;
     let items: Vec<(ParsedDocument, PathBuf)> = items
         .into_iter()
-        .map(|(doc, path)| resolve_vault_path(&base_path, &path).map(|path| (doc, path)))
+        .map(|(doc, path)| {
+            resolve_vault_path(&base_path, &path)
+                .map(|resolved_path| (doc, resolved_path))
+                .map_err(|e| format!("failed to resolve document path {path}: {e}"))
+        })
         .collect::<Result<_, _>>()?;
 
     let relative_paths: Vec<String> = items
@@ -112,13 +119,31 @@ pub(crate) async fn write_document_batch<R: tauri::Runtime>(
 
     spawn_blocking!({
         items.into_par_iter().try_for_each(|(doc, path)| {
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-            }
-            let content = doc.render().map_err(|e| e.to_string())?;
-            std::fs::write(path, content).map_err(|e| e.to_string())
+            create_parent_dir_for_write(&path)?;
+            let content = doc
+                .render()
+                .map_err(|e| format!("failed to render document for {}: {e}", path.display()))?;
+            write_file_with_context(&path, content)
         })
     })
+}
+
+fn create_parent_dir_for_write(path: &Path) -> Result<(), String> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+
+    std::fs::create_dir_all(parent).map_err(|e| {
+        format!(
+            "failed to create parent directory {} for {}: {e}",
+            parent.display(),
+            path.display()
+        )
+    })
+}
+
+fn write_file_with_context(path: &Path, content: String) -> Result<(), String> {
+    std::fs::write(path, content).map_err(|e| format!("failed to write {}: {e}", path.display()))
 }
 
 #[tauri::command]
@@ -460,4 +485,23 @@ pub(crate) async fn attachment_remove<R: tauri::Runtime>(
             .attachment_remove(&session_id, &attachment_id)
             .map_err(|e| e.to_string())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_parent_dir_error_includes_parent_and_target_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let blocker = temp.path().join("sessions");
+        std::fs::write(&blocker, "not a directory").unwrap();
+
+        let target = blocker.join("session-1").join("_meta.json");
+        let error = create_parent_dir_for_write(&target).unwrap_err();
+
+        assert!(error.contains("failed to create parent directory"));
+        assert!(error.contains(&target.parent().unwrap().display().to_string()));
+        assert!(error.contains(&target.display().to_string()));
+    }
 }


### PR DESCRIPTION
Include target paths when JSON and document batch writes fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized changes to error strings and a small path-resolution edge case in vault writes; behavior is covered by new tests with no auth or data-model impact.
> 
> **Overview**
> **Vault batch writes** (`write_json_batch`, `write_document_batch`) now return clearer failures: path resolution, JSON serialize, document render, parent directory creation, and file write each include the **vault-relative path** and, where relevant, the resolved filesystem path in the error string. Shared helpers `create_parent_dir_for_write` and `write_file_with_context` centralize that messaging.
> 
> **Path resolution** in `resolve_path_inside_base` handles the case where the target is an **existing file** (empty suffix after strip): it returns the canonical path directly instead of joining an empty suffix, with a test confirming relative paths to existing files remain writable.
> 
> Adds **`tempfile`** as a dev dependency for a unit test on parent-directory creation errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dc3afdf23e8808f4d778949bad30638d3dd6d79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->