### PR TITLE
Flatten transcript scroll chips

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -184,6 +184,7 @@ describe("TranscriptViewer", () => {
     const button = screen.getByRole("button", { name: "Go to bottom" });
     button.click();
 
+    expect(button.firstElementChild?.tagName.toLowerCase()).toBe("svg");
     expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
     expect(mocks.scrollToBottom).toHaveBeenCalledTimes(1);
   });
@@ -204,11 +205,41 @@ describe("TranscriptViewer", () => {
     const button = screen.getByRole("button", { name: "Go to top" });
     button.click();
 
-    expect(button.style.bottom).toBe(
-      "var(--transcript-scroll-chip-bottom, calc(3.75rem + env(safe-area-inset-bottom)))",
+    expect(button.firstElementChild?.tagName.toLowerCase()).toBe("svg");
+    expect(button.className).not.toContain("bg-linear-to-t");
+    expect(button.className).not.toContain("shadow");
+    expect(button.className).not.toContain("scale");
+    expect(button.style.top).toBe(
+      "var(--transcript-scroll-chip-top, calc(1.5rem + env(safe-area-inset-top)))",
     );
+    expect(button.style.bottom).toBe("");
     expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
     expect(mocks.scrollToTop).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the bottom chip near the bottom without translucent styling", () => {
+    mocks.scrollDetection.isAtTop = false;
+    mocks.scrollDetection.isAtBottom = false;
+    mocks.scrollDetection.scrollTarget = "bottom";
+
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive
+        scrollRef={createRef()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Go to bottom" });
+
+    expect(button.style.bottom).toBe(
+      "var(--transcript-scroll-chip-bottom, calc(1.5rem + env(safe-area-inset-bottom)))",
+    );
+    expect(button.style.top).toBe("");
+    expect(button.className).not.toContain("/85");
+    expect(button.className).not.toContain("/90");
+    expect(button.className).not.toContain("opacity");
   });
 
   it("hides the scroll chip while floating chat is expanded", () => {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -1,3 +1,4 @@
+import { ArrowDownIcon, ArrowUpIcon } from "lucide-react";
 import {
   type RefObject,
   useCallback,
@@ -57,7 +58,7 @@ export function TranscriptViewer({
     scrollTarget,
     scrollToTop,
     scrollToBottom,
-  } = useScrollDetection(containerRef);
+  } = useScrollDetection(containerRef, currentActive);
 
   const {
     state: playerState,
@@ -106,15 +107,19 @@ export function TranscriptViewer({
       ? null
       : currentActive && scrollTarget === "bottom" && !isAtBottom
         ? {
+            icon: ArrowDownIcon,
             label: "Go to bottom",
             onClick: scrollToBottom,
           }
         : currentActive && scrollTarget === "top" && !isAtTop
           ? {
+              icon: ArrowUpIcon,
               label: "Go to top",
               onClick: scrollToTop,
             }
           : null;
+  const ScrollChipIcon = scrollChip?.icon;
+  const isBottomScrollChip = scrollTarget === "bottom";
 
   const handleSelectionAction = (action: string, selectedText: string) => {
     if (action === "copy") {
@@ -166,18 +171,25 @@ export function TranscriptViewer({
           data-transcript-scroll-chip
           onClick={scrollChip.onClick}
           style={{
-            bottom:
-              "var(--transcript-scroll-chip-bottom, calc(3.75rem + env(safe-area-inset-bottom)))",
+            [isBottomScrollChip ? "bottom" : "top"]: isBottomScrollChip
+              ? "var(--transcript-scroll-chip-bottom, calc(1.5rem + env(safe-area-inset-bottom)))"
+              : "var(--transcript-scroll-chip-top, calc(1.5rem + env(safe-area-inset-top)))",
           }}
           className={cn([
-            "absolute left-1/2 z-30 -translate-x-1/2",
-            "rounded-full px-4 py-2",
-            "from-muted to-accent text-foreground bg-linear-to-t",
-            "shadow-xs hover:scale-[102%] hover:shadow-md active:scale-[98%]",
+            "absolute left-1/2 z-30 inline-flex -translate-x-1/2 items-center gap-1.5",
+            "border-border bg-muted text-foreground rounded-full border px-3 py-1.5",
+            "hover:bg-muted active:bg-muted",
             "text-xs font-light",
-            "transition-[bottom,opacity,transform,box-shadow] duration-150",
+            "transition-[top,bottom,background-color,border-color] duration-150",
           ])}
         >
+          {ScrollChipIcon && (
+            <ScrollChipIcon
+              aria-hidden="true"
+              className="size-3"
+              strokeWidth={2.25}
+            />
+          )}
           {scrollChip.label}
         </button>
       )}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.test.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+
+import { useScrollDetection } from "./viewport-hooks";
+
+function setScrollMetrics(
+  element: HTMLDivElement,
+  {
+    clientHeight,
+    scrollHeight,
+    scrollTop,
+  }: {
+    clientHeight: number;
+    scrollHeight: number;
+    scrollTop: number;
+  },
+) {
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    value: clientHeight,
+  });
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    value: scrollHeight,
+  });
+  element.scrollTop = scrollTop;
+}
+
+describe("useScrollDetection", () => {
+  it("preserves manual scroll-away state when a transcript becomes active again", () => {
+    const element = document.createElement("div");
+    setScrollMetrics(element, {
+      clientHeight: 100,
+      scrollHeight: 1000,
+      scrollTop: 890,
+    });
+    const containerRef = createRef<HTMLDivElement>();
+    containerRef.current = element;
+
+    const { result, rerender } = renderHook(
+      ({ active }) => useScrollDetection(containerRef, active),
+      { initialProps: { active: true } },
+    );
+
+    act(() => {
+      element.scrollTop = 500;
+      element.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(result.current.autoScrollEnabled).toBe(false);
+    expect(result.current.scrollTarget).toBe("bottom");
+
+    rerender({ active: false });
+    rerender({ active: true });
+
+    expect(result.current.autoScrollEnabled).toBe(false);
+    expect(result.current.scrollTarget).toBe("bottom");
+  });
+});

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
@@ -66,8 +66,7 @@ export function useScrollDetection(
   }, [containerRef]);
 
   useEffect(() => {
-    if (active && !wasActiveRef.current) {
-      userScrolledAwayRef.current = false;
+    if (active && !wasActiveRef.current && !userScrolledAwayRef.current) {
       setAutoScrollEnabled(true);
       setScrollTarget(null);
     }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
@@ -9,6 +9,7 @@ import {
 
 export function useScrollDetection(
   containerRef: RefObject<HTMLDivElement | null>,
+  active = true,
 ) {
   const [isAtTop, setIsAtTop] = useState(true);
   const [isAtBottom, setIsAtBottom] = useState(true);
@@ -18,6 +19,7 @@ export function useScrollDetection(
   );
   const lastScrollTopRef = useRef(0);
   const userScrolledAwayRef = useRef(false);
+  const wasActiveRef = useRef(active);
 
   useEffect(() => {
     const element = containerRef.current;
@@ -63,6 +65,16 @@ export function useScrollDetection(
     return () => element.removeEventListener("scroll", handleScroll);
   }, [containerRef]);
 
+  useEffect(() => {
+    if (active && !wasActiveRef.current) {
+      userScrolledAwayRef.current = false;
+      setAutoScrollEnabled(true);
+      setScrollTarget(null);
+    }
+
+    wasActiveRef.current = active;
+  }, [active]);
+
   const scrollToBottom = () => {
     const element = containerRef.current;
     if (!element) {
@@ -101,6 +113,7 @@ export function useAutoScroll(
   const rafRef = useRef<number | null>(null);
   const lastHeightRef = useRef(0);
   const initialFlushRef = useRef(enabled);
+  const previousEnabledRef = useRef(enabled);
 
   useEffect(() => {
     const element = containerRef.current;
@@ -137,9 +150,12 @@ export function useAutoScroll(
     if (initialFlushRef.current) {
       initialFlushRef.current = false;
       schedule(true);
+    } else if (enabled && !previousEnabledRef.current) {
+      schedule(true);
     } else {
-      schedule();
+      schedule(enabled);
     }
+    previousEnabledRef.current = enabled;
 
     const resizeObserver = new ResizeObserver(() => {
       const nextHeight = element.scrollHeight;
@@ -147,7 +163,7 @@ export function useAutoScroll(
         return;
       }
       lastHeightRef.current = nextHeight;
-      schedule();
+      schedule(enabled);
     });
 
     const targets = new Set<Element>([element]);

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -243,7 +243,9 @@
 
   [data-chat-floating-anchor]:has([data-chat-cta-trigger]:is(:hover, :focus-visible, :focus-within))
     [data-transcript-scroll-chip] {
-    --transcript-scroll-chip-bottom: calc(5rem + env(safe-area-inset-bottom));
+    --transcript-scroll-chip-bottom: calc(
+      3.75rem + env(safe-area-inset-bottom)
+    );
   }
 }
 

--- a/plugins/windows/swift-lib/src/FloatingBarView.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarView.swift
@@ -219,8 +219,8 @@ struct FloatingBarView: View {
                     shouldAutoScrollTranscript = true
                   }
                 }
-                .padding(.bottom, 8)
-                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                .padding(.bottom, 0)
+                .transition(.move(edge: .bottom))
               }
             }
             .animation(.easeOut(duration: 0.12), value: shouldAutoScrollTranscript)
@@ -476,27 +476,42 @@ struct FloatingBarView: View {
 
   private func transcriptBottomChip(action: @escaping () -> Void) -> some View {
     Button(action: action) {
-      HStack(spacing: 5) {
+      HStack(spacing: 6) {
         Image(systemName: "arrow.down")
-          .font(.system(size: 10, weight: .bold))
-        Text("Back to bottom")
-          .font(.system(size: 11, weight: .semibold))
+          .font(.system(size: 10, weight: .semibold))
+        Text("Go to bottom")
+          .font(.system(size: 11, weight: .medium))
       }
       .foregroundStyle(primaryContentColor)
-      .padding(.horizontal, 10)
-      .padding(.vertical, 6)
+      .padding(.horizontal, 12)
+      .padding(.vertical, 7)
       .background(
         Capsule(style: .continuous)
-          .fill(surfaceColor.opacity(0.92))
+          .fill(transcriptChipFillColor)
       )
       .overlay(
         Capsule(style: .continuous)
-          .strokeBorder(innerStrokeColor, lineWidth: 0.5)
+          .strokeBorder(transcriptChipStrokeColor, lineWidth: 0.5)
       )
-      .shadow(color: .black.opacity(0.12), radius: 8, y: 3)
     }
     .buttonStyle(.plain)
     .accessibilityLabel("Scroll transcript to bottom")
+  }
+
+  private var transcriptChipFillColor: Color {
+    if model.colorScheme == .dark {
+      return Color(red: 0.18, green: 0.18, blue: 0.17)
+    }
+
+    return Color(red: 0.95, green: 0.95, blue: 0.93)
+  }
+
+  private var transcriptChipStrokeColor: Color {
+    if model.colorScheme == .dark {
+      return Color(red: 0.36, green: 0.36, blue: 0.34)
+    }
+
+    return Color(red: 0.76, green: 0.75, blue: 0.72)
   }
 }
 

--- a/plugins/windows/swift-lib/src/FloatingBarView.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarView.swift
@@ -642,7 +642,6 @@ private struct TranscriptScrollObserver: NSViewRepresentable {
     context.coordinator.isPinnedToBottom = $isPinnedToBottom
     DispatchQueue.main.async {
       context.coordinator.bind(to: view.enclosingScrollView)
-      context.coordinator.updatePinnedState()
     }
   }
 
@@ -650,15 +649,11 @@ private struct TranscriptScrollObserver: NSViewRepresentable {
     var isPinnedToBottom: Binding<Bool>?
     private weak var scrollView: NSScrollView?
     private var boundsObserver: NSObjectProtocol?
-    private var frameObserver: NSObjectProtocol?
     private let threshold: CGFloat = 20
 
     deinit {
       if let boundsObserver {
         NotificationCenter.default.removeObserver(boundsObserver)
-      }
-      if let frameObserver {
-        NotificationCenter.default.removeObserver(frameObserver)
       }
     }
 
@@ -668,9 +663,6 @@ private struct TranscriptScrollObserver: NSViewRepresentable {
       if let boundsObserver {
         NotificationCenter.default.removeObserver(boundsObserver)
       }
-      if let frameObserver {
-        NotificationCenter.default.removeObserver(frameObserver)
-      }
 
       self.scrollView = scrollView
       guard let scrollView else { return }
@@ -679,15 +671,6 @@ private struct TranscriptScrollObserver: NSViewRepresentable {
       boundsObserver = NotificationCenter.default.addObserver(
         forName: NSView.boundsDidChangeNotification,
         object: scrollView.contentView,
-        queue: .main
-      ) { [weak self] _ in
-        self?.updatePinnedState()
-      }
-
-      scrollView.documentView?.postsFrameChangedNotifications = true
-      frameObserver = NotificationCenter.default.addObserver(
-        forName: NSView.frameDidChangeNotification,
-        object: scrollView.documentView,
         queue: .main
       ) { [weak self] _ in
         self?.updatePinnedState()


### PR DESCRIPTION
Summary:
- Tighten transcript scroll chip spacing and add directional icons
- Align the Swift floating panel bottom chip with the flat transcript style
- Preserve user scroll position by preventing bottom snapping when content changes after manual scroll

Testing:
- Not run in this PR creation pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and transcript scroll UX only; behavior is covered by new/updated unit tests with no auth, data, or security impact.
> 
> **Overview**
> **Desktop transcript scroll chips** get a flatter look: bordered muted pills with **up/down icons**, tighter insets (`1.5rem`), and top chips anchored at the top instead of only bottom-offset styling. Gradient, shadow, and scale hover effects are removed; floating-chat CSS nudges the bottom chip offset to `3.75rem`.
> 
> **Scroll behavior** changes so manual “scroll away” isn’t lost when a session toggles inactive/active: `useScrollDetection` takes `currentActive` and only resets auto-scroll on re-activation if the user hadn’t scrolled away. `useAutoScroll` re-pins when auto-scroll turns back on and skips resize-driven snaps when auto-scroll is off, so new transcript content doesn’t yank the viewport after the user scrolled up.
> 
> **Windows Swift floating bar** aligns its bottom chip with the same flat capsule styling (“Go to bottom”), drops extra shadow/padding, and simplifies scroll pinning observers (bounds-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f5c71ab9a9c87bf4e27a8db00a179c39f1f6a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->