### PR TITLE
Close deleted note windows

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Deel gebruiksdata"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Wys die kompakte drywende beheer terwyl jy luister."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "የአጠቃቀም ውሂብ አጋራ"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "በማዳመጥ ጊዜ የታመቀ ተንሳፋፊ መቆጣጠሪያውን አሳይ።"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "مشاركة بيانات الاستخدام"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "إظهار عنصر التحكم العائم المدمج أثناء الاستماع."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "ব্যৱহাৰৰ তথ্য অংশীদাৰী কৰক"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "শুনি থকাৰ সময়ত কমপেক্ট ভাসমান নিয়ন্ত্ৰণ দেখুৱাওক।"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "İstifadə datasını paylaşın"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Qulaq asarkən kompakt üzən idarəetməni göstərin."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Ҡулланыу мәғлүмәттәре менән уртаҡлашыу"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Тыңлағанда компактлы йөҙөүсе идара итеү ҡоролмаһын күрһәтегеҙ."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Абагульваць дадзеныя аб выкарыстанні"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Паказваць кампактны плаваючы элемент кіравання падчас праслухоўвання."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Споделяне на данни за използване"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Показване на компактния плаващ контрол, докато слушате."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "ব্যবহারের ডেটা শেয়ার করুন"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "শোনার সময় কমপ্যাক্ট ফ্লোটিং কন্ট্রোল দেখান।"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "བེད་སྤྱོད་ཀྱི་གཞི་གྲངས་མཉམ་སྤྱོད།"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "ཉན་པའི་སྐབས་སུ་འཕྱོ་བའི་ཚོད་འཛིན་ཆུང་ཆུང་དེ་སྟོན།"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Rannañ roadennoù implij"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Diskouez ar c'hontroll neuial bihan e-pad ma selaouer."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Dijelite podatke o korištenju"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Prikaži kompaktnu plutajuću kontrolu dok slušate."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Comparteix les dades d'ús"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Mostra el control flotant compacte mentre escoltes."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Sdílet údaje o využití"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Při poslechu ukažte kompaktní plovoucí ovládání."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Rhannu data defnydd"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Dangos y rheolydd arnofio cryno wrth wrando."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Del brugsdata"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Vis den kompakte flydende kontrol, mens du lytter."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Nutzungsdaten teilen"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Die kompakte schwebende Steuerung beim Zuhören anzeigen."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Κοινή χρήση δεδομένων χρήσης"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Εμφάνιση του συμπαγούς αιωρούμενου χειριστηρίου κατά την ακρόαση."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -478,17 +478,17 @@ msgstr "Dark"
 msgid "Date and time are required"
 msgstr "Date and time are required"
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr "Delete"
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr "Delete All Recurring Events"
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr "Delete Event"
 
@@ -496,11 +496,11 @@ msgstr "Delete Event"
 msgid "Delete model"
 msgstr "Delete model"
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr "Delete Note"
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr "Delete recording"
 
@@ -508,11 +508,11 @@ msgstr "Delete recording"
 msgid "Delete Selected ({sessionCount})"
 msgstr "Delete Selected ({sessionCount})"
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr "Delete This Event"
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr "Deleting..."
 
@@ -1147,12 +1147,12 @@ msgstr "Open calendar account actions"
 msgid "Open floating panel"
 msgstr "Open floating panel"
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr "Open in New Tab"
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr "Open in New Window"
 
@@ -1533,7 +1533,7 @@ msgstr "Settings"
 msgid "Share usage data"
 msgstr "Share usage data"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr "Show All Recurring Events"
 
@@ -1549,7 +1549,7 @@ msgstr "Show app in Dock"
 msgid "Show Deleted Events"
 msgstr "Show Deleted Events"
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr "Show Event"
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr "Show floating bar"
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr "Show in Finder"
 
@@ -1566,7 +1566,7 @@ msgstr "Show in Finder"
 msgid "Show the compact floating control while listening."
 msgstr "Show the compact floating control while listening."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr "Show This Event"
 
@@ -1678,7 +1678,7 @@ msgstr "Starting your trial..."
 msgid "Stop"
 msgstr "Stop"
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr "Stop listening"
 
