### PR TITLE
Sync standalone summary tasks

### DIFF
--- a/apps/desktop/src/ai/task-window-sync.tsx
+++ b/apps/desktop/src/ai/task-window-sync.tsx
@@ -1,0 +1,241 @@
+import { emit, emitTo, listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useEffect } from "react";
+
+import { getCurrentWebviewWindowLabel } from "@hypr/plugin-windows";
+
+import { getEnhancerService } from "~/services/enhancer";
+import type { AITaskStore } from "~/store/zustand/ai-task";
+import type { RemoteTaskState, TaskState } from "~/store/zustand/ai-task/tasks";
+
+const TASK_SYNC_EVENT = "hypr:ai-task-sync";
+const TASK_SYNC_REQUEST_EVENT = "hypr:ai-task-sync-request";
+const TASK_CANCEL_EVENT = "hypr:ai-task-cancel";
+const TASK_ENHANCE_EVENT = "hypr:ai-task-enhance";
+
+type TaskSyncPayload = {
+  sourceLabel: string;
+  tasks: Record<string, RemoteTaskState>;
+};
+
+type TaskSyncRequestPayload = {
+  sourceLabel: string;
+};
+
+type TaskCancelPayload = {
+  taskId: string;
+};
+
+type TaskEnhancePayload = {
+  sessionId: string;
+  opts?: {
+    isAuto?: boolean;
+    templateId?: string | null;
+    targetNoteId?: string;
+    templateTitle?: string;
+  };
+};
+
+export function isMainAITaskHostWindow() {
+  return getCurrentWebviewWindowLabel() === "main";
+}
+
+export async function requestMainAITaskCancel(taskId: string) {
+  await emitTo("main", TASK_CANCEL_EVENT, {
+    taskId,
+  } satisfies TaskCancelPayload);
+}
+
+export async function requestMainEnhance(
+  sessionId: string,
+  opts?: TaskEnhancePayload["opts"],
+) {
+  await emitTo("main", TASK_ENHANCE_EVENT, {
+    sessionId,
+    opts,
+  } satisfies TaskEnhancePayload);
+}
+
+export function AITaskWindowSyncBridge({ store }: { store: AITaskStore }) {
+  const isMain = isMainAITaskHostWindow();
+
+  if (isMain) {
+    return <MainAITaskWindowSyncBridge store={store} />;
+  }
+
+  return <RemoteAITaskWindowSyncBridge store={store} />;
+}
+
+function MainAITaskWindowSyncBridge({ store }: { store: AITaskStore }) {
+  useEffect(() => {
+    const sourceLabel = getCurrentWebviewWindowLabel();
+    let active = true;
+    let syncRequestUnlisten: UnlistenFn | null = null;
+    let cancelUnlisten: UnlistenFn | null = null;
+    let enhanceUnlisten: UnlistenFn | null = null;
+
+    const emitSnapshot = () => {
+      void emit(TASK_SYNC_EVENT, {
+        sourceLabel,
+        tasks: serializeEnhanceTasks(store.getState().tasks),
+      } satisfies TaskSyncPayload);
+    };
+
+    const unsubscribe = store.subscribe(emitSnapshot);
+    emitSnapshot();
+
+    void listen<TaskSyncRequestPayload>(TASK_SYNC_REQUEST_EVENT, (event) => {
+      if (!active || !isTaskSyncRequestPayload(event.payload)) {
+        return;
+      }
+
+      void emitTo(event.payload.sourceLabel, TASK_SYNC_EVENT, {
+        sourceLabel,
+        tasks: serializeEnhanceTasks(store.getState().tasks),
+      } satisfies TaskSyncPayload);
+    }).then((unlisten) => {
+      if (active) {
+        syncRequestUnlisten = unlisten;
+      } else {
+        unlisten();
+      }
+    });
+
+    void listen<TaskCancelPayload>(TASK_CANCEL_EVENT, (event) => {
+      if (!active || !isTaskCancelPayload(event.payload)) {
+        return;
+      }
+
+      store.getState().cancel(event.payload.taskId);
+    }).then((unlisten) => {
+      if (active) {
+        cancelUnlisten = unlisten;
+      } else {
+        unlisten();
+      }
+    });
+
+    void listen<TaskEnhancePayload>(TASK_ENHANCE_EVENT, (event) => {
+      if (!active || !isTaskEnhancePayload(event.payload)) {
+        return;
+      }
+
+      getEnhancerService()?.enhance(
+        event.payload.sessionId,
+        event.payload.opts,
+      );
+    }).then((unlisten) => {
+      if (active) {
+        enhanceUnlisten = unlisten;
+      } else {
+        unlisten();
+      }
+    });
+
+    return () => {
+      active = false;
+      unsubscribe();
+      syncRequestUnlisten?.();
+      cancelUnlisten?.();
+      enhanceUnlisten?.();
+    };
+  }, [store]);
+
+  return null;
+}
+
+function RemoteAITaskWindowSyncBridge({ store }: { store: AITaskStore }) {
+  useEffect(() => {
+    const sourceLabel = getCurrentWebviewWindowLabel();
+    let active = true;
+    let syncUnlisten: UnlistenFn | null = null;
+
+    void listen<TaskSyncPayload>(TASK_SYNC_EVENT, (event) => {
+      if (
+        !active ||
+        !isTaskSyncPayload(event.payload) ||
+        event.payload.sourceLabel === sourceLabel
+      ) {
+        return;
+      }
+
+      store.getState().syncRemoteTasks(event.payload.tasks);
+    }).then((unlisten) => {
+      if (active) {
+        syncUnlisten = unlisten;
+        void emitTo("main", TASK_SYNC_REQUEST_EVENT, {
+          sourceLabel,
+        } satisfies TaskSyncRequestPayload);
+      } else {
+        unlisten();
+      }
+    });
+
+    return () => {
+      active = false;
+      syncUnlisten?.();
+    };
+  }, [store]);
+
+  return null;
+}
+
+function serializeEnhanceTasks(tasks: Record<string, TaskState>) {
+  return Object.fromEntries(
+    Object.entries(tasks)
+      .filter(([, task]) => task.taskType === "enhance")
+      .map(([taskId, task]) => [
+        taskId,
+        {
+          taskType: task.taskType,
+          status: task.status,
+          streamedText: task.streamedText,
+          error: task.error
+            ? { name: task.error.name, message: task.error.message }
+            : undefined,
+          currentStep: task.currentStep,
+        } satisfies RemoteTaskState,
+      ]),
+  );
+}
+
+function isTaskSyncPayload(payload: unknown): payload is TaskSyncPayload {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  const candidate = payload as Partial<TaskSyncPayload>;
+  return (
+    typeof candidate.sourceLabel === "string" &&
+    Boolean(candidate.tasks) &&
+    typeof candidate.tasks === "object"
+  );
+}
+
+function isTaskSyncRequestPayload(
+  payload: unknown,
+): payload is TaskSyncRequestPayload {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  return (
+    typeof (payload as Partial<TaskSyncRequestPayload>).sourceLabel === "string"
+  );
+}
+
+function isTaskCancelPayload(payload: unknown): payload is TaskCancelPayload {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  return typeof (payload as Partial<TaskCancelPayload>).taskId === "string";
+}
+
+function isTaskEnhancePayload(payload: unknown): payload is TaskEnhancePayload {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  const candidate = payload as Partial<TaskEnhancePayload>;
+  return typeof candidate.sessionId === "string";
+}

