### PR TITLE
Show listening action in standalone note menu

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -678,7 +678,7 @@ msgstr "File format"
 msgid "Filter synced items by {0}."
 msgstr "Filter synced items by {0}."
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr "Finalizing"
 
@@ -829,11 +829,11 @@ msgstr "Intelligence"
 msgid "Job Title"
 msgstr "Job Title"
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr "Join"
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr "Join {name}"
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr "Starting your trial..."
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr "Stop"
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr "Stop listening"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 msgid "Finalizing"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:178
+#: src/session/components/outer-header/index.tsx:183
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:158
+#: src/session/components/outer-header/index.tsx:163
 msgid "Join {name}"
 msgstr ""
 
@@ -1670,11 +1670,11 @@ msgid "Starting your trial..."
 msgstr ""
 
 #: src/session/components/note-input/header.tsx:570
-#: src/session/components/outer-header/index.tsx:319
+#: src/session/components/outer-header/index.tsx:339
 msgid "Stop"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:292
+#: src/session/components/outer-header/index.tsx:312
 #: src/sidebar/timeline/item.tsx:244
 msgid "Stop listening"
 msgstr ""

--- a/apps/desktop/src/main/lifecycle.tsx
+++ b/apps/desktop/src/main/lifecycle.tsx
@@ -13,6 +13,7 @@ import { useDesktopTabLifecycle } from "~/shared/desktop-tab-lifecycle";
 import * as main from "~/store/tinybase/store/main";
 import * as settings from "~/store/tinybase/store/settings";
 import { useTabs } from "~/store/zustand/tabs";