@@ -1823,9 +1823,9 @@ msgstr "Unnamed"
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Compartir datos de uso"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Mostrar el control flotante compacto mientras escucha."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Kasutusandmete jagamine"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Kuulamise ajal kompaktse ujuva juhtelemendi kuvamine."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Partekatu erabilera datuak"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Erakutsi kontrol mugikor trinkoa entzuten duzun bitartean."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "به اشتراک گذاری داده های استفاده"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "کنترل شناور فشرده را هنگام گوش دادن نشان دهید."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Renndinde dokke kuutoragol"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Hollit jokkorgal ɓuuɓngal compact nde aɗa nana."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Jaa käyttötiedot"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Näytä kompakti kelluva säädin kuunnellessasi."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Deil nýtsludátur"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Vís kompaktu flótandi stýringina, meðan tú lurtar."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Partager les données d'utilisation"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Afficher le contrôle flottant compact pendant l'écoute."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Comhroinn sonraí úsáide"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Taispeáin an dlúthrialtán ar snámh agus tú ag éisteacht."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Compartir datos de uso"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Mostra o control flotante compacto mentres escoitas."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "વપરાશનો ડેટા શેર કરો"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "સાંભળતી વખતે કોમ્પેક્ટ ફ્લોટિંગ કંટ્રોલ બતાવો."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Raba bayanan amfani"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Nuna ƙaramin iko mai iyo yayin sauraro."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "שתף נתוני שימוש"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "הצג את הבקרה הציפה הקומפקטית תוך כדי האזנה."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "उपयोग डेटा साझा करें"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "सुनते समय कॉम्पैक्ट फ़्लोटिंग नियंत्रण दिखाएं।"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Dijeljenje podataka o korištenju"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Pokažite kompaktnu lebdeću kontrolu dok slušate."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Pataje done itilizasyon"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Montre kontwòl k ap flote kontra a pandan w ap koute."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Használati adatok megosztása"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "A kompakt lebegő vezérlő megjelenítése hallgatás közben."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Կիսեք օգտագործման տվյալները"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Ցույց տալ կոմպակտ լողացող կառավարը լսելիս:"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Bagikan data penggunaan"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Tampilkan kontrol mengambang ringkas sambil mendengarkan."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Kekọrịta data ojiji"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Gosi kọmpat njikwa na-ese n'elu mmiri mgbe ị na-ege ntị."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Deildu notkunargögnum"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Sýndu fyrirferðarlítið fljótandi stjórn á meðan þú hlustar."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Condividi dati di utilizzo"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Mostra il controllo flottante compatto durante l'ascolto."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "使用状況データを共有"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "リスニング中にコンパクトなフローティングコントロールを表示します。"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Nuduhake data panggunaan"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Tampilake kontrol ngambang kompak nalika ngrungokake."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "გამოყენების მონაცემების გაზიარება"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "კომპაქტური მცურავი მართვის ჩვენება მოსმენისას."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Пайдалану деректерін бөлісу"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Тыңдау кезінде ықшам қалқымалы басқару элементін көрсетіңіз."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "ចែករំលែកទិន្នន័យការប្រើប្រាស់"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "បង្ហាញការគ្រប់គ្រងបណ្តែតតូចខណៈពេលកំពុងស្តាប់។"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "ಬಳಕೆಯ ಡೇಟಾವನ್ನು ಹಂಚಿಕೊಳ್ಳಿ"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "ಕೇಳುತ್ತಿರುವಾಗ ಕಾಂಪ್ಯಾಕ್ಟ್ ಫ್ಲೋಟಿಂಗ್ ನಿಯಂತ್ರಣವನ್ನು ತೋರಿಸಿ."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "사용 데이터 공유"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "듣는 동안 작은 플로팅 컨트롤을 표시합니다."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Daneyên bikaranînê parve bikin"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Dema ku guhdarî dike, kontrolê ya kompakt nîşan bide."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Колдонуу дайындарын бөлүшүү"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Угуу учурунда чакан калкыма башкарууну көрсөтүңүз."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Phare usus data"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Monstrare pactionem fluitantem imperium audiendo."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Verbrauchsdaten deelen"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Weist déi kompakt schwiewend Kontroll beim Nolauschteren."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Gabana data y'enkozesa"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Laga ekifuga ekitengejja ekitono nga owuliriza."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Kabola ba données ya bosaleli"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Lakisa contrôle flottante compact tango ozali koyoka."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "ແບ່ງປັນຂໍ້ມູນການນຳໃຊ້"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "ສະແດງການຄວບຄຸມການລອຍຕົວແບບກະທັດຮັດໃນຂະນະທີ່ຟັງ."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Bendrinti naudojimo duomenis"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Klausydami rodykite kompaktišką slankiojantį valdiklį."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Kopīgojiet lietojuma datus"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Klausīšanās laikā parādiet kompakto peldošo vadību."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Mizara angona fampiasana"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Asehoy ny fanaraha-maso mitsingevana kanto eo am-pihainoana."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Tirihia nga raraunga whakamahinga"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Whakaatuhia te mana maanu kiato i te wa e whakarongo ana."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Споделете податоци за користење"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Покажете ја компактната пловечка контрола додека слушате."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "ഉപയോഗ ഡാറ്റ പങ്കിടുക"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "ശ്രവിക്കുന്ന സമയത്ത് ഒതുക്കമുള്ള ഫ്ലോട്ടിംഗ് നിയന്ത്രണം കാണിക്കുക."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Ашиглалтын өгөгдлийг хуваалцах"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Сонсож байхдаа авсаархан хөвөгч удирдлагыг харуул."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "वापर डेटा सामायिक करा"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "ऐकताना कॉम्पॅक्ट फ्लोटिंग कंट्रोल दाखवा."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Kongsi data penggunaan"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Tunjukkan kawalan terapung padat semasa mendengar."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Aqsam id-dejta tal-użu"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Uri l-kontroll kompatt f'wiċċ l-ilma waqt li tisma'."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "အသုံးပြုမှုဒေတာကို မျှဝေပါ"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "နားထောင်နေစဉ် ကျစ်လျစ်သော ရေပေါ်ထိန်းချုပ်မှုကို ပြသပါ။"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "उपयोग डाटा साझेदारी गर्नुहोस्"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "सुन्दा कम्प्याक्ट फ्लोटिंग नियन्त्रण देखाउनुहोस्।"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Gebruiksgegevens delen"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Laat de compacte zwevende bediening zien terwijl je luistert."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Del bruksdata"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Vis den kompakte flytende kontrollen mens du lytter."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Del bruksdata"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Vis den kompakte flytende kontrollen mens du lytter."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Gawani zogwiritsa ntchito"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Onetsani chowongolera choyandama uku mukumvetsera."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Partejar las donadas d'utilizacion"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Afichar lo contraròtle flotant compacte pendent l'escota."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "ବ୍ୟବହାର ତଥ୍ୟ ଅଂଶୀଦାର କରନ୍ତୁ |"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "ଶୁଣିବା ସମୟରେ କମ୍ପାକ୍ଟ ଫ୍ଲୋଟିଂ କଣ୍ଟ୍ରୋଲ୍ ଦେଖାନ୍ତୁ |"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "ਵਰਤੋਂ ਡੇਟਾ ਸਾਂਝਾ ਕਰੋ"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "ਸੁਣਦੇ ਸਮੇਂ ਸੰਖੇਪ ਫਲੋਟਿੰਗ ਕੰਟਰੋਲ ਦਿਖਾਓ।"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Udostępnij dane o użytkowaniu"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Pokaż kompaktowy, pływający element sterujący podczas słuchania."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "د کارونې ډاټا شریک کړئ"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "د اوریدلو پر مهال د کمپیکٹ فلوټینګ کنټرول وښایاست."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Compartilhar dados de uso"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Mostrar o controle flutuante compacto durante a escuta."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Partajați datele de utilizare"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Afișați controlul flotant compact în timp ce ascultați."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Поделиться данными об использовании"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Показывать компактный плавающий элемент управления во время прослушивания."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "उपयोगदत्तांशं साझां कुर्वन्तु"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "श्रवणकाले संकुचितं प्लवमानं नियन्त्रणं दर्शयतु।"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "استعمال ڊيٽا حصيداري ڪريو"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "ٻڌڻ دوران ڪمپيڪٽ سچل ڪنٽرول ڏيکاريو."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "භාවිතා දත්ත බෙදා ගන්න"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "සවන් දෙන අතරතුර සංයුක්ත පාවෙන පාලනය පෙන්වන්න."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Zdieľať údaje o používaní"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Pri počúvaní ukážte kompaktné plávajúce ovládanie."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Skupna raba podatkov o uporabi"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Prikažite kompaktni lebdeči kontrolnik med poslušanjem."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Goverana data rekushandisa"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Ratidza chibatiso chinoyangarara uchiteerera."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "La wadaag xogta isticmaalka"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Muuji xakamaynta sabbaynaysa is haysta markaad dhegaysanayso."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Ndani të dhënat e përdorimit"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Trego kontrollin kompakt lundrues gjatë dëgjimit."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Делите податке о коришћењу"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Покажите компактну плутајућу контролу док слушате."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Bagikeun data pamakean"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Témbongkeun kadali ngambang kompak bari ngadangukeun."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Dela användningsdata"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Visa den kompakta flytande kontrollen medan du lyssnar."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Shiriki data ya matumizi"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Onyesha kidhibiti fumbatio cha kuelea unaposikiliza."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "பயன்பாட்டுத் தரவைப் பகிரவும்"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "கேட்கும்போது சிறிய மிதக்கும் கட்டுப்பாட்டைக் காட்டு."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "వినియోగ డేటాను భాగస్వామ్యం చేయండి"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "వింటున్నప్పుడు కాంపాక్ట్ ఫ్లోటింగ్ కంట్రోల్‌ని చూపండి."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Мубодилаи маълумоти истифода"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Ҳангоми гӯш кардани назорати шинокунандаи паймон нишон диҳед."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "แชร์ข้อมูลการใช้งาน"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "แสดงตัวควบคุมแบบลอยขนาดกะทัดรัดขณะฟัง"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Ulanyş maglumatlaryny paýlaşyň"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Diňlän wagtyňyz ykjam ýüzýän dolandyryşy görkeziň."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Ibahagi ang data ng paggamit"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Ipakita ang compact floating control habang nakikinig."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Kullanım verilerini paylaşın"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Dinlerken kompakt değişken kontrolü gösterin."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Куллану мәгълүматларын бүлешү"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Тыңлаганда компакт йөзү контролен күрсәтегез."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Обмін даними про використання"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Показувати компактний плаваючий елемент керування під час прослуховування."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "استعمال کا ڈیٹا شیئر کریں"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "سنتے وقت کمپیکٹ فلوٹنگ کنٹرول دکھائیں۔"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Foydalanish ma'lumotlarini baham ko'rish"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Tinglash paytida ixcham suzuvchi boshqaruvni ko'rsating."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Chia sẻ dữ liệu sử dụng"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Hiển thị điều khiển nổi nhỏ gọn trong khi nghe."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Séddoo done jëfandikoo"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Waneel seytukat biy féey bi ngay déglu."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Yabelana ngedatha yosetyenziso"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Bonisa ulawulo olubambekayo xa umamele."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "ייַנטיילן באַניץ דאַטן"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "ווייַזן די סאָליד פלאָוטינג קאָנטראָל בשעת צוגעהערט."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Pin data lilo"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Ṣafihan iṣakoso lilefoofo iwapọ lakoko gbigbọ."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "分享使用数据"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "聆听时显示紧凑的浮动控件。"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -478,17 +478,17 @@ msgstr ""
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:98
+#: src/session/components/outer-header/overflow/delete.tsx:73
 #: src/templates/sections-editor.tsx:280
 #: src/templates/template-form.tsx:285
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:419
+#: src/sidebar/timeline/item.tsx:414
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete Event"
 msgstr ""
 
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:611
+#: src/sidebar/timeline/item.tsx:575
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:51
+#: src/session/components/outer-header/overflow/delete.tsx:44
 msgid "Delete recording"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:412
