### PR TITLE
Move Soniqo live streaming into owhisper client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12669,6 +12669,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "transcribe-soniqo",
  "url",
  "ws-client",
 ]

--- a/crates/listener-core/Cargo.toml
+++ b/crates/listener-core/Cargo.toml
@@ -20,7 +20,7 @@ hypr-transcribe-soniqo = { workspace = true }
 hypr-transcript = { workspace = true }
 hypr-vad-masking = { workspace = true }
 
-owhisper-client = { workspace = true }
+owhisper-client = { workspace = true, features = ["local"] }
 owhisper-interface = { workspace = true }
 
 hound = { workspace = true }

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -14,15 +14,8 @@ use owhisper_interface::{ControlMessage, MixedMessage};
 
 use super::stream::process_stream;
 use super::{ChannelSender, DEVICE_FINGERPRINT_HEADER, ListenerArgs, ListenerMsg, actor_error};
-use crate::SessionErrorEvent;
 
-const SONIQO_ECHO_GATE_MIN_SAMPLES: usize = 512;
-const SONIQO_ECHO_GATE_MAX_LAG_SAMPLES: isize = 1600;
-const SONIQO_ECHO_GATE_LAG_STEP_SAMPLES: isize = 80;
-const SONIQO_ECHO_GATE_MIN_MIC_RMS: f32 = 0.0025;
-const SONIQO_ECHO_GATE_MIN_SPEAKER_RMS: f32 = 0.01;
-const SONIQO_ECHO_GATE_MIN_CORRELATION: f32 = 0.55;
-const SONIQO_ECHO_GATE_MAX_RESIDUAL_RATIO: f32 = 0.45;
+use crate::SessionErrorEvent;
 
 pub(super) async fn spawn_rx_task(
     args: ListenerArgs,
@@ -144,8 +137,44 @@ async fn spawn_soniqo_rx_task(
     ),
     ActorProcessingErr,
 > {
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let (session_offset_secs, extra) = build_extra(&args);
+
     if matches!(args.mode, crate::actors::ChannelMode::MicAndSpeaker) {
-        spawn_soniqo_rx_task_dual(model, args, myself).await
+        let (tx, rx) =
+            tokio::sync::mpsc::channel::<MixedMessage<(Bytes, Bytes), ControlMessage>>(32);
+        let outbound = tokio_stream::wrappers::ReceiverStream::new(rx);
+        let client = owhisper_client::LocalSoniqoLiveClient::new(model);
+        let (listen_stream, handle) = match client.from_realtime_audio_dual(outbound).await {
+            Ok(result) => result,
+            Err(error) => {
+                tracing::error!(
+                    hyprnote.session.id = %args.session_id,
+                    error.message = ?error,
+                    "soniqo_live_start_failed(dual)"
+                );
+                args.runtime.emit_error(SessionErrorEvent::ConnectionError {
+                    session_id: args.session_id.clone(),
+                    error: format!("soniqo_live_start_failed: {error}"),
+                });
+                return Err(actor_error(format!("soniqo_live_start_failed: {error}")));
+            }
+        };
+
+        let rx_task = tokio::spawn(async move {
+            futures_util::pin_mut!(listen_stream);
+            process_stream(
+                listen_stream,
+                handle,
+                myself,
+                shutdown_rx,
+                session_offset_secs,
+                extra,
+            )
+            .await;
+        });
+
+        Ok((ChannelSender::Dual(tx), rx_task, shutdown_tx))
     } else {
         let source = if matches!(args.mode, crate::actors::ChannelMode::SpeakerOnly) {
             hypr_transcribe_soniqo::TranscriptSource::System
@@ -153,510 +182,41 @@ async fn spawn_soniqo_rx_task(
             hypr_transcribe_soniqo::TranscriptSource::Microphone
         };
 
-        spawn_soniqo_rx_task_single(model, args, myself, source).await
-    }
-}
-
-async fn spawn_soniqo_rx_task_single(
-    model: hypr_transcribe_soniqo::SoniqoModel,
-    args: ListenerArgs,
-    myself: ActorRef<ListenerMsg>,
-    source: hypr_transcribe_soniqo::TranscriptSource,
-) -> Result<
-    (
-        ChannelSender,
-        tokio::task::JoinHandle<()>,
-        tokio::sync::oneshot::Sender<()>,
-    ),
-    ActorProcessingErr,
-> {
-    let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    let (session_offset_secs, extra) = build_extra(&args);
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<MixedMessage<Bytes, ControlMessage>>(32);
-
-    let session = start_soniqo_live_session(model).await?;
-
-    let rx_task = tokio::spawn(async move {
-        let mut session = session;
-        let mut buffer = Vec::<f32>::new();
-        let mut cursor = 0.0;
-        let mut interval = tokio::time::interval(Duration::from_millis(250));
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-
-        loop {
-            tokio::select! {
-                _ = &mut shutdown_rx => {
-                    break;
+        let (tx, rx) = tokio::sync::mpsc::channel::<MixedMessage<Bytes, ControlMessage>>(32);
+        let outbound = tokio_stream::wrappers::ReceiverStream::new(rx);
+        let client = owhisper_client::LocalSoniqoLiveClient::new(model);
+        let (listen_stream, handle) =
+            match client.from_realtime_audio_single(outbound, source).await {
+                Ok(result) => result,
+                Err(error) => {
+                    tracing::error!(
+                        hyprnote.session.id = %args.session_id,
+                        error.message = ?error,
+                        "soniqo_live_start_failed(single)"
+                    );
+                    args.runtime.emit_error(SessionErrorEvent::ConnectionError {
+                        session_id: args.session_id.clone(),
+                        error: format!("soniqo_live_start_failed: {error}"),
+                    });
+                    return Err(actor_error(format!("soniqo_live_start_failed: {error}")));
                 }
-                maybe_msg = rx.recv() => {
-                    let Some(msg) = maybe_msg else {
-                        break;
-                    };
+            };
 
-                    match msg {
-                        MixedMessage::Audio(audio) => {
-                            buffer.extend(i16_bytes_to_f32(&audio));
-                        }
-                        MixedMessage::Control(ControlMessage::CloseStream) => {
-                            break;
-                        }
-                        MixedMessage::Control(ControlMessage::Finalize | ControlMessage::KeepAlive) => {}
-                    }
-                }
-                _ = interval.tick() => {
-                    match flush_soniqo_buffer(
-                        session,
-                        model,
-                        source,
-                        &mut buffer,
-                        &mut cursor,
-                        &myself,
-                        session_offset_secs,
-                        &extra,
-                    )
-                    .await
-                    {
-                        Ok(next_session) => session = next_session,
-                        Err(error) => {
-                            let _ = myself.cast(ListenerMsg::StreamError(error));
-                            return;
-                        }
-                    }
-                }
-            }
-        }
+        let rx_task = tokio::spawn(async move {
+            futures_util::pin_mut!(listen_stream);
+            process_stream(
+                listen_stream,
+                handle,
+                myself,
+                shutdown_rx,
+                session_offset_secs,
+                extra,
+            )
+            .await;
+        });
 
-        match flush_soniqo_buffer(
-            session,
-            model,
-            source,
-            &mut buffer,
-            &mut cursor,
-            &myself,
-            session_offset_secs,
-            &extra,
-        )
-        .await
-        {
-            Ok(next_session) => session = next_session,
-            Err(error) => {
-                tracing::warn!(%error, "soniqo_final_flush_failed");
-                return;
-            }
-        }
-
-        match finalize_soniqo_source(
-            session,
-            model,
-            source,
-            cursor,
-            myself,
-            session_offset_secs,
-            extra,
-        )
-        .await
-        {
-            Ok(next_session) => session = next_session,
-            Err(error) => {
-                tracing::warn!(%error, "soniqo_final_finalize_failed");
-                return;
-            }
-        }
-
-        let _ = tokio::task::spawn_blocking(move || session.stop()).await;
-    });
-
-    Ok((ChannelSender::Single(tx), rx_task, shutdown_tx))
-}
-
-async fn spawn_soniqo_rx_task_dual(
-    model: hypr_transcribe_soniqo::SoniqoModel,
-    args: ListenerArgs,
-    myself: ActorRef<ListenerMsg>,
-) -> Result<
-    (
-        ChannelSender,
-        tokio::task::JoinHandle<()>,
-        tokio::sync::oneshot::Sender<()>,
-    ),
-    ActorProcessingErr,
-> {
-    let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    let (session_offset_secs, extra) = build_extra(&args);
-    let (tx, mut rx) =
-        tokio::sync::mpsc::channel::<MixedMessage<(Bytes, Bytes), ControlMessage>>(32);
-
-    let session = start_soniqo_live_session(model).await?;
-
-    let rx_task = tokio::spawn(async move {
-        let mut session = session;
-        let mut mic_buffer = Vec::<f32>::new();
-        let mut spk_buffer = Vec::<f32>::new();
-        let mut mic_cursor = 0.0;
-        let mut spk_cursor = 0.0;
-        let mut interval = tokio::time::interval(Duration::from_millis(250));
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-
-        loop {
-            tokio::select! {
-                _ = &mut shutdown_rx => {
-                    break;
-                }
-                maybe_msg = rx.recv() => {
-                    let Some(msg) = maybe_msg else {
-                        break;
-                    };
-
-                    match msg {
-                        MixedMessage::Audio((mic, spk)) => {
-                            let mut mic_samples = i16_bytes_to_f32(&mic);
-                            let spk_samples = i16_bytes_to_f32(&spk);
-                            if suppress_soniqo_echo_dominant_mic(
-                                &mut mic_samples,
-                                &spk_samples,
-                            ) {
-                                tracing::debug!("soniqo_echo_dominant_mic_chunk_suppressed");
-                            }
-                            mic_buffer.extend(mic_samples);
-                            spk_buffer.extend(spk_samples);
-                        }
-                        MixedMessage::Control(ControlMessage::CloseStream) => {
-                            break;
-                        }
-                        MixedMessage::Control(ControlMessage::Finalize | ControlMessage::KeepAlive) => {}
-                    }
-                }
-                _ = interval.tick() => {
-                    match flush_soniqo_buffer(
-                        session,
-                        model,
-                        hypr_transcribe_soniqo::TranscriptSource::Microphone,
-                        &mut mic_buffer,
-                        &mut mic_cursor,
-                        &myself,
-                        session_offset_secs,
-                        &extra,
-                    )
-                    .await
-                    {
-                        Ok(next_session) => session = next_session,
-                        Err(error) => {
-                            let _ = myself.cast(ListenerMsg::StreamError(error));
-                            return;
-                        }
-                    }
-
-                    match flush_soniqo_buffer(
-                        session,
-                        model,
-                        hypr_transcribe_soniqo::TranscriptSource::System,
-                        &mut spk_buffer,
-                        &mut spk_cursor,
-                        &myself,
-                        session_offset_secs,
-                        &extra,
-                    )
-                    .await
-                    {
-                        Ok(next_session) => session = next_session,
-                        Err(error) => {
-                            let _ = myself.cast(ListenerMsg::StreamError(error));
-                            return;
-                        }
-                    }
-                }
-            }
-        }
-
-        match flush_soniqo_buffer(
-            session,
-            model,
-            hypr_transcribe_soniqo::TranscriptSource::Microphone,
-            &mut mic_buffer,
-            &mut mic_cursor,
-            &myself,
-            session_offset_secs,
-            &extra,
-        )
-        .await
-        {
-            Ok(next_session) => session = next_session,
-            Err(error) => {
-                tracing::warn!(%error, "soniqo_final_mic_flush_failed");
-                return;
-            }
-        }
-
-        match flush_soniqo_buffer(
-            session,
-            model,
-            hypr_transcribe_soniqo::TranscriptSource::System,
-            &mut spk_buffer,
-            &mut spk_cursor,
-            &myself,
-            session_offset_secs,
-            &extra,
-        )
-        .await
-        {
-            Ok(next_session) => session = next_session,
-            Err(error) => {
-                tracing::warn!(%error, "soniqo_final_system_flush_failed");
-                return;
-            }
-        }
-
-        match finalize_soniqo_source(
-            session,
-            model,
-            hypr_transcribe_soniqo::TranscriptSource::Microphone,
-            mic_cursor,
-            myself.clone(),
-            session_offset_secs,
-            extra.clone(),
-        )
-        .await
-        {
-            Ok(next_session) => session = next_session,
-            Err(error) => {
-                tracing::warn!(%error, "soniqo_final_mic_finalize_failed");
-                return;
-            }
-        }
-
-        match finalize_soniqo_source(
-            session,
-            model,
-            hypr_transcribe_soniqo::TranscriptSource::System,
-            spk_cursor,
-            myself,
-            session_offset_secs,
-            extra,
-        )
-        .await
-        {
-            Ok(next_session) => session = next_session,
-            Err(error) => {
-                tracing::warn!(%error, "soniqo_final_system_finalize_failed");
-                return;
-            }
-        }
-
-        let _ = tokio::task::spawn_blocking(move || session.stop()).await;
-    });
-
-    Ok((ChannelSender::Dual(tx), rx_task, shutdown_tx))
-}
-
-async fn start_soniqo_live_session(
-    model: hypr_transcribe_soniqo::SoniqoModel,
-) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, ActorProcessingErr> {
-    tokio::task::spawn_blocking(move || {
-        hypr_transcribe_soniqo::LiveTranscriptionSession::start(model)
-    })
-    .await
-    .map_err(|e| actor_error(format!("soniqo_live_start_join_failed: {e}")))?
-    .map_err(|e| actor_error(format!("soniqo_live_start_failed: {e}")))
-}
-
-async fn flush_soniqo_buffer(
-    session: hypr_transcribe_soniqo::LiveTranscriptionSession,
-    model: hypr_transcribe_soniqo::SoniqoModel,
-    source: hypr_transcribe_soniqo::TranscriptSource,
-    buffer: &mut Vec<f32>,
-    cursor: &mut f64,
-    myself: &ActorRef<ListenerMsg>,
-    session_offset_secs: f64,
-    extra: &Extra,
-) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, String> {
-    if buffer.is_empty() {
-        return Ok(session);
+        Ok((ChannelSender::Single(tx), rx_task, shutdown_tx))
     }
-
-    let samples = std::mem::take(buffer);
-    let duration = samples.len() as f64 / super::super::SAMPLE_RATE as f64;
-    let start = *cursor;
-    *cursor += duration;
-
-    flush_soniqo_source(
-        session,
-        model,
-        source,
-        samples,
-        start,
-        duration,
-        myself.clone(),
-        session_offset_secs,
-        extra.clone(),
-    )
-    .await
-}
-
-async fn flush_soniqo_source(
-    session: hypr_transcribe_soniqo::LiveTranscriptionSession,
-    model: hypr_transcribe_soniqo::SoniqoModel,
-    source: hypr_transcribe_soniqo::TranscriptSource,
-    samples: Vec<f32>,
-    start: f64,
-    duration: f64,
-    myself: ActorRef<ListenerMsg>,
-    session_offset_secs: f64,
-    extra: Extra,
-) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, String> {
-    let joined = tokio::task::spawn_blocking(move || {
-        let mut session = session;
-        let result = session.append(source, &samples);
-        (session, result)
-    })
-    .await
-    .map_err(|e| format!("soniqo_live_append_join_failed: {e}"))?;
-
-    let (session, partials) = joined;
-    let partials = partials.map_err(|e| format!("soniqo_live_append_failed: {e}"))?;
-
-    for partial in partials {
-        let mut response = partial.into_stream_response(model, start, duration);
-        response.apply_offset(session_offset_secs);
-        response.set_extra(&extra);
-
-        let _ = myself.cast(ListenerMsg::StreamResponse(response));
-    }
-
-    Ok(session)
-}
-
-async fn finalize_soniqo_source(
-    session: hypr_transcribe_soniqo::LiveTranscriptionSession,
-    model: hypr_transcribe_soniqo::SoniqoModel,
-    source: hypr_transcribe_soniqo::TranscriptSource,
-    start: f64,
-    myself: ActorRef<ListenerMsg>,
-    session_offset_secs: f64,
-    extra: Extra,
-) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, String> {
-    let joined = tokio::task::spawn_blocking(move || {
-        let mut session = session;
-        let result = session.finalize(source);
-        (session, result)
-    })
-    .await
-    .map_err(|e| format!("soniqo_live_finalize_join_failed: {e}"))?;
-
-    let (session, partials) = joined;
-    let partials = partials.map_err(|e| format!("soniqo_live_finalize_failed: {e}"))?;
-
-    for partial in partials {
-        let mut response = partial.into_stream_response(model, start, 0.05);
-        response.apply_offset(session_offset_secs);
-        response.set_extra(&extra);
-
-        let _ = myself.cast(ListenerMsg::StreamResponse(response));
-    }
-
-    Ok(session)
-}
-
-fn i16_bytes_to_f32(bytes: &Bytes) -> Vec<f32> {
-    bytes
-        .chunks_exact(2)
-        .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / i16::MAX as f32)
-        .collect()
-}
-
-fn suppress_soniqo_echo_dominant_mic(mic: &mut [f32], speaker: &[f32]) -> bool {
-    let Some(score) = best_soniqo_echo_score(mic, speaker) else {
-        return false;
-    };
-
-    if score.correlation < SONIQO_ECHO_GATE_MIN_CORRELATION
-        || score.residual_ratio > SONIQO_ECHO_GATE_MAX_RESIDUAL_RATIO
-        || score.mic_rms < SONIQO_ECHO_GATE_MIN_MIC_RMS
-        || score.speaker_rms < SONIQO_ECHO_GATE_MIN_SPEAKER_RMS
-    {
-        return false;
-    }
-
-    mic.fill(0.0);
-    true
-}
-
-#[derive(Debug, Clone, Copy)]
-struct SoniqoEchoScore {
-    correlation: f32,
-    residual_ratio: f32,
-    mic_rms: f32,
-    speaker_rms: f32,
-}
-
-fn best_soniqo_echo_score(mic: &[f32], speaker: &[f32]) -> Option<SoniqoEchoScore> {
-    let len = mic.len().min(speaker.len());
-    if len < SONIQO_ECHO_GATE_MIN_SAMPLES {
-        return None;
-    }
-
-    let max_lag =
-        SONIQO_ECHO_GATE_MAX_LAG_SAMPLES.min((len - SONIQO_ECHO_GATE_MIN_SAMPLES) as isize);
-    let mut best = soniqo_echo_score_at_lag(&mic[..len], &speaker[..len], 0);
-    let mut lag = SONIQO_ECHO_GATE_LAG_STEP_SAMPLES;
-
-    while lag <= max_lag {
-        for lag in [-lag, lag] {
-            if let Some(score) = soniqo_echo_score_at_lag(&mic[..len], &speaker[..len], lag) {
-                if best
-                    .map(|current| score.correlation > current.correlation)
-                    .unwrap_or(true)
-                {
-                    best = Some(score);
-                }
-            }
-        }
-        lag += SONIQO_ECHO_GATE_LAG_STEP_SAMPLES;
-    }
-
-    best
-}
-
-fn soniqo_echo_score_at_lag(mic: &[f32], speaker: &[f32], lag: isize) -> Option<SoniqoEchoScore> {
-    let len = mic.len().min(speaker.len());
-    let (mic_start, speaker_start) = if lag >= 0 {
-        (lag as usize, 0)
-    } else {
-        (0, lag.unsigned_abs())
-    };
-    let overlap = len.saturating_sub(mic_start.max(speaker_start));
-    if overlap < SONIQO_ECHO_GATE_MIN_SAMPLES {
-        return None;
-    }
-
-    let mut mic_energy = 0.0;
-    let mut speaker_energy = 0.0;
-    let mut cross_energy = 0.0;
-    for idx in 0..overlap {
-        let mic_sample = mic[mic_start + idx];
-        let speaker_sample = speaker[speaker_start + idx];
-        mic_energy += mic_sample * mic_sample;
-        speaker_energy += speaker_sample * speaker_sample;
-        cross_energy += mic_sample * speaker_sample;
-    }
-
-    if mic_energy <= f32::EPSILON || speaker_energy <= f32::EPSILON {
-        return None;
-    }
-
-    let overlap_f32 = overlap as f32;
-    let mic_rms = (mic_energy / overlap_f32).sqrt();
-    let speaker_rms = (speaker_energy / overlap_f32).sqrt();
-    let correlation = cross_energy.abs() / (mic_energy * speaker_energy).sqrt().max(1e-6);
-    let residual_energy =
-        (mic_energy - (cross_energy * cross_energy / speaker_energy.max(1e-6))).max(0.0);
-    let residual_ratio = residual_energy.sqrt() / mic_energy.sqrt().max(1e-6);
-
-    Some(SoniqoEchoScore {
-        correlation,
-        residual_ratio,
-        mic_rms,
-        speaker_rms,
-    })
 }
 
 fn build_listen_params(args: &ListenerArgs) -> owhisper_interface::ListenParams {
@@ -899,89 +459,6 @@ mod tests {
             participant_human_ids: vec![],
             self_human_id: None,
         }
-    }
-
-    fn test_signal(len: usize, seed: u32) -> Vec<f32> {
-        let mut state = seed;
-        (0..len)
-            .map(|idx| {
-                state ^= state << 13;
-                state ^= state >> 17;
-                state ^= state << 5;
-                let noise = (state as f32 / u32::MAX as f32) * 2.0 - 1.0;
-                let pulse = if idx % 257 == 0 { 0.8 } else { 0.0 };
-                0.45 * noise + pulse
-            })
-            .collect()
-    }
-
-    fn delayed(input: &[f32], delay_samples: usize, gain: f32) -> Vec<f32> {
-        let mut out = vec![0.0; input.len()];
-        for idx in delay_samples..input.len() {
-            out[idx] = input[idx - delay_samples] * gain;
-        }
-        out
-    }
-
-    #[test]
-    fn suppresses_soniqo_mic_when_chunk_is_echo_dominant() {
-        let speaker = test_signal(1920, 0x1234_5678);
-        let mut mic = delayed(&speaker, 160, 0.35);
-
-        assert!(suppress_soniqo_echo_dominant_mic(&mut mic, &speaker));
-        assert!(mic.iter().all(|sample| *sample == 0.0));
-    }
-
-    #[test]
-    fn suppresses_soniqo_mic_when_aec_residual_has_longer_capture_lag() {
-        let speaker = test_signal(2400, 0x1234_5678);
-        let mut mic = delayed(&speaker, 1120, 0.25);
-
-        assert!(suppress_soniqo_echo_dominant_mic(&mut mic, &speaker));
-        assert!(mic.iter().all(|sample| *sample == 0.0));
-    }
-
-    #[test]
-    fn suppresses_soniqo_mic_when_minimum_chunk_matches_zero_lag() {
-        let speaker = test_signal(SONIQO_ECHO_GATE_MIN_SAMPLES, 0x1234_5678);
-        let mut mic: Vec<f32> = speaker.iter().map(|sample| sample * 0.35).collect();
-
-        assert!(suppress_soniqo_echo_dominant_mic(&mut mic, &speaker));
-        assert!(mic.iter().all(|sample| *sample == 0.0));
-    }
-
-    #[test]
-    fn best_soniqo_echo_score_considers_zero_lag_when_step_grid_skips_it() {
-        let speaker = test_signal(1024, 0x1234_5678);
-        let mic: Vec<f32> = speaker.iter().map(|sample| sample * 0.35).collect();
-
-        let score = best_soniqo_echo_score(&mic, &speaker).expect("echo score");
-
-        assert!(score.correlation > 0.99);
-    }
-
-    #[test]
-    fn keeps_soniqo_mic_when_independent_speech_dominates() {
-        let speaker = test_signal(1920, 0x1234_5678);
-        let local = test_signal(1920, 0x8765_4321);
-        let mut mic = delayed(&speaker, 160, 0.15);
-        for (mic_sample, local_sample) in mic.iter_mut().zip(local) {
-            *mic_sample += 0.45 * local_sample;
-        }
-        let original = mic.clone();
-
-        assert!(!suppress_soniqo_echo_dominant_mic(&mut mic, &speaker));
-        assert_eq!(mic, original);
-    }
-
-    #[test]
-    fn keeps_soniqo_mic_when_speaker_reference_is_quiet() {
-        let speaker = vec![0.001; 1920];
-        let mut mic = test_signal(1920, 0x1234_5678);
-        let original = mic.clone();
-
-        assert!(!suppress_soniqo_echo_dominant_mic(&mut mic, &speaker));
-        assert_eq!(mic, original);
     }
 
     #[test]

--- a/crates/owhisper-client/Cargo.toml
+++ b/crates/owhisper-client/Cargo.toml
@@ -5,13 +5,14 @@ edition = "2024"
 
 [features]
 default = []
-local = ["hypr-audio-utils"]
+local = ["hypr-audio-utils", "hypr-transcribe-soniqo"]
 
 [dependencies]
 hypr-am = { workspace = true }
 hypr-audio-utils = { workspace = true, optional = true }
 hypr-language = { workspace = true }
 hypr-observability = { workspace = true }
+hypr-transcribe-soniqo = { workspace = true, optional = true }
 hypr-ws-client = { workspace = true }
 soniox = { workspace = true }
 

--- a/crates/owhisper-client/src/lib.rs
+++ b/crates/owhisper-client/src/lib.rs
@@ -4,6 +4,8 @@ mod error;
 mod error_detection;
 mod http_client;
 mod live;
+#[cfg(feature = "local")]
+mod local_soniqo_live;
 pub(crate) mod polling;
 mod providers;
 
@@ -31,7 +33,14 @@ pub use adapter::{StreamingBatchEvent, StreamingBatchStream};
 pub use batch::{BatchClient, BatchClientBuilder};
 pub use error::Error;
 pub use hypr_ws_client;
-pub use live::{DualHandle, FinalizeHandle, ListenClient, ListenClientBuilder, ListenClientDual};
+pub use live::{
+    DualHandle, FinalizeHandle, ListenClient, ListenClientBuilder, ListenClientDual,
+    ListenClientDualInput, ListenClientInput,
+};
+#[cfg(feature = "local")]
+pub use local_soniqo_live::{
+    LocalSoniqoLiveClient, LocalSoniqoLiveError, LocalSoniqoLiveHandle, LocalSoniqoLiveStream,
+};
 
 pub fn normalize_listen_params(mut params: ListenParams) -> ListenParams {
     params.languages = adapter::normalize_languages(&params.languages);

--- a/crates/owhisper-client/src/local_soniqo_live.rs
+++ b/crates/owhisper-client/src/local_soniqo_live.rs
@@ -1,0 +1,608 @@
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures_util::{Stream, StreamExt};
+use owhisper_interface::stream::StreamResponse;
+use owhisper_interface::{ControlMessage, MixedMessage};
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::{FinalizeHandle, ListenClientDualInput, ListenClientInput};
+
+const FLUSH_INTERVAL: Duration = Duration::from_millis(250);
+const ECHO_GATE_MIN_SAMPLES: usize = 512;
+const ECHO_GATE_MAX_LAG_SAMPLES: isize = 1600;
+const ECHO_GATE_LAG_STEP_SAMPLES: isize = 80;
+const ECHO_GATE_MIN_MIC_RMS: f32 = 0.0025;
+const ECHO_GATE_MIN_SPEAKER_RMS: f32 = 0.01;
+const ECHO_GATE_MIN_CORRELATION: f32 = 0.55;
+const ECHO_GATE_MAX_RESIDUAL_RATIO: f32 = 0.45;
+
+pub type LocalSoniqoLiveStream = ReceiverStream<Result<StreamResponse, LocalSoniqoLiveError>>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum LocalSoniqoLiveError {
+    #[error("soniqo_live_start_join_failed: {0}")]
+    StartJoin(String),
+    #[error("soniqo_live_start_failed: {0}")]
+    Start(String),
+    #[error("soniqo_live_append_join_failed: {0}")]
+    AppendJoin(String),
+    #[error("soniqo_live_append_failed: {0}")]
+    Append(String),
+    #[error("soniqo_live_finalize_join_failed: {0}")]
+    FinalizeJoin(String),
+    #[error("soniqo_live_finalize_failed: {0}")]
+    Finalize(String),
+}
+
+pub struct LocalSoniqoLiveClient {
+    model: hypr_transcribe_soniqo::SoniqoModel,
+}
+
+impl LocalSoniqoLiveClient {
+    pub fn new(model: hypr_transcribe_soniqo::SoniqoModel) -> Self {
+        Self { model }
+    }
+
+    pub async fn from_realtime_audio_single(
+        self,
+        stream: impl Stream<Item = ListenClientInput> + Send + Unpin + 'static,
+        source: hypr_transcribe_soniqo::TranscriptSource,
+    ) -> Result<(LocalSoniqoLiveStream, LocalSoniqoLiveHandle), LocalSoniqoLiveError> {
+        let session = start_session(self.model).await?;
+        let (response_tx, response_rx) = tokio::sync::mpsc::channel(32);
+        let (finalize_tx, finalize_rx) = tokio::sync::mpsc::channel(1);
+
+        tokio::spawn(run_single(
+            session,
+            self.model,
+            source,
+            stream,
+            response_tx,
+            finalize_rx,
+        ));
+
+        Ok((
+            ReceiverStream::new(response_rx),
+            LocalSoniqoLiveHandle {
+                finalize_tx,
+                expected_finalize_count: 1,
+            },
+        ))
+    }
+
+    pub async fn from_realtime_audio_dual(
+        self,
+        stream: impl Stream<Item = ListenClientDualInput> + Send + Unpin + 'static,
+    ) -> Result<(LocalSoniqoLiveStream, LocalSoniqoLiveHandle), LocalSoniqoLiveError> {
+        let session = start_session(self.model).await?;
+        let (response_tx, response_rx) = tokio::sync::mpsc::channel(32);
+        let (finalize_tx, finalize_rx) = tokio::sync::mpsc::channel(1);
+
+        tokio::spawn(run_dual(
+            session,
+            self.model,
+            stream,
+            response_tx,
+            finalize_rx,
+        ));
+
+        Ok((
+            ReceiverStream::new(response_rx),
+            LocalSoniqoLiveHandle {
+                finalize_tx,
+                expected_finalize_count: 2,
+            },
+        ))
+    }
+}
+
+pub struct LocalSoniqoLiveHandle {
+    finalize_tx: tokio::sync::mpsc::Sender<()>,
+    expected_finalize_count: usize,
+}
+
+impl FinalizeHandle for LocalSoniqoLiveHandle {
+    async fn finalize(&self) {
+        let _ = self.finalize_tx.send(()).await;
+    }
+
+    fn expected_finalize_count(&self) -> usize {
+        self.expected_finalize_count
+    }
+}
+
+async fn run_single(
+    session: hypr_transcribe_soniqo::LiveTranscriptionSession,
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    source: hypr_transcribe_soniqo::TranscriptSource,
+    mut stream: impl Stream<Item = ListenClientInput> + Send + Unpin + 'static,
+    response_tx: tokio::sync::mpsc::Sender<Result<StreamResponse, LocalSoniqoLiveError>>,
+    mut finalize_rx: tokio::sync::mpsc::Receiver<()>,
+) {
+    let mut session = session;
+    let mut buffer = Vec::<f32>::new();
+    let mut cursor = 0.0;
+    let mut interval = tokio::time::interval(FLUSH_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            _ = finalize_rx.recv() => {
+                let result = finalize_single(session, model, source, &mut buffer, &mut cursor, &response_tx).await;
+                stop_after_finalize(result).await;
+                return;
+            }
+            maybe_msg = stream.next() => {
+                let Some(msg) = maybe_msg else {
+                    stop_session(session).await;
+                    return;
+                };
+
+                match msg {
+                    MixedMessage::Audio(audio) => {
+                        buffer.extend(i16_bytes_to_f32(&audio));
+                    }
+                    MixedMessage::Control(ControlMessage::CloseStream | ControlMessage::Finalize) => {
+                        let result = finalize_single(session, model, source, &mut buffer, &mut cursor, &response_tx).await;
+                        stop_after_finalize(result).await;
+                        return;
+                    }
+                    MixedMessage::Control(ControlMessage::KeepAlive) => {}
+                }
+            }
+            _ = interval.tick() => {
+                match flush_buffer(session, model, source, &mut buffer, &mut cursor, &response_tx).await {
+                    Ok(next_session) => session = next_session,
+                    Err(error) => {
+                        let _ = response_tx.send(Err(error)).await;
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn run_dual(
+    session: hypr_transcribe_soniqo::LiveTranscriptionSession,
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    mut stream: impl Stream<Item = ListenClientDualInput> + Send + Unpin + 'static,
+    response_tx: tokio::sync::mpsc::Sender<Result<StreamResponse, LocalSoniqoLiveError>>,
+    mut finalize_rx: tokio::sync::mpsc::Receiver<()>,
+) {
+    let mut session = session;
+    let mut mic_buffer = Vec::<f32>::new();
+    let mut spk_buffer = Vec::<f32>::new();
+    let mut mic_cursor = 0.0;
+    let mut spk_cursor = 0.0;
+    let mut interval = tokio::time::interval(FLUSH_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            _ = finalize_rx.recv() => {
+                let result = finalize_dual(session, model, &mut mic_buffer, &mut spk_buffer, &mut mic_cursor, &mut spk_cursor, &response_tx).await;
+                stop_after_finalize(result).await;
+                return;
+            }
+            maybe_msg = stream.next() => {
+                let Some(msg) = maybe_msg else {
+                    stop_session(session).await;
+                    return;
+                };
+
+                match msg {
+                    MixedMessage::Audio((mic, spk)) => {
+                        let mut mic_samples = i16_bytes_to_f32(&mic);
+                        let spk_samples = i16_bytes_to_f32(&spk);
+                        if suppress_echo_dominant_mic(&mut mic_samples, &spk_samples) {
+                            tracing::debug!("soniqo_echo_dominant_mic_chunk_suppressed");
+                        }
+                        mic_buffer.extend(mic_samples);
+                        spk_buffer.extend(spk_samples);
+                    }
+                    MixedMessage::Control(ControlMessage::CloseStream | ControlMessage::Finalize) => {
+                        let result = finalize_dual(session, model, &mut mic_buffer, &mut spk_buffer, &mut mic_cursor, &mut spk_cursor, &response_tx).await;
+                        stop_after_finalize(result).await;
+                        return;
+                    }
+                    MixedMessage::Control(ControlMessage::KeepAlive) => {}
+                }
+            }
+            _ = interval.tick() => {
+                match flush_buffer(
+                    session,
+                    model,
+                    hypr_transcribe_soniqo::TranscriptSource::Microphone,
+                    &mut mic_buffer,
+                    &mut mic_cursor,
+                    &response_tx,
+                )
+                .await
+                {
+                    Ok(next_session) => session = next_session,
+                    Err(error) => {
+                        let _ = response_tx.send(Err(error)).await;
+                        return;
+                    }
+                }
+
+                match flush_buffer(
+                    session,
+                    model,
+                    hypr_transcribe_soniqo::TranscriptSource::System,
+                    &mut spk_buffer,
+                    &mut spk_cursor,
+                    &response_tx,
+                )
+                .await
+                {
+                    Ok(next_session) => session = next_session,
+                    Err(error) => {
+                        let _ = response_tx.send(Err(error)).await;
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn finalize_single(
+    session: hypr_transcribe_soniqo::LiveTranscriptionSession,
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    source: hypr_transcribe_soniqo::TranscriptSource,
+    buffer: &mut Vec<f32>,
+    cursor: &mut f64,
+    response_tx: &tokio::sync::mpsc::Sender<Result<StreamResponse, LocalSoniqoLiveError>>,
+) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, LocalSoniqoLiveError> {
+    let session = flush_buffer(session, model, source, buffer, cursor, response_tx).await?;
+    finalize_source(session, model, source, *cursor, response_tx).await
+}
+
+async fn finalize_dual(
+    session: hypr_transcribe_soniqo::LiveTranscriptionSession,
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    mic_buffer: &mut Vec<f32>,
+    spk_buffer: &mut Vec<f32>,
+    mic_cursor: &mut f64,
+    spk_cursor: &mut f64,
+    response_tx: &tokio::sync::mpsc::Sender<Result<StreamResponse, LocalSoniqoLiveError>>,
+) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, LocalSoniqoLiveError> {
+    let session = flush_buffer(
+        session,
+        model,
+        hypr_transcribe_soniqo::TranscriptSource::Microphone,
+        mic_buffer,
+        mic_cursor,
+        response_tx,
+    )
+    .await?;
+    let session = flush_buffer(
+        session,
+        model,
+        hypr_transcribe_soniqo::TranscriptSource::System,
+        spk_buffer,
+        spk_cursor,
+        response_tx,
+    )
+    .await?;
+    let session = finalize_source(
+        session,
+        model,
+        hypr_transcribe_soniqo::TranscriptSource::Microphone,
+        *mic_cursor,
+        response_tx,
+    )
+    .await?;
+    finalize_source(
+        session,
+        model,
+        hypr_transcribe_soniqo::TranscriptSource::System,
+        *spk_cursor,
+        response_tx,
+    )
+    .await
+}
+
+async fn stop_after_finalize(
+    result: Result<hypr_transcribe_soniqo::LiveTranscriptionSession, LocalSoniqoLiveError>,
+) {
+    match result {
+        Ok(session) => stop_session(session).await,
+        Err(error) => tracing::warn!(error.message = %error, "soniqo_live_finalize_failed"),
+    }
+}
+
+async fn start_session(
+    model: hypr_transcribe_soniqo::SoniqoModel,
+) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, LocalSoniqoLiveError> {
+    tokio::task::spawn_blocking(move || {
+        hypr_transcribe_soniqo::LiveTranscriptionSession::start(model)
+    })
+    .await
+    .map_err(|error| LocalSoniqoLiveError::StartJoin(error.to_string()))?
+    .map_err(|error| LocalSoniqoLiveError::Start(error.to_string()))
+}
+
+async fn stop_session(session: hypr_transcribe_soniqo::LiveTranscriptionSession) {
+    let _ = tokio::task::spawn_blocking(move || session.stop()).await;
+}
+
+async fn flush_buffer(
+    session: hypr_transcribe_soniqo::LiveTranscriptionSession,
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    source: hypr_transcribe_soniqo::TranscriptSource,
+    buffer: &mut Vec<f32>,
+    cursor: &mut f64,
+    response_tx: &tokio::sync::mpsc::Sender<Result<StreamResponse, LocalSoniqoLiveError>>,
+) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, LocalSoniqoLiveError> {
+    if buffer.is_empty() {
+        return Ok(session);
+    }
+
+    let samples = std::mem::take(buffer);
+    let duration = samples.len() as f64 / 16_000.0;
+    let start = *cursor;
+    *cursor += duration;
+
+    append_source(
+        session,
+        model,
+        source,
+        samples,
+        start,
+        duration,
+        response_tx,
+    )
+    .await
+}
+
+async fn append_source(
+    session: hypr_transcribe_soniqo::LiveTranscriptionSession,
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    source: hypr_transcribe_soniqo::TranscriptSource,
+    samples: Vec<f32>,
+    start: f64,
+    duration: f64,
+    response_tx: &tokio::sync::mpsc::Sender<Result<StreamResponse, LocalSoniqoLiveError>>,
+) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, LocalSoniqoLiveError> {
+    let joined = tokio::task::spawn_blocking(move || {
+        let mut session = session;
+        let result = session.append(source, &samples);
+        (session, result)
+    })
+    .await
+    .map_err(|error| LocalSoniqoLiveError::AppendJoin(error.to_string()))?;
+
+    let (session, partials) = joined;
+    let partials = partials.map_err(|error| LocalSoniqoLiveError::Append(error.to_string()))?;
+
+    for partial in partials {
+        let response = partial.into_stream_response(model, start, duration);
+        if response_tx.send(Ok(response)).await.is_err() {
+            break;
+        }
+    }
+
+    Ok(session)
+}
+
+async fn finalize_source(
+    session: hypr_transcribe_soniqo::LiveTranscriptionSession,
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    source: hypr_transcribe_soniqo::TranscriptSource,
+    start: f64,
+    response_tx: &tokio::sync::mpsc::Sender<Result<StreamResponse, LocalSoniqoLiveError>>,
+) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, LocalSoniqoLiveError> {
+    let joined = tokio::task::spawn_blocking(move || {
+        let mut session = session;
+        let result = session.finalize(source);
+        (session, result)
+    })
+    .await
+    .map_err(|error| LocalSoniqoLiveError::FinalizeJoin(error.to_string()))?;
+
+    let (session, partials) = joined;
+    let partials = partials.map_err(|error| LocalSoniqoLiveError::Finalize(error.to_string()))?;
+
+    for partial in partials {
+        let response = partial.into_stream_response(model, start, 0.05);
+        if response_tx.send(Ok(response)).await.is_err() {
+            break;
+        }
+    }
+
+    Ok(session)
+}
+
+fn i16_bytes_to_f32(bytes: &Bytes) -> Vec<f32> {
+    bytes
+        .chunks_exact(2)
+        .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / i16::MAX as f32)
+        .collect()
+}
+
+fn suppress_echo_dominant_mic(mic: &mut [f32], speaker: &[f32]) -> bool {
+    let Some(score) = best_echo_score(mic, speaker) else {
+        return false;
+    };
+
+    if score.correlation < ECHO_GATE_MIN_CORRELATION
+        || score.residual_ratio > ECHO_GATE_MAX_RESIDUAL_RATIO
+        || score.mic_rms < ECHO_GATE_MIN_MIC_RMS
+        || score.speaker_rms < ECHO_GATE_MIN_SPEAKER_RMS
+    {
+        return false;
+    }
+
+    mic.fill(0.0);
+    true
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EchoScore {
+    correlation: f32,
+    residual_ratio: f32,
+    mic_rms: f32,
+    speaker_rms: f32,
+}
+
+fn best_echo_score(mic: &[f32], speaker: &[f32]) -> Option<EchoScore> {
+    let len = mic.len().min(speaker.len());
+    if len < ECHO_GATE_MIN_SAMPLES {
+        return None;
+    }
+
+    let max_lag = ECHO_GATE_MAX_LAG_SAMPLES.min((len - ECHO_GATE_MIN_SAMPLES) as isize);
+    let mut best = echo_score_at_lag(&mic[..len], &speaker[..len], 0);
+    let mut lag = ECHO_GATE_LAG_STEP_SAMPLES;
+
+    while lag <= max_lag {
+        for lag in [-lag, lag] {
+            if let Some(score) = echo_score_at_lag(&mic[..len], &speaker[..len], lag) {
+                if best
+                    .map(|current| score.correlation > current.correlation)
+                    .unwrap_or(true)
+                {
+                    best = Some(score);
+                }
+            }
+        }
+        lag += ECHO_GATE_LAG_STEP_SAMPLES;
+    }
+
+    best
+}
+
+fn echo_score_at_lag(mic: &[f32], speaker: &[f32], lag: isize) -> Option<EchoScore> {
+    let len = mic.len().min(speaker.len());
+    let (mic_start, speaker_start) = if lag >= 0 {
+        (lag as usize, 0)
+    } else {
+        (0, lag.unsigned_abs())
+    };
+    let overlap = len.saturating_sub(mic_start.max(speaker_start));
+    if overlap < ECHO_GATE_MIN_SAMPLES {
+        return None;
+    }
+
+    let mut mic_energy = 0.0;
+    let mut speaker_energy = 0.0;
+    let mut cross_energy = 0.0;
+    for idx in 0..overlap {
+        let mic_sample = mic[mic_start + idx];
+        let speaker_sample = speaker[speaker_start + idx];
+        mic_energy += mic_sample * mic_sample;
+        speaker_energy += speaker_sample * speaker_sample;
+        cross_energy += mic_sample * speaker_sample;
+    }
+
+    if mic_energy <= f32::EPSILON || speaker_energy <= f32::EPSILON {
+        return None;
+    }
+
+    let overlap_f32 = overlap as f32;
+    let mic_rms = (mic_energy / overlap_f32).sqrt();
+    let speaker_rms = (speaker_energy / overlap_f32).sqrt();
+    let correlation = cross_energy.abs() / (mic_energy * speaker_energy).sqrt().max(1e-6);
+    let residual_energy =
+        (mic_energy - (cross_energy * cross_energy / speaker_energy.max(1e-6))).max(0.0);
+    let residual_ratio = residual_energy.sqrt() / mic_energy.sqrt().max(1e-6);
+
+    Some(EchoScore {
+        correlation,
+        residual_ratio,
+        mic_rms,
+        speaker_rms,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_signal(len: usize, seed: u32) -> Vec<f32> {
+        let mut state = seed;
+        (0..len)
+            .map(|idx| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                let noise = (state as f32 / u32::MAX as f32) * 2.0 - 1.0;
+                let pulse = if idx % 257 == 0 { 0.8 } else { 0.0 };
+                0.45 * noise + pulse
+            })
+            .collect()
+    }
+
+    fn delayed(input: &[f32], delay_samples: usize, gain: f32) -> Vec<f32> {
+        let mut out = vec![0.0; input.len()];
+        for idx in delay_samples..input.len() {
+            out[idx] = input[idx - delay_samples] * gain;
+        }
+        out
+    }
+
+    #[test]
+    fn suppresses_mic_when_chunk_is_echo_dominant() {
+        let speaker = test_signal(1920, 0x1234_5678);
+        let mut mic = delayed(&speaker, 160, 0.35);
+
+        assert!(suppress_echo_dominant_mic(&mut mic, &speaker));
+        assert!(mic.iter().all(|sample| *sample == 0.0));
+    }
+
+    #[test]
+    fn suppresses_mic_when_aec_residual_has_longer_capture_lag() {
+        let speaker = test_signal(2400, 0x1234_5678);
+        let mut mic = delayed(&speaker, 1120, 0.25);
+
+        assert!(suppress_echo_dominant_mic(&mut mic, &speaker));
+        assert!(mic.iter().all(|sample| *sample == 0.0));
+    }
+
+    #[test]
+    fn suppresses_mic_when_minimum_chunk_matches_zero_lag() {
+        let speaker = test_signal(ECHO_GATE_MIN_SAMPLES, 0x1234_5678);
+        let mut mic: Vec<f32> = speaker.iter().map(|sample| sample * 0.35).collect();
+
+        assert!(suppress_echo_dominant_mic(&mut mic, &speaker));
+        assert!(mic.iter().all(|sample| *sample == 0.0));
+    }
+
+    #[test]
+    fn best_echo_score_considers_zero_lag_when_step_grid_skips_it() {
+        let speaker = test_signal(1024, 0x1234_5678);
+        let mic: Vec<f32> = speaker.iter().map(|sample| sample * 0.35).collect();
+
+        let score = best_echo_score(&mic, &speaker).expect("echo score");
+
+        assert!(score.correlation > 0.99);
+    }
+
+    #[test]
+    fn keeps_mic_when_independent_speech_dominates() {
+        let speaker = test_signal(1920, 0x1234_5678);
+        let local = test_signal(1920, 0x8765_4321);
+        let mut mic = delayed(&speaker, 160, 0.15);
+        for (mic_sample, local_sample) in mic.iter_mut().zip(local) {
+            *mic_sample += 0.45 * local_sample;
+        }
+        let original = mic.clone();
+
+        assert!(!suppress_echo_dominant_mic(&mut mic, &speaker));
+        assert_eq!(mic, original);
+    }
+
+    #[test]
+    fn keeps_mic_when_speaker_reference_is_quiet() {
+        let speaker = vec![0.001; 1920];
+        let mut mic = test_signal(1920, 0x1234_5678);
+        let original = mic.clone();
+
+        assert!(!suppress_echo_dominant_mic(&mut mic, &speaker));
+        assert_eq!(mic, original);
+    }
+}


### PR DESCRIPTION
Route local Soniqo Parakeet live audio through an owhisper-client local live client and reuse the shared listener stream finalization path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the realtime transcription pipeline (buffering, finalize, dual-mic echo gate) with a large logic move; regressions could affect live session timing or transcript metadata even though behavior is intended to match via shared `process_stream`.
> 
> **Overview**
> **Moves local Soniqo Parakeet live transcription out of `listener-core` and into `owhisper-client` behind the `local` feature**, so Soniqo follows the same live-client pattern as remote STT adapters.
> 
> `listener-core` now enables `owhisper-client` with `features = ["local"]` and **`spawn_soniqo_rx_task` wires mic/speaker audio through `LocalSoniqoLiveClient`** (`from_realtime_audio_single` / `dual`) and the existing **`process_stream` + `FinalizeHandle` path**, replacing hundreds of lines of inline buffering, flush timers, session lifecycle, and echo gating in `adapters.rs`.
> 
> The new **`local_soniqo_live` module** owns session start/stop on a blocking pool, 250ms buffer flushes, i16→f32 conversion, dual-channel echo suppression, and streams `Result<StreamResponse, LocalSoniqoLiveError>`; echo-gate unit tests moved with it. **`Cargo.lock`** picks up the `transcribe-soniqo` dependency on the consumer that enables `local`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6de2ed13ec958cba04cef2b9d12f235ece0a5e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->