### PR TITLE
Update participant placeholder

### DIFF
--- a/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
@@ -40,10 +40,7 @@ export function ParticipantInput({ sessionId }: { sessionId: string }) {
   } = useParticipantInput(sessionId);
   const { enhanceContact, enhancingHumanId, showEnhancementButtons } =
     useEventContactEnhancement(sessionId);
-  const placeholder =
-    mappingIds.length > 0
-      ? "Who else was in the meeting?"
-      : "Who was in this meeting?";
+  const placeholder = "Add participants";
 
   const inputRef = useRef<HTMLInputElement>(null);
   const autoCloserRef = useAutoCloser(() => setShowDropdown(false), {


### PR DESCRIPTION
Use direct add-participants copy for the participant metadata input.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to a placeholder string with no logic or data-path impact.
> 
> **Overview**
> Updates the participant metadata input placeholder from **context-dependent meeting copy** ("Who was in this meeting?" vs "Who else was in the meeting?" based on whether participants are already listed) to a **single static label**: `Add participants`.
> 
> No behavior, validation, or UI structure changes—only the input hint text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89a52d4c86f08e848412677f9293d71a5488eb0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->