### PR TITLE
Fix chat panel width test

### DIFF
--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -281,26 +281,6 @@ describe("MainChatPanels", () => {
     );
   });
 
-  it("expands left when opening the sidebar would make the empty surface narrower than 500px", () => {
-    mocks.currentTab = { type: "empty" };
-    mocks.leftSidebarExpanded = true;
-    mockPanelWidths({
-      bodyPanelWidth: 640,
-      leftSidebarWidth: 200,
-    });
-
-    render(
-      <MainChatPanels>
-        <div data-left-sidebar-chrome />
-        <div data-chat-floating-anchor>
-          <div data-testid="empty-surface" />
-        </div>
-      </MainChatPanels>,
-    );
-
-    expect(mocks.windowExpandWidth).toHaveBeenCalledWith(60, null, false, true);
-  });
-
   it("expands right when docked chat would make a note surface narrower than 500px", () => {
     mocks.chatMode = "RightPanelOpen";
     mocks.currentTab = { type: "sessions" };


### PR DESCRIPTION
Remove a stale duplicate empty-surface width expectation that still used the previous windowExpandWidth signature. This repairs desktop CI on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only cleanup with no production code changes.
> 
> **Overview**
> Removes a **duplicate** test case in `chat-panels.test.tsx` for left expansion when the empty surface would drop below 500px beside an open sidebar.
> 
> The deleted test still asserted `windowExpandWidth` with the **old four-argument** signature (`60, null, false, true`). The same scenario remains covered by the sibling test that expects the **current five-argument** call (`60, null, false, true, false`), aligning the suite with the updated `windowExpandWidth` API and fixing failing desktop CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ee14319d6d2980e0acac8249ac2a9b9182494a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->