### PR TITLE
Hide Soniox mode chips

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -119,7 +119,7 @@ msgstr "Bykomende gesproke tale"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -119,7 +119,7 @@ msgstr "ተጨማሪ የሚነገሩ ቋንቋዎች"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -119,7 +119,7 @@ msgstr "اللغات المنطوقة الإضافية"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -119,7 +119,7 @@ msgstr "অতিৰিক্ত কথিত ভাষা"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -119,7 +119,7 @@ msgstr "Əlavə danışıq dilləri"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -119,7 +119,7 @@ msgstr "Өҫтәмә һөйләү телдәре"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -119,7 +119,7 @@ msgstr "Дадатковыя размоўныя мовы"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -119,7 +119,7 @@ msgstr "Допълнителни говорими езици"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -119,7 +119,7 @@ msgstr "অতিরিক্ত কথ্য ভাষা"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -119,7 +119,7 @@ msgstr "ཁ་སྣོན་གྱི་སྐད་ཆ"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -119,7 +119,7 @@ msgstr "Yezhoù komzet ouzhpenn"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -119,7 +119,7 @@ msgstr "Dodatni govorni jezici"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -119,7 +119,7 @@ msgstr "Idiomes parlats addicionals"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -119,7 +119,7 @@ msgstr "Další mluvené jazyky"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -119,7 +119,7 @@ msgstr "Ieithoedd llafar ychwanegol"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -119,7 +119,7 @@ msgstr "Yderligere talte sprog"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -119,7 +119,7 @@ msgstr "Weitere gesprochene Sprachen"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -119,7 +119,7 @@ msgstr "Πρόσθετες ομιλούμενες γλώσσες"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -119,7 +119,7 @@ msgstr "Additional spoken languages"
 msgid "Advanced"
 msgstr "Advanced"
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr "After recording"
 
@@ -261,7 +261,7 @@ msgstr "Calendar"
 msgid "Calendar connected"
 msgstr "Calendar connected"
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr "Can transcribe while the meeting is happening."
 
@@ -488,7 +488,7 @@ msgstr "Delete All Recurring Events"
 msgid "Delete Event"
 msgstr "Delete Event"
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr "Delete model"
 
@@ -545,7 +545,7 @@ msgstr "Don't save"
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr "Don't show notifications when Do-Not-Disturb is enabled on your system"
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr "Download"
 
@@ -870,7 +870,7 @@ msgstr "Light"
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr "Live"
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr "Retry"
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr "Runs after the recording finishes, not during the meeting."
 
