### PR TITLE
Update desktop 1.1.5 changelog

### DIFF
--- a/packages/changelog/content/1.1.5.md
+++ b/packages/changelog/content/1.1.5.md
@@ -1,0 +1,33 @@
+---
+date: "2026-07-03"
+summary: "Anarlog keeps live meeting controls cleaner, preserves more transcript context, and makes chat corrections more useful."
+---
+
+## Live Notes
+
+- Live transcript overlays now keep earlier transcript bubbles reachable while new speech arrives
+- Overlapping speaker turns now show subtle timing markers in the live transcript overlay
+- Live transcript jump controls now stay hidden during active transcription so they do not compete with live text
+- Inactive transcript tabs now stay visually neutral while still showing that live capture is running
+- Deleted standalone notes now close their matching windows automatically
+
+## Meeting Controls
+
+- The floating meeting bar is now hidden from screen sharing
+- Floating bar controls now use a smaller, cleaner layout
+- Expanding the floating bar now preserves the dragged control anchor more reliably
+
+## Sidebar
+
+- Upcoming meetings now avoid duplicate calendar tracking labels across repeated event rows
+- Upcoming meeting countdown chips now take up less space
+
+## Chat
+
+- Chat now respects manual scrolling during streaming instead of snapping back to the bottom too aggressively
+- Chat corrections can now update transcripts and summaries together, remember uncommon terms, and use session context to improve future transcription
+
+## Notes
+
+- Automatic summary enhancement now reuses the existing summary tab and selected template instead of creating duplicate summaries
+- Participant metadata now uses clearer copy when adding people to a note


### PR DESCRIPTION
Summary:
- Add the next stable desktop changelog entry for 1.1.5.
- Keep the release notes focused on user-facing desktop changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition of release notes; no application or runtime code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.1.5.md`**, the stable desktop **1.1.5** changelog entry, using the same frontmatter (`date`, `summary`) and sectioned bullet layout as prior releases.
> 
> The notes cover user-facing desktop changes across **Live Notes** (transcript overlay scrolling, overlap markers, jump controls, tab styling, window cleanup on delete), **Meeting Controls** (screen-share hiding, compact floating bar, drag anchor on expand), **Sidebar** (calendar label deduping, smaller countdown chips), **Chat** (streaming scroll behavior, richer corrections with transcript/summary updates and term memory), and **Notes** (summary enhancement reuse, participant copy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78f60fd8c643668b6cc9058face20c8f6a9240bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->