### PR TITLE
Reduce calendar fallback log noise

### DIFF
--- a/crates/calendar/src/lib.rs
+++ b/crates/calendar/src/lib.rs
@@ -83,9 +83,15 @@ pub async fn list_connection_ids(
                 }
             }
             Err(e) => {
-                tracing::warn!(
-                    "failed to fetch remote connection ids: {e}; continuing with local providers only"
-                );
+                if is_local_api_base_url(api_base_url) {
+                    tracing::debug!(
+                        "failed to fetch remote connection ids from local API: {e}; continuing with local providers only"
+                    );
+                } else {
+                    tracing::warn!(
+                        "failed to fetch remote connection ids: {e}; continuing with local providers only"
+                    );
+                }
             }
         }
     }
@@ -97,6 +103,16 @@ pub async fn list_connection_ids(
             connection_ids,
         })
         .collect())
+}
+
+fn is_local_api_base_url(api_base_url: &str) -> bool {
+    reqwest::Url::parse(api_base_url)
+        .ok()
+        .and_then(|url| {
+            url.host_str()
+                .map(|host| matches!(host, "localhost" | "127.0.0.1" | "::1" | "[::1]"))
+        })
+        .unwrap_or(false)
 }
 
 pub async fn is_provider_enabled(
@@ -212,6 +228,15 @@ pub fn parse_meeting_link(text: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn detects_local_api_base_urls() {
+        assert!(is_local_api_base_url("http://localhost:3001"));
+        assert!(is_local_api_base_url("http://127.0.0.1:3001"));
+        assert!(is_local_api_base_url("http://[::1]:3001"));
+        assert!(!is_local_api_base_url("https://api.example.com"));
+        assert!(!is_local_api_base_url("not a url"));
+    }
 
     #[test]
     fn parse_meeting_link_real_world() {


### PR DESCRIPTION
Downgrade expected local API connection failures to debug while keeping remote API failures as warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with no effect on connection resolution or error handling paths.
> 
> **Overview**
> When **`list_connection_ids`** cannot fetch remote Google/Outlook connection IDs, logging now depends on **`api_base_url`**: failures against **localhost / loopback** hosts are **`tracing::debug!`** (expected in local dev); other URLs still **`tracing::warn!`**.
> 
> Adds **`is_local_api_base_url`** (parses the URL and matches `localhost`, `127.0.0.1`, `::1`, `[::1]`) plus unit tests. Behavior is unchanged—still continues with local providers only on error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a23c666649f394f1187e4df718ecfe2ec860a18a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->