### PR TITLE
Defer editor document serialization during typing

### DIFF
--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -537,14 +537,22 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       [taskSource, taskStorage],
     );
 
-    const onUpdate = useDebounceCallback((content: JSONContent) => {
+    const flushChange = useCallback(() => {
+      const view = viewRef.current;
+      if (!view) {
+        return;
+      }
+
+      const content = view.state.doc.toJSON() as JSONContent;
       syncTasks(content);
       if (!handleChange) {
         return;
       }
 
       handleChange(content);
-    }, 500);
+    }, [handleChange, syncTasks]);
+
+    const onUpdate = useDebounceCallback(flushChange, 500);
 
     const plugins = useMemo(
       () => [
@@ -674,8 +682,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
                 dispatchEditorTransaction({
                   view: this,
                   transaction: tr,
-                  onDocChanged: () =>
-                    onUpdate(this.state.doc.toJSON() as JSONContent),
+                  onDocChanged: () => onUpdate(),
                 });
               }}
               attributes={{


### PR DESCRIPTION
Move full ProseMirror document JSON serialization into the existing debounced change flush so keyboard transactions stay lightweight.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5899
- <kbd>&nbsp;1&nbsp;</kbd> #5898 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to when serialization runs (still debounced at 500ms); if the view is missing at flush time, change propagation is skipped silently.
> 
> **Overview**
> **Note editor** no longer runs `doc.toJSON()` on every ProseMirror transaction while typing. Document serialization, task sync, and `handleChange` now happen together inside a new **`flushChange`** callback that reads the live view from `viewRef` and only runs after the existing **500ms** debounce.
> 
> The transaction handler’s `onDocChanged` path now only schedules **`onUpdate()`** with no arguments, so keyboard-driven updates stay lighter on the hot path while persisted content should still match the editor once the debounce fires.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 903fd2fb1736f7b5c6bab614d5d4db349c2c02a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->