### PR TITLE
Expand Soniqo echo lag gate

### DIFF
--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -17,8 +17,8 @@ use super::{ChannelSender, DEVICE_FINGERPRINT_HEADER, ListenerArgs, ListenerMsg,
 use crate::SessionErrorEvent;
 
 const SONIQO_ECHO_GATE_MIN_SAMPLES: usize = 512;
-const SONIQO_ECHO_GATE_MAX_LAG_SAMPLES: isize = 640;
-const SONIQO_ECHO_GATE_LAG_STEP_SAMPLES: isize = 160;
+const SONIQO_ECHO_GATE_MAX_LAG_SAMPLES: isize = 1600;
+const SONIQO_ECHO_GATE_LAG_STEP_SAMPLES: isize = 80;
 const SONIQO_ECHO_GATE_MIN_MIC_RMS: f32 = 0.0025;
 const SONIQO_ECHO_GATE_MIN_SPEAKER_RMS: f32 = 0.01;
 const SONIQO_ECHO_GATE_MIN_CORRELATION: f32 = 0.55;
@@ -927,6 +927,15 @@ mod tests {
     fn suppresses_soniqo_mic_when_chunk_is_echo_dominant() {
         let speaker = test_signal(1920, 0x1234_5678);
         let mut mic = delayed(&speaker, 160, 0.35);
+
+        assert!(suppress_soniqo_echo_dominant_mic(&mut mic, &speaker));
+        assert!(mic.iter().all(|sample| *sample == 0.0));
+    }
+
+    #[test]
+    fn suppresses_soniqo_mic_when_aec_residual_has_longer_capture_lag() {
+        let speaker = test_signal(2400, 0x1234_5678);
+        let mut mic = delayed(&speaker, 1120, 0.25);
 
         assert!(suppress_soniqo_echo_dominant_mic(&mut mic, &speaker));
         assert!(mic.iter().all(|sample| *sample == 0.0));


### PR DESCRIPTION
Extend local Soniqo echo suppression to match the capture AEC lag range and add a regression test for delayed residual echo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only tunes local echo-gate constants and tests for Soniqo mic/speaker streaming; no auth, persistence, or API surface changes.
> 
> **Overview**
> **Soniqo dual-channel echo suppression** now searches speaker–mic alignment over a wider lag window so post-AEC residual echo still gets zeroed before transcription.
> 
> `SONIQO_ECHO_GATE_MAX_LAG_SAMPLES` increases from **640 → 1600** and the lag scan step shrinks from **160 → 80** samples, giving finer coverage up to longer capture delays. A unit test asserts suppression when the mic is a **1120-sample-delayed** echo of the speaker (a case that previously fell outside the old max lag).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b7eb57212a4ba8d207ff8bf21a3ad2ad66143d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->