+#: src/sidebar/timeline/item.tsx:407
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:49
+#: src/session/components/outer-header/overflow/delete.tsx:42
 msgid "Deleting..."
 msgstr ""
 
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:406
+#: src/sidebar/timeline/item.tsx:401
 msgid "Open in New Tab"
 msgstr ""
 
 #: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:600
+#: src/sidebar/timeline/item.tsx:564
 msgid "Open in New Window"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Share usage data"
 msgstr "Yabelana ngedatha yokusetshenziswa"
 
-#: src/sidebar/timeline/item.tsx:394
+#: src/sidebar/timeline/item.tsx:389
 msgid "Show All Recurring Events"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:400
+#: src/sidebar/timeline/item.tsx:395
 msgid "Show Event"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgid "Show floating bar"
 msgstr ""
 
 #: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:605
+#: src/sidebar/timeline/item.tsx:569
 msgid "Show in Finder"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Show the compact floating control while listening."
 msgstr "Bonisa isilawuli esintantayo esihlangene ngenkathi ulalele."
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx:384
 msgid "Show This Event"
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:244
+#: src/sidebar/timeline/item.tsx:239
 msgid "Stop listening"
 msgstr ""
 
@@ -1823,9 +1823,9 @@ msgstr ""
 #: src/session/components/title-input.tsx:385
 #: src/shared/open-note-dialog.tsx:107
 #: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:205