@@ -1553,7 +1553,7 @@ msgstr "Show Event"
 msgid "Show floating bar"
 msgstr "Show floating bar"
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr "Show in Finder"
@@ -1854,7 +1854,7 @@ msgstr "Upgrade to Pro for {0}"
 msgid "Upgrade to Pro to use this provider."
 msgstr "Upgrade to Pro to use this provider."
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr "Upgrade to use"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -119,7 +119,7 @@ msgstr "Idiomas hablados adicionales"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -119,7 +119,7 @@ msgstr "Täiendavad kõnekeeled"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -119,7 +119,7 @@ msgstr "Ahozko hizkuntza gehigarriak"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -119,7 +119,7 @@ msgstr "زبان‌های گفتاری دیگر"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -119,7 +119,7 @@ msgstr "Ɗemɗe kaaleteeɗe ɓeydaaɗe"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -119,7 +119,7 @@ msgstr "Muita puhuttuja kieliä"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -119,7 +119,7 @@ msgstr "Eyka talumál"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -119,7 +119,7 @@ msgstr "Langues parlées supplémentaires"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -119,7 +119,7 @@ msgstr "Teangacha breise labhartha"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -119,7 +119,7 @@ msgstr "Idiomas falados adicionais"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -119,7 +119,7 @@ msgstr "અતિરિક્ત બોલાતી ભાષાઓ"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -119,7 +119,7 @@ msgstr "Ƙarin harsunan magana"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -119,7 +119,7 @@ msgstr "שפות מדוברות נוספות"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -119,7 +119,7 @@ msgstr "अतिरिक्त बोली जाने वाली भा�
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -119,7 +119,7 @@ msgstr "Dodatni govorni jezici"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -119,7 +119,7 @@ msgstr "Anplis lang ki pale"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -119,7 +119,7 @@ msgstr "További beszélt nyelvek"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -119,7 +119,7 @@ msgstr "Լրացուցիչ խոսակցական լեզուներ"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -119,7 +119,7 @@ msgstr "Bahasa lisan tambahan"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -119,7 +119,7 @@ msgstr "Asụsụ ndị agbakwunyere"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -119,7 +119,7 @@ msgstr "Viðbótar töluð tungumál"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -119,7 +119,7 @@ msgstr "Lingue parlate aggiuntive"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -119,7 +119,7 @@ msgstr "追加の音声言語"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -119,7 +119,7 @@ msgstr "Basa lisan tambahan"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -119,7 +119,7 @@ msgstr "დამატებითი სალაპარაკო ენე�
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -119,7 +119,7 @@ msgstr "Қосымша ауызекі тілдер"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -119,7 +119,7 @@ msgstr "ភាសានិយាយបន្ថែម"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -119,7 +119,7 @@ msgstr "ಹೆಚ್ಚುವರಿ ಮಾತನಾಡುವ ಭಾಷೆಗಳ�
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -119,7 +119,7 @@ msgstr "추가 음성 언어"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -119,7 +119,7 @@ msgstr "Zimanên axaftinê yên zêde"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -119,7 +119,7 @@ msgstr "Кошумча сүйлөө тилдери"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -119,7 +119,7 @@ msgstr "Additional linguas vocales"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -119,7 +119,7 @@ msgstr "Zousätzlech geschwat Sproochen"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -119,7 +119,7 @@ msgstr "Ennimi endala ezoogerwa"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -119,7 +119,7 @@ msgstr "Minoko ya kobakisa oyo balobaka"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -119,7 +119,7 @@ msgstr "ພາສາເວົ້າເພີ່ມເຕີມ"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -119,7 +119,7 @@ msgstr "Papildomos šnekamosios kalbos"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -119,7 +119,7 @@ msgstr "Papildu runātās valodas"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -119,7 +119,7 @@ msgstr "Fiteny ampiasaina fanampiny"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -119,7 +119,7 @@ msgstr "Apiti atu reo korero"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -119,7 +119,7 @@ msgstr "Дополнителни говорни јазици"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -119,7 +119,7 @@ msgstr "കൂടുതൽ സംസാരിക്കുന്ന ഭാഷക�
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -119,7 +119,7 @@ msgstr "Нэмэлт ярианы хэлүүд"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -119,7 +119,7 @@ msgstr "अतिरिक्त बोलल्या जाणाऱ्या 
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -119,7 +119,7 @@ msgstr "Bahasa pertuturan tambahan"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -119,7 +119,7 @@ msgstr "Lingwi mitkellma addizzjonali"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -119,7 +119,7 @@ msgstr "နောက်ထပ် ပြောဆိုသော ဘာသာစ�
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -119,7 +119,7 @@ msgstr "अतिरिक्त बोलिने भाषाहरू"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -119,7 +119,7 @@ msgstr "Extra gesproken talen"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -119,7 +119,7 @@ msgstr "Flere talespråk"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -119,7 +119,7 @@ msgstr "Flere talespråk"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -119,7 +119,7 @@ msgstr "Zilankhulo zina zoyankhulidwa"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -119,7 +119,7 @@ msgstr "Lengas parladas suplementàrias"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -119,7 +119,7 @@ msgstr "ଅତିରିକ୍ତ କଥିତ ଭାଷା |"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -119,7 +119,7 @@ msgstr "ਵਧੀਕ ਬੋਲੀਆਂ ਜਾਣ ਵਾਲੀਆਂ ਭਾਸ�
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -119,7 +119,7 @@ msgstr "Dodatkowe języki mówione"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -119,7 +119,7 @@ msgstr "اضافي خبرې شوي ژبې"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -119,7 +119,7 @@ msgstr "Idiomas falados adicionais"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -119,7 +119,7 @@ msgstr "Limbi vorbite suplimentare"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -119,7 +119,7 @@ msgstr "Дополнительные разговорные языки"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -119,7 +119,7 @@ msgstr "अतिरिक्तभाष्यभाषा"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -119,7 +119,7 @@ msgstr "اضافي ڳالهائيندڙ ٻوليون"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -119,7 +119,7 @@ msgstr "අමතර කථන භාෂා"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -119,7 +119,7 @@ msgstr "Ďalšie hovorené jazyky"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -119,7 +119,7 @@ msgstr "Dodatni govorjeni jeziki"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -119,7 +119,7 @@ msgstr "Mitauro inowedzerwa"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -119,7 +119,7 @@ msgstr "Afafka lagu hadlo dheeraadka ah"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -119,7 +119,7 @@ msgstr "Gjuhë të tjera të folura"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -119,7 +119,7 @@ msgstr "Додатни говорни језици"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -119,7 +119,7 @@ msgstr "Basa lisan tambahan"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -119,7 +119,7 @@ msgstr "Ytterligare talade språk"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -119,7 +119,7 @@ msgstr "Lugha za ziada zinazozungumzwa"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -119,7 +119,7 @@ msgstr "கூடுதல் பேசும் மொழிகள்"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -119,7 +119,7 @@ msgstr "అదనపు మాట్లాడే భాషలు"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -119,7 +119,7 @@ msgstr "Забонҳои иловагии гуфтугӯӣ"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -119,7 +119,7 @@ msgstr "ภาษาพูดเพิ่มเติม"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -119,7 +119,7 @@ msgstr "Goşmaça gürleýän diller"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -119,7 +119,7 @@ msgstr "Mga karagdagang sinasalitang wika"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -119,7 +119,7 @@ msgstr "Ek konuşulan diller"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -119,7 +119,7 @@ msgstr "Өстәмә сөйләм телләре"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -119,7 +119,7 @@ msgstr "Додаткові розмовні мови"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -119,7 +119,7 @@ msgstr "اضافی بولی جانے والی زبانیں"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -119,7 +119,7 @@ msgstr "Qo'shimcha og'zaki tillar"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -119,7 +119,7 @@ msgstr "Ngôn ngữ nói bổ sung"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -119,7 +119,7 @@ msgstr "Yeneen làkk yi ñuy làkk"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -119,7 +119,7 @@ msgstr "Iilwimi ezongezelelweyo ezithethwayo"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -119,7 +119,7 @@ msgstr "נאך גערעדטע שפראכן"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -119,7 +119,7 @@ msgstr "Awọn ede ti a sọ ni afikun"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -119,7 +119,7 @@ msgstr "其他口语语言"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -119,7 +119,7 @@ msgstr "Izilimi ezengeziwe ezikhulunywayo"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:696
+#: src/settings/ai/stt/select.tsx:710
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:768
+#: src/settings/ai/stt/select.tsx:782
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Download"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:691
+#: src/settings/ai/stt/select.tsx:705
 msgid "Live"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:698
