### PR TITLE
Keep floating transcript panel corners rounded

### DIFF
--- a/plugins/windows/swift-lib/src/FloatingBarView.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarView.swift
@@ -26,7 +26,6 @@ enum FloatingBarLayout {
   static let hoverHandleDotSize: CGFloat = 1.6
   static let hoverHandleDotSpacing: CGFloat = 7
   static let hoverHandleHorizontalPadding: CGFloat = 17
-  static let hoverSurfaceTopRadius: CGFloat = 7
   static let dragClickThreshold: CGFloat = 4
 
   static func compactControlsWidth(showsExpand: Bool) -> CGFloat {
@@ -150,9 +149,7 @@ struct FloatingBarView: View {
 
   private var expandedPanel: some View {
     let surfaceShape = FloatingBarSurfaceShape(
-      topRadius: isBarHovered
-        ? FloatingBarLayout.hoverSurfaceTopRadius
-        : FloatingBarLayout.expandedCornerRadius,
+      topRadius: FloatingBarLayout.expandedCornerRadius,
       bottomRadius: FloatingBarLayout.expandedCornerRadius
     )
 
@@ -176,7 +173,7 @@ struct FloatingBarView: View {
 
             Spacer(minLength: 12)
           }
-          .padding(.leading, FloatingBarLayout.expandedPadding)
+          .padding(.leading, FloatingBarLayout.expandedPadding + 4)
           .padding(
             .trailing,
             FloatingBarLayout.compactControlsWidth(showsExpand: model.liveCaptionToggleVisible)


### PR DESCRIPTION
Adjust expanded floating bar hover radius and title spacing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SwiftUI layout and styling only in the Windows floating bar; no logic, auth, or data changes.
> 
> **Overview**
> Fixes the **expanded live transcript panel** so its top corners stay at the full **`expandedCornerRadius`** when the bar is hovered, instead of shrinking to a tighter hover-only radius.
> 
> Removes the unused **`hoverSurfaceTopRadius`** layout constant and nudges the title row **4pt** further from the leading edge (`expandedPadding + 4`) for alignment with the updated shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 770c95ab214ae94b615ac4662005065d99c3a264. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->