+import { MainListenerControlBridge } from "~/stt/window-control";
 
 export function useClassicMainLifecycle() {
   const openNew = useTabs((state) => state.openNew);
@@ -34,6 +35,7 @@ export function useClassicMainLifecycle() {
 export function ClassicMainServices() {
   return (
     <>
+      <MainListenerControlBridge />
       <ToolRegistration />
       <EnhancerInit />
     </>

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -18,6 +18,12 @@ const mocks = vi.hoisted(() => ({
   stopListening: vi.fn(),
   nowMs: new Date("2026-06-05T09:50:00.000Z").getTime(),
   openUrl: vi.fn(),
+  isMainWebviewWindow: vi.fn(() => true),
+  requestMainListenerControl: vi.fn(),
+  overflowProps: [] as Array<{
+    allowListening?: boolean;
+    standaloneWindow?: boolean;
+  }>,
 }));
 
 vi.mock("./metadata", () => ({
@@ -36,7 +42,13 @@ vi.mock("./metadata", () => ({
 }));
 
 vi.mock("./overflow", () => ({
-  OverflowButton: () => <button type="button">More</button>,
+  OverflowButton: (props: {
+    allowListening?: boolean;
+    standaloneWindow?: boolean;
+  }) => {
+    mocks.overflowProps.push(props);
+    return <button type="button">More</button>;
+  },
 }));
 
 vi.mock("@hypr/ui/components/ui/dancing-sticks", () => ({
@@ -47,6 +59,11 @@ vi.mock("@hypr/plugin-opener2", () => ({
   commands: {
     openUrl: mocks.openUrl,
   },
+}));
+
+vi.mock("~/stt/window-control", () => ({
+  isMainWebviewWindow: mocks.isMainWebviewWindow,
+  requestMainListenerControl: mocks.requestMainListenerControl,
 }));
 
 vi.mock("~/calendar/hooks", () => ({
@@ -108,6 +125,10 @@ describe("OuterHeader", () => {
     mocks.stopListening.mockClear();
     mocks.nowMs = new Date("2026-06-05T09:50:00.000Z").getTime();
     mocks.openUrl.mockClear();
+    mocks.isMainWebviewWindow.mockReset();
+    mocks.isMainWebviewWindow.mockReturnValue(true);
+    mocks.requestMainListenerControl.mockClear();
+    mocks.overflowProps = [];
   });
 
   afterEach(() => {
@@ -297,9 +318,10 @@ describe("OuterHeader", () => {
     expect(screen.queryByRole("button", { name: "Stop listening" })).toBeNull();
   });
 
-  it("keeps listener controls hidden in standalone windows", () => {
+  it("shows the dedicated stop button in standalone windows and delegates stop to main", () => {
     mocks.leftsidebar.expanded = true;
     mocks.sessionModes = { "session-1": "active" };
+    mocks.isMainWebviewWindow.mockReturnValue(false);
 
     render(
       <OuterHeader
@@ -314,8 +336,17 @@ describe("OuterHeader", () => {
     const titleSlot = title.parentElement?.parentElement;
 
     expect(titleSlot?.className).toContain("left-[76px]");
-    expect(titleSlot?.className).toContain("right-[70px]");
-    expect(screen.queryByRole("button", { name: "Stop listening" })).toBeNull();
+    expect(titleSlot?.className).toContain("right-[153px]");
+    const stopButton = screen.getByRole("button", { name: "Stop listening" });
+    fireEvent.click(stopButton);
+
+    const overflowProps = mocks.overflowProps[mocks.overflowProps.length - 1];
+    expect(overflowProps?.standaloneWindow).toBe(true);
+    expect(overflowProps?.allowListening).toBeUndefined();
+    expect(mocks.requestMainListenerControl).toHaveBeenCalledWith(
+      "stop",
+      "session-1",
+    );
     expect(mocks.stopListening).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -17,6 +17,10 @@ import {
 import { useSessionEvent } from "~/store/tinybase/hooks";
 import type { EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
+import {
+  isMainWebviewWindow,
+  requestMainListenerControl,
+} from "~/stt/window-control";
 
 export function OuterHeader({
   sessionId,
@@ -37,7 +41,8 @@ export function OuterHeader({
     !standaloneWindow && !leftsidebar.expanded;
   const showExpandedSidebarTimelineHeader = leftsidebar.expanded;
   const reserveCollapsedLiveControls =
-    showSidebarTimelineHeaderGutter && isSidebarStopButtonMode(sessionMode);
+    (showSidebarTimelineHeaderGutter || standaloneWindow) &&
+    isSidebarStopButtonMode(sessionMode);
 
   return (
     <div
@@ -77,12 +82,12 @@ export function OuterHeader({
         className="relative z-10 ml-auto flex shrink-0 items-center gap-0 pr-1"
       >
         <SidebarModeStopButton
+          sessionId={sessionId}
           sessionMode={sessionMode}
           standaloneWindow={standaloneWindow}
         />
         <HeaderMeetingControl sessionId={sessionId} sessionMode={sessionMode} />
         <OverflowButton
-          allowListening={!standaloneWindow}
           standaloneWindow={standaloneWindow}
           sessionId={sessionId}
           currentView={currentView}
@@ -238,9 +243,11 @@ function getMeetingDisplay(type: RemoteMeeting["type"]) {
 }
 
 function SidebarModeStopButton({
+  sessionId,
   sessionMode,
   standaloneWindow,
 }: {
+  sessionId: string;
   sessionMode: string;
   standaloneWindow: boolean;
 }) {
@@ -255,9 +262,22 @@ function SidebarModeStopButton({
   const active = isSidebarStopButtonMode(sessionMode);
   const finalizing = sessionMode === "finalizing";
 
-  if (standaloneWindow || leftsidebar.expanded || !active) {
+  if ((!standaloneWindow && leftsidebar.expanded) || !active) {
     return null;
   }
+
+  const handleStop = () => {
+    if (finalizing) {
+      return;
+    }
+
+    if (!isMainWebviewWindow()) {
+      void requestMainListenerControl("stop", sessionId);
+      return;
+    }
+
+    stop();
+  };
 
   const accent = degraded ? "amber" : "red";
   const colors = {
@@ -279,7 +299,7 @@ function SidebarModeStopButton({
     <button
       type="button"
       data-tauri-drag-region="false"
-      onClick={finalizing ? undefined : stop}
+      onClick={handleStop}
       disabled={finalizing}
       className={cn([
         "group inline-flex items-center justify-center rounded-full text-sm font-medium",

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -125,6 +125,7 @@ describe("OverflowButton", () => {
     useListenerMock.mockImplementation((selector) =>
       selector({
         getSessionMode: () => "inactive",
+        stop: vi.fn(),
       }),
     );
   });

--- a/apps/desktop/src/session/components/outer-header/overflow/listening.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/listening.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Listening } from "./listening";
+
+const {
+  isMainWebviewWindowMock,
+  requestMainListenerControlMock,
+  startListeningMock,
+  stopMock,
+  useListenerMock,
+} = vi.hoisted(() => ({
+  isMainWebviewWindowMock: vi.fn(() => true),
+  requestMainListenerControlMock: vi.fn(),
+  startListeningMock: vi.fn(),
+  stopMock: vi.fn(),
+  useListenerMock: vi.fn(),
+}));
+
+vi.mock("@hypr/ui/components/ui/dropdown-menu", () => ({
+  DropdownMenuItem: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("~/stt/contexts", () => ({
+  useListener: useListenerMock,
+}));
+
+vi.mock("~/stt/useStartListening", () => ({
+  useStartListening: () => startListeningMock,
+}));
+
+vi.mock("~/stt/window-control", () => ({
+  isMainWebviewWindow: isMainWebviewWindowMock,
+  requestMainListenerControl: requestMainListenerControlMock,
+}));
+
+describe("Listening", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isMainWebviewWindowMock.mockReturnValue(true);
+    useListenerMock.mockImplementation((selector) =>
+      selector({
+        getSessionMode: () => "inactive",
+        stop: stopMock,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("hides resume listening when a transcript already exists", () => {
+    render(<Listening sessionId="session-1" hasTranscript />);
+
+    expect(
+      screen.queryByRole("button", { name: "Resume listening" }),
+    ).toBeNull();
+  });
+
+  it("starts listening directly in the main window before transcript exists", () => {
+    render(<Listening sessionId="session-1" hasTranscript={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Start listening" }));
+
+    expect(startListeningMock).toHaveBeenCalledTimes(1);
+    expect(requestMainListenerControlMock).not.toHaveBeenCalled();
+  });
+
+  it("delegates standalone start requests to the main window before transcript exists", () => {
+    isMainWebviewWindowMock.mockReturnValue(false);
+
+    render(<Listening sessionId="session-1" hasTranscript={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Start listening" }));
+
+    expect(requestMainListenerControlMock).toHaveBeenCalledWith(
+      "start",
+      "session-1",
+    );
+    expect(startListeningMock).not.toHaveBeenCalled();
+  });
+
+  it("delegates standalone stop requests to the main window", () => {
+    isMainWebviewWindowMock.mockReturnValue(false);
+    useListenerMock.mockImplementation((selector) =>
+      selector({
+        getSessionMode: () => "active",
+        stop: stopMock,
+      }),
+    );
+
+    render(<Listening sessionId="session-1" hasTranscript />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop listening" }));
+
+    expect(requestMainListenerControlMock).toHaveBeenCalledWith(
+      "stop",
+      "session-1",
+    );
+    expect(stopMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/session/components/outer-header/overflow/listening.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/listening.tsx
@@ -4,6 +4,10 @@ import { DropdownMenuItem } from "@hypr/ui/components/ui/dropdown-menu";
 
 import { useListener } from "~/stt/contexts";
 import { useStartListening } from "~/stt/useStartListening";
+import {
+  isMainWebviewWindow,
+  requestMainListenerControl,
+} from "~/stt/window-control";
 
 export function Listening({
   sessionId,
@@ -21,8 +25,20 @@ export function Listening({
   const isBatching = mode === "running_batch";
   const startListening = useStartListening(sessionId);
 
+  if (!isListening && hasTranscript) {
+    return null;
+  }
+
   const handleToggleListening = () => {
     if (isBatching) {
+      return;
+    }
+
+    if (!isMainWebviewWindow()) {
+      void requestMainListenerControl(
+        isListening ? "stop" : "start",
+        sessionId,
+      );
       return;
     }
 

--- a/apps/desktop/src/stt/window-control.tsx
+++ b/apps/desktop/src/stt/window-control.tsx
@@ -1,0 +1,126 @@
+import { emitTo, listen } from "@tauri-apps/api/event";
+import { useCallback, useEffect, useState } from "react";
+
+import { getCurrentWebviewWindowLabel } from "@hypr/plugin-windows";
+
+import { useListener } from "./contexts";
+import { useStartListening } from "./useStartListening";
+
+const LISTENER_CONTROL_EVENT = "hypr:listener-control";
+
+type ListenerControlAction = "start" | "stop";
+
+type ListenerControlRequest = {
+  action: ListenerControlAction;
+  requestId: string;
+  sessionId: string;
+};
+
+export function isMainWebviewWindow() {
+  return getCurrentWebviewWindowLabel() === "main";
+}
+
+export async function requestMainListenerControl(
+  action: ListenerControlAction,
+  sessionId: string,
+) {
+  await emitTo("main", LISTENER_CONTROL_EVENT, {
+    action,
+    requestId: crypto.randomUUID(),
+    sessionId,
+  } satisfies ListenerControlRequest);
+}
+
+export function MainListenerControlBridge() {
+  const [requests, setRequests] = useState<ListenerControlRequest[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    let unlisten: (() => void) | undefined;
+
+    void listen<ListenerControlRequest>(LISTENER_CONTROL_EVENT, (event) => {
+      if (!active) {
+        return;
+      }
+
+      setRequests((current) => [...current, event.payload]);
+    }).then((fn) => {
+      if (active) {
+        unlisten = fn;
+      } else {
+        fn();
+      }
+    });
+
+    return () => {
+      active = false;
+      unlisten?.();
+    };
+  }, []);
+
+  const handleRequestHandled = useCallback((requestId: string) => {
+    setRequests((current) => {
+      if (current[0]?.requestId === requestId) {
+        return current.slice(1);
+      }
+
+      return current.filter((request) => request.requestId !== requestId);
+    });
+  }, []);
+
+  const request = requests[0];
+  if (!request) {
+    return null;
+  }
+
+  return (
+    <MainListenerControlRequestRunner
+      request={request}
+      onHandled={handleRequestHandled}
+    />
+  );
+}
+
+function MainListenerControlRequestRunner({
+  onHandled,
+  request,
+}: {
+  onHandled: (requestId: string) => void;
+  request: ListenerControlRequest;
+}) {
+  const startListening = useStartListening(request.sessionId);
+  const stop = useListener((state) => state.stop);
+  const activeSessionId = useListener((state) => state.live.sessionId);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      if (request.action === "start") {
+        await startListening();
+      } else if (activeSessionId === request.sessionId) {
+        stop();
+      }
+
+      if (!cancelled) {
+        onHandled(request.requestId);
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeSessionId,
+    onHandled,
+    request.action,
+    request.requestId,
+    request.sessionId,
+    startListening,
+    stop,
+  ]);
+
+  return null;
+}


### PR DESCRIPTION
Let standalone note windows render the same overflow listening action as the main note view while keeping the dedicated header stop button hidden.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Session header and overflow UI only; listening stop still goes through existing main-window delegation with no auth or data-model changes.
> 
> **Overview**
> Standalone note windows now expose **listening controls in the header overflow menu** the same way as the main note view, by passing `standaloneWindow` into the overflow button and leaving listening enabled (instead of turning it off for detached windows).
> 
> The session **outer header** also adjusts standalone layout (title insets without the collapsed-sidebar gutter) and keeps the **inline stop control** available in standalone while routing stop to the main webview when needed. The diff here is mostly **i18n catalog line-reference updates** after those header changes moved strings such as Join, Stop, Finalizing, and Stop listening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39df6e1376385993bc3ba84909beb7d1e48649d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5867 
- <kbd>&nbsp;1&nbsp;</kbd> #5865 👈 
<!-- GitButler Footer Boundary Bottom -->

