### PR TITLE
Deduplicate upcoming timeline items

### DIFF
--- a/apps/desktop/src/sidebar/timeline/utils/index.test.ts
+++ b/apps/desktop/src/sidebar/timeline/utils/index.test.ts
@@ -359,6 +359,74 @@ describe("timeline utils", () => {
     expect(containsLinkedEvent).toBe(false);
   });
 
+  test("buildTimelineBuckets deduplicates event rows with the same tracking id", () => {
+    const timelineEventsTable: TimelineEventsTable = {
+      "event-a": {
+        title: "Team standup",
+        started_at: "2024-01-15T12:03:00.000Z",
+        ended_at: "2024-01-15T12:30:00.000Z",
+        calendar_id: "cal-1",
+        tracking_id_event: "event-standup",
+        has_recurrence_rules: false,
+      },
+      "event-b": {
+        title: "Team standup",
+        started_at: "2024-01-15T12:03:00.000Z",
+        ended_at: "2024-01-15T12:30:00.000Z",
+        calendar_id: "cal-1",
+        tracking_id_event: "event-standup",
+        has_recurrence_rules: false,
+      },
+    };
+
+    const buckets = buildTimelineBuckets({
+      timelineEventsTable,
+      timelineSessionsTable: null,
+    });
+
+    const eventItems = buckets
+      .flatMap((bucket) => bucket.items)
+      .filter((item) => item.type === "event");
+
+    expect(eventItems).toHaveLength(1);
+    expect(eventItems[0]?.id).toBe("event-a");
+  });
+
+  test("buildTimelineBuckets deduplicates event-backed sessions with the same tracking id", () => {
+    const timelineSessionsTable: TimelineSessionsTable = {
+      "session-a": {
+        title: "Team standup",
+        created_at: "2024-01-15T11:50:00.000Z",
+        event_json: JSON.stringify({
+          tracking_id: "event-standup",
+          started_at: "2024-01-15T12:03:00.000Z",
+          ended_at: "2024-01-15T12:30:00.000Z",
+        }),
+      },
+      "session-b": {
+        title: "Team standup",
+        created_at: "2024-01-15T11:55:00.000Z",
+        event_json: JSON.stringify({
+          tracking_id: "event-standup",
+          started_at: "2024-01-15T12:03:00.000Z",
+          ended_at: "2024-01-15T12:30:00.000Z",
+        }),
+      },
+    };
+
+    const buckets = buildTimelineBuckets({
+      timelineEventsTable: null,
+      timelineSessionsTable,
+    });
+
+    const sessionItems = buckets
+      .flatMap((bucket) => bucket.items)
+      .filter((item) => item.type === "session");
+
+    expect(sessionItems).toHaveLength(1);
+    expect(sessionItems[0]?.id).toBe("session-a");
+  });
+
   test("buildTimelineBuckets excludes past events but keeps related sessions", () => {
     const timelineEventsTable: TimelineEventsTable = {
       "event-past": {

--- a/apps/desktop/src/sidebar/timeline/utils/index.ts
+++ b/apps/desktop/src/sidebar/timeline/utils/index.ts
@@ -461,15 +461,20 @@ export function buildTimelineBuckets({
         return;
       }
 
+      const trackingId = getSessionTrackingId(row);
+      if (trackingId) {
+        if (seenEventKeys.has(trackingId)) {
+          return;
+        }
+
+        seenEventKeys.add(trackingId);
+      }
+
       items.push({
         type: "session",
         id: sessionId,
         data: row,
       });
-      const trackingId = getSessionTrackingId(row);
-      if (trackingId) {
-        seenEventKeys.add(trackingId);
-      }
     });
   }
 
@@ -487,6 +492,10 @@ export function buildTimelineBuckets({
       }
 
       if (!isPast(timeToCheck)) {
+        if (trackingId) {
+          seenEventKeys.add(trackingId);
+        }
+
         items.push({
           type: "event",
           id: eventId,


### PR DESCRIPTION
Ensure calendar tracking ids render once across duplicated event rows and event-backed sessions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop timeline display logic with new unit tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes duplicate sidebar timeline entries when the same calendar **tracking id** appears on multiple event rows or on several event-backed sessions.
> 
> **`buildTimelineBuckets`** now registers a session’s tracking id in `seenEventKeys` *before* adding the session, and skips later sessions that share that id (first row wins). For events, tracking ids are only recorded when a non-past event is actually included, so past duplicates don’t block upcoming ones incorrectly.
> 
> Adds unit tests for duplicate event rows and duplicate sessions sharing one tracking id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc53d0483a8a1d9a733fbbf704d899e2575a2a53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->