### PR TITLE
Show transcript scroll chips after meetings end

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -189,6 +189,27 @@ describe("TranscriptViewer", () => {
     expect(mocks.scrollToBottom).toHaveBeenCalledTimes(1);
   });
 
+  it("shows the bottom chip after upward scroll movement in inactive sessions", () => {
+    mocks.scrollDetection.isAtTop = false;
+    mocks.scrollDetection.isAtBottom = false;
+    mocks.scrollDetection.scrollTarget = "bottom";
+
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive={false}
+        scrollRef={createRef()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Go to bottom" });
+    button.click();
+
+    expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
+    expect(mocks.scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
   it("shows the top chip after downward scroll movement", () => {
     mocks.scrollDetection.isAtTop = false;
     mocks.scrollDetection.scrollTarget = "top";
@@ -213,6 +234,26 @@ describe("TranscriptViewer", () => {
       "var(--transcript-scroll-chip-top, calc(1.5rem + env(safe-area-inset-top)))",
     );
     expect(button.style.bottom).toBe("");
+    expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
+    expect(mocks.scrollToTop).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the top chip after downward scroll movement in inactive sessions", () => {
+    mocks.scrollDetection.isAtTop = false;
+    mocks.scrollDetection.scrollTarget = "top";
+
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive={false}
+        scrollRef={createRef()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Go to top" });
+    button.click();
+
     expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
     expect(mocks.scrollToTop).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -102,24 +102,7 @@ export function TranscriptViewer({
         ? [LIVE_TRANSCRIPT_PLACEHOLDER_ID]
         : [];
 
-  const scrollChip =
-    chat.mode === "FloatingOpen"
-      ? null
-      : currentActive && scrollTarget === "bottom" && !isAtBottom
-        ? {
-            icon: ArrowDownIcon,
-            label: "Go to bottom",
-            onClick: scrollToBottom,
-          }
-        : currentActive && scrollTarget === "top" && !isAtTop
-          ? {
-              icon: ArrowUpIcon,
-              label: "Go to top",
-              onClick: scrollToTop,
-            }
-          : null;
-  const ScrollChipIcon = scrollChip?.icon;
-  const isBottomScrollChip = scrollTarget === "bottom";
+  const canScrollTranscript = !isAtTop || !isAtBottom;
 
   const handleSelectionAction = (action: string, selectedText: string) => {
     if (action === "copy") {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -103,6 +103,24 @@ export function TranscriptViewer({
         : [];
 
   const canScrollTranscript = !isAtTop || !isAtBottom;
+  const scrollChip =
+    chat.mode === "FloatingOpen" || !canScrollTranscript
+      ? null
+      : scrollTarget === "bottom" && !isAtBottom
+        ? {
+            icon: ArrowDownIcon,
+            label: "Go to bottom",
+            onClick: scrollToBottom,
+          }
+        : scrollTarget === "top" && !isAtTop
+          ? {
+              icon: ArrowUpIcon,
+              label: "Go to top",
+              onClick: scrollToTop,
+            }
+          : null;
+  const ScrollChipIcon = scrollChip?.icon;
+  const isBottomScrollChip = scrollTarget === "bottom";
 
   const handleSelectionAction = (action: string, selectedText: string) => {
     if (action === "copy") {


### PR DESCRIPTION
Allows transcript top and bottom scroll chips to render for inactive sessions while preserving live-only auto-scroll behavior. Adds regression coverage for both chip directions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI change in transcript scrolling with existing guards preserved; no auth, data, or API impact.
> 
> **Overview**
> **Transcript scroll chips** (“Go to top” / “Go to bottom”) now appear for **inactive** sessions when the user scrolls away from an edge, not only while a meeting is live.
> 
> Chip visibility no longer depends on `currentActive`; it still respects floating chat (`FloatingOpen` hides chips) and adds a `canScrollTranscript` guard so chips stay hidden when the viewport is effectively at both top and bottom. **Live-only behavior is unchanged**: auto-scroll and pinning the last transcript to the end remain tied to `currentActive`.
> 
> Regression tests cover top and bottom chips with `currentActive={false}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fe0ce346181206dba44eac05e8cda3afa0e61fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5882
- <kbd>&nbsp;1&nbsp;</kbd> #5881 👈 
<!-- GitButler Footer Boundary Bottom -->