### PR TITLE
Fix chat session corrections

### DIFF
--- a/apps/desktop/src/chat/tools/index.ts
+++ b/apps/desktop/src/chat/tools/index.ts
@@ -210,6 +210,7 @@ type LocalTools = {
       enhancedNoteId?: string;
       oldText: string;
       newText: string;
+      dictionaryTerms?: string[];
     };
     output: {
       status: string;
@@ -225,6 +226,9 @@ type LocalTools = {
         wordReplacements: number;
         memoReplacements: number;
       }>;
+      dictionaryChanges?: {
+        addedTerms: string[];
+      };
     };
   };
 };

--- a/apps/desktop/src/chat/tools/session-correction.test.ts
+++ b/apps/desktop/src/chat/tools/session-correction.test.ts
@@ -28,6 +28,15 @@ function createStore(tables: Record<string, Record<string, any>>) {
   } as any;
 }
 
+function createSettingsStore(values: Record<string, unknown> = {}) {
+  return {
+    getValue: vi.fn((key: string) => values[key]),
+    setValue: vi.fn((key: string, value: unknown) => {
+      values[key] = value;
+    }),
+  } as any;
+}
+
 function createIndexes(tables: Record<string, Record<string, any>>) {
   return {
     getSliceRowIds: vi.fn((indexId: string, sessionId: string) => {
@@ -257,6 +266,131 @@ describe("session correction chat tool internals", () => {
     ]);
   });
 
+  it("updates summary, transcript, and dictionary terms by default", async () => {
+    const tables = {
+      enhanced_notes: {
+        "note-1": {
+          session_id: "session-1",
+          title: "Summary",
+          content: summaryContent(
+            "Sam (from Airborne Brothers) liked the OpenWorld concept.",
+          ),
+        },
+      },
+      transcripts: {
+        "transcript-1": {
+          session_id: "session-1",
+          words: JSON.stringify([
+            { id: "w1", text: "sam", start_ms: 0, end_ms: 100, channel: 0 },
+            {
+              id: "w2",
+              text: "from",
+              start_ms: 100,
+              end_ms: 200,
+              channel: 0,
+            },
+            {
+              id: "w3",
+              text: "Airborne",
+              start_ms: 200,
+              end_ms: 300,
+              channel: 0,
+            },
+            {
+              id: "w4",
+              text: "Brothers,",
+              start_ms: 300,
+              end_ms: 400,
+              channel: 0,
+            },
+          ]),
+          memo_md: "Speaker 1: sam from Airborne Brothers, liked it.",
+        },
+      },
+    };
+    const store = createStore(tables);
+    const settingsStore = createSettingsStore({
+      personalization_dictionary_terms: JSON.stringify(["Anarlog"]),
+    });
+    const indexes = createIndexes(tables);
+    const tool = buildApplySessionCorrectionTool({
+      getStore: () => store,
+      getSettingsStore: () => settingsStore,
+      getIndexes: () => indexes,
+      getSessionId: () => "session-1",
+      getEnhancedNoteId: () => "note-1",
+    });
+
+    const result = await (tool as any).execute({
+      oldText: "Sam (from Airborne Brothers)",
+      newText: "Tim from Erebor",
+      dictionaryTerms: ["Erebor"],
+    });
+
+    expect(result).toMatchObject({
+      status: "applied",
+      summaryChanges: [{ enhancedNoteId: "note-1", replacements: 1 }],
+      transcriptChanges: [
+        {
+          transcriptId: "transcript-1",
+          wordReplacements: 1,
+          memoReplacements: 1,
+        },
+      ],
+      dictionaryChanges: { addedTerms: ["Erebor"] },
+    });
+    expect(tables.enhanced_notes["note-1"].content).toContain(
+      "Tim from Erebor liked the OpenWorld concept.",
+    );
+    expect(JSON.parse(tables.transcripts["transcript-1"].words)).toMatchObject([
+      { text: "Tim" },
+      { text: "from" },
+      { text: "Erebor" },
+    ]);
+    expect(tables.transcripts["transcript-1"].memo_md).toBe(
+      "Speaker 1: Tim from Erebor, liked it.",
+    );
+    expect(settingsStore.setValue).toHaveBeenCalledWith(
+      "personalization_dictionary_terms",
+      JSON.stringify(["Anarlog", "Erebor"]),
+    );
+  });
+
+  it("reports partial success when a requested target does not match", async () => {
+    const tables = {
+      enhanced_notes: {
+        "note-1": {
+          session_id: "session-1",
+          title: "Summary",
+          content: summaryContent("Discussed X roadmap."),
+        },
+      },
+      transcripts: {},
+    };
+    const store = createStore(tables);
+    const indexes = createIndexes(tables);
+    const tool = buildApplySessionCorrectionTool({
+      getStore: () => store,
+      getSettingsStore: () => createSettingsStore(),
+      getIndexes: () => indexes,
+      getSessionId: () => "session-1",
+      getEnhancedNoteId: () => "note-1",
+    });
+
+    const result = await (tool as any).execute({
+      oldText: "X roadmap",
+      newText: "Y roadmap",
+    });
+
+    expect(result).toMatchObject({
+      status: "partial",
+      message:
+        "Applied correction where matched, but no matching transcript text was found.",
+      summaryChanges: [{ enhancedNoteId: "note-1", replacements: 1 }],
+      transcriptChanges: [],
+    });
+  });
+
   it("returns an explicit error for a summary id outside the session", async () => {
     const tables = {
       enhanced_notes: {
@@ -272,6 +406,7 @@ describe("session correction chat tool internals", () => {
     const indexes = createIndexes(tables);
     const tool = buildApplySessionCorrectionTool({
       getStore: () => store,
+      getSettingsStore: () => createSettingsStore(),
       getIndexes: () => indexes,
       getSessionId: () => "session-1",
       getEnhancedNoteId: () => undefined,
@@ -315,6 +450,7 @@ describe("session correction chat tool internals", () => {
     const indexes = createIndexes(tables);
     const tool = buildApplySessionCorrectionTool({
       getStore: () => store,
+      getSettingsStore: () => createSettingsStore(),
       getIndexes: () => indexes,
       getSessionId: () => "session-1",
       getEnhancedNoteId: () => undefined,
@@ -364,6 +500,7 @@ describe("session correction chat tool internals", () => {
     const indexes = createIndexes(tables);
     const tool = buildApplySessionCorrectionTool({
       getStore: () => store,
+      getSettingsStore: () => createSettingsStore(),
       getIndexes: () => indexes,
       getSessionId: () => "session-1",
       getEnhancedNoteId: () => "note-1",
@@ -409,6 +546,7 @@ describe("session correction chat tool internals", () => {
     const indexes = createIndexes(tables);
     const tool = buildApplySessionCorrectionTool({
       getStore: () => store,
+      getSettingsStore: () => createSettingsStore(),
       getIndexes: () => indexes,
       getSessionId: () => "session-1",
       getEnhancedNoteId: () => "note-1",

--- a/apps/desktop/src/chat/tools/session-correction.ts
+++ b/apps/desktop/src/chat/tools/session-correction.ts
@@ -6,9 +6,13 @@ import { json2md, md2json, parseJsonContent } from "@hypr/editor/markdown";
 import type { ToolDependencies } from "./types";
 
 import * as main from "~/store/tinybase/store/main";
+import { normalizeKeywordList } from "~/stt/keywords";
 
 type Store = NonNullable<ReturnType<typeof main.UI.useStore>>;
 type Indexes = NonNullable<ReturnType<typeof main.UI.useIndexes>>;
+type SettingsStore = NonNullable<
+  ReturnType<NonNullable<ToolDependencies["getSettingsStore"]>>
+>;
 
 type CorrectionTarget = "summary" | "transcript" | "summary_and_transcript";
 
@@ -37,6 +41,10 @@ type TranscriptChange = {
   transcriptId: string;
   wordReplacements: number;
   memoReplacements: number;
+};
+
+type DictionaryChange = {
+  addedTerms: string[];
 };
 
 function replaceExact(
@@ -157,10 +165,28 @@ function parseTranscriptWords(value: unknown): TranscriptWord[] {
   }
 }
 
+function trimTokenPunctuation(value: string): string {
+  return value.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, "") || value;
+}
+
+function normalizeComparableToken(value: string): string {
+  return value
+    .normalize("NFKC")
+    .toLocaleLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, "");
+}
+
 function tokenizeReplacement(value: string): string[] {
   return value
     .split(/\s+/)
     .map((item) => item.trim())
+    .map(trimTokenPunctuation)
+    .filter(Boolean);
+}
+
+function tokenizeComparable(value: string): string[] {
+  return tokenizeReplacement(value)
+    .map(normalizeComparableToken)
     .filter(Boolean);
 }
 
@@ -173,7 +199,10 @@ function wordRangeMatchesAt(
     return false;
   }
 
-  return target.every((text, index) => words[start + index].text === text);
+  return target.every(
+    (text, index) =>
+      normalizeComparableToken(words[start + index].text ?? "") === text,
+  );
 }
 
 function buildReplacementWords(
@@ -217,7 +246,7 @@ function replaceTranscriptWords(
   oldText: string,
   newText: string,
 ): { words: TranscriptWord[]; count: number } {
-  const target = tokenizeReplacement(oldText);
+  const target = tokenizeComparable(oldText);
   const replacementTokens = tokenizeReplacement(newText);
   if (
     target.length === 0 ||
@@ -243,6 +272,71 @@ function replaceTranscriptWords(
   }
 
   return count === 0 ? { words, count: 0 } : { words: nextWords, count };
+}
+
+const TEXT_TOKEN_PATTERN = /[\p{L}\p{N}]+(?:['’_-][\p{L}\p{N}]+)*/gu;
+
+function findComparableTextTokens(
+  value: string,
+): Array<{ text: string; start: number; end: number }> {
+  return Array.from(value.matchAll(TEXT_TOKEN_PATTERN)).flatMap((match) => {
+    const start = match.index;
+    if (start === undefined) {
+      return [];
+    }
+
+    const text = normalizeComparableToken(match[0]);
+    return text ? [{ text, start, end: start + match[0].length }] : [];
+  });
+}
+
+function replaceLoosePhrase(
+  value: string,
+  oldText: string,
+  newText: string,
+): ReplacementResult {
+  const target = tokenizeComparable(oldText);
+  const tokens = findComparableTextTokens(value);
+  if (target.length === 0 || target.length > tokens.length) {
+    return { text: value, count: 0 };
+  }
+
+  const parts: string[] = [];
+  let cursor = 0;
+  let count = 0;
+
+  for (let index = 0; index < tokens.length; ) {
+    const matches = target.every(
+      (text, offset) => tokens[index + offset]?.text === text,
+    );
+    if (!matches) {
+      index++;
+      continue;
+    }
+
+    const first = tokens[index];
+    const last = tokens[index + target.length - 1];
+    parts.push(value.slice(cursor, first.start), newText);
+    cursor = last.end;
+    count++;
+    index += target.length;
+  }
+
+  if (count === 0) {
+    return { text: value, count: 0 };
+  }
+
+  parts.push(value.slice(cursor));
+  return { text: parts.join(""), count };
+}
+
+function replaceTranscriptText(
+  value: string,
+  oldText: string,
+  newText: string,
+): ReplacementResult {
+  const exact = replaceExact(value, oldText, newText);
+  return exact.count > 0 ? exact : replaceLoosePhrase(value, oldText, newText);
 }
 
 function applyTranscriptCorrection({
@@ -275,7 +369,11 @@ function applyTranscriptCorrection({
 
     const rawMemo = store.getCell("transcripts", transcriptId, "memo_md");
     const hasMemo = typeof rawMemo === "string" && rawMemo.length > 0;
-    const memoResult = replaceExact(hasMemo ? rawMemo : "", oldText, newText);
+    const memoResult = replaceTranscriptText(
+      hasMemo ? rawMemo : "",
+      oldText,
+      newText,
+    );
 
     if (wordResult.count === 0 && memoResult.count === 0) {
       continue;
@@ -310,6 +408,56 @@ function applyTranscriptCorrection({
   return changes;
 }
 
+function parseStoredDictionaryTerms(value: unknown): string[] {
+  if (typeof value !== "string") {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? normalizeKeywordList(parsed.filter((term) => typeof term === "string"))
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function dictionaryKey(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLocaleLowerCase();
+}
+
+function saveDictionaryTerms({
+  settingsStore,
+  terms,
+}: {
+  settingsStore?: SettingsStore;
+  terms?: string[];
+}): DictionaryChange {
+  if (!settingsStore || !terms || terms.length === 0) {
+    return { addedTerms: [] };
+  }
+
+  const currentTerms = parseStoredDictionaryTerms(
+    settingsStore.getValue("personalization_dictionary_terms"),
+  );
+  const currentKeys = new Set(currentTerms.map(dictionaryKey));
+  const addedTerms = normalizeKeywordList(terms).filter(
+    (term) => !currentKeys.has(dictionaryKey(term)),
+  );
+
+  if (addedTerms.length === 0) {
+    return { addedTerms: [] };
+  }
+
+  settingsStore.setValue(
+    "personalization_dictionary_terms",
+    JSON.stringify(normalizeKeywordList([...currentTerms, ...addedTerms])),
+  );
+
+  return { addedTerms };
+}
+
 function shouldEditSummary(target: CorrectionTarget): boolean {
   return target === "summary" || target === "summary_and_transcript";
 }
@@ -321,12 +469,16 @@ function shouldEditTranscript(target: CorrectionTarget): boolean {
 export const buildApplySessionCorrectionTool = (
   deps: Pick<
     ToolDependencies,
-    "getStore" | "getIndexes" | "getSessionId" | "getEnhancedNoteId"
+    | "getStore"
+    | "getSettingsStore"
+    | "getIndexes"
+    | "getSessionId"
+    | "getEnhancedNoteId"
   >,
 ) =>
   tool({
     description:
-      "Apply an exact correction to a session summary and/or transcript. Use this when the user corrects note content, for example 'it's not X but Y'. Read the note first if you need the exact old text.",
+      "Apply a correction to a session summary and/or transcript. Use this when the user corrects note content, for example 'it's not X but Y'. Prefer summary_and_transcript for factual meeting corrections unless the user explicitly asks for one target only. Read the note first if you need exact summary text.",
     inputSchema: z.object({
       sessionId: z
         .string()
@@ -335,7 +487,9 @@ export const buildApplySessionCorrectionTool = (
       target: z
         .enum(["summary", "transcript", "summary_and_transcript"])
         .default("summary_and_transcript")
-        .describe("Which session content to correct."),
+        .describe(
+          "Which session content to correct. Use summary only or transcript only when the user explicitly scopes the correction.",
+        ),
       enhancedNoteId: z
         .string()
         .optional()
@@ -347,6 +501,12 @@ export const buildApplySessionCorrectionTool = (
         .min(1)
         .describe("Exact text currently present in the note or transcript."),
       newText: z.string().describe("Replacement text."),
+      dictionaryTerms: z
+        .array(z.string().min(1))
+        .default([])
+        .describe(
+          "Uncommon names, company/product names, acronyms, or jargon from the correction to save for future transcription. Skip common names.",
+        ),
     }),
     execute: async (params: {
       sessionId?: string;
@@ -354,6 +514,7 @@ export const buildApplySessionCorrectionTool = (
       enhancedNoteId?: string;
       oldText: string;
       newText: string;
+      dictionaryTerms?: string[];
     }) => {
       const store = deps.getStore();
       const indexes = deps.getIndexes();
@@ -411,7 +572,8 @@ export const buildApplySessionCorrectionTool = (
             newText,
           })
         : [];
-      const transcriptChanges = shouldEditTranscript(target)
+      const editTranscript = shouldEditTranscript(target);
+      const transcriptChanges = editTranscript
         ? applyTranscriptCorrection({
             store,
             indexes,
@@ -430,11 +592,25 @@ export const buildApplySessionCorrectionTool = (
         };
       }
 
+      const dictionaryChanges = saveDictionaryTerms({
+        settingsStore: deps.getSettingsStore(),
+        terms: params.dictionaryTerms,
+      });
+      const missingTargets = [
+        editSummary && summaryChanges.length === 0 ? "summary" : null,
+        editTranscript && transcriptChanges.length === 0 ? "transcript" : null,
+      ].filter(Boolean);
+
       return {
-        status: "applied",
+        status: missingTargets.length > 0 ? "partial" : "applied",
+        message:
+          missingTargets.length > 0
+            ? `Applied correction where matched, but no matching ${missingTargets.join(" or ")} text was found.`
+            : undefined,
         sessionId,
         summaryChanges,
         transcriptChanges,
+        dictionaryChanges,
       };
     },
   });
@@ -443,5 +619,6 @@ export const sessionCorrectionTestInternals = {
   applySummaryCorrection,
   applyTranscriptCorrection,
   replaceExact,
+  replaceLoosePhrase,
   replaceTranscriptWords,
 };

--- a/apps/desktop/src/chat/tools/types.ts
+++ b/apps/desktop/src/chat/tools/types.ts
@@ -1,8 +1,10 @@
 import type { SearchFilters, SearchHit } from "~/search/contexts/engine/types";
 import type * as main from "~/store/tinybase/store/main";
+import type * as settings from "~/store/tinybase/store/settings";
 
 type Store = NonNullable<ReturnType<typeof main.UI.useStore>>;
 type Indexes = NonNullable<ReturnType<typeof main.UI.useIndexes>>;
+type SettingsStore = NonNullable<ReturnType<typeof settings.UI.useStore>>;
 
 export type ContactSearchResult = {
   id: string;
@@ -55,6 +57,7 @@ export interface ToolDependencies {
     limit: number,
   ) => Promise<CalendarEventSearchResult[]>;
   getStore: () => Store | undefined;
+  getSettingsStore: () => SettingsStore | undefined;
   getIndexes: () => Indexes | undefined;
   getSessionId: () => string | undefined;
   getEnhancedNoteId: () => string | undefined;

--- a/apps/desktop/src/chat/transport/use-transport.ts
+++ b/apps/desktop/src/chat/transport/use-transport.ts
@@ -19,7 +19,7 @@ Context and local-note tool guidance:
 - When the user asks about "this note", "this meeting", "the current note", or pronouns that likely refer to the open note, use read_current_note before answering.
 - When the user asks to find or search for exact wording in notes, use grep_notes. If the answer needs the full source after a match, use read_note with the returned session id.
 - When the user asks about people from the current note or related meetings, use list_related_notes and then read_note as needed.
-- When the user corrects note content with wording like "it's not X but Y", use apply_session_correction to update the current session summary and/or transcript. Use read_current_note first when you need the exact current text. Do not merely acknowledge the correction when it should update the note.
+- When the user corrects note content with wording like "it's not X but Y", use apply_session_correction to update the current session summary and transcript unless they explicitly ask for one target only. Use read_current_note first when you need exact summary text. Add uncommon names, companies, products, acronyms, or jargon from the correction to dictionaryTerms so future transcription can prefer them; skip common names. If the tool reports partial, read the note or retry with the exact remaining text instead of claiming both were updated.
 - Do not ask the user to open or share a meeting note until search_sessions, grep_notes, or read_note cannot find enough local context.
 - Do not assume note contents from chat history when a file-backed tool can read the current source of truth.
 

--- a/apps/desktop/src/main/lifecycle.tsx
+++ b/apps/desktop/src/main/lifecycle.tsx
@@ -47,10 +47,13 @@ function ToolRegistration() {
   const { search } = useSearchEngine();
   const store = main.UI.useStore(main.STORE_ID);
   const indexes = main.UI.useIndexes(main.STORE_ID);
+  const settingsStore = settings.UI.useStore(settings.STORE_ID);
   const storeRef = useRef(store);
   storeRef.current = store;
   const indexesRef = useRef(indexes);
   indexesRef.current = indexes;
+  const settingsStoreRef = useRef(settingsStore);
+  settingsStoreRef.current = settingsStore;
 
   const getContactSearchResults = useCallback(
     async (query: string, limit: number) => {
@@ -254,6 +257,7 @@ function ToolRegistration() {
         getContactSearchResults,
         getCalendarEventSearchResults,
         getStore: () => storeRef.current ?? undefined,
+        getSettingsStore: () => settingsStoreRef.current ?? undefined,
         getIndexes: () => indexesRef.current ?? undefined,
         getSessionId,
         getEnhancedNoteId,

--- a/apps/desktop/src/stt/useKeywords.test.ts
+++ b/apps/desktop/src/stt/useKeywords.test.ts
@@ -5,7 +5,10 @@ import {
   normalizeKeywordList,
   parseDictionaryTermsText,
 } from "./keywords";
-import { extractKeywordsFromMarkdown } from "./useKeywords";
+import {
+  buildKeywordSourceText,
+  extractKeywordsFromMarkdown,
+} from "./useKeywords";
 
 describe("extractKeywordsFromMarkdown", () => {
   const cases: Array<{
@@ -106,6 +109,30 @@ Next steps: testing and validation of the algorithms
     const result = extractKeywordsFromMarkdown(input);
     expect(result.keywords).toEqual(expect.arrayContaining(keywords));
     expect(result.keyphrases).toEqual(expect.arrayContaining(keyphrases));
+  });
+});
+
+describe("buildKeywordSourceText", () => {
+  it("includes session note, title, and event metadata", () => {
+    expect(
+      buildKeywordSourceText({
+        rawMd: "Discuss product launch",
+        title: "Erebor sync",
+        eventJson: JSON.stringify({
+          title: "OpenWorld review",
+          description: "Airborne Brothers follow-up",
+          location: "Zoom",
+        }),
+      }),
+    ).toBe(
+      [
+        "Discuss product launch",
+        "Erebor sync",
+        "OpenWorld review",
+        "Airborne Brothers follow-up",
+        "Zoom",
+      ].join("\n"),
+    );
   });
 });
 

--- a/apps/desktop/src/stt/useKeywords.ts
+++ b/apps/desktop/src/stt/useKeywords.ts
@@ -16,12 +16,24 @@ import { normalizeKeywordList } from "~/stt/keywords";
 
 export function useKeywords(sessionId: string) {
   const rawMd = main.UI.useCell("sessions", sessionId, "raw_md", main.STORE_ID);
+  const title = main.UI.useCell("sessions", sessionId, "title", main.STORE_ID);
+  const eventJson = main.UI.useCell(
+    "sessions",
+    sessionId,
+    "event_json",
+    main.STORE_ID,
+  );
   const dictionaryTerms = useConfigValue("personalization_dictionary_terms");
 
   return useMemo(() => {
+    const sourceText = buildKeywordSourceText({
+      rawMd,
+      title,
+      eventJson,
+    });
     const { keywords, keyphrases } =
-      rawMd && typeof rawMd === "string"
-        ? extractKeywordsFromMarkdown(rawMd)
+      sourceText.length > 0
+        ? extractKeywordsFromMarkdown(sourceText)
         : { keywords: [], keyphrases: [] };
 
     return normalizeKeywordList([
@@ -29,7 +41,25 @@ export function useKeywords(sessionId: string) {
       ...keywords,
       ...keyphrases,
     ]);
-  }, [dictionaryTerms, rawMd]);
+  }, [dictionaryTerms, eventJson, rawMd, title]);
+}
+
+export function buildKeywordSourceText({
+  rawMd,
+  title,
+  eventJson,
+}: {
+  rawMd: unknown;
+  title: unknown;
+  eventJson: unknown;
+}): string {
+  return [
+    stringValue(rawMd),
+    stringValue(title),
+    ...eventKeywordFields(eventJson),
+  ]
+    .filter((value) => value.length > 0)
+    .join("\n");
 }
 
 export const extractKeywordsFromMarkdown = (
@@ -106,6 +136,27 @@ const extractKeyphraseMatches = (phrase: Keyphrase): string[] =>
     const text = toString(match.nodes).trim();
     return text.length > 0 ? [text] : [];
   });
+
+const stringValue = (value: unknown): string =>
+  typeof value === "string" ? value.trim() : "";
+
+const eventKeywordFields = (eventJson: unknown): string[] => {
+  if (typeof eventJson !== "string" || !eventJson) {
+    return [];
+  }
+
+  try {
+    const event = JSON.parse(eventJson);
+    return [event?.title, event?.description, event?.location].flatMap(
+      (value) => {
+        const text = stringValue(value);
+        return text ? [text] : [];
+      },
+    );
+  } catch {
+    return [];
+  }
+};
 
 const removeCodeBlocks = (text: string): string =>
   text.replace(/```[\s\S]*?```/g, "").replace(/`[^`]+`/g, "");


### PR DESCRIPTION
Update session correction tooling to edit transcript and summary context together and preserve uncommon terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes directly to enhanced notes, transcript words/memos, and user dictionary settings; behavior changes could mis-apply or partially apply corrections if matching is too loose.
> 
> **Overview**
> **Chat session corrections** now default to updating **both** summary and transcript, return **`partial`** when only one side matches, and accept **`dictionaryTerms`** to merge uncommon names/jargon into `personalization_dictionary_terms` for future transcription.
> 
> Transcript fixes use **case- and punctuation-tolerant** word matching and a **loose phrase** fallback on memo markdown so corrections like “Sam (from Airborne Brothers)” → “Tim from Erebor” work when STT casing differs. Tool deps gain **`getSettingsStore`** (wired in app lifecycle); chat system guidance tells the model to use both targets, pass dictionary terms, and handle partial results.
> 
> **STT keyword sourcing** expands beyond session `raw_md` to include **title** and **calendar event** title/description/location via `buildKeywordSourceText`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f0c1460376adc5a64542f3b760c36bf7fc2f71b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->