### PR TITLE
Avoid eager transcription keyword extraction

### DIFF
--- a/apps/desktop/src/stt/useKeywords.test.ts
+++ b/apps/desktop/src/stt/useKeywords.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   buildKeywordSourceText,
   extractKeywordsFromMarkdown,
+  getSessionKeywords,
 } from "./useKeywords";
 
 describe("extractKeywordsFromMarkdown", () => {
@@ -133,6 +134,35 @@ describe("buildKeywordSourceText", () => {
         "Zoom",
       ].join("\n"),
     );
+  });
+});
+
+describe("getSessionKeywords", () => {
+  it("builds keywords from the current session snapshot", () => {
+    const cells = new Map([
+      ["raw_md", "Discuss #Launch and production systems"],
+      ["title", "Erebor sync"],
+      [
+        "event_json",
+        JSON.stringify({
+          title: "OpenWorld review",
+          description: "Airborne Brothers follow-up",
+          location: "Zoom",
+        }),
+      ],
+    ]);
+    const store = {
+      getCell: (_tableId: "sessions", _rowId: string, cellId: string) =>
+        cells.get(cellId),
+    };
+
+    expect(
+      getSessionKeywords({
+        store,
+        sessionId: "session-1",
+        dictionaryTerms: ["Anarlog"],
+      }),
+    ).toEqual(expect.arrayContaining(["Anarlog", "Launch"]));
   });
 });
 