--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -817,7 +817,7 @@ msgstr "Insert above"
 msgid "Insert below"
 msgstr "Insert below"
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr "Insights"
 
@@ -935,7 +935,7 @@ msgstr "members"
 msgid "Memo"
 msgstr "Memo"
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr "Memos"
 
@@ -1432,7 +1432,7 @@ msgstr "Search or type owner/repo"
 msgid "Search people"
 msgstr "Search people"
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr "Search templates..."
@@ -1450,7 +1450,7 @@ msgstr "Search..."
 msgid "Section actions"
 msgstr "Section actions"
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr "See all templates"
 
@@ -1508,7 +1508,7 @@ msgstr "Send email"
 msgid "Send message"
 msgstr "Send message"
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr "Session note tabs"
 
@@ -1670,7 +1670,7 @@ msgstr "Start with permissions"
 msgid "Starting your trial..."
 msgstr "Starting your trial..."
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr "Stop"
@@ -1776,7 +1776,7 @@ msgstr "Timezone"
 msgid "Tip: The Anarlog team loves our users!"
 msgstr "Tip: The Anarlog team loves our users!"
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:818
+#: src/session/components/note-input/header.tsx:831
 msgid "Insights"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:268
+#: src/session/components/note-input/header.tsx:272
 msgid "Memos"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1249
+#: src/session/components/note-input/header.tsx:1262
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1317
+#: src/session/components/note-input/header.tsx:1330
 msgid "See all templates"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1358
+#: src/session/components/note-input/header.tsx:1371
 msgid "Session note tabs"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:557
