### PR TITLE
Hide finalizing header control

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -147,6 +147,26 @@ describe("OuterHeader", () => {
     expect(mocks.stopListening).toHaveBeenCalledTimes(1);
   });
 
+  it("hides the finalizing header button while the sidebar is collapsed", () => {
+    mocks.leftsidebar.expanded = false;
+    mocks.sessionModes = { "session-1": "finalizing" };
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    const title = screen.getByText("Session title");
+    const titleSlot = title.parentElement?.parentElement;
+
+    expect(screen.queryByRole("button", { name: "Finalizing" })).toBeNull();
+    expect(titleSlot?.className).toContain("right-[70px]");
+    expect(titleSlot?.className).not.toContain("right-[153px]");
+  });
+
   it("raises the tightened title field when the sidebar is collapsed", () => {
     mocks.leftsidebar.expanded = false;
 

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -326,5 +326,5 @@ function SidebarModeStopButton({
 }
 
 function isSidebarStopButtonMode(sessionMode: string) {
-  return sessionMode === "active" || sessionMode === "finalizing";
+  return sessionMode === "active";
 }


### PR DESCRIPTION
Stop rendering the collapsed-sidebar finalizing pill and cover the header layout with a regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/layout change in the desktop session header with a focused unit test; no auth, data, or backend impact.
> 
> **Overview**
> When the sidebar is collapsed, the session header no longer shows the **Finalizing** pill or reserves extra width for live stop controls during `finalizing` mode—only **active** listening still gets the collapsed-sidebar stop button and `right-[153px]` title inset.
> 
> This is done by narrowing `isSidebarStopButtonMode` to `sessionMode === "active"` (removing `finalizing`). A regression test asserts no **Finalizing** button and the tighter `right-[70px]` title layout while finalizing with a collapsed sidebar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c52c7a4951f8c361fc03d26c3f23ec15e951d87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->