### PR TITLE
Shrink floating bar controls

### DIFF
--- a/plugins/windows/swift-lib/src/FloatingBarManager.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarManager.swift
@@ -49,7 +49,10 @@ final class FloatingBarManager {
           panelOrigin: { [weak self] in self?.panel?.frame.origin },
           movePanel: { [weak self] origin in
             guard let self, let panel = self.panel else { return }
-            self.placement.moveByUserDrag(panel, to: origin)
+            self.placement.moveByUserDrag(
+              panel,
+              to: origin,
+              anchorOffset: self.controlAnchorOffset(for: self.currentLayout))
           }))
       hostingView.frame = NSRect(
         x: 0,
@@ -131,7 +134,8 @@ final class FloatingBarManager {
     placement.position(
       panel,
       force: force,
-      size: size
+      size: size,
+      anchorOffset: controlAnchorOffset(for: currentLayout)
     ) { screen, size in
       let frame = screen.visibleFrame
       let x = frame.maxX - size.width - FloatingBarLayout.screenMargin
@@ -154,16 +158,18 @@ final class FloatingBarManager {
     let nextLayout = currentLayout
     let previousAnchorOffset = controlAnchorOffset(for: previousLayout)
     let nextAnchorOffset = controlAnchorOffset(for: nextLayout)
-    let anchor = NSPoint(
-      x: panel.frame.minX + previousAnchorOffset.x,
-      y: panel.frame.minY + previousAnchorOffset.y
-    )
+    let anchor = placement.anchorPoint(for: panel, offset: previousAnchorOffset)
     let frame = NSRect(
       x: anchor.x - nextAnchorOffset.x,
       y: anchor.y - nextAnchorOffset.y,
       width: size.width,
       height: size.height)
-    placement.setFrame(panel, to: frame, display: true, animate: false)
+    placement.setFrame(
+      panel,
+      to: frame,
+      display: true,
+      animate: false,
+      anchorOffset: nextAnchorOffset)
     panel.contentView?.frame = NSRect(origin: .zero, size: size)
     return true
   }

--- a/plugins/windows/swift-lib/src/FloatingBarView.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarView.swift
@@ -4,12 +4,12 @@ import SwiftUI
 enum FloatingBarLayout {
   static let inset: CGFloat = 4
   static let screenMargin: CGFloat = 8
-  static let compactHeight: CGFloat = 42
-  static let compactStopWidth: CGFloat = 72
-  static let compactSoloStopWidth: CGFloat = 78
-  static let compactIconSize: CGFloat = 34
-  static let compactGap: CGFloat = 4
-  static let compactHorizontalPadding: CGFloat = 5
+  static let compactHeight: CGFloat = 38
+  static let compactStopWidth: CGFloat = 62
+  static let compactSoloStopWidth: CGFloat = 68
+  static let compactIconSize: CGFloat = 30
+  static let compactGap: CGFloat = 3
+  static let compactHorizontalPadding: CGFloat = 4
   static let compactCornerControlFactor: CGFloat = 0.55228475
   static let expandedWidth: CGFloat = 360
   static let expandedHeight: CGFloat = 430

--- a/plugins/windows/swift-lib/src/FloatingPanelPositionController.swift
+++ b/plugins/windows/swift-lib/src/FloatingPanelPositionController.swift
@@ -3,6 +3,7 @@ import Cocoa
 final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
   private var activeScreenId: CGDirectDisplayID?
   private var pinnedOrigin: NSPoint?
+  private var pinnedAnchor: NSPoint?
   private var isProgrammaticMove = false
   private var programmaticMoveId = 0
   private var programmaticOrigin: NSPoint?
@@ -12,15 +13,21 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
     _ panel: NSPanel,
     force: Bool = false,
     size: NSSize? = nil,
+    anchorOffset: NSPoint? = nil,
     defaultOrigin: (NSScreen, NSSize) -> NSPoint
   ) {
     let panelSize = size ?? panel.frame.size
 
     if let pinnedOrigin {
       if force {
-        let origin = clampedOrigin(pinnedOrigin, size: panelSize)
+        let origin = clampedOrigin(
+          originForPinnedFrame(pinnedOrigin, anchorOffset: anchorOffset),
+          size: panelSize)
         move(panel, to: origin)
         self.pinnedOrigin = origin
+        self.pinnedAnchor = anchorOffset.map { anchorOffset in
+          NSPoint(x: origin.x + anchorOffset.x, y: origin.y + anchorOffset.y)
+        }
         let frame = NSRect(origin: origin, size: panelSize)
         activeScreenId =
           (screen(containing: frame) ?? panel.screen).flatMap { displayId(for: $0) }
@@ -38,7 +45,13 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
     activeScreenId = screenId
   }
 
-  func setFrame(_ panel: NSPanel, to frame: NSRect, display: Bool, animate: Bool) {
+  func setFrame(
+    _ panel: NSPanel,
+    to frame: NSRect,
+    display: Bool,
+    animate: Bool,
+    anchorOffset: NSPoint? = nil
+  ) {
     let wasPinned = pinnedOrigin != nil
 
     performProgrammaticMove(expectedOrigin: frame.origin) {
@@ -48,6 +61,9 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
 
     if wasPinned {
       pinnedOrigin = frame.origin
+      pinnedAnchor = anchorOffset.map { anchorOffset in
+        NSPoint(x: frame.origin.x + anchorOffset.x, y: frame.origin.y + anchorOffset.y)
+      }
       activeScreenId =
         (screen(containing: frame) ?? panel.screen).flatMap { displayId(for: $0) }
     }
@@ -59,11 +75,15 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
 
   func clearPinnedOrigin() {
     pinnedOrigin = nil
+    pinnedAnchor = nil
   }
 
-  func moveByUserDrag(_ panel: NSPanel, to origin: NSPoint) {
+  func moveByUserDrag(_ panel: NSPanel, to origin: NSPoint, anchorOffset: NSPoint? = nil) {
     panel.setFrameOrigin(origin)
     pinnedOrigin = panel.frame.origin
+    pinnedAnchor = anchorOffset.map { anchorOffset in
+      NSPoint(x: panel.frame.origin.x + anchorOffset.x, y: panel.frame.origin.y + anchorOffset.y)
+    }
     activeScreenId = panel.screen.flatMap { displayId(for: $0) }
     programmaticOrigin = nil
   }
@@ -77,6 +97,7 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
       width: size.width,
       height: size.height)
     pinnedOrigin = frame.origin
+    pinnedAnchor = nil
     activeScreenId =
       (screen(containing: frame) ?? panel.screen).flatMap { displayId(for: $0) }
   }
@@ -101,7 +122,13 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
 
     programmaticOrigin = nil
     pinnedOrigin = origin
+    pinnedAnchor = nil
     activeScreenId = panel.screen.flatMap { displayId(for: $0) }
+  }
+
+  func anchorPoint(for panel: NSPanel, offset: NSPoint) -> NSPoint {
+    pinnedAnchor
+      ?? NSPoint(x: panel.frame.minX + offset.x, y: panel.frame.minY + offset.y)
   }
 
   private func move(_ panel: NSPanel, to origin: NSPoint) {
@@ -109,6 +136,14 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
       panel.setFrameOrigin(origin)
       return panel.frame.origin
     }
+  }
+
+  private func originForPinnedFrame(_ origin: NSPoint, anchorOffset: NSPoint?) -> NSPoint {
+    guard let pinnedAnchor, let anchorOffset else { return origin }
+
+    return NSPoint(
+      x: pinnedAnchor.x - anchorOffset.x,
+      y: pinnedAnchor.y - anchorOffset.y)
   }
 
   private func performProgrammaticMove(expectedOrigin: NSPoint, updateFrame: () -> NSPoint) {


### PR DESCRIPTION
Reduce compact native floating bar padding and control sizes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI sizing and macOS overlay positioning only; no auth, data, or backend changes.
> 
> **Overview**
> **Shrinks the compact native floating bar** by tightening layout constants in `FloatingBarLayout` (pill height, stop/icon widths, icon size, gaps, and horizontal padding).
> 
> **Adds anchor-aware panel positioning** so those size changes do not jump the bar when the user has pinned it or when toggling compact vs expanded. `FloatingPanelPositionController` now tracks a `pinnedAnchor` alongside `pinnedOrigin`, accepts `anchorOffset` on `position`, `setFrame`, and `moveByUserDrag`, and recomputes origin from the anchor when forcing layout updates. `FloatingBarManager` wires `controlAnchorOffset(for:)` through drag, position, and resize (using `anchorPoint` when computing the frame on expand/collapse).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634d744f41421fc6a6e6f3638bcccf89111f1b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->