### PR TITLE
Fix chat auto-scroll user scroll clamp

### DIFF
--- a/apps/desktop/src/chat/components/body/use-chat-auto-scroll.test.tsx
+++ b/apps/desktop/src/chat/components/body/use-chat-auto-scroll.test.tsx
@@ -1,0 +1,89 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import type { ChatStatus } from "ai";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useChatAutoScroll } from "./use-chat-auto-scroll";
+
+const resizeObservers: MockResizeObserver[] = [];
+
+class MockResizeObserver implements ResizeObserver {
+  constructor(private readonly callback: ResizeObserverCallback) {
+    resizeObservers.push(this);
+  }
+
+  observe() {}
+
+  unobserve() {}
+
+  disconnect() {}
+
+  trigger() {
+    this.callback([], this);
+  }
+}
+
+function TestAutoScroll({ status = "streaming" }: { status?: ChatStatus }) {
+  const { contentRef, handleWheel, scrollRef, updateAutoScrollState } =
+    useChatAutoScroll(status);
+
+  return (
+    <div
+      data-testid="scroll-area"
+      onScroll={updateAutoScrollState}
+      onWheel={handleWheel}
+      ref={(element) => {
+        scrollRef.current = element;
+
+        if (element) {
+          setScrollMetrics(element);
+        }
+      }}
+    >
+      <div ref={contentRef} />
+    </div>
+  );
+}
+
+function setScrollMetrics(element: HTMLElement) {
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    value: 500,
+  });
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    value: 1000,
+  });
+}
+
+describe("useChatAutoScroll", () => {
+  beforeEach(() => {
+    cleanup();
+    resizeObservers.length = 0;
+    globalThis.ResizeObserver = MockResizeObserver;
+  });
+
+  it("does not clamp back to bottom after a slow upward wheel during streaming", () => {
+    render(<TestAutoScroll />);
+
+    const scrollArea = screen.getByTestId("scroll-area");
+
+    scrollArea.scrollTop = 500;
+    fireEvent.scroll(scrollArea);
+
+    fireEvent.wheel(scrollArea, { deltaY: -8 });
+    scrollArea.scrollTop = 492;
+    fireEvent.scroll(scrollArea);
+
+    act(() => {
+      resizeObservers.forEach((observer) => observer.trigger());
+    });
+
+    expect(scrollArea.scrollTop).toBe(492);
+  });
+});

--- a/apps/desktop/src/chat/components/body/use-chat-auto-scroll.ts
+++ b/apps/desktop/src/chat/components/body/use-chat-auto-scroll.ts
@@ -1,5 +1,10 @@
 import type { ChatStatus } from "ai";
-import { type WheelEvent, useEffect, useRef, useState } from "react";
+import { type WheelEvent, useLayoutEffect, useRef, useState } from "react";
+
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
+
+const AUTO_SCROLL_BOTTOM_THRESHOLD = 24;
+const PINNED_BOTTOM_THRESHOLD = 1;
 
 export function useChatAutoScroll(status: ChatStatus) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -30,8 +35,14 @@ export function useChatAutoScroll(status: ChatStatus) {
 
     const { scrollTop, clientHeight, scrollHeight } = scrollRef.current;
     const distanceFromBottom = scrollHeight - (scrollTop + clientHeight);
-    const nextIsAtBottom = distanceFromBottom <= 24;
+    const nextIsAtBottom = distanceFromBottom <= AUTO_SCROLL_BOTTOM_THRESHOLD;
+    const isPinnedAtBottom = distanceFromBottom <= PINNED_BOTTOM_THRESHOLD;
     setIsAtBottom(nextIsAtBottom);
+
+    if (pendingUserScrollIntentRef.current && !isPinnedAtBottom) {
+      shouldAutoScrollRef.current = false;
+      return;
+    }
 
     if (nextIsAtBottom) {
       shouldAutoScrollRef.current = true;
@@ -44,23 +55,25 @@ export function useChatAutoScroll(status: ChatStatus) {
   };
 
   const handleWheel = (event: WheelEvent<HTMLDivElement>) => {
+    if (event.deltaY < 0) {
+      shouldAutoScrollRef.current = false;
+      pendingUserScrollIntentRef.current = true;
+      setShowGoToRecent(false);
+      return;
+    }
+
     if (event.deltaY > 0 && !isAtBottom) {
+      pendingUserScrollIntentRef.current = false;
       setShowGoToRecent(true);
       return;
     }
 
-    if (event.deltaY < 0) {
-      setShowGoToRecent(false);
+    if (event.deltaY > 0) {
+      pendingUserScrollIntentRef.current = false;
     }
-
-    if (!isGenerating || event.deltaY >= 0) {
-      return;
-    }
-
-    pendingUserScrollIntentRef.current = true;
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (isGenerating && !previousIsGeneratingRef.current) {
       shouldAutoScrollRef.current = true;
       pendingUserScrollIntentRef.current = false;
@@ -74,8 +87,8 @@ export function useChatAutoScroll(status: ChatStatus) {
     }
   });
 
-  useEffect(() => {
-    if (!contentRef.current) {
+  useMountEffect(() => {
+    if (!contentRef.current || typeof ResizeObserver === "undefined") {
       return;
     }
 
@@ -88,7 +101,7 @@ export function useChatAutoScroll(status: ChatStatus) {
     observer.observe(contentRef.current);
 
     return () => observer.disconnect();
-  }, []);
+  });
 
   return {
     contentRef,


### PR DESCRIPTION
Keep user scroll-up intent from being overwritten while chat streaming continues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX fix in the chat scroll hook with a focused regression test; no auth, data, or API changes.
> 
> **Overview**
> Fixes **chat auto-scroll snapping back to the bottom** while the assistant is still streaming after the user scrolls up (including slow wheel deltas).
> 
> `useChatAutoScroll` now treats **upward wheel** as immediate intent to leave follow mode: it clears `shouldAutoScroll` and sets a pending user-scroll flag. On scroll updates, that flag **keeps auto-scroll off** until the user is essentially pinned at the bottom (1px), so staying within the looser “near bottom” band (24px) no longer re-enables follow. Downward wheel handling is reordered so “go to recent” still appears when scrolling down while not at bottom.
> 
> Generation follow-up uses **`useLayoutEffect`** instead of `useEffect` for scroll-to-bottom on updates, and **`ResizeObserver`** is wired via `useMountEffect` with an undefined guard. A new unit test asserts **scroll position is unchanged** after content resize when the user scrolled up during streaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 451bfd55d644620d42ca8907ceeb67a5c811efaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->