### PR TITLE
Show transcription language warning as toast

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Bykomende gesproke tale"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "ተጨማሪ የሚነገሩ ቋንቋዎች"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "اللغات المنطوقة الإضافية"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "অতিৰিক্ত কথিত ভাষা"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Əlavə danışıq dilləri"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Өҫтәмә һөйләү телдәре"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Дадатковыя размоўныя мовы"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Допълнителни говорими езици"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "অতিরিক্ত কথ্য ভাষা"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "ཁ་སྣོན་གྱི་སྐད་ཆ"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Yezhoù komzet ouzhpenn"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Dodatni govorni jezici"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Idiomes parlats addicionals"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Další mluvené jazyky"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Ieithoedd llafar ychwanegol"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Yderligere talte sprog"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Weitere gesprochene Sprachen"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Πρόσθετες ομιλούμενες γλώσσες"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -34,7 +34,7 @@ msgstr "{trialDaysRemaining} days left"
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 
@@ -119,7 +119,7 @@ msgstr "Additional spoken languages"
 msgid "Advanced"
 msgstr "Advanced"
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr "After recording"
 
@@ -261,7 +261,7 @@ msgstr "Calendar"
 msgid "Calendar connected"
 msgstr "Calendar connected"
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr "Can transcribe while the meeting is happening."
 
@@ -488,7 +488,7 @@ msgstr "Delete All Recurring Events"
 msgid "Delete Event"
 msgstr "Delete Event"
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr "Delete model"
 
@@ -545,7 +545,7 @@ msgstr "Don't save"
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr "Don't show notifications when Do-Not-Disturb is enabled on your system"
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr "Download"
 
@@ -587,7 +587,7 @@ msgstr "Enhance contact"
 msgid "Enhance contact {label}"
 msgstr "Enhance contact {label}"
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr "Enter a model identifier"
 
@@ -870,7 +870,7 @@ msgstr "Light"
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr "Live"
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr "Microphone detection"
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr "Model being used"
 
@@ -1251,7 +1251,7 @@ msgstr "Preparing transcript..."
 msgid "Previous match"
 msgstr "Previous match"
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr "Pro"
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr "Retry"
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr "Runs after the recording finishes, not during the meeting."
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr "Select a different folder"
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr "Select a model"
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr "Select a person to view details"
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr "Select a provider"
 
