### PR TITLE
Show overlapping live transcript bubbles

### DIFF
--- a/apps/desktop/src/meeting-float/host.test.ts
+++ b/apps/desktop/src/meeting-float/host.test.ts
@@ -163,6 +163,10 @@ describe("getFloatingRouteState", () => {
         text: "summary yep.",
         isSelf: true,
         isFinal: true,
+        startMs: 100,
+        endMs: 200,
+        overlapsPrevious: false,
+        overlapsNext: false,
       },
       {
         id: "remote-1",
@@ -170,6 +174,10 @@ describe("getFloatingRouteState", () => {
         text: "being bingo",
         isSelf: false,
         isFinal: false,
+        startMs: 200,
+        endMs: 300,
+        overlapsPrevious: false,
+        overlapsNext: false,
       },
     ]);
   });
@@ -277,6 +285,10 @@ describe("getFloatingTranscriptBubbles", () => {
         text: "hello",
         isSelf: true,
         isFinal: true,
+        startMs: 0,
+        endMs: 100,
+        overlapsPrevious: false,
+        overlapsNext: false,
       },
     ]);
   });
@@ -303,6 +315,52 @@ describe("getFloatingTranscriptBubbles", () => {
         text: "hello",
         isSelf: true,
         isFinal: true,
+        startMs: 0,
+        endMs: 100,
+        overlapsPrevious: false,
+        overlapsNext: false,
+      },
+    ]);
+  });
+
+  it("marks bubbles that overlap different speakers", () => {
+    const bubbles = getFloatingTranscriptBubbles([
+      createSegment({
+        id: "you",
+        key: {
+          channel: "DirectMic",
+          speaker_index: null,
+          speaker_human_id: null,
+        },
+        start_ms: 100,
+        end_ms: 900,
+        text: "how it changes",
+        words: [{ text: "how" }, { text: "it" }, { text: "changes" }],
+      }),
+      createSegment({
+        id: "speaker",
+        key: {
+          channel: "RemoteParty",
+          speaker_index: 0,
+          speaker_human_id: null,
+        },
+        start_ms: 500,
+        end_ms: 1100,
+        text: "ah how it changes",
+        words: [{ text: "ah" }, { text: "how" }, { text: "it" }],
+      }),
+    ]);
+
+    expect(bubbles).toMatchObject([
+      {
+        id: "you",
+        overlapsPrevious: false,
+        overlapsNext: true,
+      },
+      {
+        id: "speaker",
+        overlapsPrevious: true,
+        overlapsNext: false,
       },
     ]);
   });

