### PR TITLE
Adjust standalone note tab offset

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -313,7 +313,7 @@ describe("OuterHeader", () => {
     const title = screen.getByText("Session title");
     const titleSlot = title.parentElement?.parentElement;
 
-    expect(titleSlot?.className).toContain("left-[68px]");
+    expect(titleSlot?.className).toContain("left-[76px]");
     expect(titleSlot?.className).toContain("right-[70px]");
     expect(screen.queryByRole("button", { name: "Stop listening" })).toBeNull();
     expect(mocks.stopListening).not.toHaveBeenCalled();
@@ -336,7 +336,7 @@ describe("OuterHeader", () => {
     const header = container.firstElementChild;
 
     expect(header?.className).not.toContain("pl-[156px]");
-    expect(titleSlot?.className).toContain("left-[68px]");
+    expect(titleSlot?.className).toContain("left-[76px]");
     expect(titleSlot?.className).toContain("right-[70px]");
   });
 

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -56,7 +56,7 @@ export function OuterHeader({
             centerTitle && "justify-center",
             reserveCollapsedLiveControls ? "right-[153px]" : "right-[70px]",
             standaloneWindow
-              ? "left-[68px]"
+              ? "left-[76px]"
               : showSidebarTimelineHeaderGutter
                 ? "left-[104px]"
                 : showExpandedSidebarTimelineHeader


### PR DESCRIPTION
Move standalone note header tabs 8px right and update header layout assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic layout tweak for standalone windows only; no logic or data-path changes.
> 
> **Overview**
> Shifts the **standalone note/window** session header title area **8px to the right** by changing the title slot’s left inset from `left-[68px]` to `left-[76px]` in `OuterHeader` when `standaloneWindow` is true.
> 
> **Unit tests** for standalone windows (expanded and collapsed sidebar) now assert `left-[76px]` instead of `left-[68px]`; other header layout branches are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4780b9231b1d942d3ce78b39a96164098cd0942d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->