@@ -1553,7 +1553,7 @@ msgstr "Show Event"
 msgid "Show floating bar"
 msgstr "Show floating bar"
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr "Show in Finder"
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr "Upgrade to Pro for {0}"
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr "Upgrade to Pro to use this provider."
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr "Upgrade to use"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Idiomas hablados adicionales"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Täiendavad kõnekeeled"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Ahozko hizkuntza gehigarriak"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "زبان‌های گفتاری دیگر"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Ɗemɗe kaaleteeɗe ɓeydaaɗe"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Muita puhuttuja kieliä"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Eyka talumál"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Langues parlées supplémentaires"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Teangacha breise labhartha"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Idiomas falados adicionais"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "અતિરિક્ત બોલાતી ભાષાઓ"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Ƙarin harsunan magana"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "שפות מדוברות נוספות"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "अतिरिक्त बोली जाने वाली भा�
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Dodatni govorni jezici"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Anplis lang ki pale"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "További beszélt nyelvek"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Լրացուցիչ խոսակցական լեզուներ"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Bahasa lisan tambahan"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Asụsụ ndị agbakwunyere"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Viðbótar töluð tungumál"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Lingue parlate aggiuntive"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "追加の音声言語"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Basa lisan tambahan"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "დამატებითი სალაპარაკო ენე�
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Қосымша ауызекі тілдер"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "ភាសានិយាយបន្ថែម"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "ಹೆಚ್ಚುವರಿ ಮಾತನಾಡುವ ಭಾಷೆಗಳ�
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "추가 음성 언어"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Zimanên axaftinê yên zêde"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Кошумча сүйлөө тилдери"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Additional linguas vocales"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Zousätzlech geschwat Sproochen"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Ennimi endala ezoogerwa"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Minoko ya kobakisa oyo balobaka"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "ພາສາເວົ້າເພີ່ມເຕີມ"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Papildomos šnekamosios kalbos"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Papildu runātās valodas"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Fiteny ampiasaina fanampiny"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Apiti atu reo korero"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Дополнителни говорни јазици"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "കൂടുതൽ സംസാരിക്കുന്ന ഭാഷക�
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Нэмэлт ярианы хэлүүд"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "अतिरिक्त बोलल्या जाणाऱ्या 
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Bahasa pertuturan tambahan"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Lingwi mitkellma addizzjonali"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "နောက်ထပ် ပြောဆိုသော ဘာသာစ�
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "अतिरिक्त बोलिने भाषाहरू"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Extra gesproken talen"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Flere talespråk"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Flere talespråk"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Zilankhulo zina zoyankhulidwa"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Lengas parladas suplementàrias"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "ଅତିରିକ୍ତ କଥିତ ଭାଷା |"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "ਵਧੀਕ ਬੋਲੀਆਂ ਜਾਣ ਵਾਲੀਆਂ ਭਾਸ�
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Dodatkowe języki mówione"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "اضافي خبرې شوي ژبې"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Idiomas falados adicionais"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Limbi vorbite suplimentare"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Дополнительные разговорные языки"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "अतिरिक्तभाष्यभाषा"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "اضافي ڳالهائيندڙ ٻوليون"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "අමතර කථන භාෂා"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Ďalšie hovorené jazyky"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Dodatni govorjeni jeziki"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Mitauro inowedzerwa"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Afafka lagu hadlo dheeraadka ah"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Gjuhë të tjera të folura"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Додатни говорни језици"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Basa lisan tambahan"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Ytterligare talade språk"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Lugha za ziada zinazozungumzwa"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "கூடுதல் பேசும் மொழிகள்"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "అదనపు మాట్లాడే భాషలు"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Забонҳои иловагии гуфтугӯӣ"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "ภาษาพูดเพิ่มเติม"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Goşmaça gürleýän diller"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Mga karagdagang sinasalitang wika"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Ek konuşulan diller"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Өстәмә сөйләм телләре"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Додаткові розмовні мови"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "اضافی بولی جانے والی زبانیں"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Qo'shimcha og'zaki tillar"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Ngôn ngữ nói bổ sung"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Yeneen làkk yi ñuy làkk"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Iilwimi ezongezelelweyo ezithethwayo"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "נאך גערעדטע שפראכן"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Awọn ede ti a sọ ni afikun"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "其他口语语言"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:154
+#: src/settings/ai/stt/select.tsx:159
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Izilimi ezengeziwe ezikhulunywayo"
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "After recording"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:710
+#: src/settings/ai/stt/select.tsx:755
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:782
+#: src/settings/ai/stt/select.tsx:827
 msgid "Delete model"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Download"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:227
+#: src/settings/ai/stt/select.tsx:232
 msgid "Enter a model identifier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:705
+#: src/settings/ai/stt/select.tsx:750
 msgid "Live"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgid "Microphone detection"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:166
+#: src/settings/ai/stt/select.tsx:171
 msgid "Model being used"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:202
+#: src/settings/ai/stt/select.tsx:207
 msgid "Pro"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgid "Retry"
 msgstr ""
 
 #: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:712
+#: src/settings/ai/stt/select.tsx:757
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Select a different folder"
 msgstr ""
 
 #: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:244
+#: src/settings/ai/stt/select.tsx:249
 msgid "Select a model"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Select a person to view details"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:175
+#: src/settings/ai/stt/select.tsx:180
 msgid "Select a provider"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:767
