### PR TITLE
Fix floating bar expand anchor

### DIFF
--- a/plugins/windows/swift-lib/src/FloatingBarManager.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarManager.swift
@@ -17,12 +17,13 @@ final class FloatingBarManager {
   private init() {
     model.$isExpanded
       .removeDuplicates()
-      .sink { [weak self] _ in
+      .sink { [weak self] isExpanded in
         guard let self, let panel = self.panel else { return }
         guard !self.isApplyingExternalState else { return }
-        let didResize = self.resize(panel)
+        let layout = self.layout(isExpanded: isExpanded)
+        let didResize = self.resize(panel, to: layout)
         if !didResize {
-          self.position(panel, force: true)
+          self.position(panel, force: true, layout: layout)
         }
       }
       .store(in: &cancellables)
@@ -129,13 +130,18 @@ final class FloatingBarManager {
     return panel
   }
 
-  private func position(_ panel: NSPanel, force: Bool = false) {
-    let size = currentSize
+  private func position(
+    _ panel: NSPanel,
+    force: Bool = false,
+    layout targetLayout: FloatingBarWindowLayout? = nil
+  ) {
+    let layout = targetLayout ?? currentLayout
+    let size = size(for: layout)
     placement.position(
       panel,
       force: force,
       size: size,
-      anchorOffset: controlAnchorOffset(for: currentLayout)
+      anchorOffset: controlAnchorOffset(for: layout)
     ) { screen, size in
       let frame = screen.visibleFrame
       let x = frame.maxX - size.width - FloatingBarLayout.screenMargin
@@ -144,8 +150,12 @@ final class FloatingBarManager {
     }
   }
 
-  private func resize(_ panel: NSPanel) -> Bool {
-    let size = currentSize
+  private func resize(
+    _ panel: NSPanel,
+    to targetLayout: FloatingBarWindowLayout? = nil
+  ) -> Bool {
+    let nextLayout = targetLayout ?? currentLayout
+    let size = size(for: nextLayout)
     let previousSize = panel.frame.size
     panel.minSize = size
     guard previousSize != size else { return false }
@@ -153,9 +163,8 @@ final class FloatingBarManager {
     let previousLayout =
       layout(matching: previousSize)
       ?? FloatingBarWindowLayout(
-        isExpanded: !model.isExpanded,
+        isExpanded: !nextLayout.isExpanded,
         showsExpand: model.liveCaptionToggleVisible)
-    let nextLayout = currentLayout
     let previousAnchorOffset = controlAnchorOffset(for: previousLayout)
     let nextAnchorOffset = controlAnchorOffset(for: nextLayout)
     let anchor = placement.anchorPoint(for: panel, offset: previousAnchorOffset)
@@ -179,8 +188,12 @@ final class FloatingBarManager {
   }
 
   private var currentLayout: FloatingBarWindowLayout {
+    layout(isExpanded: model.isExpanded)
+  }
+
+  private func layout(isExpanded: Bool) -> FloatingBarWindowLayout {
     FloatingBarWindowLayout(
-      isExpanded: model.isExpanded,
+      isExpanded: isExpanded,
       showsExpand: model.liveCaptionToggleVisible
     )
   }


### PR DESCRIPTION
Use the incoming expand state when resizing the floating bar so dragged panels preserve the control anchor without an intermediate snap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Swift UI window geometry in the floating bar manager; no auth, data, or shared API surface.
> 
> **Overview**
> Fixes the macOS floating bar **jumping or snapping** when toggling expand/collapse after the user has dragged it.
> 
> On `isExpanded` changes, **`resize`** and **`position`** now take an explicit target **`FloatingBarWindowLayout`** built from the **incoming** expand state (via new **`layout(isExpanded:)`**), instead of always deriving size and anchor from **`currentLayout`**. When inferring the prior layout from frame size fails, the fallback uses **`!nextLayout.isExpanded`** so the resize math stays aligned with the transition. Reposition-only paths pass the same layout so **`controlAnchorOffset`** matches the resize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77d31a9cf082e93974ffd6c4b048df615b15ff09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->