-#: src/sidebar/timeline/item.tsx:312
-#: src/sidebar/timeline/item.tsx:552
+#: src/sidebar/timeline/item.tsx:200
+#: src/sidebar/timeline/item.tsx:307
+#: src/sidebar/timeline/item.tsx:543
 #: src/templates/details.tsx:122
 #: src/templates/sections-editor.tsx:293
 msgid "Untitled"

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -28,6 +28,7 @@ import { FloatingMeetingWindowHost } from "./meeting-float/host";
 import { routeTree } from "./routeTree.gen";
 import { EventListeners } from "./services/event-listeners";
 import { TaskManager } from "./services/task-manager";
+import { useRemoteSessionDeletionUndoListener } from "./session/hooks/useDeleteSession";
 import { RawEditorSyncBridge } from "./session/raw-editor-sync";
 import { ErrorComponent, NotFoundComponent } from "./shared/control";
 import { bootstrapThemeFromSettings } from "./shared/theme/apply";
@@ -116,6 +117,7 @@ function AppWithTiny() {
     return createManager().start();
   });
   const isMainWindow = getCurrentWebviewWindowLabel() === "main";
+  useRemoteSessionDeletionUndoListener(isMainWindow);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/apps/desktop/src/session/components/outer-header/overflow/delete.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/delete.tsx
@@ -7,14 +7,7 @@ import { DropdownMenuItem } from "@hypr/ui/components/ui/dropdown-menu";
 import { cn } from "@hypr/utils";
 
 import { useAudioPlayer } from "~/audio-player";
-import {
-  captureSessionData,
-  deleteSessionCascade,
-  finalizeSessionDeletion,
-} from "~/store/tinybase/store/deleteSession";
-import * as main from "~/store/tinybase/store/main";
-import { useTabs } from "~/store/zustand/tabs";
-import { useUndoDelete } from "~/store/zustand/undo-delete";
+import { useDeleteSession } from "~/session/hooks/useDeleteSession";
 import { useListener } from "~/stt/contexts";
 
 export function DeleteRecording({ sessionId }: { sessionId: string }) {
@@ -56,34 +49,16 @@ export function DeleteRecording({ sessionId }: { sessionId: string }) {
 }
 
 export function DeleteNote({ sessionId }: { sessionId: string }) {
-  const store = main.UI.useStore(main.STORE_ID);
-  const indexes = main.UI.useIndexes(main.STORE_ID);
-  const invalidateResource = useTabs((state) => state.invalidateResource);
-  const addDeletion = useUndoDelete((state) => state.addDeletion);
+  const deleteSession = useDeleteSession();
 
   const handleDeleteNote = useCallback(() => {
-    if (!store) {
-      return;
-    }
-
-    const capturedData = captureSessionData(store, indexes, sessionId);
-
-    invalidateResource("sessions", sessionId);
-    void deleteSessionCascade(store, indexes, sessionId, {
-      deferFilesystemDelete: true,
-    });
-
-    if (capturedData) {
-      addDeletion(capturedData, () => {
-        void finalizeSessionDeletion(sessionId);
-      });
-    }
+    deleteSession(sessionId);
 
     void analyticsCommands.event({
       event: "session_deleted",
       includes_recording: true,
     });
-  }, [store, indexes, sessionId, invalidateResource, addDeletion]);
+  }, [sessionId, deleteSession]);
 
   return (
     <DropdownMenuItem

--- a/apps/desktop/src/session/hooks/useDeleteSession.test.tsx
+++ b/apps/desktop/src/session/hooks/useDeleteSession.test.tsx
@@ -18,16 +18,19 @@ const mocks = vi.hoisted(() => {
     participants: [],
     tagSessions: [],
     enhancedNotes: [],
+    keyFacts: null,
     deletedAt: 1,
   };
 
   return {
     addDeletion: vi.fn(),
     captureSessionData: vi.fn(() => deletedSessionData),
-    close: vi.fn(() => Promise.resolve()),
     deleteSessionCascade: vi.fn(),
     emitTo: vi.fn(() => Promise.resolve()),
     finalizeSessionDeletion: vi.fn(),
+    getAllWebviewWindows: vi.fn<
+      () => Promise<Array<{ label: string; close: () => Promise<void> }>>
+    >(() => Promise.resolve([])),
     getCurrentWebviewWindowLabel: vi.fn(() => "main"),
     ignoreEvent: vi.fn(),
     indexes: {},
@@ -43,10 +46,8 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: mocks.listen,
 }));
 