--- a/apps/desktop/src/stt/useKeywords.ts
+++ b/apps/desktop/src/stt/useKeywords.ts
@@ -26,22 +26,62 @@ export function useKeywords(sessionId: string) {
   const dictionaryTerms = useConfigValue("personalization_dictionary_terms");
 
   return useMemo(() => {
-    const sourceText = buildKeywordSourceText({
+    return buildKeywords({
       rawMd,
       title,
       eventJson,
+      dictionaryTerms,
     });
-    const { keywords, keyphrases } =
-      sourceText.length > 0
-        ? extractKeywordsFromMarkdown(sourceText)
-        : { keywords: [], keyphrases: [] };
-
-    return normalizeKeywordList([
-      ...dictionaryTerms,
-      ...keywords,
-      ...keyphrases,
-    ]);
   }, [dictionaryTerms, eventJson, rawMd, title]);
+}
+
+type KeywordStore = {
+  getCell: (
+    tableId: "sessions",
+    rowId: string,
+    cellId: "raw_md" | "title" | "event_json",
+  ) => unknown;
+};
+
+export function getSessionKeywords({
+  store,
+  sessionId,
+  dictionaryTerms,
+}: {
+  store: KeywordStore;
+  sessionId: string;
+  dictionaryTerms: string[];
+}) {
+  return buildKeywords({
+    rawMd: store.getCell("sessions", sessionId, "raw_md"),
+    title: store.getCell("sessions", sessionId, "title"),
+    eventJson: store.getCell("sessions", sessionId, "event_json"),
+    dictionaryTerms,
+  });
+}
+
+export function buildKeywords({
+  rawMd,
+  title,
+  eventJson,
+  dictionaryTerms,
+}: {
+  rawMd: unknown;
+  title: unknown;
+  eventJson: unknown;
+  dictionaryTerms: string[];
+}) {
+  const sourceText = buildKeywordSourceText({
+    rawMd,
+    title,
+    eventJson,
+  });
+  const { keywords, keyphrases } =
+    sourceText.length > 0
+      ? extractKeywordsFromMarkdown(sourceText)
+      : { keywords: [], keyphrases: [] };
+
+  return normalizeKeywordList([...dictionaryTerms, ...keywords, ...keyphrases]);
 }
 
 export function buildKeywordSourceText({

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -48,6 +48,7 @@ vi.mock("./contexts", () => ({
 }));
 
 vi.mock("./useKeywords", () => ({
+  getSessionKeywords: vi.fn(() => []),
   useKeywords: vi.fn(() => []),
 }));
 

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -5,7 +5,7 @@ import type { TranscriptStorage } from "@hypr/store";
 import { sonnerToast } from "@hypr/ui/components/ui/toast";
 
 import { useListener } from "./contexts";
-import { useKeywords } from "./useKeywords";
+import { getSessionKeywords } from "./useKeywords";
 import { useSTTConnection } from "./useSTTConnection";
 
 import { useAuth } from "~/auth";
@@ -203,9 +203,9 @@ export const useRunBatch = (sessionId: string) => {
   const { conn } = useSTTConnection();
   const auth = useAuth();
   const billing = useBillingAccess();
-  const keywords = useKeywords(sessionId);
   const aiLanguage = useConfigValue("ai_language");
   const spokenLanguages = useConfigValue("spoken_languages");
+  const dictionaryTerms = useConfigValue("personalization_dictionary_terms");
 
   return useCallback(
     async (filePath: string, options?: RunOptions) => {
@@ -264,6 +264,13 @@ export const useRunBatch = (sessionId: string) => {
 
       const createdAt = new Date().toISOString();
       const memoMd = store.getCell("sessions", sessionId, "raw_md");
+      const keywords =
+        options?.keywords ??
+        getSessionKeywords({
+          store,
+          sessionId,
+          dictionaryTerms,
+        });
       let transcriptId: string | null = null;
       const inferredNumSpeakers =
         options?.numSpeakers === undefined &&
@@ -395,7 +402,7 @@ export const useRunBatch = (sessionId: string) => {
         model: target.model,
         base_url: target.baseUrl,
         api_key: target.apiKey,
-        keywords: options?.keywords ?? keywords ?? [],
+        keywords,
         languages,
         num_speakers: options?.numSpeakers ?? inferredNumSpeakers,
         min_speakers: options?.minSpeakers,
@@ -426,8 +433,8 @@ export const useRunBatch = (sessionId: string) => {
       auth?.session?.access_token,
       aiLanguage,
       billing.isPaid,
+      dictionaryTerms,
       indexes,
-      keywords,
       spokenLanguages,
       startTranscription,
       sessionId,

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+import { getSessionKeywords } from "./useKeywords";
 import { getPostCaptureAction } from "./useStartListening";
 import { useStartListening } from "./useStartListening";
 
@@ -60,6 +61,7 @@ vi.mock("./contexts", () => ({
 }));
 
 vi.mock("./useKeywords", () => ({
+  getSessionKeywords: vi.fn(() => []),
   useKeywords: vi.fn(() => []),
 }));
 
@@ -233,6 +235,29 @@ describe("useStartListening", () => {
     });
 
     expect(setLeftSidebarExpandedMock).not.toHaveBeenCalled();
+  });
+
+  test("reads keywords from the same pre-start snapshot as the transcript memo", async () => {
+    const calls: string[] = [];
+    vi.mocked(getSessionKeywords).mockImplementation(() => {
+      calls.push("keywords");
+      return ["launch"];
+    });
+    startMock.mockImplementation(async () => {
+      calls.push("start");
+      return true;
+    });
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(calls).toEqual(["keywords", "start"]);
+    expect(startMock.mock.calls[0]?.[0]).toMatchObject({
+      keywords: ["launch"],
+    });
   });
 
   test("runs batch transcription after record-only capture stops", async () => {

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -4,7 +4,7 @@ import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 import type { TranscriptStorage } from "@hypr/store";
 
 import { useListener } from "./contexts";
-import { useKeywords } from "./useKeywords";
+import { getSessionKeywords } from "./useKeywords";
 import {
   canRunBatchTranscription,
   isStoppedTranscriptionError,
@@ -73,6 +73,7 @@ export function useStartListening(sessionId: string) {
 
   const aiLanguage = useConfigValue("ai_language");
   const spokenLanguages = useConfigValue("spoken_languages");
+  const dictionaryTerms = useConfigValue("personalization_dictionary_terms");
 
   const start = useListener((state) => state.start);
   const { conn } = useSTTConnection();
@@ -80,7 +81,6 @@ export function useStartListening(sessionId: string) {
   const { leftsidebar } = useShell();
   const setLeftSidebarExpanded = leftsidebar.setExpanded;
 
-  const keywords = useKeywords(sessionId);
   const runBatchRef = useRef(runBatch);
   const canRunBatchRef = useRef(canRunBatchTranscription(conn));
   runBatchRef.current = runBatch;
@@ -103,6 +103,11 @@ export function useStartListening(sessionId: string) {
     const transcriptAccumulatorRef: {
       current: TranscriptAccumulator | null;
     } = { current: null };
+    const keywords = getSessionKeywords({
+      store,
+      sessionId,
+      dictionaryTerms,
+    });
 
     const onStopped: OnStoppedCallback = async (_sessionId, details) => {
       transcriptAccumulatorRef.current?.dispose();
@@ -259,11 +264,11 @@ export function useStartListening(sessionId: string) {
   }, [
     aiLanguage,
     conn,
+    dictionaryTerms,
     store,
     indexes,
     sessionId,
     start,
-    keywords,
     user_id,
     spokenLanguages,
     setLeftSidebarExpanded,


### PR DESCRIPTION
Compute transcription keywords when starting live or batch transcription instead of from mounted session controls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Same keyword-building rules with a timing change only; limited to desktop STT startup paths with added tests for snapshot ordering.
> 
> **Overview**
> **Defers** expensive session keyword extraction so it no longer runs on every render while session STT UI is mounted.
> 
> Shared logic moves into **`buildKeywords`** and a store-backed **`getSessionKeywords`**. **`useStartListening`** and **`useRunBatch`** now read **`raw_md`**, title, event JSON, and dictionary terms from the Tinybase store **at the moment** live or batch transcription starts (alongside the transcript memo snapshot), instead of subscribing via **`useKeywords`**. The **`useKeywords`** hook still wraps **`buildKeywords`** for any remaining reactive consumers.
> 
> Tests cover **`getSessionKeywords`** output and assert live start resolves keywords **before** calling **`start`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f799e7a8f69d59f1b957890c99133587b4297df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->