### PR TITLE
Keep live transcript overlay history

### DIFF
--- a/apps/desktop/src/meeting-float/host.test.ts
+++ b/apps/desktop/src/meeting-float/host.test.ts
@@ -226,7 +226,7 @@ describe("getFloatingRouteState", () => {
 });
 
 describe("getFloatingTranscriptBubbles", () => {
-  it("keeps only the most recent transcript bubbles", () => {
+  it("keeps all transcript bubbles in chronological order", () => {
     const bubbles = getFloatingTranscriptBubbles(
       Array.from({ length: 8 }, (_, index) =>
         createSegment({
@@ -244,6 +244,8 @@ describe("getFloatingTranscriptBubbles", () => {
     );
 
     expect(bubbles.map((bubble) => bubble.id)).toEqual([
+      "segment-0",
+      "segment-1",
       "segment-2",
       "segment-3",
       "segment-4",

--- a/apps/desktop/src/meeting-float/host.tsx
+++ b/apps/desktop/src/meeting-float/host.tsx
@@ -93,7 +93,6 @@ const LIVE_CAPTION_MIN_LINE_COUNT = 1;
 const LIVE_CAPTION_MAX_LINE_COUNT = 4;
 const LIVE_CAPTION_HORIZONTAL_PADDING_PX = 32;
 const LIVE_CAPTION_AVERAGE_CHARACTER_WIDTH_PX = 7.8;
-const FLOATING_TRANSCRIPT_BUBBLE_LIMIT = 6;
 
 const LIVE_CAPTION_POSITIONS: ReadonlySet<string> = new Set([
   "topCenter",
@@ -565,8 +564,7 @@ export function getFloatingTranscriptBubbles(
         isFinal: segment.words.every((word) => word.is_final),
       };
     })
-    .filter((bubble): bubble is FloatingTranscriptBubble => bubble !== null)
-    .slice(-FLOATING_TRANSCRIPT_BUBBLE_LIMIT);
+    .filter((bubble): bubble is FloatingTranscriptBubble => bubble !== null);
 }
 
 function getFloatingSegmentText(


### PR DESCRIPTION
Send all live transcript bubbles to the floating overlay so scrolling can reach earlier entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/data-shape change in meeting-float host logic with no auth or persistence impact; longer sessions may send more bubbles to the native floating bar.
> 
> **Overview**
> The floating meeting overlay no longer caps live transcript bubbles at six entries. **`getFloatingTranscriptBubbles`** now returns every non-empty segment in start-time order instead of only the most recent slice, so the overlay can scroll back through earlier lines.
> 
> The **`FLOATING_TRANSCRIPT_BUBBLE_LIMIT`** constant and trailing **`.slice(-6)`** were removed; the unit test was updated to assert all eight segments are kept.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ece7254ef847fe0621310c361a9b3d4f87ffaa5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5884
- <kbd>&nbsp;1&nbsp;</kbd> #5883 👈 
<!-- GitButler Footer Boundary Bottom -->