-vi.mock("@tauri-apps/api/window", () => ({
-  getCurrentWindow: () => ({
-    close: mocks.close,
-  }),
+vi.mock("@tauri-apps/api/webviewWindow", () => ({
+  getAllWebviewWindows: mocks.getAllWebviewWindows,
 }));
 
 vi.mock("@hypr/plugin-windows", () => ({
@@ -103,8 +104,8 @@ describe("useDeleteSession", () => {
     cleanup();
     vi.clearAllMocks();
     mocks.captureSessionData.mockReturnValue(mocks.deletedSessionData);
-    mocks.close.mockResolvedValue(undefined);
     mocks.emitTo.mockResolvedValue(undefined);
+    mocks.getAllWebviewWindows.mockResolvedValue([]);
     mocks.getCurrentWebviewWindowLabel.mockReturnValue("main");
     mocks.listen.mockResolvedValue(vi.fn());
   });
@@ -137,11 +138,15 @@ describe("useDeleteSession", () => {
       expect.any(Function),
     );
     expect(mocks.emitTo).not.toHaveBeenCalled();
-    expect(mocks.close).not.toHaveBeenCalled();
   });
 
   it("forwards undo data to main and closes the matching note window", async () => {
+    const close = vi.fn(() => Promise.resolve());
     mocks.getCurrentWebviewWindowLabel.mockReturnValue("note-session-1");
+    mocks.getAllWebviewWindows.mockResolvedValue([
+      { label: "note-session-1", close },
+      { label: "note-session-2", close: vi.fn() },
+    ]);
     const { result } = renderHook(() => useDeleteSession());
 
     act(() => {
@@ -157,10 +162,44 @@ describe("useDeleteSession", () => {
           data: mocks.deletedSessionData,
         },
       );
-      expect(mocks.close).toHaveBeenCalled();
+      expect(close).toHaveBeenCalled();
     });
 
     expect(mocks.addDeletion).not.toHaveBeenCalled();
+  });
+
+  it("closes the matching note window when deleting from the main window", async () => {
+    const close = vi.fn(() => Promise.resolve());
+    mocks.getAllWebviewWindows.mockResolvedValue([
+      { label: "note-session-1", close },
+    ]);
+    const { result } = renderHook(() => useDeleteSession());
+
+    act(() => {
+      result.current("session-1");
+    });
+
+    await waitFor(() => {
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it("still closes the standalone note window when forwarding undo data fails", async () => {
+    const close = vi.fn(() => Promise.resolve());
+    mocks.getCurrentWebviewWindowLabel.mockReturnValue("note-session-1");
+    mocks.emitTo.mockRejectedValue(new Error("main window unavailable"));
+    mocks.getAllWebviewWindows.mockResolvedValue([
+      { label: "note-session-1", close },
+    ]);
+    const { result } = renderHook(() => useDeleteSession());
+
+    act(() => {
+      result.current("session-1");
+    });
+
+    await waitFor(() => {
+      expect(close).toHaveBeenCalled();
+    });
   });
 
   it("listens for forwarded standalone note deletions in the main window", async () => {
@@ -195,6 +234,16 @@ describe("useDeleteSession", () => {
     expect(mocks.addDeletion).toHaveBeenCalledWith(
       mocks.deletedSessionData,
       expect.any(Function),
+    );
+    expect(mocks.invalidateResource).toHaveBeenCalledWith(
+      "sessions",
+      "session-1",
+    );
+    expect(mocks.deleteSessionCascade).toHaveBeenCalledWith(
+      mocks.store,
+      mocks.indexes,
+      "session-1",
+      { deferFilesystemDelete: true },
     );
   });
 });

--- a/apps/desktop/src/session/hooks/useDeleteSession.test.tsx
+++ b/apps/desktop/src/session/hooks/useDeleteSession.test.tsx
@@ -1,0 +1,200 @@
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DeletedSessionData } from "~/store/zustand/undo-delete";
+
+const mocks = vi.hoisted(() => {
+  const deletedSessionData: DeletedSessionData = {
+    session: {
+      id: "session-1",
+      user_id: "user-1",
+      created_at: "2026-01-01T00:00:00Z",
+      folder_id: "",
+      event_json: "",
+      title: "Deleted note",
+      raw_md: "",
+    },
+    transcripts: [],
+    participants: [],
+    tagSessions: [],
+    enhancedNotes: [],
+    deletedAt: 1,
+  };
+
+  return {
+    addDeletion: vi.fn(),
+    captureSessionData: vi.fn(() => deletedSessionData),
+    close: vi.fn(() => Promise.resolve()),
+    deleteSessionCascade: vi.fn(),
+    emitTo: vi.fn(() => Promise.resolve()),
+    finalizeSessionDeletion: vi.fn(),
+    getCurrentWebviewWindowLabel: vi.fn(() => "main"),
+    ignoreEvent: vi.fn(),
+    indexes: {},
+    invalidateResource: vi.fn(),
+    listen: vi.fn(),
+    store: {},
+    deletedSessionData,
+  };
+});
+
+vi.mock("@tauri-apps/api/event", () => ({
+  emitTo: mocks.emitTo,
+  listen: mocks.listen,
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    close: mocks.close,
+  }),
+}));
+
+vi.mock("@hypr/plugin-windows", () => ({
+  getCurrentWebviewWindowLabel: mocks.getCurrentWebviewWindowLabel,
+}));
+
+vi.mock("~/store/tinybase/hooks", () => ({
+  useIgnoredEvents: () => ({
+    ignoreEvent: mocks.ignoreEvent,
+  }),
+}));
+
+vi.mock("~/store/tinybase/store/deleteSession", () => ({
+  captureSessionData: mocks.captureSessionData,
+  deleteSessionCascade: mocks.deleteSessionCascade,
+  finalizeSessionDeletion: mocks.finalizeSessionDeletion,
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useStore: () => mocks.store,
+    useIndexes: () => mocks.indexes,
+  },
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: (
+    selector: (state: {
+      invalidateResource: typeof mocks.invalidateResource;
+    }) => unknown,
+  ) =>
+    selector({
+      invalidateResource: mocks.invalidateResource,
+    }),
+}));
+
+vi.mock("~/store/zustand/undo-delete", () => ({
+  useUndoDelete: (
+    selector: (state: { addDeletion: typeof mocks.addDeletion }) => unknown,
+  ) =>
+    selector({
+      addDeletion: mocks.addDeletion,
+    }),
+}));
+
+import {
+  useDeleteSession,
+  useRemoteSessionDeletionUndoListener,
+} from "./useDeleteSession";
+
+describe("useDeleteSession", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mocks.captureSessionData.mockReturnValue(mocks.deletedSessionData);
+    mocks.close.mockResolvedValue(undefined);
+    mocks.emitTo.mockResolvedValue(undefined);
+    mocks.getCurrentWebviewWindowLabel.mockReturnValue("main");
+    mocks.listen.mockResolvedValue(vi.fn());
+  });
+
+  it("adds the undo deletion locally in the main window", () => {
+    const { result } = renderHook(() => useDeleteSession());
+
+    act(() => {
+      result.current("session-1", "tracking-1");
+    });
+
+    expect(mocks.ignoreEvent).toHaveBeenCalledWith("tracking-1");
+    expect(mocks.captureSessionData).toHaveBeenCalledWith(
+      mocks.store,
+      mocks.indexes,
+      "session-1",
+    );
+    expect(mocks.invalidateResource).toHaveBeenCalledWith(
+      "sessions",
+      "session-1",
+    );
+    expect(mocks.deleteSessionCascade).toHaveBeenCalledWith(
+      mocks.store,
+      mocks.indexes,
+      "session-1",
+      { deferFilesystemDelete: true },
+    );
+    expect(mocks.addDeletion).toHaveBeenCalledWith(
+      mocks.deletedSessionData,
+      expect.any(Function),
+    );
+    expect(mocks.emitTo).not.toHaveBeenCalled();
+    expect(mocks.close).not.toHaveBeenCalled();
+  });
+
+  it("forwards undo data to main and closes the matching note window", async () => {
+    mocks.getCurrentWebviewWindowLabel.mockReturnValue("note-session-1");
+    const { result } = renderHook(() => useDeleteSession());
+
+    act(() => {
+      result.current("session-1");
+    });
+
+    await waitFor(() => {
+      expect(mocks.emitTo).toHaveBeenCalledWith(
+        "main",
+        "hypr://session-deleted-for-undo",
+        {
+          sessionId: "session-1",
+          data: mocks.deletedSessionData,
+        },
+      );
+      expect(mocks.close).toHaveBeenCalled();
+    });
+
+    expect(mocks.addDeletion).not.toHaveBeenCalled();
+  });
+
+  it("listens for forwarded standalone note deletions in the main window", async () => {
+    let handler:
+      | ((event: {
+          payload: { sessionId: string; data: DeletedSessionData };
+        }) => void)
+      | null = null;
+    mocks.listen.mockImplementation((_, callback) => {
+      handler = callback;
+      return Promise.resolve(vi.fn());
+    });
+
+    renderHook(() => useRemoteSessionDeletionUndoListener(true));
+
+    await waitFor(() => {
+      expect(mocks.listen).toHaveBeenCalledWith(
+        "hypr://session-deleted-for-undo",
+        expect.any(Function),
+      );
+    });
+
+    act(() => {
+      handler?.({
+        payload: {
+          sessionId: "session-1",
+          data: mocks.deletedSessionData,
+        },
+      });
+    });
+
+    expect(mocks.addDeletion).toHaveBeenCalledWith(
+      mocks.deletedSessionData,
+      expect.any(Function),
+    );
+  });
+});

--- a/apps/desktop/src/session/hooks/useDeleteSession.ts
+++ b/apps/desktop/src/session/hooks/useDeleteSession.ts
@@ -1,5 +1,5 @@
 import { emitTo, listen } from "@tauri-apps/api/event";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { getAllWebviewWindows } from "@tauri-apps/api/webviewWindow";
 import { useCallback, useEffect } from "react";
 
 import { getCurrentWebviewWindowLabel } from "@hypr/plugin-windows";
@@ -23,6 +23,20 @@ type SessionDeletedForUndoPayload = {
   sessionId: string;
   data: DeletedSessionData;
 };
+
+async function closeSessionNoteWindows(sessionId: string) {
+  try {
+    const noteWindowLabel = `note-${sessionId}`;
+    const windows = await getAllWebviewWindows();
+    await Promise.all(
+      windows
+        .filter((window) => window.label === noteWindowLabel)
+        .map((window) => window.close().catch(() => undefined)),
+    );
+  } catch {
+    // Closing note windows should not block the deletion path.
+  }
+}
 
 function isSessionDeletedForUndoPayload(
   payload: unknown,
@@ -64,21 +78,23 @@ export function useDeleteSession() {
       });
 
       void (async () => {
-        if (capturedData) {
-          if (windowLabel === "main") {
-            addDeletion(capturedData, () => {
-              void finalizeSessionDeletion(sessionId);
-            });
-          } else {
-            await emitTo("main", SESSION_DELETED_FOR_UNDO_EVENT, {
-              sessionId,
-              data: capturedData,
-            } satisfies SessionDeletedForUndoPayload);
+        try {
+          if (capturedData) {
+            if (windowLabel === "main") {
+              addDeletion(capturedData, () => {
+                void finalizeSessionDeletion(sessionId);
+              });
+            } else {
+              await emitTo("main", SESSION_DELETED_FOR_UNDO_EVENT, {
+                sessionId,
+                data: capturedData,
+              } satisfies SessionDeletedForUndoPayload);
+            }
           }
-        }
-
-        if (windowLabel === `note-${sessionId}`) {
-          await getCurrentWindow().close();
+        } catch {
+          // The note was already deleted locally, so still close matching windows.
+        } finally {
+          await closeSessionNoteWindows(sessionId);
         }
       })();
     },
@@ -87,10 +103,13 @@ export function useDeleteSession() {
 }
 
 export function useRemoteSessionDeletionUndoListener(active: boolean) {
+  const store = main.UI.useStore(main.STORE_ID);
+  const indexes = main.UI.useIndexes(main.STORE_ID);
+  const invalidateResource = useTabs((state) => state.invalidateResource);
   const addDeletion = useUndoDelete((state) => state.addDeletion);
 
   useEffect(() => {
-    if (!active) {
+    if (!active || !store) {
       return;
     }
 
@@ -102,9 +121,14 @@ export function useRemoteSessionDeletionUndoListener(active: boolean) {
         return;
       }
 
+      invalidateResource("sessions", payload.sessionId);
+      deleteSessionCascade(store, indexes, payload.sessionId, {
+        deferFilesystemDelete: true,
+      });
       addDeletion(payload.data, () => {
         void finalizeSessionDeletion(payload.sessionId);
       });
+      void closeSessionNoteWindows(payload.sessionId);
     }).then((fn) => {
       unlisten = fn;
     });
@@ -112,5 +136,5 @@ export function useRemoteSessionDeletionUndoListener(active: boolean) {
     return () => {
       unlisten?.();
     };
-  }, [active, addDeletion]);
+  }, [active, store, indexes, invalidateResource, addDeletion]);
 }

--- a/apps/desktop/src/session/hooks/useDeleteSession.ts
+++ b/apps/desktop/src/session/hooks/useDeleteSession.ts
@@ -1,4 +1,8 @@
-import { useCallback } from "react";
+import { emitTo, listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useCallback, useEffect } from "react";
+
+import { getCurrentWebviewWindowLabel } from "@hypr/plugin-windows";
 
 import { useIgnoredEvents } from "~/store/tinybase/hooks";
 import {
@@ -8,7 +12,31 @@ import {
 } from "~/store/tinybase/store/deleteSession";
 import * as main from "~/store/tinybase/store/main";
 import { useTabs } from "~/store/zustand/tabs";
-import { useUndoDelete } from "~/store/zustand/undo-delete";
+import {
+  type DeletedSessionData,
+  useUndoDelete,
+} from "~/store/zustand/undo-delete";
+
+const SESSION_DELETED_FOR_UNDO_EVENT = "hypr://session-deleted-for-undo";
+
+type SessionDeletedForUndoPayload = {
+  sessionId: string;
+  data: DeletedSessionData;
+};
+
+function isSessionDeletedForUndoPayload(
+  payload: unknown,
+): payload is SessionDeletedForUndoPayload {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "sessionId" in payload &&
+    typeof payload.sessionId === "string" &&
+    "data" in payload &&
+    typeof payload.data === "object" &&
+    payload.data !== null
+  );
+}
 
 export function useDeleteSession() {
   const store = main.UI.useStore(main.STORE_ID);
@@ -28,18 +56,61 @@ export function useDeleteSession() {
       }
 
       const capturedData = captureSessionData(store, indexes, sessionId);
+      const windowLabel = getCurrentWebviewWindowLabel();
 
       invalidateResource("sessions", sessionId);
-      void deleteSessionCascade(store, indexes, sessionId, {
+      deleteSessionCascade(store, indexes, sessionId, {
         deferFilesystemDelete: true,
       });
 
-      if (capturedData) {
-        addDeletion(capturedData, () => {
-          void finalizeSessionDeletion(sessionId);
-        });
-      }
+      void (async () => {
+        if (capturedData) {
+          if (windowLabel === "main") {
+            addDeletion(capturedData, () => {
+              void finalizeSessionDeletion(sessionId);
+            });
+          } else {
+            await emitTo("main", SESSION_DELETED_FOR_UNDO_EVENT, {
+              sessionId,
+              data: capturedData,
+            } satisfies SessionDeletedForUndoPayload);
+          }
+        }
+
+        if (windowLabel === `note-${sessionId}`) {
+          await getCurrentWindow().close();
+        }
+      })();
     },
     [store, indexes, ignoreEvent, invalidateResource, addDeletion],
   );
+}
+
+export function useRemoteSessionDeletionUndoListener(active: boolean) {
+  const addDeletion = useUndoDelete((state) => state.addDeletion);
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+
+    let unlisten: (() => void) | undefined;
+
+    void listen(SESSION_DELETED_FOR_UNDO_EVENT, (event) => {
+      const payload = event.payload;
+      if (!isSessionDeletedForUndoPayload(payload)) {
+        return;
+      }
+
+      addDeletion(payload.data, () => {
+        void finalizeSessionDeletion(payload.sessionId);
+      });
+    }).then((fn) => {
+      unlisten = fn;
+    });
+
+    return () => {
+      unlisten?.();
+    };
+  }, [active, addDeletion]);
 }

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -23,23 +23,18 @@ import {
 } from "./utils";
 
 import { writeSessionContextDragData } from "~/chat/context/session-drag";
