### PR TITLE
Persist empty summary note tabs

### DIFF
--- a/apps/desktop/src/store/tinybase/persister/session/save/note.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/save/note.test.ts
@@ -9,6 +9,54 @@ vi.mock("@tauri-apps/api/path", () => ({
 }));
 
 describe("buildNoteSaveOps", () => {
+  test("persists empty enhanced notes so standalone windows can render the tab", () => {
+    const store = createTestMainStore();
+    store.setRow("sessions", "session-1", {
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:00Z",
+      title: "Test Session",
+      folder_id: "work",
+      event_json: "",
+      raw_md: "",
+    });
+    store.setRow("enhanced_notes", "summary-1", {
+      user_id: "user-1",
+      session_id: "session-1",
+      content: "",
+      template_id: "",
+      position: 1,
+      title: "Summary",
+    });
+
+    const ops = buildNoteSaveOps(
+      store,
+      store.getTables(),
+      "/data",
+      new Set(["session-1"]),
+      { deleteEmptyMemos: false },
+    );
+
+    expect(ops).toEqual([
+      {
+        type: "write-document-batch",
+        items: [
+          [
+            {
+              frontmatter: {
+                id: "summary-1",
+                session_id: "session-1",
+                position: 1,
+                title: "Summary",
+              },
+              content: "",
+            },
+            "/data/sessions/work/session-1/_summary.md",
+          ],
+        ],
+      },
+    ]);
+  });
+
   test("does not delete empty memos when folder-only changes are saved", () => {
     const store = createTestMainStore();
     store.setRow("sessions", "session-1", {

--- a/apps/desktop/src/store/tinybase/persister/session/save/note.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/save/note.ts
@@ -49,13 +49,15 @@ function collectEnhancedNotes(ctx: BuildContext): DocumentItem[] {
   const { tables, dataDir, changedSessionIds } = ctx;
 
   return Array.from(iterateTableRows(tables, "enhanced_notes"))
-    .filter((note) => note.content && note.session_id)
+    .filter((note) => note.session_id)
     .filter(
       (note) => !changedSessionIds || changedSessionIds.has(note.session_id!),
     )
     .map((note) => {
-      const markdown = tryParseAndConvertToMarkdown(note.content!);
-      if (!markdown) return null;
+      const markdown = note.content
+        ? tryParseAndConvertToMarkdown(note.content)
+        : "";
+      if (markdown === undefined) return null;
 
       const session = tables.sessions?.[note.session_id!];
       const sessionDir = buildSessionPath(


### PR DESCRIPTION
Save enhanced-note frontmatter even when content is empty so standalone note windows can render default Summary tabs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to note persistence with a focused unit test; no auth or shared infra impact.
> 
> **Overview**
> **Enhanced notes with empty content are now written to disk** instead of being skipped during session save, so standalone note windows can load default Summary tabs from `_summary.md` frontmatter even before any body text exists.
> 
> `collectEnhancedNotes` no longer filters on non-empty `content`; it only requires `session_id`. Empty content is saved as an empty markdown body, while invalid JSON/editor content still drops the write (`markdown === undefined`). Memo save/delete behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75413e3d879c8bfb0d1b55ac7602a1263f0c552a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->