### PR TITLE
Update 1.1.4 changelog

### DIFF
--- a/packages/changelog/content/1.1.4.md
+++ b/packages/changelog/content/1.1.4.md
@@ -1,6 +1,6 @@
 ---
-date: "2026-06-26"
-summary: "Anarlog chat can use meeting notes more reliably, transcripts stay easier to follow while you work, and the website explains Anarlog more clearly."
+date: "2026-07-02"
+summary: "Anarlog keeps live transcripts easier to follow, puts listening controls where you work, and makes settings and summaries clearer."
 ---
 
 ## Chat
@@ -23,6 +23,8 @@ summary: "Anarlog chat can use meeting notes more reliably, transcripts stay eas
 - Floating transcript controls now take up less space and stay easier to use during meetings
 - Transcript word spacing now stays more natural while live text updates
 - Transcript jump controls now stay out of the way while floating chat is open
+- Transcript jump controls now use a solid background and sit closer to the relevant edge, including in floating panels
+- Resuming live listening now follows the newest transcript text by default while still letting you scroll back manually
 - Live transcript tabs no longer show a spinner during active meetings
 - Transcript speaker headers now stay cleaner by hiding timestamp ranges
 - Live transcription now keeps Parakeet models in streaming mode instead of switching to a slower batch path
@@ -37,17 +39,20 @@ summary: "Anarlog chat can use meeting notes more reliably, transcripts stay eas
 ## Notes
 
 - Transcript and summary generation actions are now easier to reach from the note header
+- Summary generation now stays in sync when used from standalone note windows
 - Auto summaries can now use a selected template, making generated notes easier to standardize
 - Summary title generation now shows a clearer placeholder while Anarlog is working
 - Insights and transcripts now live in editor tabs instead of a separate bottom panel
 - Session metadata now loads before note content so sidebar details are available more reliably after startup
 - Active session transcript state now restores correctly when returning to a live note
+- Live listening controls now live inside the transcript tab, with standalone note windows keeping the same controls available from the note menu
 - Contact suggestions can now use event titles to identify meeting contacts more accurately
 - Title formatting controls no longer appear in places where title styling does not apply
 
 ## Sidebar
 
 - The sidebar can now be resized by dragging, making it easier to balance navigation and note space
+- Custom sidebars now keep their configured width instead of being compressed by the default layout
 
 ## Website
 
@@ -62,4 +67,5 @@ summary: "Anarlog chat can use meeting notes more reliably, transcripts stay eas
 - Pro model rows in transcription settings now use cleaner spacing around upgrade chips
 - Custom transcription providers now stay grouped after built-in providers
 - Personalization dictionary settings now make it easier to manage custom names and terms for transcription
+- Settings navigation now groups app, context, and AI controls more clearly, with storage settings living under App
 - LLM providers now require their configured API keys and base URLs before use, making provider setup clearer


### PR DESCRIPTION
Summary:\n- refreshes the desktop 1.1.4 changelog with the final transcript, listening, summary, sidebar, and settings changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no application code changes.
> 
> **Overview**
> Updates the **1.1.4** release notes with release date **2026-07-02** and a revised top-level summary focused on live transcripts, in-context listening controls, and clearer settings/summaries.
> 
> **Transcription** adds bullets for transcript jump control styling/placement (solid background, edge alignment in floating panels) and default scroll-to-latest when resuming live listening.
> 
> **Notes** documents summary sync from standalone windows and moving live listening controls into the transcript tab (with the same controls in the note menu on standalone windows).
> 
> **Sidebar** notes that custom sidebars retain their configured width. **Settings** notes regrouped navigation (app, context, AI) with storage under App.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dab24f213402c835d4cc696aa456340c14f8ca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->