+import { useDeleteSession } from "~/session/hooks/useDeleteSession";
 import { useIsSessionEnhancing } from "~/session/hooks/useEnhancedNotes";
 import { getSessionEvent } from "~/session/utils";
 import { openStandaloneNoteWindow } from "~/session/window";
 import type { MenuItemDef } from "~/shared/hooks/useNativeContextMenu";
 import { InteractiveButton } from "~/shared/ui/interactive-button";
 import { useIgnoredEvents } from "~/store/tinybase/hooks";
-import {
-  captureSessionData,
-  deleteSessionCascade,
-  finalizeSessionDeletion,
-} from "~/store/tinybase/store/deleteSession";
 import * as main from "~/store/tinybase/store/main";
 import { getOrCreateSessionForEventId } from "~/store/tinybase/store/sessions";
 import { useSessionTitle } from "~/store/zustand/live-title";
 import { type TabInput, useTabs } from "~/store/zustand/tabs";
 import { useTimelineSelection } from "~/store/zustand/timeline-selection";
-import { useUndoDelete } from "~/store/zustand/undo-delete";
 import { useListener } from "~/stt/contexts";
 
 export const TimelineItemComponent = memo(
@@ -478,12 +473,8 @@ const SessionItem = memo(
     upcomingLabel?: string;
   }) => {
     const { t } = useLingui();
-    const store = main.UI.useStore(main.STORE_ID);
-    const indexes = main.UI.useIndexes(main.STORE_ID);
     const openCurrent = useTabs((state) => state.openCurrent);
-    const invalidateResource = useTabs((state) => state.invalidateResource);
-    const addDeletion = useUndoDelete((state) => state.addDeletion);
-    const { ignoreEvent } = useIgnoredEvents();
+    const deleteSession = useDeleteSession();
 
     const sessionId = item.id;
     const storeTitle = main.UI.useCell(
@@ -556,35 +547,8 @@ const SessionItem = memo(
     );
 
     const handleDelete = useCallback(() => {
-      if (!store) {
-        return;
-      }
-
-      if (sessionEvent?.tracking_id) {
-        ignoreEvent(sessionEvent.tracking_id);
-      }
-
-      const capturedData = captureSessionData(store, indexes, sessionId);
-
-      invalidateResource("sessions", sessionId);
-      void deleteSessionCascade(store, indexes, sessionId, {
-        deferFilesystemDelete: true,
-      });
-
-      if (capturedData) {
-        addDeletion(capturedData, () => {
-          void finalizeSessionDeletion(sessionId);
-        });
-      }
-    }, [
-      store,
-      indexes,
-      sessionId,
-      sessionEvent,
-      ignoreEvent,
-      invalidateResource,
-      addDeletion,
-    ]);
+      deleteSession(sessionId, sessionEvent?.tracking_id);
+    }, [deleteSession, sessionId, sessionEvent?.tracking_id]);
 
     const handleShowInFinder = useCallback(async () => {
       const result = await fsSyncCommands.sessionDir(sessionId);


### PR DESCRIPTION
Forward standalone note deletions to the main window so undo toasts remain available, and consolidate note deletion callers through the shared hook.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session deletion, multi-window IPC, and undo restore paths; mistakes could leave orphan windows or skip undo, but behavior is covered by `useDeleteSession` tests.
> 
> **Overview**
> **Note deletion from standalone note windows** now routes undo state to the main window via `hypr://session-deleted-for-undo`, so delete-from-sidebar or delete-from-note-window still surfaces the same undo toast in main. After any delete, matching `note-{sessionId}` webview windows are closed.
> 
> **Callers** for deleting a note/session (session overflow menu, sidebar timeline context menu, calendar session chip) go through **`useDeleteSession`** instead of ad-hoc delete logic. The main app registers **`useRemoteSessionDeletionUndoListener`** so it can apply the forwarded deletion and undo flow.
> 
> The large **locale `.po` diff** only updates Lingui source line references after those UI files moved or shrank (e.g. `delete.tsx`, `sidebar/timeline/item.tsx`); no new user-facing strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecf31c9089c6a0dd3d99ba61f515403f0f8222f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->