### PR TITLE
Hide live transcript scroll chips

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -167,7 +167,7 @@ describe("TranscriptViewer", () => {
     expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
   });
 
-  it("shows the bottom chip after upward scroll movement", () => {
+  it("does not show the bottom chip after upward scroll movement in active sessions", () => {
     mocks.scrollDetection.isAtTop = false;
     mocks.scrollDetection.isAtBottom = false;
     mocks.scrollDetection.scrollTarget = "bottom";
@@ -181,6 +181,24 @@ describe("TranscriptViewer", () => {
       />,
     );
 
+    expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
+    expect(mocks.scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it("shows the bottom chip after upward scroll movement in inactive sessions", () => {
+    mocks.scrollDetection.isAtTop = false;
+    mocks.scrollDetection.isAtBottom = false;
+    mocks.scrollDetection.scrollTarget = "bottom";
+
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive={false}
+        scrollRef={createRef()}
+      />,
+    );
+
     const button = screen.getByRole("button", { name: "Go to bottom" });
     button.click();
 
@@ -189,7 +207,7 @@ describe("TranscriptViewer", () => {
     expect(mocks.scrollToBottom).toHaveBeenCalledTimes(1);
   });
 
-  it("shows the top chip after downward scroll movement", () => {
+  it("does not show the top chip after downward scroll movement in active sessions", () => {
     mocks.scrollDetection.isAtTop = false;
     mocks.scrollDetection.scrollTarget = "top";
 
@@ -198,6 +216,23 @@ describe("TranscriptViewer", () => {
         transcriptIds={["transcript-1"]}
         liveSegments={[]}
         currentActive
+        scrollRef={createRef()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
+    expect(mocks.scrollToTop).not.toHaveBeenCalled();
+  });
+
+  it("shows the top chip after downward scroll movement in inactive sessions", () => {
+    mocks.scrollDetection.isAtTop = false;
+    mocks.scrollDetection.scrollTarget = "top";
+
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive={false}
         scrollRef={createRef()}
       />,
     );
@@ -226,7 +261,7 @@ describe("TranscriptViewer", () => {
       <TranscriptViewer
         transcriptIds={["transcript-1"]}
         liveSegments={[]}
-        currentActive
+        currentActive={false}
         scrollRef={createRef()}
       />,
     );
@@ -251,7 +286,7 @@ describe("TranscriptViewer", () => {
       <TranscriptViewer
         transcriptIds={["transcript-1"]}
         liveSegments={[]}
-        currentActive
+        currentActive={false}
         scrollRef={createRef()}
       />,
     );

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -102,16 +102,17 @@ export function TranscriptViewer({
         ? [LIVE_TRANSCRIPT_PLACEHOLDER_ID]
         : [];
 
+  const canShowScrollChip = !currentActive && (!isAtTop || !isAtBottom);
   const scrollChip =
-    chat.mode === "FloatingOpen"
+    chat.mode === "FloatingOpen" || !canShowScrollChip
       ? null
-      : currentActive && scrollTarget === "bottom" && !isAtBottom
+      : scrollTarget === "bottom" && !isAtBottom
         ? {
             icon: ArrowDownIcon,
             label: "Go to bottom",
             onClick: scrollToBottom,
           }
-        : currentActive && scrollTarget === "top" && !isAtTop
+        : scrollTarget === "top" && !isAtTop
           ? {
               icon: ArrowUpIcon,
               label: "Go to top",


### PR DESCRIPTION
Suppress top and bottom scroll chips while sessions are actively transcribing and keep regular transcript scroll chip coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized transcript viewer UI gating with no auth, data, or API changes; behavior is covered by updated unit tests.
> 
> **Overview**
> **Go to top / Go to bottom** scroll chips no longer appear while a session is actively transcribing (`currentActive`), even if the user scrolls away from the top or bottom.
> 
> Chips still show for **inactive** transcript sessions when scroll detection indicates the user is not at an edge, and they remain hidden when floating chat is expanded. Tests were split to assert suppression for active sessions and preserved chip behavior for inactive ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 974083bfb3b6acdc46fd551c87550268de96b85e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->