### PR TITLE
Replace transcript scroll chips with side controls

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -189,6 +189,27 @@ describe("TranscriptViewer", () => {
     expect(mocks.scrollToBottom).toHaveBeenCalledTimes(1);
   });
 
+  it("shows the bottom chip after upward scroll movement in inactive sessions", () => {
+    mocks.scrollDetection.isAtTop = false;
+    mocks.scrollDetection.isAtBottom = false;
+    mocks.scrollDetection.scrollTarget = "bottom";
+
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive={false}
+        scrollRef={createRef()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Go to bottom" });
+    button.click();
+
+    expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
+    expect(mocks.scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
   it("shows the top chip after downward scroll movement", () => {
     mocks.scrollDetection.isAtTop = false;
     mocks.scrollDetection.scrollTarget = "top";
@@ -213,6 +234,26 @@ describe("TranscriptViewer", () => {
       "var(--transcript-scroll-chip-top, calc(1.5rem + env(safe-area-inset-top)))",
     );
     expect(button.style.bottom).toBe("");
+    expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
+    expect(mocks.scrollToTop).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the top chip after downward scroll movement in inactive sessions", () => {
+    mocks.scrollDetection.isAtTop = false;
+    mocks.scrollDetection.scrollTarget = "top";
+
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive={false}
+        scrollRef={createRef()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Go to top" });
+    button.click();
+
     expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
     expect(mocks.scrollToTop).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -180,18 +180,32 @@ describe("TranscriptViewer", () => {
       />,
     );
 
-    const button = screen.getByRole("button", { name: "Go to bottom" });
-    button.click();
+    const controls = document.querySelector(
+      "[data-transcript-scroll-controls]",
+    );
+    const topButton = screen.getByRole("button", { name: "Scroll to top" });
+    const bottomButton = screen.getByRole("button", {
+      name: "Scroll to bottom",
+    });
 
-    expect(button.firstElementChild?.tagName.toLowerCase()).toBe("svg");
-    expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
+    topButton.click();
+    bottomButton.click();
+
+    expect(controls?.className).toContain("right-1");
+    expect(controls?.className).toContain("top-1/2");
+    expect(controls?.className).toContain("bg-muted/70");
+    expect(controls?.className).toContain("border-border/60");
+    expect((topButton as HTMLButtonElement).disabled).toBe(false);
+    expect((bottomButton as HTMLButtonElement).disabled).toBe(false);
+    expect(topButton.firstElementChild?.tagName.toLowerCase()).toBe("svg");
+    expect(bottomButton.firstElementChild?.tagName.toLowerCase()).toBe("svg");
+    expect(mocks.scrollToTop).toHaveBeenCalledTimes(1);
     expect(mocks.scrollToBottom).toHaveBeenCalledTimes(1);
   });
 
-  it("shows the bottom chip after upward scroll movement in inactive sessions", () => {
-    mocks.scrollDetection.isAtTop = false;
+  it("disables the top control at the top", () => {
+    mocks.scrollDetection.isAtTop = true;
     mocks.scrollDetection.isAtBottom = false;
-    mocks.scrollDetection.scrollTarget = "bottom";
 
     render(
       <TranscriptViewer
@@ -202,44 +216,22 @@ describe("TranscriptViewer", () => {
       />,
     );
 
-    const button = screen.getByRole("button", { name: "Go to bottom" });
-    button.click();
+    const topButton = screen.getByRole("button", { name: "Scroll to top" });
+    const bottomButton = screen.getByRole("button", {
+      name: "Scroll to bottom",
+    });
 
-    expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
+    bottomButton.click();
+
+    expect((topButton as HTMLButtonElement).disabled).toBe(true);
+    expect((bottomButton as HTMLButtonElement).disabled).toBe(false);
+    expect(mocks.scrollToTop).not.toHaveBeenCalled();
     expect(mocks.scrollToBottom).toHaveBeenCalledTimes(1);
   });
 
-  it("shows the top chip after downward scroll movement", () => {
+  it("disables the bottom control at the bottom", () => {
     mocks.scrollDetection.isAtTop = false;
-    mocks.scrollDetection.scrollTarget = "top";
-
-    render(
-      <TranscriptViewer
-        transcriptIds={["transcript-1"]}
-        liveSegments={[]}
-        currentActive
-        scrollRef={createRef()}
-      />,
-    );
-
-    const button = screen.getByRole("button", { name: "Go to top" });
-    button.click();
-
-    expect(button.firstElementChild?.tagName.toLowerCase()).toBe("svg");
-    expect(button.className).not.toContain("bg-linear-to-t");
-    expect(button.className).not.toContain("shadow");
-    expect(button.className).not.toContain("scale");
-    expect(button.style.top).toBe(
-      "var(--transcript-scroll-chip-top, calc(0.75rem + env(safe-area-inset-top)))",
-    );
-    expect(button.style.bottom).toBe("");
-    expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
-    expect(mocks.scrollToTop).toHaveBeenCalledTimes(1);
-  });
-
-  it("shows the top chip after downward scroll movement in inactive sessions", () => {
-    mocks.scrollDetection.isAtTop = false;
-    mocks.scrollDetection.scrollTarget = "top";
+    mocks.scrollDetection.isAtBottom = true;
 
     render(
       <TranscriptViewer
@@ -250,41 +242,22 @@ describe("TranscriptViewer", () => {
       />,
     );
 
-    const button = screen.getByRole("button", { name: "Go to top" });
-    button.click();
+    const topButton = screen.getByRole("button", { name: "Scroll to top" });
+    const bottomButton = screen.getByRole("button", {
+      name: "Scroll to bottom",
+    });
 
-    expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
+    topButton.click();
+
+    expect((topButton as HTMLButtonElement).disabled).toBe(false);
+    expect((bottomButton as HTMLButtonElement).disabled).toBe(true);
     expect(mocks.scrollToTop).toHaveBeenCalledTimes(1);
+    expect(mocks.scrollToBottom).not.toHaveBeenCalled();
   });
 
-  it("renders the bottom chip near the bottom without translucent styling", () => {
+  it("keeps scroll controls available while floating chat is expanded", () => {
     mocks.scrollDetection.isAtTop = false;
     mocks.scrollDetection.isAtBottom = false;
-    mocks.scrollDetection.scrollTarget = "bottom";
-
-    render(
-      <TranscriptViewer
-        transcriptIds={["transcript-1"]}
-        liveSegments={[]}
-        currentActive
-        scrollRef={createRef()}
-      />,
-    );
-
-    const button = screen.getByRole("button", { name: "Go to bottom" });
-
-    expect(button.style.bottom).toBe(
-      "var(--transcript-scroll-chip-bottom, calc(1.5rem + env(safe-area-inset-bottom)))",
-    );
-    expect(button.style.top).toBe("");
-    expect(button.className).not.toContain("/85");
-    expect(button.className).not.toContain("/90");
-    expect(button.className).not.toContain("opacity");
-  });
-
-  it("hides the scroll chip while floating chat is expanded", () => {
-    mocks.scrollDetection.isAtTop = false;
-    mocks.scrollDetection.scrollTarget = "top";
     mocks.chatMode = "FloatingOpen";
 
     render(

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   scrollDetection: {
     isAtTop: true,
     isAtBottom: true,
+    canScroll: false,
     autoScrollEnabled: true,
     scrollTarget: null as "top" | "bottom" | null,
   },
@@ -86,6 +87,7 @@ describe("TranscriptViewer", () => {
     mocks.scrollToTop.mockReset();
     mocks.scrollDetection.isAtTop = true;
     mocks.scrollDetection.isAtBottom = true;
+    mocks.scrollDetection.canScroll = false;
     mocks.scrollDetection.autoScrollEnabled = true;
     mocks.scrollDetection.scrollTarget = null;
     mocks.chatMode = "FloatingClosed";
@@ -170,6 +172,7 @@ describe("TranscriptViewer", () => {
   it("renders right-side scroll controls when the transcript can scroll", () => {
     mocks.scrollDetection.isAtTop = false;
     mocks.scrollDetection.isAtBottom = false;
+    mocks.scrollDetection.canScroll = true;
 
     render(
       <TranscriptViewer
@@ -203,9 +206,32 @@ describe("TranscriptViewer", () => {
     expect(mocks.scrollToBottom).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps scroll controls visible when overflow exists inside both edge thresholds", () => {
+    mocks.scrollDetection.isAtTop = true;
+    mocks.scrollDetection.isAtBottom = true;
+    mocks.scrollDetection.canScroll = true;
+
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive
+        scrollRef={createRef()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Scroll to top" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Scroll to bottom" }),
+    ).not.toBeNull();
+  });
+
   it("disables the top control at the top", () => {
     mocks.scrollDetection.isAtTop = true;
     mocks.scrollDetection.isAtBottom = false;
+    mocks.scrollDetection.canScroll = true;
 
     render(
       <TranscriptViewer
@@ -232,6 +258,7 @@ describe("TranscriptViewer", () => {
   it("disables the bottom control at the bottom", () => {
     mocks.scrollDetection.isAtTop = false;
     mocks.scrollDetection.isAtBottom = true;
+    mocks.scrollDetection.canScroll = true;
 
     render(
       <TranscriptViewer
@@ -258,6 +285,7 @@ describe("TranscriptViewer", () => {
   it("keeps scroll controls available while floating chat is expanded", () => {
     mocks.scrollDetection.isAtTop = false;
     mocks.scrollDetection.isAtBottom = false;
+    mocks.scrollDetection.canScroll = true;
     mocks.chatMode = "FloatingOpen";
 
     render(

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -151,9 +151,7 @@ describe("TranscriptViewer", () => {
     );
   });
 
-  it("does not show a scroll chip before scroll movement starts", () => {
-    mocks.scrollDetection.isAtBottom = false;
-
+  it("does not show scroll controls when the transcript cannot scroll", () => {
     render(
       <TranscriptViewer
         transcriptIds={["transcript-1"]}
@@ -163,14 +161,15 @@ describe("TranscriptViewer", () => {
       />,
     );
 
-    expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Scroll to top" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Scroll to bottom" }),
+    ).toBeNull();
   });
 
-  it("shows the bottom chip after upward scroll movement", () => {
+  it("renders right-side scroll controls when the transcript can scroll", () => {
     mocks.scrollDetection.isAtTop = false;
     mocks.scrollDetection.isAtBottom = false;
-    mocks.scrollDetection.scrollTarget = "bottom";
 
     render(
       <TranscriptViewer
@@ -231,7 +230,7 @@ describe("TranscriptViewer", () => {
     expect(button.className).not.toContain("shadow");
     expect(button.className).not.toContain("scale");
     expect(button.style.top).toBe(
-      "var(--transcript-scroll-chip-top, calc(1.5rem + env(safe-area-inset-top)))",
+      "var(--transcript-scroll-chip-top, calc(0.75rem + env(safe-area-inset-top)))",
     );
     expect(button.style.bottom).toBe("");
     expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
@@ -297,6 +296,11 @@ describe("TranscriptViewer", () => {
       />,
     );
 
-    expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Scroll to top" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Scroll to bottom" }),
+    ).not.toBeNull();
   });
 });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -102,24 +102,7 @@ export function TranscriptViewer({
         ? [LIVE_TRANSCRIPT_PLACEHOLDER_ID]
         : [];
 
-  const scrollChip =
-    chat.mode === "FloatingOpen"
-      ? null
-      : currentActive && scrollTarget === "bottom" && !isAtBottom
-        ? {
-            icon: ArrowDownIcon,
-            label: "Go to bottom",
-            onClick: scrollToBottom,
-          }
-        : currentActive && scrollTarget === "top" && !isAtTop
-          ? {
-              icon: ArrowUpIcon,
-              label: "Go to top",
-              onClick: scrollToTop,
-            }
-          : null;
-  const ScrollChipIcon = scrollChip?.icon;
-  const isBottomScrollChip = scrollTarget === "bottom";
+  const canScrollTranscript = !isAtTop || !isAtBottom;
 
   const handleSelectionAction = (action: string, selectedText: string) => {
     if (action === "copy") {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -21,7 +21,6 @@ import {
 
 import { useAudioPlayer } from "~/audio-player";
 import { useAudioTime } from "~/audio-player/provider";
-import { useShell } from "~/contexts/shell";
 import type { Segment } from "~/stt/live-segment";
 
 const LIVE_TRANSCRIPT_PLACEHOLDER_ID = "__live-transcript__";
@@ -37,7 +36,6 @@ export function TranscriptViewer({
   currentActive: boolean;
   scrollRef: RefObject<HTMLDivElement | null>;
 }) {
-  const { chat } = useShell();
   const containerRef = useRef<HTMLDivElement>(null);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
     null,
@@ -55,7 +53,6 @@ export function TranscriptViewer({
     isAtTop,
     isAtBottom,
     autoScrollEnabled,
-    scrollTarget,
     scrollToTop,
     scrollToBottom,
   } = useScrollDetection(containerRef, currentActive);
@@ -149,32 +146,42 @@ export function TranscriptViewer({
         />
       </div>
 
-      {scrollChip && (
-        <button
-          data-transcript-scroll-chip
-          onClick={scrollChip.onClick}
-          style={{
-            [isBottomScrollChip ? "bottom" : "top"]: isBottomScrollChip
-              ? "var(--transcript-scroll-chip-bottom, calc(1.5rem + env(safe-area-inset-bottom)))"
-              : "var(--transcript-scroll-chip-top, calc(1.5rem + env(safe-area-inset-top)))",
-          }}
+      {canScrollTranscript && (
+        <div
+          data-transcript-scroll-controls
           className={cn([
-            "absolute left-1/2 z-30 inline-flex -translate-x-1/2 items-center gap-1.5",
-            "border-border bg-muted text-foreground rounded-full border px-3 py-1.5",
-            "hover:bg-muted active:bg-muted",
-            "text-xs font-light",
-            "transition-[top,bottom,background-color,border-color] duration-150",
+            "absolute top-1/2 right-1 z-40 flex -translate-y-1/2 flex-col overflow-hidden",
+            "border-border/60 bg-muted/70 text-foreground rounded-full border",
           ])}
         >
-          {ScrollChipIcon && (
-            <ScrollChipIcon
-              aria-hidden="true"
-              className="size-3"
-              strokeWidth={2.25}
-            />
-          )}
-          {scrollChip.label}
-        </button>
+          <button
+            type="button"
+            aria-label="Scroll to top"
+            onClick={scrollToTop}
+            disabled={isAtTop}
+            className={cn([
+              "flex size-8 items-center justify-center",
+              "hover:bg-muted/85 active:bg-muted/85",
+              "disabled:pointer-events-none disabled:opacity-30",
+            ])}
+          >
+            <ArrowUpIcon aria-hidden="true" className="size-3.5" />
+          </button>
+          <div className="bg-border/70 h-px w-full" />
+          <button
+            type="button"
+            aria-label="Scroll to bottom"
+            onClick={scrollToBottom}
+            disabled={isAtBottom}
+            className={cn([
+              "flex size-8 items-center justify-center",
+              "hover:bg-muted/85 active:bg-muted/85",
+              "disabled:pointer-events-none disabled:opacity-30",
+            ])}
+          >
+            <ArrowDownIcon aria-hidden="true" className="size-3.5" />
+          </button>
+        </div>
       )}
     </div>
   );

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -52,6 +52,7 @@ export function TranscriptViewer({
   const {
     isAtTop,
     isAtBottom,
+    canScroll,
     autoScrollEnabled,
     scrollToTop,
     scrollToBottom,
@@ -99,8 +100,6 @@ export function TranscriptViewer({
         ? [LIVE_TRANSCRIPT_PLACEHOLDER_ID]
         : [];
 
-  const canScrollTranscript = !isAtTop || !isAtBottom;
-
   const handleSelectionAction = (action: string, selectedText: string) => {
     if (action === "copy") {
       void navigator.clipboard.writeText(selectedText);
@@ -146,7 +145,7 @@ export function TranscriptViewer({
         />
       </div>
 
-      {canScrollTranscript && (
+      {canScroll && (
         <div
           data-transcript-scroll-controls
           className={cn([

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
@@ -13,6 +13,7 @@ export function useScrollDetection(
 ) {
   const [isAtTop, setIsAtTop] = useState(true);
   const [isAtBottom, setIsAtBottom] = useState(true);
+  const [canScroll, setCanScroll] = useState(false);
   const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
   const [scrollTarget, setScrollTarget] = useState<"top" | "bottom" | null>(
     null,
@@ -29,15 +30,23 @@ export function useScrollDetection(
 
     lastScrollTopRef.current = element.scrollTop;
 
-    const handleScroll = () => {
+    const updateScrollState = () => {
       const topThreshold = 40;
       const bottomThreshold = 100;
       const distanceToBottom =
         element.scrollHeight - element.scrollTop - element.clientHeight;
+      const hasOverflow = element.scrollHeight - element.clientHeight > 1;
       const isNearTop = element.scrollTop < topThreshold;
       const isNearBottom = distanceToBottom < bottomThreshold;
-      setIsAtTop(isNearTop);
-      setIsAtBottom(isNearBottom);
+      setCanScroll(hasOverflow);
+      setIsAtTop(!hasOverflow || isNearTop);
+      setIsAtBottom(!hasOverflow || isNearBottom);
+
+      return isNearBottom;
+    };
+
+    const handleScroll = () => {
+      const isNearBottom = updateScrollState();
 
       const currentTop = element.scrollTop;
       const prevTop = lastScrollTopRef.current;
@@ -62,7 +71,25 @@ export function useScrollDetection(
 
     element.addEventListener("scroll", handleScroll);
     handleScroll();
-    return () => element.removeEventListener("scroll", handleScroll);
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(updateScrollState);
+    resizeObserver?.observe(element);
+
+    const mutationObserver = new MutationObserver(updateScrollState);
+    mutationObserver.observe(element, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+
+    return () => {
+      element.removeEventListener("scroll", handleScroll);
+      resizeObserver?.disconnect();
+      mutationObserver.disconnect();
+    };
   }, [containerRef]);
 
   useEffect(() => {
@@ -97,6 +124,7 @@ export function useScrollDetection(
   return {
     isAtTop,
     isAtBottom,
+    canScroll,
     autoScrollEnabled,
     scrollTarget,
     scrollToTop,

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -240,13 +240,6 @@
   [data-settings-content] [data-slot="select-trigger"]:hover {
     box-shadow: none !important;
   }
-
-  [data-chat-floating-anchor]:has([data-chat-cta-trigger]:is(:hover, :focus-visible, :focus-within))
-    [data-transcript-scroll-chip] {
-    --transcript-scroll-chip-bottom: calc(
-      3.75rem + env(safe-area-inset-bottom)
-    );
-  }
 }
 
 /* Search result highlighting styles — matches transcript's bg-yellow-200/50 and bg-yellow-500 */


### PR DESCRIPTION
## Summary
- replace top/bottom transcript chips with a right-side vertical arrow control
- disable each arrow based on the current scroll offset
- keep the control available while the floating chat is expanded

## Verification
- pnpm exec dprint fmt
- pnpm -F desktop test src/session/components/note-input/transcript/renderer/index.test.tsx
- pnpm -F desktop typecheck

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5882 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5881
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only transcript scroll UX in the desktop session view; auto-scroll logic is largely unchanged aside from richer overflow detection.
> 
> **Overview**
> Replaces the transcript’s contextual **Go to top** / **Go to bottom** center chips with a **right-side vertical control** (up/down icon buttons) shown whenever the viewport has overflow (`canScroll`).
> 
> Each button is **disabled** at the corresponding edge (`isAtTop` / `isAtBottom`). Controls stay visible when floating chat is expanded; **`useShell` / chat-mode gating** and the **globals.css** rule that nudged chip position near the floating chat CTA are removed.
> 
> **`useScrollDetection`** now exposes `canScroll`, treats non-scrollable content as at both edges, and refreshes state on **ResizeObserver** and **MutationObserver** (not only scroll). Tests are updated for the new labels, layout, and behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56b583305910ff5c53304614dbfe4deda816e84d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->