### PR TITLE
Add calendar accordion gutters

### DIFF
--- a/apps/desktop/src/calendar/components/calendar-selection.tsx
+++ b/apps/desktop/src/calendar/components/calendar-selection.tsx
@@ -1,21 +1,13 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import {
   CalendarOffIcon,
-  ChevronDown,
   CheckIcon,
   EllipsisIcon,
   Loader2Icon,
   RefreshCwIcon,
 } from "lucide-react";
-import { type MouseEvent, useMemo } from "react";
+import { type MouseEvent } from "react";
 
-import {
-  Accordion,
-  AccordionContent,
-  AccordionHeader,
-  AccordionItem,
-  AccordionTriggerPrimitive,
-} from "@hypr/ui/components/ui/accordion";
 import { cn } from "@hypr/utils";
 
 import {
@@ -55,11 +47,6 @@ export function CalendarSelection({
   disableHoverTone,
 }: CalendarSelectionProps) {
   const { t } = useLingui();
-  const defaultOpen = useMemo(
-    () => groups.map((group) => group.id ?? group.sourceName),
-    [groups],
-  );
-  const accordionKey = groups.length === 0 ? "empty" : "loaded";
 
   if (groups.length === 0) {
     return (
@@ -100,61 +87,42 @@ export function CalendarSelection({
     );
   }
 
-  if (groups.length === 1) {
-    return (
-      <div className={cn(["flex flex-col gap-1 px-2", className])}>
-        <CalendarGroupHeader group={groups[0]} />
-
-        {groups[0].calendars.map((cal) => (
-          <CalendarToggleRow
-            key={cal.id}
-            calendar={cal}
-            enabled={cal.enabled}
-            onToggle={(enabled) => onToggle(cal, enabled)}
-          />
-        ))}
-      </div>
-    );
-  }
-
   return (
-    <Accordion
-      key={accordionKey}
-      type="multiple"
-      defaultValue={defaultOpen}
-      className={cn(["divide-y", className])}
-    >
+    <div className={cn(["flex flex-col gap-3", className])}>
       {groups.map((group) => {
+        const showHeader =
+          groups.length > 1 || (group.menuItems?.length ?? 0) > 0;
+
         return (
-          <AccordionItem
+          <div
             key={group.id ?? group.sourceName}
-            value={group.id ?? group.sourceName}
-            className="group/group border-none px-2"
+            className="flex flex-col gap-1"
           >
-            <CalendarGroupAccordionHeader
-              group={group}
-              disableHoverTone={disableHoverTone}
-            />
-            <AccordionContent className="pb-2">
-              <div className="flex flex-col gap-1">
-                {group.calendars.map((cal) => (
-                  <CalendarToggleRow
-                    key={cal.id}
-                    calendar={cal}
-                    enabled={cal.enabled}
-                    onToggle={(enabled) => onToggle(cal, enabled)}
-                  />
-                ))}
-              </div>
-            </AccordionContent>
-          </AccordionItem>
+            {showHeader ? (
+              <CalendarGroupHeader
+                group={group}
+                disableHoverTone={disableHoverTone}
+              />
+            ) : null}
+
+            <div className="flex flex-col gap-1">
+              {group.calendars.map((cal) => (
+                <CalendarToggleRow
+                  key={cal.id}
+                  calendar={cal}
+                  enabled={cal.enabled}
+                  onToggle={(enabled) => onToggle(cal, enabled)}
+                />
+              ))}
+            </div>
+          </div>
         );
       })}
-    </Accordion>
+    </div>
   );
 }
 
-function CalendarGroupAccordionHeader({
+function CalendarGroupHeader({
   group,
   disableHoverTone,
 }: {
@@ -163,70 +131,20 @@ function CalendarGroupAccordionHeader({
 }) {
   const showContextMenu = useNativeContextMenu(group.menuItems ?? []);
   const hasMenu = (group.menuItems?.length ?? 0) > 0;
-  const hoverPadding = hasMenu
-    ? "group-hover/calendar-group-row:pr-12 group-focus-within/calendar-group-row:pr-12"
-    : "group-hover/calendar-group-row:pr-6 group-focus-within/calendar-group-row:pr-6";
 
   return (
     <div
       onContextMenu={hasMenu ? showContextMenu : undefined}
       className={cn([
-        "group/calendar-group-row relative -mx-2 flex items-center rounded-md px-2",
-        !disableHoverTone && "hover:bg-accent",
+        "flex items-center justify-between gap-2 py-1",
+        hasMenu && "group -mx-2 rounded-full px-2",
+        hasMenu && !disableHoverTone && "hover:bg-accent",
       ])}
-    >
-      <AccordionHeader className="min-w-0 flex-1">
-        <AccordionTriggerPrimitive
-          className={cn([
-            "flex w-full min-w-0 cursor-pointer items-center py-2 pr-0 text-left transition-[padding] duration-150 hover:no-underline",
-            hoverPadding,
-          ])}
-        >
-          <span className="text-muted-foreground truncate text-xs font-medium">
-            {group.sourceName}
-          </span>
-        </AccordionTriggerPrimitive>
-      </AccordionHeader>
-
-      <div
-        className={cn([
-          "pointer-events-none absolute top-1/2 right-1 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity duration-150",
-          "group-focus-within/calendar-group-row:opacity-100 group-hover/calendar-group-row:opacity-100",
-        ])}
-      >
-        {hasMenu && (
-          <CalendarGroupMenuButton
-            onClick={showContextMenu}
-            className="pointer-events-none opacity-100 group-focus-within/calendar-group-row:pointer-events-auto group-hover/calendar-group-row:pointer-events-auto"
-          />
-        )}
-
-        <ChevronDown
-          className={cn([
-            "text-muted-foreground pointer-events-none size-4 shrink-0 transition-transform duration-200",
-            "group-data-[state=open]/group:rotate-180",
-          ])}
-        />
-      </div>
-    </div>
-  );
-}
-
-function CalendarGroupHeader({ group }: { group: CalendarGroup }) {
-  const showContextMenu = useNativeContextMenu(group.menuItems ?? []);
-  const hasMenu = (group.menuItems?.length ?? 0) > 0;
-
-  if (!hasMenu) return null;
-
-  return (
-    <div
-      onContextMenu={showContextMenu}
-      className="group flex items-center justify-between gap-2 py-1"
     >
       <span className="text-muted-foreground truncate text-xs font-medium">
         {group.sourceName}
       </span>
-      <CalendarGroupMenuButton onClick={showContextMenu} />
+      {hasMenu ? <CalendarGroupMenuButton onClick={showContextMenu} /> : null}
     </div>
   );
 }
@@ -244,8 +162,8 @@ function CalendarGroupMenuButton({
       type="button"
       onClick={onClick}
       className={cn([
-        "text-muted-foreground shrink-0 rounded p-1 transition-colors",
-        "opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
+        "text-muted-foreground shrink-0 rounded-full p-1 transition-colors",
+        "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100",
         "hover:bg-accent hover:text-muted-foreground",
         className,
       ])}
@@ -271,7 +189,7 @@ function CalendarToggleRow({
     <button
       type="button"
       onClick={() => onToggle(!enabled)}
-      className="flex w-full items-center gap-2 py-1 text-left"
+      className="flex w-full items-center gap-2 py-1 pr-2 pl-0 text-left"
     >
       <div
         className={cn([

--- a/apps/desktop/src/calendar/components/sidebar.tsx
+++ b/apps/desktop/src/calendar/components/sidebar.tsx
@@ -1,6 +1,6 @@
 import { useLingui } from "@lingui/react/macro";
 import { platform } from "@tauri-apps/plugin-os";
-import { ChevronDown, PlusIcon } from "lucide-react";
+import { ChevronRight, PlusIcon } from "lucide-react";
 import { useCallback, useMemo, type MouseEvent } from "react";
 
 import type { ConnectionItem } from "@hypr/api-client";
@@ -125,7 +125,7 @@ export function CalendarSidebarContent({
         provider.disabled ? (
           <div
             key={provider.id}
-            className="border-border flex items-center gap-2 border-b py-3 opacity-50 last:border-none"
+            className="-mx-2 flex items-center gap-2 px-2 py-3 opacity-50"
           >
             <ProviderIcon provider={provider} />
             <span className="text-sm font-medium">{provider.displayName}</span>
@@ -246,16 +246,13 @@ function ProviderAccordionItem({
   const hasAddAccountButton = canAddAccount && !requiresPro;
 
   return (
-    <AccordionItem
-      value={provider.id}
-      className="group/provider border-border border-b last:border-none"
-    >
+    <AccordionItem value={provider.id} className="group/provider border-none">
       <div
         onContextMenu={
           providerMenuItems.length > 0 ? showProviderMenu : undefined
         }
         className={cn([
-          "group/row hover:bg-accent relative grid items-center gap-1 rounded-md",
+          "group/row hover:bg-accent relative -mx-2 grid items-center gap-1 rounded-full px-2",
           hasAddAccountButton
             ? "grid-cols-[minmax(0,1fr)_auto_auto]"
             : "grid-cols-[minmax(0,1fr)_auto]",
@@ -303,7 +300,7 @@ function ProviderAccordionItem({
           <button
             type="button"
             onClick={handleAddAccount}
-            className="text-muted-foreground hover:bg-accent hover:text-foreground shrink-0 rounded p-1 transition-colors"
+            className="text-muted-foreground hover:bg-accent hover:text-foreground shrink-0 rounded-full p-1 transition-colors"
             aria-label={t`Add ${provider.displayName} account`}
           >
             <PlusIcon className="size-4" />
@@ -311,10 +308,10 @@ function ProviderAccordionItem({
         ) : null}
 
         {!requiresPro && (
-          <ChevronDown
+          <ChevronRight
             className={cn([
-              "text-muted-foreground size-4 shrink-0 opacity-0 transition-all duration-200 group-focus-within/row:opacity-100 group-hover/row:opacity-100",
-              "group-data-[state=open]/provider:rotate-180",
+              "text-muted-foreground size-4 shrink-0 transition-transform duration-200",
+              "group-data-[state=open]/provider:rotate-90",
             ])}
           />
         )}

--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -82,7 +82,7 @@ msgstr "Add \"{0}\""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr "Add {0} account"
 
@@ -250,7 +250,7 @@ msgstr "Browse"
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr "Browser handoff not working? Paste the callback link instead"
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr "LinkedIn"
 msgid "Live"
 msgstr "Live"
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr "Loading calendars..."
 
@@ -1019,7 +1019,7 @@ msgstr "Next match"
 msgid "No apps found."
 msgstr "No apps found."
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr "No calendars found"
 
@@ -1139,7 +1139,7 @@ msgstr "Open Anarlog"
 msgid "Open calendar"
 msgstr "Open calendar"
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr "Open calendar account actions"
 
@@ -1276,7 +1276,7 @@ msgstr "Reconnect required"
 msgid "Refresh billing status"
 msgstr "Refresh billing status"
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr "Refresh calendars"
 
@@ -1840,12 +1840,12 @@ msgstr "Upgrade for private repos."
 msgid "Upgrade to connect"
 msgstr "Upgrade to connect"
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr "Upgrade to Pro"
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr "Upgrade to Pro for {0}"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #. placeholder {0}: provider.displayName
 #: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:307
+#: src/calendar/components/sidebar.tsx:304
 msgid "Add {0} account"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:328
+#: src/calendar/components/sidebar.tsx:325
 #: src/settings/general/permissions.tsx:191
 #: src/sidebar/calendar.tsx:10
 #: src/sidebar/settings.tsx:106
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:76
+#: src/calendar/components/calendar-selection.tsx:63
 msgid "Loading calendars..."
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:84
+#: src/calendar/components/calendar-selection.tsx:71
 msgid "No calendars found"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:252
+#: src/calendar/components/calendar-selection.tsx:170
 msgid "Open calendar account actions"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:91
+#: src/calendar/components/calendar-selection.tsx:78
 msgid "Refresh calendars"
 msgstr ""
 
@@ -1840,12 +1840,12 @@ msgstr ""
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:300
+#: src/calendar/components/sidebar.tsx:297
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:298
+#: src/calendar/components/sidebar.tsx:295
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 


### PR DESCRIPTION
Adds matching negative margins and padding to calendar provider accordion rows so hover surfaces expand without moving labels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to calendar sidebar UI; toggle and provider accordion behavior are preserved aside from removing collapse on calendar groups.
> 
> **Overview**
> Refines the **calendar sidebar** so provider rows and calendar lists share the same hover/gutter treatment, and calendar toggles are always visible without a nested accordion.
> 
> In **`calendar-selection`**, the per-group **accordion is removed** in favor of a flat list. Group headers show only when there are multiple groups or account actions (`menuItems`). The old accordion trigger, chevron, and single-group shortcut layout are gone; account actions use a simpler header with **rounded-full** hover on rows that have a menu.
> 
> In **`sidebar`**, provider **accordion rows** use **`-mx-2` / `px-2`** and **`rounded-full`** hover surfaces (matching the PR’s gutter goal), drop bottom borders between items, and swap **`ChevronDown`** for **`ChevronRight`** (90° when open). Disabled provider rows get the same horizontal inset styling.
> 
> Locale **`.po` files** only update source line references for unchanged strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 528e4d5e8de720fea6426954ca49bb12da4caa11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->