### PR TITLE
Focus note editor blank space

### DIFF
--- a/apps/desktop/src/session/components/note-input/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/index.test.tsx
@@ -8,14 +8,39 @@ import type { EditorView } from "~/store/zustand/tabs/schema";
 const hoisted = vi.hoisted(() => ({
   editorTabs: [{ type: "raw" }, { type: "transcript" }] as EditorView[],
   hotkeys: [] as Array<{ keys: string; callback: () => void }>,
+  focusAtTrailingEmptyLine: vi.fn(),
   onBeforeTabChange: vi.fn(),
   sessionMode: "inactive",
   updateSessionTabState: vi.fn(),
 }));
 
-vi.mock("./enhanced", () => ({
-  Enhanced: () => <div data-testid="enhanced-editor" />,
-}));
+vi.mock("./enhanced", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    Enhanced: React.forwardRef((_props, ref) => {
+      React.useImperativeHandle(
+        ref,
+        () => ({
+          view: null,
+          commands: {
+            focus: () => {},
+            focusAtStart: () => {},
+            focusAtTrailingEmptyLine: hoisted.focusAtTrailingEmptyLine,
+            focusAtPixelWidth: () => {},
+            insertAtStartAndFocus: () => {},
+            replaceContent: () => {},
+            setSearch: () => {},
+            replace: () => {},
+          },
+        }),
+        [],
+      );
+
+      return React.createElement("div", { "data-testid": "enhanced-editor" });
+    }),
+  };
+});
 
 vi.mock("./header", () => ({
   Header: ({
@@ -46,9 +71,40 @@ vi.mock("./header", () => ({
   useEditorTabs: () => hoisted.editorTabs,
 }));
 
-vi.mock("./raw", () => ({
-  RawEditor: () => <div data-testid="raw-editor" />,
-}));
+vi.mock("./raw", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    RawEditor: React.forwardRef((_props, ref) => {
+      React.useImperativeHandle(
+        ref,
+        () => ({
+          view: null,
+          commands: {
+            focus: () => {},
+            focusAtStart: () => {},
+            focusAtTrailingEmptyLine: hoisted.focusAtTrailingEmptyLine,
+            focusAtPixelWidth: () => {},
+            insertAtStartAndFocus: () => {},
+            replaceContent: () => {},
+            setSearch: () => {},
+            replace: () => {},
+          },
+        }),
+        [],
+      );
+
+      return React.createElement(
+        "div",
+        { "data-testid": "raw-editor" },
+        React.createElement("div", {
+          className: "ProseMirror",
+          "data-testid": "mock-prosemirror",
+        }),
+      );
+    }),
+  };
+});
 
 vi.mock("./search/bar", () => ({
   SearchBar: () => <div data-testid="search-bar" />,
@@ -140,6 +196,7 @@ describe("NoteInput tab selection", () => {
 
   beforeEach(() => {
     hoisted.hotkeys = [];
+    hoisted.focusAtTrailingEmptyLine.mockClear();
     hoisted.onBeforeTabChange.mockClear();
     hoisted.sessionMode = "inactive";
     hoisted.updateSessionTabState.mockClear();
@@ -199,5 +256,24 @@ describe("NoteInput tab selection", () => {
     renderNoteInput();
 
     expect(screen.getByTestId("is-transcribing").textContent).toBe("true");
+  });
+
+  it("focuses the trailing body line when blank editor space is clicked", () => {
+    renderNoteInput();
+
+    const scrollContainer = screen.getByTestId("raw-editor").parentElement;
+    expect(scrollContainer).not.toBeNull();
+
+    fireEvent.mouseDown(scrollContainer!, { button: 0 });
+
+    expect(hoisted.focusAtTrailingEmptyLine).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets ProseMirror handle clicks inside the document", () => {
+    renderNoteInput();
+
+    fireEvent.mouseDown(screen.getByTestId("mock-prosemirror"), { button: 0 });
+
+    expect(hoisted.focusAtTrailingEmptyLine).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -1,6 +1,7 @@
 import type { EditorView } from "prosemirror-view";
 import {
   forwardRef,
+  type MouseEventHandler,
   type UIEventHandler,
   useCallback,
   useDeferredValue,
@@ -184,12 +185,27 @@ export const NoteInput = forwardRef<
       search?.close();
     }, [currentTab]);
 
-    const handleContainerClick = () => {
+    const handleContainerMouseDown: MouseEventHandler<HTMLDivElement> = (
+      event,
+    ) => {
       if (!isEditableTab) {
         return;
       }
 
-      internalEditorRef.current?.commands.focus();
+      if (event.button !== 0) {
+        return;
+      }
+
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        target.closest(".ProseMirror") !== null
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      internalEditorRef.current?.commands.focusAtTrailingEmptyLine();
     };
 
     return (
@@ -219,7 +235,7 @@ export const NoteInput = forwardRef<
               scrollRef.current = node;
               setContainer(node);
             }}
-            onClick={handleContainerClick}
+            onMouseDown={handleContainerMouseDown}
             onScroll={onScroll}
             className={cn([
               "h-full px-3",

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -91,7 +91,10 @@ import {
 } from "./linked-item-open-behavior";
 import { schema } from "./schema";
 import { normalizeTitleHeadingDoc, titleHeadingPlugin } from "./title-layout";
-import { trailingEmptyLineClickPlugin } from "./trailing-empty-line-click";
+import {
+  focusTrailingEmptyLine,
+  trailingEmptyLineClickPlugin,
+} from "./trailing-empty-line-click";
 
 export type { MentionConfig, FileHandlerConfig, PlaceholderFunction };
 export { schema };
@@ -117,6 +120,7 @@ export interface SearchReplaceParams {
 export interface EditorCommands {
   focus: () => void;
   focusAtStart: () => void;
+  focusAtTrailingEmptyLine: () => void;
   focusAtPixelWidth: (pixelWidth: number) => void;
   insertAtStartAndFocus: (content: string) => void;
   replaceContent: (content: JSONContent) => void;
@@ -308,6 +312,7 @@ function ViewCapture({
 const noopCommands: EditorCommands = {
   focus: () => {},
   focusAtStart: () => {},
+  focusAtTrailingEmptyLine: () => {},
   focusAtPixelWidth: () => {},
   insertAtStartAndFocus: () => {},
   replaceContent: () => {},
@@ -336,6 +341,9 @@ function EditorCommandsBridge({
             view.state.tr.setSelection(Selection.atStart(view.state.doc)),
           );
           view.focus();
+        },
+        focusAtTrailingEmptyLine: () => {
+          focusTrailingEmptyLine(view);
         },
         focusAtPixelWidth: (pixelWidth: number) => {
           const blockStart = Selection.atStart(view.state.doc).from;

--- a/packages/editor/src/note/trailing-empty-line-click.test.ts
+++ b/packages/editor/src/note/trailing-empty-line-click.test.ts
@@ -30,6 +30,29 @@ describe("handleTrailingEmptyLineMouseDown", () => {
     expect(view.focus).toHaveBeenCalled();
   });
 
+  it("adds a body paragraph when clicking below a title-only document", () => {
+    const { view, getState } = createView([
+      schema.node("heading", { level: 1 }, [schema.text("Weekly sync")]),
+    ]);
+    const event = createMouseEvent({ target: view.dom, clientY: 40 });
+
+    const handled = handleTrailingEmptyLineMouseDown(view, event);
+
+    expect(handled).toBe(true);
+    expect(getState().doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Weekly sync" }],
+        },
+        { type: "paragraph" },
+      ],
+    });
+    expect(getState().selection.from).toBe(getState().doc.content.size - 1);
+  });
+
   it("uses an existing trailing empty paragraph instead of adding another", () => {
     const { view, getState } = createView([
       schema.node("paragraph", null, [schema.text("Follow up")]),

--- a/packages/editor/src/note/trailing-empty-line-click.ts
+++ b/packages/editor/src/note/trailing-empty-line-click.ts
@@ -40,7 +40,17 @@ export function handleTrailingEmptyLineMouseDown(
 
   event.preventDefault();
 
+  focusTrailingEmptyLine(view);
+  return true;
+}
+
+export function focusTrailingEmptyLine(view: EditorView) {
   const { doc } = view.state;
+  const paragraph = view.state.schema.nodes.paragraph;
+  if (!paragraph) {
+    return false;
+  }
+
   const lastChild = doc.lastChild;
   if (lastChild?.type === paragraph && !lastChild.textContent.trim()) {
     view.dispatch(view.state.tr.setSelection(Selection.atEnd(doc)));


### PR DESCRIPTION
Add a shared trailing body-line command and wire blank note-surface clicks to it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized note-editing UX and focus/selection behavior with new unit tests; no auth, persistence, or API contract changes beyond the editor command surface.
> 
> **Overview**
> Clicking **empty padding** around the session note editor now moves the caret to the **trailing body line** (reusing or inserting an empty paragraph) instead of a generic focus.
> 
> The shared ProseMirror helper **`focusTrailingEmptyLine`** is exported and exposed as **`focusAtTrailingEmptyLine`** on note editor commands. **`NoteInput`** switches the scroll container from **`onClick`** to **`onMouseDown`**, ignores non–left-clicks and clicks inside **`.ProseMirror`**, and routes the rest to that command. The in-editor trailing-empty-line plugin still uses the same helper, including **title-only** notes that need a new body paragraph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62c2562e616bf39b86679f64fb8b0dbf9237e32f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->