--- a/apps/desktop/src/meeting-float/host.tsx
+++ b/apps/desktop/src/meeting-float/host.tsx
@@ -48,6 +48,10 @@ type FloatingTranscriptBubble = {
   text: string;
   isSelf: boolean;
   isFinal: boolean;
+  startMs: number;
+  endMs: number;
+  overlapsPrevious: boolean;
+  overlapsNext: boolean;
 };
 type FloatingRouteState = {
   sessionId: string;
@@ -93,6 +97,7 @@ const LIVE_CAPTION_MIN_LINE_COUNT = 1;
 const LIVE_CAPTION_MAX_LINE_COUNT = 4;
 const LIVE_CAPTION_HORIZONTAL_PADDING_PX = 32;
 const LIVE_CAPTION_AVERAGE_CHARACTER_WIDTH_PX = 7.8;
+const FLOATING_TRANSCRIPT_OVERLAP_THRESHOLD_MS = 300;
 
 const LIVE_CAPTION_POSITIONS: ReadonlySet<string> = new Set([
   "topCenter",
@@ -547,9 +552,14 @@ function getFloatingTitle(title: string | null | undefined) {
 export function getFloatingTranscriptBubbles(
   segments: ListenerState["liveSegments"],
 ): FloatingTranscriptBubble[] {
-  return segments
+  const bubbles = segments
     .slice()
-    .sort((a, b) => a.start_ms - b.start_ms)
+    .sort(
+      (a, b) =>
+        a.start_ms - b.start_ms ||
+        a.end_ms - b.end_ms ||
+        a.id.localeCompare(b.id),
+    )
     .map((segment) => {
       const text = getFloatingSegmentText(segment);
       if (!text) {
@@ -562,9 +572,23 @@ export function getFloatingTranscriptBubbles(
         text,
         isSelf: isFloatingSelfSpeaker(segment.key),
         isFinal: segment.words.every((word) => word.is_final),
+        startMs: segment.start_ms,
+        endMs: segment.end_ms,
+        overlapsPrevious: false,
+        overlapsNext: false,
       };
     })
     .filter((bubble): bubble is FloatingTranscriptBubble => bubble !== null);
+
+  return bubbles.map((bubble, index) => ({
+    ...bubble,
+    overlapsPrevious: bubbles
+      .slice(0, index)
+      .some((previous) => doFloatingTranscriptBubblesOverlap(previous, bubble)),
+    overlapsNext: bubbles
+      .slice(index + 1)
+      .some((next) => doFloatingTranscriptBubblesOverlap(bubble, next)),
+  }));
 }
 
 function getFloatingSegmentText(
@@ -601,6 +625,22 @@ function isFloatingSelfSpeaker(
   key: ListenerState["liveSegments"][number]["key"],
 ) {
   return key.channel === "DirectMic";
+}
+
+function doFloatingTranscriptBubblesOverlap(
+  left: FloatingTranscriptBubble,
+  right: FloatingTranscriptBubble,
+) {
+  if (
+    left.isSelf === right.isSelf &&
+    left.speakerLabel === right.speakerLabel
+  ) {
+    return false;
+  }
+
+  const overlapMs =
+    Math.min(left.endMs, right.endMs) - Math.max(left.startMs, right.startMs);
+  return overlapMs >= FLOATING_TRANSCRIPT_OVERLAP_THRESHOLD_MS;
 }
 
 export function shouldShowFloatingLiveCaptionToggle({
@@ -754,7 +794,11 @@ function isSameFloatingTranscriptBubbles(
       bubble.speakerLabel === other.speakerLabel &&
       bubble.text === other.text &&
       bubble.isSelf === other.isSelf &&
-      bubble.isFinal === other.isFinal
+      bubble.isFinal === other.isFinal &&
+      bubble.startMs === other.startMs &&
+      bubble.endMs === other.endMs &&
+      bubble.overlapsPrevious === other.overlapsPrevious &&
+      bubble.overlapsNext === other.overlapsNext
     );
   });
 }

--- a/plugins/windows/js/bindings.gen.ts
+++ b/plugins/windows/js/bindings.gen.ts
@@ -371,6 +371,10 @@ export type FloatingTranscriptBubble = {
   text: string;
   isSelf: boolean;
   isFinal: boolean;
+  startMs: number;
+  endMs: number;
+  overlapsPrevious: boolean;
+  overlapsNext: boolean;
 };
 export type JsonValue =
   | null

--- a/plugins/windows/src/window/floating_bar.rs
+++ b/plugins/windows/src/window/floating_bar.rs
@@ -25,6 +25,10 @@ pub struct FloatingTranscriptBubble {
     pub text: String,
     pub is_self: bool,
     pub is_final: bool,
+    pub start_ms: f64,
+    pub end_ms: f64,
+    pub overlaps_previous: bool,
+    pub overlaps_next: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]

--- a/plugins/windows/swift-lib/src/FloatingBarModels.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarModels.swift
@@ -16,6 +16,10 @@ struct FloatingTranscriptBubblePayload: Codable, Identifiable {
   let text: String
   let isSelf: Bool
   let isFinal: Bool
+  let startMs: Double
+  let endMs: Double
+  let overlapsPrevious: Bool
+  let overlapsNext: Bool
 }
 
 struct FloatingBarStatePayload: Codable {

--- a/plugins/windows/swift-lib/src/FloatingBarView.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarView.swift
@@ -737,14 +737,21 @@ private struct TranscriptBubbleView: View {
       }
 
       VStack(alignment: bubble.isSelf ? .trailing : .leading, spacing: 4) {
-        if showsSpeakerLabel {
-          Text(bubble.speakerLabel)
-            .font(.system(size: 10, weight: .semibold))
-            .foregroundStyle(Color.white)
-            .lineLimit(1)
-            .padding(.horizontal, 3)
+        if showsSpeakerLabel || isOverlapping {
+          HStack(spacing: 4) {
+            if bubble.isSelf {
+              overlapGlyph
+              speakerLabel
+            } else {
+              speakerLabel
+              overlapGlyph
+            }
+          }
+          .frame(maxWidth: .infinity, alignment: bubble.isSelf ? .trailing : .leading)
+          .padding(.horizontal, 3)
         }
 
+        let shape = RoundedRectangle(cornerRadius: 11, style: .continuous)
         Text(bubble.text)
           .font(.system(size: 13, weight: .regular))
           .foregroundStyle(Color.white)
@@ -753,8 +760,11 @@ private struct TranscriptBubbleView: View {
           .fixedSize(horizontal: false, vertical: true)
           .padding(.horizontal, 11)
           .padding(.vertical, 8)
-          .background(bubbleBackground)
-          .clipShape(RoundedRectangle(cornerRadius: 11, style: .continuous))
+          .background(shape.fill(bubbleBackground))
+          .overlay(
+            shape
+              .strokeBorder(overlapStrokeColor, lineWidth: isOverlapping ? 1 : 0)
+          )
       }
 
       if !bubble.isSelf {
@@ -769,6 +779,37 @@ private struct TranscriptBubbleView: View {
     }
 
     return Color.black.opacity(colorScheme == .dark ? 0.28 : 0.2)
+  }
+
+  private var speakerLabel: some View {
+    Group {
+      if showsSpeakerLabel {
+        Text(bubble.speakerLabel)
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(Color.white)
+          .lineLimit(1)
+      }
+    }
+  }
+
+  private var overlapGlyph: some View {
+    Group {
+      if isOverlapping {
+        Image(systemName: "arrow.left.and.right")
+          .font(.system(size: 8, weight: .bold))
+          .foregroundStyle(Color.white.opacity(0.72))
+          .frame(width: 12, height: 12)
+          .accessibilityLabel("Overlapping speech")
+      }
+    }
+  }
+
+  private var isOverlapping: Bool {
+    bubble.overlapsPrevious || bubble.overlapsNext
+  }
+
+  private var overlapStrokeColor: Color {
+    Color.white.opacity(colorScheme == .dark ? 0.26 : 0.34)
   }
 }
 


### PR DESCRIPTION
Add overlap timing metadata to floating transcript bubbles and render subtle native markers for simultaneous speaker turns.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5884 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5883
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized live-transcript presentation and metadata; overlap logic is covered by unit tests and does not change recording or transcription pipelines.
> 
> **Overview**
> Floating transcript bubbles now carry **segment timing** (`startMs`/`endMs`) and **overlap flags** (`overlapsPrevious`/`overlapsNext`), plumbed from the meeting-float host through the Windows plugin (Rust + generated TS) into the macOS Swift floating bar.
> 
> **Overlap detection** runs in `getFloatingTranscriptBubbles`: bubbles are sorted with stable tie-breakers, then pairs from **different speakers** with ≥300ms temporal overlap are marked. Same-speaker segments are never treated as overlapping. Route-state equality checks include the new fields so native updates stay in sync.
> 
> The native **transcript bubble UI** shows a subtle **left-right arrow** beside the speaker row (when labels are shown or overlap applies) and a light **border stroke** on overlapping bubbles, with an accessibility label for overlapping speech.
> 
> Tests cover the new bubble shape and a cross-speaker overlap scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03696f2b4f95036e7b5083885b68c1c118d40b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->