+#: src/settings/ai/stt/select.tsx:712
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:753
+#: src/settings/ai/stt/select.tsx:767
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:649
+#: src/settings/ai/stt/select.tsx:657
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -369,6 +369,7 @@ type ModelCategory = "latest" | null;
 type ModelEntry = {
   id: string;
   isDownloaded: boolean;
+  providerId?: ProviderId;
   displayName?: string;
   isDeprecated?: boolean;
   category?: ModelCategory;
@@ -494,7 +495,12 @@ function useConfiguredMapping(): Record<
 
       if (provider.id === "hyprnote") {
         const models: ModelEntry[] = [
-          { id: "cloud", isDownloaded: billing.isPaid, category: "latest" },
+          {
+            id: "cloud",
+            isDownloaded: billing.isPaid,
+            providerId: provider.id,
+            category: "latest",
+          },
         ];
 
         if (isAppleSilicon) {
@@ -502,6 +508,7 @@ function useConfiguredMapping(): Record<
             models.push({
               id: model.key,
               isDownloaded: soniqoDownloaded[i]?.data ?? false,
+              providerId: provider.id,
               displayName: model.display_name,
               sizeBytes: model.size_bytes,
               mode: isRealtimeLocalModel(String(model.key))
@@ -526,6 +533,7 @@ function useConfiguredMapping(): Record<
           models: provider.models.map((model) => ({
             id: model,
             isDownloaded: true,
+            providerId: provider.id,
             mode: getProviderModelMode(provider.id, model),
           })),
         },
@@ -569,7 +577,7 @@ function ModelSelectItem({
       />
       <div className="flex shrink-0 items-center gap-2 text-[11px]">
         <LocalModelBackendBadge model={model.id} />
-        <ModelModeBadge mode={model.mode} />
+        <ModelModeBadge mode={model.mode} providerId={model.providerId} />
         {!model.isDownloaded && sizeLabel && (
           <span className="text-muted-foreground font-mono">{sizeLabel}</span>
         )}
@@ -665,13 +673,19 @@ function ModelSelectedValue({ model }: { model: ModelEntry }) {
         className={cn(["min-w-0", isDeprecated && "opacity-60"])}
         labelClassName={cn([isDeprecated && "text-muted-foreground"])}
       />
-      <ModelModeBadge mode={model.mode} />
+      <ModelModeBadge mode={model.mode} providerId={model.providerId} />
     </div>
   );
 }
 
-function ModelModeBadge({ mode }: { mode?: ModelEntry["mode"] }) {
-  if (!mode) {
+function ModelModeBadge({
+  mode,
+  providerId,
+}: {
+  mode?: ModelEntry["mode"];
+  providerId?: ProviderId;
+}) {
+  if (!mode || providerId === "soniox") {
     return null;
   }
 


### PR DESCRIPTION
Suppress mode badges for Soniox model options while preserving model capability metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in STT settings; capability metadata for Soniox is unchanged.
> 
> **Overview**
> **Soniox model rows no longer show the Live / After recording mode badges** in AI speech-to-text settings, while other providers keep those chips and tooltips.
> 
> `ModelModeBadge` now returns nothing when `providerId` is `soniox`. Soniox options still get **realtime** vs **batch** metadata from the existing resolver (e.g. `stt-rt-*` vs `stt-async-*`); only the UI badges are suppressed. Locale `.po` files were refreshed so Lingui references match the slightly shifted line numbers in `select.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 743db6bb30bae930c5f20bc5baa35bda931a2cab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->