+#: src/settings/ai/stt/select.tsx:812
 #: src/sidebar/timeline/item.tsx:605
 msgid "Show in Finder"
 msgstr ""
@@ -1851,11 +1851,11 @@ msgid "Upgrade to Pro for {0}"
 msgstr ""
 
 #: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:208
+#: src/settings/ai/stt/select.tsx:213
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:657
+#: src/settings/ai/stt/select.tsx:708
 msgid "Upgrade to use"
 msgstr ""
 

--- a/apps/desktop/src/settings/ai/stt/index.tsx
+++ b/apps/desktop/src/settings/ai/stt/index.tsx
@@ -4,7 +4,7 @@ import { ConfigureProviders } from "./configure";
 import { SttSettingsProvider } from "./context";
 import {
   SelectProviderAndModel,
-  TranscriptionLanguageWarningBanner,
+  TranscriptionLanguageWarningToast,
 } from "./select";
 
 import { SettingsPageTitle } from "~/settings/page-title";
@@ -12,7 +12,7 @@ import { SettingsPageTitle } from "~/settings/page-title";
 export function STT() {
   return (
     <SttSettingsProvider>
-      <TranscriptionLanguageWarningBanner />
+      <TranscriptionLanguageWarningToast />
       <div className="flex flex-col gap-6">
         <SettingsPageTitle title={<Trans>Transcription</Trans>} />
         <SelectProviderAndModel />

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -52,7 +52,12 @@ import {
   requiresEntitlement,
 } from "~/settings/ai/shared/eligibility";
 import { useConfigValues } from "~/shared/config";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { SettingsAlert } from "~/shared/ui/settings-alert";
+import {
+  showTransientToast,
+  useTransientToast,
+} from "~/sidebar/toast/transient";
 import * as settings from "~/store/tinybase/store/settings";
 import {
   isConfiguredSttModel,
@@ -284,24 +289,70 @@ export function SelectProviderAndModel() {
   );
 }
 
-export function TranscriptionLanguageWarningBanner() {
-  const hasLanguageWarning = useHasLanguageWarning();
+const TRANSCRIPTION_LANGUAGE_WARNING_TOAST_ID =
+  "transcription-language-warning";
+const dismissedTranscriptionLanguageWarningKeys = new Set<string>();
 
-  if (!hasLanguageWarning) {
+export function TranscriptionLanguageWarningToast() {
+  const warningKey = useTranscriptionLanguageWarningKey();
+
+  if (
+    !warningKey ||
+    dismissedTranscriptionLanguageWarningKeys.has(warningKey)
+  ) {
     return null;
   }
 
   return (
-    <div className="-mx-6 -mt-6 mb-6 border-b border-amber-200 bg-amber-50 px-6 py-3 dark:border-amber-900/60 dark:bg-amber-950/30">
-      <span className="flex items-center justify-center gap-2 text-center text-sm text-amber-600 dark:text-amber-200">
-        <AlertTriangle className="size-4 shrink-0" />
-        Selected model may not support all your spoken languages.
-      </span>
-    </div>
+    <TranscriptionLanguageWarningToastLifecycle
+      key={warningKey}
+      warningKey={warningKey}
+    />
   );
 }
 
-function useHasLanguageWarning() {
+function TranscriptionLanguageWarningToastLifecycle({
+  warningKey,
+}: {
+  warningKey: string;
+}) {
+  useMountEffect(() => {
+    showTransientToast(
+      {
+        id: TRANSCRIPTION_LANGUAGE_WARNING_TOAST_ID,
+        icon: <AlertTriangle className="size-4 shrink-0 text-amber-500" />,
+        description: "Model doesn't support all languages.",
+        anchor: "main-content-panel",
+        actions: [
+          {
+            label: "Dismiss",
+            onClick: () => {
+              dismissedTranscriptionLanguageWarningKeys.add(warningKey);
+              clearTranscriptionLanguageWarningToast();
+            },
+          },
+        ],
+        dismissible: false,
+        variant: "warning",
+      },
+      { durationMs: null },
+    );
+
+    return clearTranscriptionLanguageWarningToast;
+  });
+
+  return null;
+}
+
+function clearTranscriptionLanguageWarningToast() {
+  const { toast, clearToast } = useTransientToast.getState();
+
+  if (toast?.id === TRANSCRIPTION_LANGUAGE_WARNING_TOAST_ID) {
+    clearToast(toast.key);
+  }
+}
+
+function useTranscriptionLanguageWarningKey() {
   const { current_stt_provider, current_stt_model, spoken_languages } =
     useConfigValues([
       "current_stt_provider",
@@ -362,14 +413,21 @@ function useHasLanguageWarning() {
       !!spoken_languages?.length,
   });
 
-  return isConfigured && languageSupport.data === false && !hasError;
+  if (!isConfigured || languageSupport.data !== false || hasError) {
+    return null;
+  }
+
+  return [
+    current_stt_provider,
+    selectedSttModel,
+    ...(spoken_languages ?? []),
+  ].join(":");
 }
 
 type ModelCategory = "latest" | null;
 type ModelEntry = {
   id: string;
   isDownloaded: boolean;
-  providerId?: ProviderId;
   displayName?: string;
   isDeprecated?: boolean;
   category?: ModelCategory;
@@ -495,12 +553,7 @@ function useConfiguredMapping(): Record<
 
       if (provider.id === "hyprnote") {
         const models: ModelEntry[] = [
-          {
-            id: "cloud",
-            isDownloaded: billing.isPaid,
-            providerId: provider.id,
-            category: "latest",
-          },
+          { id: "cloud", isDownloaded: billing.isPaid, category: "latest" },
         ];
 
         if (isAppleSilicon) {
@@ -508,7 +561,6 @@ function useConfiguredMapping(): Record<
             models.push({
               id: model.key,
               isDownloaded: soniqoDownloaded[i]?.data ?? false,
-              providerId: provider.id,
               displayName: model.display_name,
               sizeBytes: model.size_bytes,
               mode: isRealtimeLocalModel(String(model.key))
@@ -533,7 +585,6 @@ function useConfiguredMapping(): Record<
           models: provider.models.map((model) => ({
             id: model,
             isDownloaded: true,
-            providerId: provider.id,
             mode: getProviderModelMode(provider.id, model),
           })),
         },
@@ -577,7 +628,7 @@ function ModelSelectItem({
       />
       <div className="flex shrink-0 items-center gap-2 text-[11px]">
         <LocalModelBackendBadge model={model.id} />
-        <ModelModeBadge mode={model.mode} providerId={model.providerId} />
+        <ModelModeBadge mode={model.mode} />
         {!model.isDownloaded && sizeLabel && (
           <span className="text-muted-foreground font-mono">{sizeLabel}</span>
         )}
@@ -673,19 +724,13 @@ function ModelSelectedValue({ model }: { model: ModelEntry }) {
         className={cn(["min-w-0", isDeprecated && "opacity-60"])}
         labelClassName={cn([isDeprecated && "text-muted-foreground"])}
       />
-      <ModelModeBadge mode={model.mode} providerId={model.providerId} />
+      <ModelModeBadge mode={model.mode} />
     </div>
   );
 }
 
-function ModelModeBadge({
-  mode,
-  providerId,
-}: {
-  mode?: ModelEntry["mode"];
-  providerId?: ProviderId;
-}) {
-  if (!mode || providerId === "soniox") {
+function ModelModeBadge({ mode }: { mode?: ModelEntry["mode"] }) {
+  if (!mode) {
     return null;
   }
 

--- a/apps/desktop/src/sidebar/toast/component.test.tsx
+++ b/apps/desktop/src/sidebar/toast/component.test.tsx
@@ -66,4 +66,33 @@ describe("Toast", () => {
     expect(action.className).toContain("bg-destructive");
     expect(action.className).toContain("text-destructive-foreground");
   });
+
+  it("does not truncate warning toast text", () => {
+    render(
+      <Toast
+        toast={{
+          id: "transcription-language-warning",
+          description: "Model doesn't support all languages.",
+          dismissible: false,
+          variant: "warning",
+          actions: [
+            {
+              label: "Dismiss",
+              onClick: vi.fn(),
+            },
+          ],
+        }}
+      />,
+    );
+
+    const description = screen.getByText(
+      "Model doesn't support all languages.",
+    );
+
+    expect(description.className).not.toContain("truncate");
+    expect(description.className).toContain("whitespace-nowrap");
+    expect(
+      screen.getByRole("button", { name: "Dismiss" }).parentElement?.className,
+    ).toContain("pl-2");
+  });
 });

--- a/apps/desktop/src/sidebar/toast/component.tsx
+++ b/apps/desktop/src/sidebar/toast/component.tsx
@@ -21,17 +21,21 @@ export function Toast({
           "border shadow-lg backdrop-blur-none",
           toast.variant === "error"
             ? "border-alert-border shadow-red-100 dark:shadow-red-950/30"
-            : "border-border",
+            : toast.variant === "warning"
+              ? "border-amber-200 bg-amber-50 text-amber-950 shadow-amber-100 dark:border-amber-800/60 dark:bg-amber-950 dark:text-amber-100 dark:shadow-amber-950/30"
+              : "border-border",
         ])}
       >
         {toast.icon ? <span className="shrink-0">{toast.icon}</span> : null}
 
         <div
           className={cn([
-            "max-w-50 truncate text-sm",
+            "min-w-0 text-sm",
             toast.variant === "error"
-              ? "text-alert-foreground"
-              : "text-muted-foreground",
+              ? "text-alert-foreground max-w-50 truncate"
+              : toast.variant === "warning"
+                ? "max-w-[min(720px,calc(100vw-16rem))] whitespace-nowrap text-amber-950 dark:text-amber-100"
+                : "text-muted-foreground max-w-50 truncate",
           ])}
         >
           {toast.description}
@@ -40,7 +44,12 @@ export function Toast({
         {progress !== null ? <ProgressPill progress={progress} /> : null}
 
         {actions.length > 0 ? (
-          <div className="flex items-center gap-1">
+          <div
+            className={cn([
+              "flex items-center gap-1",
+              toast.variant === "warning" && "pl-2",
+            ])}
+          >
             {actions.map((action, index) => (
               <button
                 key={action.label}
@@ -90,6 +99,10 @@ function getActions(
 function getActionClassName(toast: ToastType, index: number) {
   if (toast.variant === "error" && index === 0) {
     return "bg-destructive text-destructive-foreground hover:bg-destructive/90";
+  }
+
+  if (toast.variant === "warning" && index === 0) {
+    return "bg-amber-950 text-amber-50 hover:bg-amber-900 dark:bg-amber-100 dark:text-amber-950 dark:hover:bg-amber-200";
   }
 
   if (index === 0) {

--- a/apps/desktop/src/sidebar/toast/index.test.tsx
+++ b/apps/desktop/src/sidebar/toast/index.test.tsx
@@ -76,6 +76,7 @@ vi.mock("./useDismissedToasts", () => ({
 }));
 
 import { ToastArea } from "./index";
+import { showTransientToast, useTransientToast } from "./transient";
 
 describe("ToastArea", () => {
   beforeEach(() => {
@@ -86,9 +87,11 @@ describe("ToastArea", () => {
     mocks.updateSettingsTabState.mockClear();
     mocks.clearDevtoolsPreview.mockClear();
     mocks.setToastActionTarget.mockClear();
+    useTransientToast.getState().clearToast();
   });
 
   afterEach(() => {
+    useTransientToast.getState().clearToast();
     cleanup();
     document.body.innerHTML = "";
     vi.useRealTimers();
@@ -139,7 +142,7 @@ describe("ToastArea", () => {
     expect(toastContainer?.style.top).toBe("88px");
   });
 
-  it("positions the left sidebar toast relative to the main content panel", () => {
+  it("centers the left sidebar toast on the main content panel", () => {
     const mainContentPanel = document.createElement("div");
     mainContentPanel.setAttribute("data-main-content-panel", "");
     vi.spyOn(mainContentPanel, "getBoundingClientRect").mockReturnValue({
@@ -161,9 +164,9 @@ describe("ToastArea", () => {
       bottom: 520,
       height: 500,
       left: 300,
-      right: 900,
+      right: 700,
       top: 20,
-      width: 600,
+      width: 400,
       x: 300,
       y: 20,
       toJSON: () => ({}),
@@ -178,6 +181,60 @@ describe("ToastArea", () => {
 
     const toastContainer = screen
       .getByText("Pro features available")
+      .closest(".fixed") as HTMLElement | null;
+
+    expect(toastContainer?.style.left).toBe("600px");
+    expect(toastContainer?.style.top).toBe("56px");
+  });
+
+  it("centers anchored transient toasts on the main content panel", () => {
+    const mainContentPanel = document.createElement("div");
+    mainContentPanel.setAttribute("data-main-content-panel", "");
+    vi.spyOn(mainContentPanel, "getBoundingClientRect").mockReturnValue({
+      bottom: 520,
+      height: 500,
+      left: 200,
+      right: 1_000,
+      top: 20,
+      width: 800,
+      x: 200,
+      y: 20,
+      toJSON: () => ({}),
+    });
+    document.body.appendChild(mainContentPanel);
+
+    const mainSurface = document.createElement("div");
+    mainSurface.setAttribute("data-chat-floating-anchor", "");
+    vi.spyOn(mainSurface, "getBoundingClientRect").mockReturnValue({
+      bottom: 520,
+      height: 500,
+      left: 300,
+      right: 700,
+      top: 20,
+      width: 400,
+      x: 300,
+      y: 20,
+      toJSON: () => ({}),
+    });
+    document.body.appendChild(mainSurface);
+
+    showTransientToast(
+      {
+        id: "transcription-language-warning",
+        description: "Model doesn't support all languages.",
+        anchor: "main-content-panel",
+      },
+      { durationMs: null },
+    );
+
+    render(<ToastArea />);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    const toastContainer = screen
+      .getByText("Model doesn't support all languages.")
       .closest(".fixed") as HTMLElement | null;
 
     expect(toastContainer?.style.left).toBe("600px");

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -216,8 +216,12 @@ export function ToastArea({
     transientToast,
   ]);
 
-  const displayToast = transientToast ?? devtoolsToast ?? currentToast;
+  const registryPriorityToast =
+    currentToast?.id === "downloading-model" ? currentToast : null;
+  const displayToast =
+    registryPriorityToast ?? transientToast ?? devtoolsToast ?? currentToast;
   const displayToastKey =
+    registryPriorityToast?.id ??
     transientToast?.key ??
     (devtoolsPreview && devtoolsToast
       ? `${devtoolsToast.id}:${devtoolsPreview.key}`
@@ -226,6 +230,7 @@ export function ToastArea({
   const dismissAction = displayToast?.dismissible ? handleDismiss : undefined;
   const position =
     getMainSurfacePosition({
+      anchor: displayToast?.anchor,
       contentOffset,
       mainContentPanelRect,
       mainSurfaceRect,
@@ -377,11 +382,13 @@ function useElementRect(selector: string) {
 }
 
 function getMainSurfacePosition({
+  anchor,
   contentOffset,
   mainContentPanelRect,
   mainSurfaceRect,
   placement,
 }: {
+  anchor?: "main-content-panel";
   contentOffset: number;
   mainContentPanelRect: ElementRect | null;
   mainSurfaceRect: ElementRect | null;
@@ -395,7 +402,7 @@ function getMainSurfacePosition({
 
   return {
     left:
-      placement === "left-sidebar"
+      anchor === "main-content-panel" || placement === "left-sidebar"
         ? horizontalAnchorRect.left + horizontalAnchorRect.width / 2
         : `calc(50% + ${contentOffset}px)`,
     top: verticalAnchorRect.top + LEFT_SIDEBAR_TOP_OFFSET_PX,

--- a/apps/desktop/src/sidebar/toast/transient.test.ts
+++ b/apps/desktop/src/sidebar/toast/transient.test.ts
@@ -1,0 +1,32 @@
+import { act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { showTransientToast, useTransientToast } from "./transient";
+
+describe("transient toast store", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useTransientToast.getState().clearToast();
+  });
+
+  afterEach(() => {
+    useTransientToast.getState().clearToast();
+    vi.useRealTimers();
+  });
+
+  it("keeps a toast visible when duration is disabled", () => {
+    showTransientToast(
+      {
+        id: "persistent-toast",
+        description: "Persistent warning",
+      },
+      { durationMs: null },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(useTransientToast.getState().toast?.id).toBe("persistent-toast");
+  });
+});

--- a/apps/desktop/src/sidebar/toast/transient.ts
+++ b/apps/desktop/src/sidebar/toast/transient.ts
@@ -17,7 +17,7 @@ type TransientToastState = {
   toast: TransientToast | null;
   showToast: (
     toast: TransientToastInput,
-    options?: { durationMs?: number },
+    options?: { durationMs?: number | null },
   ) => void;
   clearToast: (key?: string) => void;
 };
@@ -43,6 +43,10 @@ export const useTransientToast = create<TransientToastState>((set, get) => ({
 
     set({ toast: nextToast });
 
+    if (options?.durationMs === null) {
+      return;
+    }
+
     dismissTimer = setTimeout(() => {
       if (get().toast?.key === key) {
         set({ toast: null });
@@ -66,7 +70,7 @@ export const useTransientToast = create<TransientToastState>((set, get) => ({
 
 export function showTransientToast(
   toast: TransientToastInput,
-  options?: { durationMs?: number },
+  options?: { durationMs?: number | null },
 ) {
   useTransientToast.getState().showToast(toast, options);
 }

--- a/apps/desktop/src/sidebar/toast/types.ts
+++ b/apps/desktop/src/sidebar/toast/types.ts
@@ -12,6 +12,8 @@ export type DownloadProgress = {
   progress: number;
 };
 
+export type ToastAnchor = "main-content-panel";
+
 export type ToastType = {
   id: string;
   icon?: ReactNode;
@@ -23,7 +25,8 @@ export type ToastType = {
   dismissible: boolean;
   progress?: number;
   downloads?: DownloadProgress[];
-  variant?: "default" | "error";
+  variant?: "default" | "error" | "warning";
+  anchor?: ToastAnchor;
   gradient?: string;
 };
 


### PR DESCRIPTION
Replace the transcription settings banner with a persistent warning toast that can be dismissed and clears when leaving the view.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only change in transcription settings warnings; no auth, data, or transcription pipeline logic changes.
> 
> **Overview**
> When the chosen STT model does not cover all configured spoken languages, the warning is no longer shown as an inline **Settings** banner on the transcription settings page. It is surfaced as a **persistent warning toast** (no auto-dismiss) anchored to the main content panel, with an explicit **Dismiss** action.
> 
> Dismissals are remembered per warning key (provider/model/language set) so the same mismatch does not re-nag after the user dismisses it. Leaving the transcription settings view clears the toast via mount/unmount lifecycle cleanup. Locale **`.po`** files were regenerated so string references point at the updated line numbers in `stt/select.tsx` after that refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9a718edd5c8facd73887adfe4ce9ff289a4e3e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->