### PR TITLE
Make metadata icon controls circular

### DIFF
--- a/apps/desktop/src/session/components/outer-header/metadata/date.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/date.tsx
@@ -34,7 +34,7 @@ export function DateEditor({ sessionId }: { sessionId: string }) {
           type="button"
           variant="ghost"
           size="icon"
-          className="text-muted-foreground hover:bg-accent hover:text-foreground size-7 rounded-md"
+          className="text-muted-foreground hover:bg-accent hover:text-foreground size-7 rounded-full"
           onClick={() => setIsEditing(true)}
           aria-label={t`Edit date`}
         >
@@ -141,7 +141,7 @@ function EditableDateForm({
                 type="button"
                 variant="ghost"
                 size="icon"
-                className="text-muted-foreground size-7 shrink-0 rounded-md hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/50 dark:hover:text-red-300"
+                className="text-muted-foreground size-7 shrink-0 rounded-full hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/50 dark:hover:text-red-300"
                 onClick={onCancel}
                 aria-label={t`Cancel date edit`}
               >
@@ -155,7 +155,7 @@ function EditableDateForm({
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="text-muted-foreground size-7 shrink-0 rounded-md hover:bg-green-50 hover:text-green-600 dark:hover:bg-green-950/50 dark:hover:text-green-300"
+                  className="text-muted-foreground size-7 shrink-0 rounded-full hover:bg-green-50 hover:text-green-600 dark:hover:bg-green-950/50 dark:hover:text-green-300"
                   onClick={() => void form.handleSubmit()}
                   disabled={!canSubmit}
                   aria-label={t`Save date`}

--- a/apps/desktop/src/session/components/outer-header/metadata/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DateEditor } from "./date";
+import { MetadataButton } from "./index";
+
+const mocks = vi.hoisted(() => ({
+  createdAt: "2026-07-02T03:53:00.000Z" as unknown,
+  setCreatedAt: vi.fn(),
+  sessionEvent: null as unknown,
+}));
+
+const lingui = vi.hoisted(() => {
+  const t = (input: TemplateStringsArray | string, ...values: unknown[]) => {
+    if (typeof input === "string") {
+      return input;
+    }
+
+    return Array.from(input).reduce(
+      (text, part, index) => `${text}${part}${values[index] ?? ""}`,
+      "",
+    );
+  };
+
+  return { t };
+});
+
+vi.mock("@lingui/react/macro", () => ({
+  useLingui: () => ({
+    t: lingui.t,
+  }),
+}));
+
+vi.mock("@hypr/plugin-opener2", () => ({
+  commands: {
+    openUrl: vi.fn(),
+  },
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValue: () => undefined,
+}));
+
+vi.mock("~/store/tinybase/hooks", () => ({
+  useSessionEvent: () => mocks.sessionEvent,
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useCell: () => mocks.createdAt,
+    useSetCellCallback: () => mocks.setCreatedAt,
+  },
+}));
+
+vi.mock("./participants", () => ({
+  ParticipantsDisplay: () => null,
+}));
+
+describe("Metadata controls", () => {
+  beforeEach(() => {
+    mocks.createdAt = "2026-07-02T03:53:00.000Z";
+    mocks.setCreatedAt.mockClear();
+    mocks.sessionEvent = null;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the metadata calendar trigger as a circle", () => {
+    render(<MetadataButton sessionId="session-1" />);
+
+    const metadataButton = screen.getByRole("button", {
+      name: "Open note metadata",
+    });
+
+    expect(metadataButton.className).toContain("size-7");
+    expect(metadataButton.className).toContain("rounded-full");
+  });
+
+  it("renders date edit action buttons as circles", () => {
+    render(<DateEditor sessionId="session-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit date" }));
+
+    expect(
+      screen.getByRole("button", { name: "Cancel date edit" }).className,
+    ).toContain("rounded-full");
+    expect(
+      screen.getByRole("button", { name: "Save date" }).className,
+    ).toContain("rounded-full");
+  });
+});

--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -65,7 +65,7 @@ const TriggerInner = forwardRef<
       aria-label={label}
       title={label}
       className={cn([
-        "rounded-full",
+        "size-7 rounded-full",
         "text-muted-foreground hover:bg-accent hover:text-foreground",
         open && "bg-muted text-foreground",
       ])}


### PR DESCRIPTION
Use circular hit targets for date edit actions and the metadata calendar trigger, with focused regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS class-only changes on ghost icon buttons plus new unit tests; no behavior, data, or API changes.
> 
> **Overview**
> Session note metadata icon buttons now use **circular** (`rounded-full`) hit targets instead of slightly rounded squares (`rounded-md`).
> 
> The metadata calendar trigger gets an explicit **`size-7`** alongside `rounded-full` so it matches the date editor controls. The date editor’s **edit**, **cancel**, and **save** icon buttons are updated the same way.
> 
> Adds **`index.test.tsx`** regression tests that assert `MetadataButton` and `DateEditor` action buttons include `rounded-full` (and `size-7` on the calendar trigger).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b019c2777b9e2ebe42e3ace19b992b7acb12be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->