### PR TITLE
Hide floating bar from screen sharing

### DIFF
--- a/plugins/windows/swift-lib/src/FloatingBarManager.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarManager.swift
@@ -118,7 +118,7 @@ final class FloatingBarManager {
     panel.isOpaque = false
     panel.backgroundColor = .clear
     panel.hasShadow = false
-    panel.sharingType = .readOnly
+    panel.sharingType = .none
     panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
     panel.isMovableByWindowBackground = true
     panel.minSize = currentSize


### PR DESCRIPTION
Set the native floating bar panel sharing type to none so it is excluded from screen capture like the other overlay panels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single macOS window property change for screen-capture exclusion; no auth, data, or business logic impact.
> 
> **Overview**
> The native floating bar `NSPanel` now sets **`sharingType` to `.none`** instead of `.readOnly` when created in `FloatingBarManager`, matching the other overlay panels (live caption, settings).
> 
> That excludes the bar from screen capture and screen sharing so it does not appear in shared content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3eec7503aa1fc631c5dca867931c44883dacec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->