### PR TITLE
Keep inactive transcript tab neutral

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -821,7 +821,7 @@ msgstr "Insert above"
 msgid "Insert below"
 msgstr "Insert below"
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr "Insights"
 
@@ -1436,7 +1436,7 @@ msgstr "Search or type owner/repo"
 msgid "Search people"
 msgstr "Search people"
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr "Search templates..."
@@ -1454,7 +1454,7 @@ msgstr "Search..."
 msgid "Section actions"
 msgstr "Section actions"
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr "See all templates"
 
@@ -1512,7 +1512,7 @@ msgstr "Send email"
 msgid "Send message"
 msgstr "Send message"
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr "Session note tabs"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:971
+#: src/session/components/note-input/header.tsx:973
 msgid "Insights"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1349
+#: src/session/components/note-input/header.tsx:1351
 #: src/templates/template-sidebar.tsx:354
 msgid "Search templates..."
 msgstr ""
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1415
+#: src/session/components/note-input/header.tsx:1417
 msgid "See all templates"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1456
+#: src/session/components/note-input/header.tsx:1458
 msgid "Session note tabs"
 msgstr ""
 

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -850,7 +850,10 @@ describe("Header", () => {
     const transcriptTab = screen.getByRole("button", { name: "Transcript" });
 
     expect(screen.getByTestId("dancing-sticks")).not.toBeNull();
-    expect(transcriptTab.className).toContain("bg-red-50");
+    expect(transcriptTab.className).toContain("text-muted-foreground/70");
+    expect(transcriptTab.className).toContain("hover:bg-background/60");
+    expect(transcriptTab.className).not.toContain("bg-red-50");
+    expect(transcriptTab.className).not.toContain("dark:bg-red-950/50");
     expect(transcriptTab.getAttribute("title")).toBeNull();
 
     fireEvent.click(transcriptTab);

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -721,15 +721,17 @@ function HeaderTabTranscriptButton({
           ? [
               "group/transcript-live",
               isActive ? "w-[98px] min-w-[98px] gap-1.5 pr-1.5 pl-2" : null,
-              live.degraded
-                ? [
-                    "bg-amber-50 text-amber-500 hover:bg-amber-100 hover:text-amber-600",
-                    "dark:bg-amber-950/50 dark:text-amber-300 dark:hover:bg-amber-950 dark:hover:text-amber-200",
-                  ]
-                : [
-                    "bg-red-50 text-red-500 hover:bg-red-100 hover:text-red-600",
-                    "dark:bg-red-950/50 dark:text-red-300 dark:hover:bg-red-950 dark:hover:text-red-200",
-                  ],
+              isActive
+                ? live.degraded
+                  ? [
+                      "bg-amber-50 text-amber-500 hover:bg-amber-100 hover:text-amber-600",
+                      "dark:bg-amber-950/50 dark:text-amber-300 dark:hover:bg-amber-950 dark:hover:text-amber-200",
+                    ]
+                  : [
+                      "bg-red-50 text-red-500 hover:bg-red-100 hover:text-red-600",
+                      "dark:bg-red-950/50 dark:text-red-300 dark:hover:bg-red-950 dark:hover:text-red-200",
+                    ]
+                : null,
             ]
           : null,
         canResume


### PR DESCRIPTION
Only apply the live capture tint when the transcript tab is active. Keep the animated live bars visible on inactive transcript tabs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to tab styling in the session note header; no auth, data, or transcription logic touched.
> 
> **Overview**
> **Live transcript tab styling** no longer applies the red/amber “capture” background when that tab is not selected. The tint and expanded width still apply only while the transcript tab is **active**; inactive tabs stay visually neutral.
> 
> **Live audio feedback is unchanged:** `DancingSticks` (and related live icon behavior) still run on the transcript tab whenever capture is live, even if the user is on another note tab.
> 
> Locale `messages.po` files were refreshed so source references for strings in `note-input/header.tsx` match the updated line numbers (no new copy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e30de539001ad4ecb039f808764e37638382d6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->