+#: src/session/components/note-input/header.tsx:570
 #: src/session/components/outer-header/index.tsx:319
 msgid "Stop"
 msgstr ""
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:682
+#: src/session/components/note-input/header.tsx:695
 #: src/session/components/outer-header/overflow/export-modal.tsx:245
 #: src/session/components/outer-header/overflow/export-modal.tsx:295
 #: src/session/components/outer-header/overflow/export-modal.tsx:350

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -20,6 +20,7 @@ import {
 } from "@hypr/plugin-windows";
 import { Toaster } from "@hypr/ui/components/ui/toast";
 
+import { AITaskWindowSyncBridge } from "./ai/task-window-sync";
 import { createToolRegistry } from "./contexts/tool-registry/core";
 import { env } from "./env";
 import { AppI18nProvider } from "./i18n/provider";
@@ -80,6 +81,7 @@ function App() {
   return (
     <AppThemeProvider>
       <AppI18nProvider>
+        <AITaskWindowSyncBridge store={aiTaskStore} />
         <RouterProvider
           router={router}
           context={{

--- a/apps/desktop/src/session/components/note-input/enhanced-actions.ts
+++ b/apps/desktop/src/session/components/note-input/enhanced-actions.ts
@@ -4,6 +4,11 @@ import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 
 import { useAITaskTask } from "~/ai/hooks";
 import { useLanguageModel, useLLMConnectionStatus } from "~/ai/hooks";
+import {
+  isMainAITaskHostWindow,
+  requestMainAITaskCancel,
+  requestMainEnhance,
+} from "~/ai/task-window-sync";
 import { shouldShowEmptySummaryConfigError } from "~/session/enhance-config";
 import * as main from "~/store/tinybase/store/main";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
@@ -49,6 +54,14 @@ export function useEnhancedNoteActions({
 
       setMissingModelError(null);
 
+      if (!isMainAITaskHostWindow()) {
+        void requestMainEnhance(sessionId, {
+          templateId: templateId ?? noteTemplateId,
+          targetNoteId: enhancedNoteId,
+        });
+        return;
+      }
+
       void analyticsCommands.event({
         event: "note_enhanced",
         is_auto: false,
@@ -70,12 +83,24 @@ export function useEnhancedNoteActions({
   const isIdleWithConfigError = enhanceTask.isIdle && isConfigError;
   const error = model ? enhanceTask.error : missingModelError;
   const isError = !!error || enhanceTask.isError || isIdleWithConfigError;
+  const onCancel = useCallback(() => {
+    if (!taskId) {
+      return;
+    }
+
+    if (!isMainAITaskHostWindow()) {
+      void requestMainAITaskCancel(taskId);
+      return;
+    }
+
+    enhanceTask.cancel();
+  }, [enhanceTask.cancel, taskId]);
 
   return {
     isGenerating: enhanceTask.isGenerating,
     isError,
     error,
     onRegenerate,
-    onCancel: enhanceTask.cancel,
+    onCancel,
   };
 }

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -27,6 +27,10 @@ import { Spinner } from "@hypr/ui/components/ui/spinner";
 import { sonnerToast } from "@hypr/ui/components/ui/toast";
 import { cn } from "@hypr/utils";
 
+import {
+  isMainAITaskHostWindow,
+  requestMainEnhance,
+} from "~/ai/task-window-sync";
 import * as AudioPlayer from "~/audio-player";
 import { getEnhancerService } from "~/services/enhancer";
 import { useEnhancedNoteActions } from "~/session/components/note-input/enhanced-actions";
@@ -472,6 +476,15 @@ function HeaderTabEnhancedActive({
   const applyTemplate = useCallback(
     (selection: TemplateSelection) => {
       if (isGenerating) {
+        return;
+      }
+
+      if (!isMainAITaskHostWindow()) {
+        void requestMainEnhance(sessionId, {
+          templateId: selection.templateId,
+          targetNoteId: enhancedNoteId,
+          templateTitle: selection.templateId ? selection.title : undefined,
+        });
         return;
       }
 

--- a/apps/desktop/src/store/zustand/ai-task/tasks.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/tasks.test.ts
@@ -11,6 +11,37 @@ afterEach(() => {
 });
 
 describe("createTasksSlice", () => {
+  it("hydrates a remote task snapshot without an abort controller", () => {
+    let state: ReturnType<typeof createTasksSlice>;
+    const set = (updater: any) => {
+      state =
+        typeof updater === "function"
+          ? updater(state)
+          : { ...state, ...updater };
+    };
+    const get = () => state;
+    state = createTasksSlice(set, get, {
+      persistedStore: {} as any,
+      settingsStore: {} as any,
+    });
+
+    const taskId = "summary-1-enhance" as const;
+    state.syncRemoteTask(taskId, {
+      taskType: "enhance",
+      status: "generating",
+      streamedText: "Generated",
+      currentStep: { type: "generating" },
+    });
+
+    expect(state.tasks[taskId]).toMatchObject({
+      taskType: "enhance",
+      status: "generating",
+      streamedText: "Generated",
+      currentStep: { type: "generating" },
+      abortController: null,
+    });
+  });
+
   it("keeps a task generating until onSuccess finishes", async () => {
     let state: ReturnType<typeof createTasksSlice>;
     const set = (updater: any) => {

--- a/apps/desktop/src/store/zustand/ai-task/tasks.ts
+++ b/apps/desktop/src/store/zustand/ai-task/tasks.ts
@@ -29,6 +29,11 @@ export type TasksActions = {
   ) => Promise<void>;
   cancel: (taskId: string) => void;
   reset: (taskId: string) => void;
+  syncRemoteTask: <T extends TaskType>(
+    taskId: TaskId<T>,
+    task: RemoteTaskState<T>,
+  ) => void;
+  syncRemoteTasks: (tasks: Record<string, RemoteTaskState>) => void;
   getState: <T extends TaskType>(taskId: TaskId<T>) => TaskState<T> | undefined;
 };
 
@@ -49,6 +54,14 @@ export type TaskState<T extends TaskType = TaskType> = {
   streamedText: string;
   error?: Error;
   abortController: AbortController | null;
+  currentStep?: TaskStepInfo<T>;
+};
+
+export type RemoteTaskState<T extends TaskType = TaskType> = {
+  taskType: T;
+  status: TaskStatus;
+  streamedText: string;
+  error?: { name?: string; message: string };
   currentStep?: TaskStepInfo<T>;
 };
 
@@ -116,6 +129,42 @@ export const createTasksSlice = <T extends TasksState & TasksActions>(
         }),
       );
     }
+  },
+  syncRemoteTask: <Task extends TaskType>(
+    taskId: TaskId<Task>,
+    task: RemoteTaskState<Task>,
+  ) => {
+    set((state) =>
+      mutate(state, (draft) => {
+        draft.tasks[taskId] = {
+          taskType: task.taskType,
+          status: task.status,
+          streamedText: task.streamedText,
+          error: task.error ? createSyncedTaskError(task.error) : undefined,
+          abortController: null,
+          currentStep: task.currentStep,
+        };
+      }),
+    );
+  },
+  syncRemoteTasks: (tasks) => {
+    set((state) =>
+      mutate(state, (draft) => {
+        draft.tasks = Object.fromEntries(
+          Object.entries(tasks).map(([taskId, task]) => [
+            taskId,
+            {
+              taskType: task.taskType,
+              status: task.status,
+              streamedText: task.streamedText,
+              error: task.error ? createSyncedTaskError(task.error) : undefined,
+              abortController: null,
+              currentStep: task.currentStep,
+            },
+          ]),
+        );
+      }),
+    );
   },
   generate: async <Task extends TaskType>(
     taskId: TaskId<Task>,
@@ -279,6 +328,14 @@ export const createTasksSlice = <T extends TasksState & TasksActions>(
     }
   },
 });
+
+function createSyncedTaskError(error: { name?: string; message: string }) {
+  const synced = new Error(error.message);
+  if (error.name) {
+    synced.name = error.name;
+  }
+  return synced;
+}
 
 export function extractUnderlyingError(err: unknown): Error {
   if (!(err instanceof Error)) {


### PR DESCRIPTION
Routes standalone summary template requests through the main window and keeps remote task snapshots current.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how enhance/summary AI work is started and canceled across windows; bugs could cause stale UI, duplicate runs, or failed cancels, but execution stays centralized on main.
> 
> **Overview**
> **Standalone session windows** no longer run enhance/summary work locally. Starting or canceling a summary from a non-`main` webview now sends Tauri events to the main window, which runs `getEnhancerService().enhance` and owns task cancellation.
> 
> A new **`AITaskWindowSyncBridge`** (mounted from `main.tsx`) keeps remote windows' AI task store aligned with main: the main window publishes serialized **enhance** task snapshots on store changes and on sync requests; other windows call `syncRemoteTasks` when they receive updates. Helpers `requestMainEnhance`, `requestMainAITaskCancel`, and `isMainAITaskHostWindow` are used from note **enhanced-actions** to choose local vs delegated behavior.
> 
> Locale `.po` files only refresh **source line references** for strings in `note-input/header.tsx` (no new copy in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dac19e414bed6637fe5d8578ac0e3439a0be2914. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->