### PR TITLE
Reuse existing summary template on auto enhance

### DIFF
--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -190,6 +190,46 @@ describe("EnhancerService", () => {
       );
     });
 
+    it("auto-enhance reuses an existing note with its stored template", () => {
+      const tables = createTables({
+        enhanced_notes: {
+          "existing-note": {
+            session_id: "session-1",
+            template_id: "one-on-one",
+            content: "",
+          },
+        },
+      });
+      const store = createMockStore(tables);
+      const generate = vi.fn().mockResolvedValue(undefined);
+      const aiTaskStore = createMockAITaskStore();
+      aiTaskStore.getState.mockReturnValue({
+        generate,
+        getState: vi.fn().mockReturnValue(undefined),
+      });
+      const deps = createDeps({
+        mainStore: store,
+        indexes: createMockIndexes(tables),
+        aiTaskStore,
+        getSelectedTemplateId: () => undefined,
+      });
+      const service = new EnhancerService(deps);
+
+      const result = service.enhance("session-1", { isAuto: true });
+
+      expect(result).toEqual({ type: "started", noteId: "existing-note" });
+      expect(store.setRow).not.toHaveBeenCalled();
+      expect(generate).toHaveBeenCalledWith("existing-note-enhance", {
+        model: expect.anything(),
+        taskType: "enhance",
+        args: {
+          sessionId: "session-1",
+          enhancedNoteId: "existing-note",
+          templateId: "one-on-one",
+        },
+      });
+    });
+
     it("returns already_active when task is generating", () => {
       const tables = createTables({
         enhanced_notes: {
@@ -448,6 +488,33 @@ describe("EnhancerService", () => {
 
       const result = service.queueAutoEnhanceIfSummaryEmpty("session-1");
       expect(result).toEqual({ type: "summary_exists", noteId: "note-1" });
+      expect(aiTaskStore.getState().generate).not.toHaveBeenCalled();
+      expect((service as any).activeAutoEnhance.has("session-1")).toBe(false);
+    });
+
+    it("skips auto-enhance when an existing templated summary already has content", () => {
+      const tables = createTables({
+        enhanced_notes: {
+          "note-1": {
+            session_id: "session-1",
+            template_id: "one-on-one",
+            content: "Generated summary",
+          },
+        },
+      });
+      const store = createMockStore(tables);
+      const aiTaskStore = createMockAITaskStore();
+      const deps = createDeps({
+        mainStore: store,
+        indexes: createMockIndexes(tables),
+        aiTaskStore,
+        getSelectedTemplateId: () => undefined,
+      });
+      const service = new EnhancerService(deps);
+
+      const result = service.queueAutoEnhanceIfSummaryEmpty("session-1");
+      expect(result).toEqual({ type: "summary_exists", noteId: "note-1" });
+      expect(store.setRow).not.toHaveBeenCalled();
       expect(aiTaskStore.getState().generate).not.toHaveBeenCalled();
       expect((service as any).activeAutoEnhance.has("session-1")).toBe(false);
     });

--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -189,10 +189,7 @@ export class EnhancerService {
 
   queueAutoEnhanceIfSummaryEmpty(sessionId: string): QueueEmptySummaryResult {
     const templateId = this.deps.getSelectedTemplateId();
-    const existingNoteId = this.getMatchingEnhancedNoteId(
-      sessionId,
-      templateId,
-    );
+    const existingNoteId = this.getAutoEnhancedNoteId(sessionId, templateId);
 
     if (existingNoteId && this.hasEnhancedNoteContent(existingNoteId)) {
       return { type: "summary_exists", noteId: existingNoteId };
@@ -271,12 +268,20 @@ export class EnhancerService {
     const model = getModel();
     if (!model) return { type: "no_model" };
 
-    const templateId = resolveTemplateId(opts, getSelectedTemplateId);
+    let templateId = resolveTemplateId(opts, getSelectedTemplateId);
     const targetNoteId = opts?.targetNoteId
       ? this.getSessionEnhancedNoteId(sessionId, opts.targetNoteId)
       : undefined;
+    const autoNoteId =
+      !targetNoteId && opts?.isAuto
+        ? this.getAutoEnhancedNoteId(sessionId, templateId)
+        : undefined;
+    if (autoNoteId) {
+      templateId = this.getEnhancedNoteTemplateId(autoNoteId);
+    }
+
     const enhancedNoteId =
-      targetNoteId ?? this.ensureNote(sessionId, templateId);
+      targetNoteId ?? autoNoteId ?? this.ensureNote(sessionId, templateId);
     const enhanceTaskId = createTaskId(enhancedNoteId, "enhance");
     const existingTask = aiTaskStore.getState().getState(enhanceTaskId);
     if (existingTask?.status === "generating") {
@@ -389,6 +394,43 @@ export class EnhancerService {
         | undefined;
       return (tid || undefined) === normalizedTemplateId;
     });
+  }
+
+  private getAutoEnhancedNoteId(
+    sessionId: string,
+    templateId?: string,
+  ): string | undefined {
+    return (
+      this.getMatchingEnhancedNoteId(sessionId, templateId) ??
+      this.getFirstEnhancedNoteId(sessionId)
+    );
+  }
+
+  private getFirstEnhancedNoteId(sessionId: string): string | undefined {
+    return this.getEnhancedNoteIds(sessionId).sort((a, b) => {
+      const aPosition =
+        (this.deps.mainStore.getCell("enhanced_notes", a, "position") as
+          | number
+          | undefined) ?? Number.MAX_SAFE_INTEGER;
+      const bPosition =
+        (this.deps.mainStore.getCell("enhanced_notes", b, "position") as
+          | number
+          | undefined) ?? Number.MAX_SAFE_INTEGER;
+
+      return aPosition - bPosition;
+    })[0];
+  }
+
+  private getEnhancedNoteTemplateId(
+    enhancedNoteId: string,
+  ): string | undefined {
+    return (
+      (this.deps.mainStore.getCell(
+        "enhanced_notes",
+        enhancedNoteId,
+        "template_id",
+      ) as string | undefined) || undefined
+    );
   }
 
   private hasEnhancedNoteContent(enhancedNoteId: string): boolean {


### PR DESCRIPTION
Keep automatic summary generation on the existing enhanced note and preserve its stored template selection to avoid duplicate summary tabs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change in desktop auto-enhance note selection; no auth or data migration, covered by unit tests.
> 
> **Overview**
> **Auto summary generation** now targets an existing enhanced note for the session instead of always creating a new tab when the selected template does not match.
> 
> `getAutoEnhancedNoteId` picks a template-matching note when possible, otherwise the first note by `position`. For **`enhance(..., { isAuto: true })`**, that note is reused without `setRow`, and the **stored `template_id`** on the note drives the enhance task (not the current UI template when none is selected). **`queueAutoEnhanceIfSummaryEmpty`** uses the same lookup so it treats templated summaries with content as already done.
> 
> Tests cover reusing a templated empty note and skipping when a templated note already has content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54d56461564f147ce2342c30a56cde63f685a8bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->