### PR TITLE
Shrink upcoming event countdown chip

### DIFF
--- a/apps/desktop/src/sidebar/timeline/item.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.test.tsx
@@ -286,7 +286,9 @@ describe("TimelineItemComponent", () => {
       countdown.getAttribute("data-sidebar-timeline-upcoming-countdown"),
     ).toBe("true");
     expect(countdown.className).toContain("bg-destructive");
-    expect(countdown.className).toContain("w-24");
+    expect(countdown.className).toContain("rounded-full");
+    expect(countdown.className).toContain("text-[11px]");
+    expect(countdown.className).not.toContain("w-24");
     expect(countdown.className).toContain("justify-center");
   });
 

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -222,7 +222,7 @@ function ItemBase({
               data-sidebar-timeline-upcoming-countdown
               className={cn([
                 "bg-destructive text-destructive-foreground pointer-events-none shrink-0",
-                "inline-flex h-8 w-24 items-center justify-center rounded-lg px-2 text-xs leading-none font-medium whitespace-nowrap",
+                "inline-flex h-6 items-center justify-center rounded-full px-2 text-[11px] leading-none font-medium whitespace-nowrap",
               ])}
             >
               {upcomingLabel}


### PR DESCRIPTION
Use a pill-shaped countdown badge with smaller text and no fixed width.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Tailwind class changes on the timeline countdown chip; no logic or data paths touched.
> 
> **Overview**
> The sidebar timeline **upcoming event countdown** badge is restyled to read as a smaller pill instead of a fixed-width block.
> 
> In `ItemBase`, the chip drops `h-8`, `w-24`, and `rounded-lg` in favor of **`h-6`**, **`rounded-full`**, and **`text-[11px]`** (was `text-xs`), so width follows the label. Destructive colors and centering are unchanged.
> 
> Tests for upcoming rows now assert **`rounded-full`** and **`text-[11px]`**, and that **`w-24`** is no longer applied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6b59bf5e393ec69484e3407d3be416707a3b40a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->