### PR TITLE
Keep custom sidebars fixed

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -117,6 +117,7 @@ vi.mock("@hypr/ui/components/ui/resizable", () => ({
           data-collapsible={collapsible}
           data-default-size={defaultSize}
           data-panel-id={id}
+          data-flex-basis={style?.flexBasis}
           data-max-size={maxSize}
           data-min-size={minSize}
           data-flex-grow={style?.flexGrow}
@@ -326,6 +327,64 @@ describe("ClassicMainBody", () => {
     );
     expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-width")).toBe(
       "24%",
+    );
+  });
+
+  it.each([
+    ["settings", { state: { tab: "app" } }],
+    ["calendar", {}],
+    ["contacts", { state: { selected: null } }],
+    ["templates", { state: { selectedMineId: null, selectedWebIndex: null } }],
+  ])("keeps the %s left sidebar fixed", (type, extraTabState) => {
+    mocks.currentTab = {
+      active: true,
+      pinned: false,
+      slotId: `slot-${type}`,
+      type,
+      ...extraTabState,
+    };
+
+    render(<ClassicMainBody />);
+
+    expect(screen.getByTestId("panel-group").dataset.autoSaveId).toBe(
+      undefined,
+    );
+    expect(screen.getByTestId("resize-handle").dataset.className).toContain(
+      "pointer-events-none",
+    );
+    expect(screen.getByTestId("resize-handle").dataset.className).toContain(
+      "w-0",
+    );
+    expect(screen.getByTestId("resize-handle").dataset.className).toContain(
+      "after:w-0",
+    );
+    expect(mocks.onResizeDragging).toBeNull();
+
+    const panels = screen.getAllByTestId("panel");
+    expect(panels[0]?.dataset.defaultSize).toBe("12.5");
+    expect(panels[0]?.dataset.minSize).toBe("12.5");
+    expect(panels[0]?.dataset.maxSize).toBe("12.5");
+    expect(panels[0]?.dataset.flexGrow).toBe("0");
+    expect(panels[0]?.dataset.flexBasis).toBe("200");
+    expect(panels[0]?.dataset.minWidth).toBe("200");
+    expect(panels[0]?.dataset.maxWidth).toBe("200");
+
+    const sidebarChrome = document.querySelector<HTMLElement>(
+      "[data-left-sidebar-chrome]",
+    );
+    expect(sidebarChrome?.style.width).toBe("200px");
+    expect(sidebarChrome?.style.maxWidth).toBe("200px");
+
+    const bodyRoot = screen.getByTestId("panel-group").parentElement;
+    act(() => {
+      mocks.onPanelLayout?.([24, 76]);
+    });
+
+    expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-size")).toBe(
+      "12.5",
+    );
+    expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-width")).toBe(
+      "12.5%",
     );
   });
 

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -154,6 +154,7 @@ export function ClassicMainBody() {
   const hasLeftSurfaceCustomSidebar =
     hasLeftSurfaceCustomSidebarTab(currentTab);
   const showSidebarTimelineChrome = !hasCustomSidebar && !isOnboarding;
+  const canResizeLeftSidebarPanel = showSidebarTimelineChrome;
   const showSidebarTimeline = showSidebarTimelineChrome && leftsidebar.expanded;
   const mountLeftSidebarPanel = !isOnboarding;
   const showLeftSidebarPanel = mountLeftSidebarPanel && leftsidebar.expanded;
@@ -200,6 +201,13 @@ export function ClassicMainBody() {
         return;
       }
 
+      if (!canResizeLeftSidebarPanel) {
+        leftSidebarResizeDraggingRef.current = false;
+        setLeftSidebarResizing(false);
+        pendingLeftSidebarDefaultSizeRef.current = null;
+        return;
+      }
+
       const sidebarSize = sizes[0];
       if (typeof sidebarSize === "number") {
         const pendingDefaultSize = pendingLeftSidebarDefaultSizeRef.current;
@@ -243,6 +251,7 @@ export function ClassicMainBody() {
     [
       applyLeftSidebarPanelSize,
       commitLeftSidebarPanelSize,
+      canResizeLeftSidebarPanel,
       showLeftSidebarPanel,
     ],
   );
@@ -311,17 +320,22 @@ export function ClassicMainBody() {
     restoreLeftSidebarPanelSize,
   ]);
   const syncDefaultLeftSidebarPanelSize = useCallback(() => {
-    if (
-      !mountLeftSidebarPanel ||
-      leftSidebarResizeDraggingRef.current ||
-      !leftSidebarDefaultSizeTrackingRef.current
-    ) {
+    if (!mountLeftSidebarPanel || leftSidebarResizeDraggingRef.current) {
+      return;
+    }
+
+    if (!canResizeLeftSidebarPanel) {
+      leftSidebarResizeDraggingRef.current = false;
+      setLeftSidebarResizing(false);
+      pendingLeftSidebarDefaultSizeRef.current = null;
+    } else if (!leftSidebarDefaultSizeTrackingRef.current) {
       return;
     }
 
     const currentConstraints = leftSidebarPanelConstraintsRef.current;
 
     if (
+      canResizeLeftSidebarPanel &&
       !panelSizesAreEqual(
         leftSidebarPanelSizeRef.current,
         currentConstraints.defaultSize,
@@ -349,7 +363,9 @@ export function ClassicMainBody() {
     setLeftSidebarPanelConstraints(nextConstraints);
     leftSidebarPanelSizeRef.current = nextConstraints.defaultSize;
     lastExpandedLeftSidebarPanelSizeRef.current = nextConstraints.defaultSize;
-    pendingLeftSidebarDefaultSizeRef.current = nextConstraints.defaultSize;
+    pendingLeftSidebarDefaultSizeRef.current = canResizeLeftSidebarPanel
+      ? nextConstraints.defaultSize
+      : null;
     commitLeftSidebarPanelSize(nextConstraints.defaultSize);
     applyLeftSidebarPanelSize(nextConstraints.defaultSize);
 
@@ -361,6 +377,7 @@ export function ClassicMainBody() {
     });
   }, [
     applyLeftSidebarPanelSize,
+    canResizeLeftSidebarPanel,
     commitLeftSidebarPanelSize,
     mountLeftSidebarPanel,
   ]);
@@ -417,18 +434,22 @@ export function ClassicMainBody() {
   const leftSidebarChromeStyle = useMemo(
     () =>
       ({
-        width: "var(--left-sidebar-panel-width)",
+        width: canResizeLeftSidebarPanel
+          ? "var(--left-sidebar-panel-width)"
+          : LEFT_SIDEBAR_DEFAULT_WIDTH_PX,
         minWidth: LEFT_SIDEBAR_MIN_WIDTH_PX,
-        maxWidth: LEFT_SIDEBAR_MAX_WIDTH_PX,
+        maxWidth: canResizeLeftSidebarPanel
+          ? LEFT_SIDEBAR_MAX_WIDTH_PX
+          : LEFT_SIDEBAR_DEFAULT_WIDTH_PX,
       }) satisfies CSSProperties,
-    [],
+    [canResizeLeftSidebarPanel],
   );
-  const leftSidebarPanelStyle = useMemo(
-    () =>
-      ({
-        flexGrow: leftsidebar.expanded ? "var(--left-sidebar-panel-size)" : 0,
-        maxWidth: leftsidebar.expanded ? LEFT_SIDEBAR_MAX_WIDTH_PX : 0,
-        minWidth: leftsidebar.expanded ? LEFT_SIDEBAR_MIN_WIDTH_PX : 0,
+  const leftSidebarPanelStyle = useMemo(() => {
+    if (!leftsidebar.expanded) {
+      return {
+        flexGrow: 0,
+        maxWidth: 0,
+        minWidth: 0,
         transition:
           leftSidebarResizing && leftsidebar.expanded
             ? undefined
@@ -437,9 +458,45 @@ export function ClassicMainBody() {
                 "max-width 180ms ease-out",
                 "min-width 180ms ease-out",
               ].join(", "),
-      }) satisfies CSSProperties,
-    [leftSidebarResizing, leftsidebar.expanded],
-  );
+      } satisfies CSSProperties;
+    }
+
+    if (!canResizeLeftSidebarPanel) {
+      return {
+        flexBasis: LEFT_SIDEBAR_DEFAULT_WIDTH_PX,
+        flexGrow: 0,
+        maxWidth: LEFT_SIDEBAR_DEFAULT_WIDTH_PX,
+        minWidth: LEFT_SIDEBAR_DEFAULT_WIDTH_PX,
+        transition:
+          leftSidebarResizing && leftsidebar.expanded
+            ? undefined
+            : [
+                "flex-grow 180ms ease-out",
+                "max-width 180ms ease-out",
+                "min-width 180ms ease-out",
+              ].join(", "),
+      } satisfies CSSProperties;
+    }
+
+    return {
+      flexGrow: "var(--left-sidebar-panel-size)",
+      maxWidth: LEFT_SIDEBAR_MAX_WIDTH_PX,
+      minWidth: LEFT_SIDEBAR_MIN_WIDTH_PX,
+      transition:
+        leftSidebarResizing && leftsidebar.expanded
+          ? undefined
+          : [
+              "flex-grow 180ms ease-out",
+              "max-width 180ms ease-out",
+              "min-width 180ms ease-out",
+            ].join(", "),
+    } satisfies CSSProperties;
+  }, [canResizeLeftSidebarPanel, leftSidebarResizing, leftsidebar.expanded]);
+  const leftSidebarPanelRenderConstraints = canResizeLeftSidebarPanel
+    ? leftSidebarPanelConstraints
+    : createFixedLeftSidebarPanelConstraints(
+        leftSidebarPanelConstraints.defaultSize,
+      );
   const renderedLeftSidebarPanelSize = leftSidebarResizeDraggingRef.current
     ? leftSidebarPanelSizeRef.current
     : leftSidebarPanelSize;
@@ -519,7 +576,11 @@ export function ClassicMainBody() {
         </div>
       ) : null}
       <ResizablePanelGroup
-        autoSaveId={mountLeftSidebarPanel ? "classic-main-sidebar" : undefined}
+        autoSaveId={
+          mountLeftSidebarPanel && canResizeLeftSidebarPanel
+            ? "classic-main-sidebar"
+            : undefined
+        }
         dir="ltr"
         direction="horizontal"
         className="min-h-0 flex-1 overflow-hidden"
@@ -533,9 +594,9 @@ export function ClassicMainBody() {
               order={1}
               collapsible
               collapsedSize={LEFT_SIDEBAR_COLLAPSED_SIZE}
-              defaultSize={leftSidebarPanelConstraints.defaultSize}
-              minSize={leftSidebarPanelConstraints.minSize}
-              maxSize={leftSidebarPanelConstraints.maxSize}
+              defaultSize={leftSidebarPanelRenderConstraints.defaultSize}
+              minSize={leftSidebarPanelRenderConstraints.minSize}
+              maxSize={leftSidebarPanelRenderConstraints.maxSize}
               onCollapse={handleLeftSidebarPanelCollapse}
               className={cn([
                 "min-h-0 overflow-hidden",
@@ -566,11 +627,15 @@ export function ClassicMainBody() {
             <ResizableHandle
               className={cn([
                 "z-10 !bg-transparent after:w-2",
-                showLeftSidebarPanel
+                showLeftSidebarPanel && canResizeLeftSidebarPanel
                   ? "w-1"
                   : "pointer-events-none w-0 after:w-0",
               ])}
-              onDragging={handleLeftSidebarResizeDragging}
+              onDragging={
+                canResizeLeftSidebarPanel
+                  ? handleLeftSidebarResizeDragging
+                  : undefined
+              }
             />
           </>
         ) : null}
@@ -626,6 +691,14 @@ function createLeftSidebarPanelConstraints(widthPx?: number) {
       minSize,
       percentageFromPixels(LEFT_SIDEBAR_MAX_WIDTH_PX, containerWidthPx),
     ),
+  };
+}
+
+function createFixedLeftSidebarPanelConstraints(defaultSize: number) {
+  return {
+    defaultSize,
+    minSize: defaultSize,
+    maxSize: defaultSize,
   };
 }
 

--- a/apps/desktop/src/sidebar/index.test.tsx
+++ b/apps/desktop/src/sidebar/index.test.tsx
@@ -67,6 +67,7 @@ describe("LeftSidebar", () => {
       screen.getByTestId("timeline-view").getAttribute("data-top-chrome-inset"),
     ).toBe("true");
     expect(container.firstElementChild?.className).toContain("pt-0");
+    expect(container.firstElementChild?.className).not.toContain("pr-1");
   });
 
   it.each([
@@ -82,6 +83,7 @@ describe("LeftSidebar", () => {
 
     expect(screen.getByTestId(testId)).toBeTruthy();
     expect(classList).toContain("pt-11");
+    expect(classList).toContain("pr-1");
     expect(classList).not.toContain("pt-0");
   });
 });

--- a/apps/desktop/src/sidebar/index.tsx
+++ b/apps/desktop/src/sidebar/index.tsx
@@ -30,6 +30,7 @@ export function LeftSidebar({
       className={cn([
         "flex h-full w-full shrink-0 flex-col gap-1 overflow-hidden",
         isTimelineSidebarLayout ? "pt-0" : "pt-11",
+        !isTimelineSidebarLayout && "pr-1",
       ])}
     >
       <div className="flex flex-1 flex-col gap-1 overflow-hidden">


### PR DESCRIPTION
Disable resizing for settings, calendar, contacts, and templates sidebars while preserving the resizable timeline sidebar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop layout-only changes with targeted tests; no auth, data, or API impact.
> 
> **Overview**
> **Settings, calendar, contacts, and templates** left sidebars are no longer user-resizable; only the **timeline** sidebar keeps drag-to-resize, persisted layout, and the visible resize handle.
> 
> `ClassicMainBody` gates resizing on `canResizeLeftSidebarPanel` (timeline chrome only). For custom-sidebar tabs it pins the panel at **200px** (`createFixedLeftSidebarPanelConstraints`), uses fixed chrome width, skips `autoSaveId`, hides/disables the handle, and ignores layout callbacks so drag state cannot change width. `LeftSidebar` adds **`pr-1`** on those special modes (not on timeline) for spacing under window chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0223ce4d9655106757c2e7ace77fd78090af7253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->