### PR TITLE
Reduce session action render cost

### DIFF
--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -5,6 +5,7 @@ import { FloatingActionButton } from "./index";
 
 import type { LLMConnectionStatus } from "~/ai/hooks";
 import type { Tab } from "~/store/zustand/tabs";
+import type { EditorView } from "~/store/zustand/tabs/schema";
 
 const hoisted = vi.hoisted(() => ({
   currentTab: { type: "raw" } as
@@ -141,6 +142,16 @@ describe("FloatingActionButton", () => {
     slotId: "slot-1",
     state: { view: null, autoStart: null },
   } as Extract<Tab, { type: "sessions" }>;
+  const renderFloatingActionButton = (
+    props: Partial<React.ComponentProps<typeof FloatingActionButton>> = {},
+  ) =>
+    render(
+      <FloatingActionButton
+        currentView={hoisted.currentTab as EditorView}
+        tab={tab}
+        {...props}
+      />,
+    );
 
   beforeEach(() => {
     hoisted.currentTab = { type: "raw" };
@@ -169,7 +180,7 @@ describe("FloatingActionButton", () => {
   });
 
   it("shows the chat FAB on raw memo view after transcript exists", () => {
-    render(<FloatingActionButton tab={tab} />);
+    renderFloatingActionButton();
 
     expect(
       screen.queryByRole("button", { name: "Ask Anarlog anything" }),
@@ -179,7 +190,7 @@ describe("FloatingActionButton", () => {
   it("shows chat instead of a regenerate summary FAB on generated summaries", () => {
     hoisted.currentTab = { type: "enhanced", id: "note-1" };
 
-    render(<FloatingActionButton tab={tab} />);
+    renderFloatingActionButton();
 
     expect(
       screen.queryByRole("button", { name: "Ask Anarlog anything" }),
@@ -198,7 +209,7 @@ describe("FloatingActionButton", () => {
       noteId: "note-1",
     });
 
-    render(<FloatingActionButton tab={tab} />);
+    renderFloatingActionButton();
 
     expect(
       screen.queryByRole("button", { name: "Ask Anarlog anything" }),
@@ -220,7 +231,7 @@ describe("FloatingActionButton", () => {
     hoisted.enhanceTaskStatus = "success";
     hoisted.enhancedContent = "";
 
-    render(<FloatingActionButton tab={tab} />);
+    renderFloatingActionButton();
 
     expect(
       screen.queryByRole("button", { name: "Ask Anarlog anything" }),
@@ -234,7 +245,7 @@ describe("FloatingActionButton", () => {
     hoisted.currentTab = { type: "enhanced", id: "note-1" };
     hoisted.enhanceTaskStatus = "error";
 
-    render(<FloatingActionButton tab={tab} />);
+    renderFloatingActionButton();
 
     expect(
       screen.queryByRole("button", { name: "Ask Anarlog anything" }),
@@ -247,7 +258,7 @@ describe("FloatingActionButton", () => {
     hoisted.enhancedContent = "";
     hoisted.llmStatus = { status: "pending", reason: "missing_provider" };
 
-    render(<FloatingActionButton tab={tab} />);
+    renderFloatingActionButton();
 
     expect(
       screen.queryByRole("button", { name: "Ask Anarlog anything" }),
@@ -260,7 +271,7 @@ describe("FloatingActionButton", () => {
     hoisted.enhancedContent = "";
     hoisted.llmStatus = { status: "pending", reason: "missing_provider" };
 
-    render(<FloatingActionButton tab={tab} />);
+    renderFloatingActionButton();
 
     expect(
       screen.queryByRole("button", { name: "Ask Anarlog anything" }),
@@ -271,7 +282,7 @@ describe("FloatingActionButton", () => {
   it("keeps the chat FAB visible near the editor caret", () => {
     hoisted.isCaretNearBottom = true;
 
-    render(<FloatingActionButton tab={tab} />);
+    renderFloatingActionButton();
 
     const wrapper = screen.getByText("Ask Anarlog anything").parentElement;
     const hoverZone = wrapper?.parentElement;
@@ -293,7 +304,7 @@ describe("FloatingActionButton", () => {
   it("keeps the chat FAB visible during active meetings", () => {
     hoisted.sessionMode = "active";
 
-    render(<FloatingActionButton tab={tab} />);
+    renderFloatingActionButton();
 
     const wrapper = screen.getByText("Ask Anarlog anything").parentElement;
     const hoverZone = wrapper?.parentElement;
@@ -317,7 +328,7 @@ describe("FloatingActionButton", () => {
     hoisted.sessionMode = "active";
     hoisted.hasTranscript = false;
 
-    render(<FloatingActionButton tab={tab} />);
+    renderFloatingActionButton();
 
     const wrapper = screen.getByText("Ask Anarlog anything").parentElement;
 
@@ -333,7 +344,7 @@ describe("FloatingActionButton", () => {
   it("opens chat from the active meeting FAB", () => {
     hoisted.sessionMode = "active";
 
-    render(<FloatingActionButton tab={tab} />);
+    renderFloatingActionButton();
 
     fireEvent.click(
       screen.getByRole("button", { name: "Ask Anarlog anything" }),
@@ -346,7 +357,7 @@ describe("FloatingActionButton", () => {
     hoisted.hasTranscript = false;
     hoisted.isCaretNearBottom = true;
 
-    render(<FloatingActionButton tab={tab} />);
+    renderFloatingActionButton();
 
     const wrapper = screen.getByText("Start listening").parentElement;
 
@@ -359,7 +370,7 @@ describe("FloatingActionButton", () => {
   it("hides the listen FAB when listening is disabled", () => {
     hoisted.hasTranscript = false;
 
-    render(<FloatingActionButton allowListening={false} tab={tab} />);
+    renderFloatingActionButton({ allowListening: false });
 
     expect(
       screen.queryByRole("button", { name: "Start listening" }),
@@ -370,7 +381,7 @@ describe("FloatingActionButton", () => {
     hoisted.currentTab = { type: "transcript" };
     hoisted.hasTranscript = false;
 
-    render(<FloatingActionButton audioExists tab={tab} />);
+    renderFloatingActionButton({ audioExists: true });
 
     expect(
       screen.queryByRole("button", { name: "Ask Anarlog anything" }),
@@ -387,7 +398,7 @@ describe("FloatingActionButton", () => {
     hoisted.currentTab = { type: "transcript" };
     hoisted.hasTranscript = true;
 
-    render(<FloatingActionButton audioExists tab={tab} />);
+    renderFloatingActionButton({ audioExists: true });
 
     expect(
       screen.queryByRole("button", { name: "Ask Anarlog anything" }),
@@ -404,7 +415,7 @@ describe("FloatingActionButton", () => {
     hoisted.currentTab = { type: "transcript" };
     hoisted.sessionMode = "running_batch";
 
-    render(<FloatingActionButton audioExists tab={tab} />);
+    renderFloatingActionButton({ audioExists: true });
 
     fireEvent.click(screen.getByRole("button", { name: "Stop transcription" }));
 
@@ -415,7 +426,7 @@ describe("FloatingActionButton", () => {
     hoisted.currentTab = { type: "transcript" };
     hoisted.hasTranscript = false;
 
-    render(<FloatingActionButton tab={tab} />);
+    renderFloatingActionButton();
 
     expect(
       screen.queryByRole("button", { name: "Regenerate transcript" }),
@@ -423,12 +434,9 @@ describe("FloatingActionButton", () => {
   });
 
   it("shows a skip reason in the FAB slot instead of the chat FAB", () => {
-    render(
-      <FloatingActionButton
-        tab={tab}
-        skipReason="Not enough words recorded (3/5 minimum)"
-      />,
-    );
+    renderFloatingActionButton({
+      skipReason: "Not enough words recorded (3/5 minimum)",
+    });
 
     const status = screen.getByRole("status");
 
@@ -441,12 +449,9 @@ describe("FloatingActionButton", () => {
   });
 
   it("keeps a skip reason visible without tuck behavior", () => {
-    render(
-      <FloatingActionButton
-        tab={tab}
-        skipReason="Not enough words recorded (3/5 minimum)"
-      />,
-    );
+    renderFloatingActionButton({
+      skipReason: "Not enough words recorded (3/5 minimum)",
+    });
 
     const status = screen.getByRole("status");
 

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -14,7 +14,6 @@ import { type LLMConnectionStatus, useLLMConnectionStatus } from "~/ai/hooks";
 import { getEnhancerService } from "~/services/enhancer";
 import { useRegenerateTranscript } from "~/session/components/note-input/transcript/actions";
 import {
-  useCurrentNoteTab,
   hasStoredNoteContent,
   useHasTranscript,
 } from "~/session/components/shared";
@@ -22,38 +21,72 @@ import { ChatCTA } from "~/shared/chat-cta";
 import * as main from "~/store/tinybase/store/main";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import { useTabs } from "~/store/zustand/tabs";
-import type { Tab } from "~/store/zustand/tabs/schema";
+import type { EditorView, Tab } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
 
 export function FloatingActionButton({
   allowListening = true,
   audioExists = false,
+  currentView,
   skipReason = null,
   tab,
 }: {
   allowListening?: boolean;
   audioExists?: boolean;
+  currentView: EditorView;
   skipReason?: string | null;
   tab: Extract<Tab, { type: "sessions" }>;
 }) {
   const sessionMode = useListener((state) => state.getSessionMode(tab.id));
-  const canShowListen = useShouldShowListeningFab(
-    tab,
-    sessionMode,
-    audioExists,
+  const hasTranscript = useHasTranscript(tab.id);
+  const enhancedNoteId =
+    currentView.type === "enhanced" ? currentView.id : null;
+  const taskId = enhancedNoteId
+    ? createTaskId(enhancedNoteId, "enhance")
+    : null;
+  const taskStatus = useAITask((state) =>
+    taskId ? state.tasks[taskId]?.status : undefined,
   );
-  const shouldShowListen = allowListening && canShowListen;
-  const transcriptAction = useTranscriptFloatingAction(
-    tab,
-    sessionMode,
-    audioExists,
+  const llmStatus = useLLMConnectionStatus();
+  const enhancedContent = main.UI.useCell(
+    "enhanced_notes",
+    enhancedNoteId ?? "",
+    "content",
+    main.STORE_ID,
   );
-  const shouldShowChat = useShouldShowChatFab(tab, sessionMode, audioExists);
-  const generateSummaryNoteId = useGenerateSummaryNoteId(
-    tab,
-    sessionMode,
+  const regenerateTranscript = useRegenerateTranscript(tab.id);
+  const stopTranscription = useListener((state) => state.stopTranscription);
+  const handleStopTranscription = useCallback(() => {
+    void stopTranscription(tab.id);
+  }, [stopTranscription, tab.id]);
+  const shouldShowListen =
+    allowListening &&
+    sessionMode === "inactive" &&
+    currentView.type === "raw" &&
+    !hasTranscript;
+  const transcriptAction = getTranscriptFloatingAction({
     audioExists,
-  );
+    currentView,
+    handleStopTranscription,
+    regenerateTranscript,
+    sessionMode,
+  });
+  const generateSummaryNoteId = getGenerateSummaryNoteId({
+    currentView,
+    enhancedContent,
+    hasTranscript,
+    llmStatus,
+    sessionMode,
+    taskStatus,
+  });
+  const shouldShowChat = shouldShowChatFab({
+    currentView,
+    enhancedContent,
+    hasTranscript,
+    llmStatus,
+    sessionMode,
+    taskStatus,
+  });
   const shouldShowGenerateSummary = generateSummaryNoteId !== null;
   const shouldShowTranscriptAction = transcriptAction !== null;
   const isCaretNearBottom = useCaretPosition()?.isCaretNearBottom ?? false;
@@ -227,20 +260,20 @@ function GenerateSummaryButton({
   );
 }
 
-function useTranscriptFloatingAction(
-  tab: Extract<Tab, { type: "sessions" }>,
-  sessionMode: string,
-  audioExists: boolean,
-) {
-  const currentTab = useCurrentNoteTab(tab, { audioExists });
-  const regenerateTranscript = useRegenerateTranscript(tab.id);
-  const stopTranscription = useListener((state) => state.stopTranscription);
-
-  const handleStopTranscription = useCallback(() => {
-    void stopTranscription(tab.id);
-  }, [stopTranscription, tab.id]);
-
-  if (currentTab.type !== "transcript") {
+function getTranscriptFloatingAction({
+  audioExists,
+  currentView,
+  handleStopTranscription,
+  regenerateTranscript,
+  sessionMode,
+}: {
+  audioExists: boolean;
+  currentView: EditorView;
+  handleStopTranscription: () => void;
+  regenerateTranscript: () => void;
+  sessionMode: string;
+}) {
+  if (currentView.type !== "transcript") {
     return null;
   }
 
@@ -261,40 +294,23 @@ function useTranscriptFloatingAction(
   return null;
 }
 
-function useShouldShowListeningFab(
-  tab: Extract<Tab, { type: "sessions" }>,
-  sessionMode: string,
-  audioExists: boolean,
-) {
-  const currentTab = useCurrentNoteTab(tab, { audioExists });
-  const hasTranscript = useHasTranscript(tab.id);
-
-  return (
-    sessionMode === "inactive" && currentTab.type === "raw" && !hasTranscript
-  );
-}
-
-function useGenerateSummaryNoteId(
-  tab: Extract<Tab, { type: "sessions" }>,
-  sessionMode: string,
-  audioExists: boolean,
-) {
-  const hasTranscript = useHasTranscript(tab.id);
-  const currentTab = useCurrentNoteTab(tab, { audioExists });
-  const enhancedNoteId = currentTab.type === "enhanced" ? currentTab.id : null;
-  const taskId = enhancedNoteId
-    ? createTaskId(enhancedNoteId, "enhance")
-    : null;
-  const taskStatus = useAITask((state) =>
-    taskId ? state.tasks[taskId]?.status : undefined,
-  );
-  const llmStatus = useLLMConnectionStatus();
-  const content = main.UI.useCell(
-    "enhanced_notes",
-    enhancedNoteId ?? "",
-    "content",
-    main.STORE_ID,
-  );
+function getGenerateSummaryNoteId({
+  currentView,
+  enhancedContent,
+  hasTranscript,
+  llmStatus,
+  sessionMode,
+  taskStatus,
+}: {
+  currentView: EditorView;
+  enhancedContent: unknown;
+  hasTranscript: boolean;
+  llmStatus: LLMConnectionStatus;
+  sessionMode: string;
+  taskStatus: string | undefined;
+}) {
+  const enhancedNoteId =
+    currentView.type === "enhanced" ? currentView.id : null;
   const canStartEnhance =
     taskStatus === undefined ||
     taskStatus === "idle" ||
@@ -305,7 +321,7 @@ function useGenerateSummaryNoteId(
     hasTranscript &&
     enhancedNoteId &&
     canStartEnhance &&
-    !hasStoredNoteContent(content) &&
+    !hasStoredNoteContent(enhancedContent) &&
     !isBlockingLLMStatus(llmStatus)
   ) {
     return enhancedNoteId;
@@ -314,37 +330,31 @@ function useGenerateSummaryNoteId(
   return null;
 }
 
-function useShouldShowChatFab(
-  tab: Extract<Tab, { type: "sessions" }>,
-  sessionMode: string,
-  audioExists: boolean,
-) {
-  const hasTranscript = useHasTranscript(tab.id);
-  const currentTab = useCurrentNoteTab(tab, { audioExists });
-  const enhancedNoteId = currentTab.type === "enhanced" ? currentTab.id : null;
-  const taskId = enhancedNoteId
-    ? createTaskId(enhancedNoteId, "enhance")
-    : null;
-  const taskStatus = useAITask((state) =>
-    taskId ? state.tasks[taskId]?.status : undefined,
-  );
-  const llmStatus = useLLMConnectionStatus();
-  const content = main.UI.useCell(
-    "enhanced_notes",
-    enhancedNoteId ?? "",
-    "content",
-    main.STORE_ID,
-  );
+function shouldShowChatFab({
+  currentView,
+  enhancedContent,
+  hasTranscript,
+  llmStatus,
+  sessionMode,
+  taskStatus,
+}: {
+  currentView: EditorView;
+  enhancedContent: unknown;
+  hasTranscript: boolean;
+  llmStatus: LLMConnectionStatus;
+  sessionMode: string;
+  taskStatus: string | undefined;
+}) {
   const visibleTaskStatus = taskStatus ?? "idle";
-  const hasContent = hasStoredNoteContent(content);
+  const hasContent = hasStoredNoteContent(enhancedContent);
   const hasVisibleIssue =
-    currentTab.type === "enhanced" &&
+    currentView.type === "enhanced" &&
     (visibleTaskStatus === "error" ||
       (visibleTaskStatus === "idle" &&
         !hasContent &&
         isBlockingLLMStatus(llmStatus)));
   const hasVisibleGeneration =
-    currentTab.type === "enhanced" && visibleTaskStatus === "generating";
+    currentView.type === "enhanced" && visibleTaskStatus === "generating";
 
   const canShowForSessionMode =
     sessionMode === "inactive" || sessionMode === "active";

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -9,7 +9,7 @@ import type { EditorView } from "~/store/zustand/tabs/schema";
 const {
   uploadAudioMock,
   uploadTranscriptMock,
-  useCurrentNoteHasContentMock,
+  currentNoteContent,
   useHasTranscriptMock,
   useListenerMock,
   useConfigValueMock,
@@ -19,7 +19,7 @@ const {
 } = vi.hoisted(() => ({
   uploadAudioMock: vi.fn(),
   uploadTranscriptMock: vi.fn(),
-  useCurrentNoteHasContentMock: vi.fn(),
+  currentNoteContent: { value: "" },
   useHasTranscriptMock: vi.fn(),
   useListenerMock: vi.fn(),
   useConfigValueMock: vi.fn(),
@@ -92,8 +92,19 @@ vi.mock("@hypr/plugin-windows", () => ({
 }));
 
 vi.mock("~/session/components/shared", () => ({
-  useCurrentNoteHasContent: useCurrentNoteHasContentMock,
+  hasStoredNoteContent: (value: unknown) =>
+    typeof value === "string" && value.trim().length > 0,
   useHasTranscript: useHasTranscriptMock,
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  UI: {
+    useCell: (_table: string, _row: string, cell: string) =>
+      cell === "raw_md" || cell === "content"
+        ? currentNoteContent.value
+        : undefined,
+  },
 }));
 
 vi.mock("~/shared/config", () => ({
@@ -118,7 +129,7 @@ describe("OverflowButton", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    useCurrentNoteHasContentMock.mockReturnValue(false);
+    currentNoteContent.value = "";
     useHasTranscriptMock.mockReturnValue(true);
     useConfigValueMock.mockReturnValue(false);
     useMeetingFloatMainStoreMock.mockReturnValue(mainStoreMock);
@@ -178,7 +189,7 @@ describe("OverflowButton", () => {
 
   it("hides upload actions when the current note has content", () => {
     useHasTranscriptMock.mockReturnValue(false);
-    useCurrentNoteHasContentMock.mockReturnValue(true);
+    currentNoteContent.value = "Existing content";
 
     render(
       <OverflowButton

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -27,11 +27,12 @@ import { ShowInFinder } from "./misc";
 import { useMeetingFloatMainStore } from "~/meeting-float/hooks";
 import { openFloatingMeetingPanel } from "~/meeting-float/host";
 import {
-  useCurrentNoteHasContent,
+  hasStoredNoteContent,
   useHasTranscript,
 } from "~/session/components/shared";
 import { openStandaloneNoteWindow } from "~/session/window";
 import { useConfigValue } from "~/shared/config";
+import * as main from "~/store/tinybase/store/main";
 import * as settingsStore from "~/store/tinybase/store/settings";
 import type { EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
@@ -51,9 +52,10 @@ export function OverflowButton({
   const [open, setOpen] = useState(false);
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
   const hasTranscript = useHasTranscript(sessionId);
-  const currentNoteHasContent = useCurrentNoteHasContent(
+  const currentNoteHasContent = useUploadCurrentViewHasContent(
     sessionId,
     currentView,
+    hasTranscript,
   );
   const { uploadAudio, uploadTranscript } = useUploadFile(sessionId);
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
@@ -178,4 +180,28 @@ export function OverflowButton({
       />
     </>
   );
+}
+
+function useUploadCurrentViewHasContent(
+  sessionId: string,
+  currentView: EditorView,
+  hasTranscript: boolean,
+): boolean {
+  const rawMd = main.UI.useCell("sessions", sessionId, "raw_md", main.STORE_ID);
+  const enhancedContent = main.UI.useCell(
+    "enhanced_notes",
+    currentView.type === "enhanced" ? currentView.id : "",
+    "content",
+    main.STORE_ID,
+  );
+
+  if (currentView.type === "raw") {
+    return hasStoredNoteContent(rawMd);
+  }
+
+  if (currentView.type === "enhanced") {
+    return hasStoredNoteContent(enhancedContent);
+  }
+
+  return currentView.type === "transcript" ? hasTranscript : true;
 }

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -219,59 +219,62 @@ function TabContentNoteInner({
     [tab, updateSessionTabState],
   );
   return (
-    <SessionSurface
-      header={
-        <OuterHeader
-          sessionId={tab.id}
-          currentView={currentView}
-          standaloneWindow={standaloneWindow}
-          title={
-            <NoteInputHeader
-              sessionId={tab.id}
-              editorTabs={editorTabs}
-              currentTab={currentView}
-              handleTabChange={handleTabChange}
-              isTranscribing={isTranscribing}
-            />
-          }
-        />
-      }
-      floatingButton={
-        <FloatingActionButton
-          allowListening={!standaloneWindow}
-          audioExists={audioExists}
-          skipReason={skipReason}
-          tab={tab}
-        />
-      }
-    >
-      <div className="flex h-full min-h-0 flex-col">
-        {showTopAudioPlayer ? (
-          <div
-            data-session-top-audio-player
-            className="shrink-0 px-1 pt-1 pb-2"
-          >
-            <div className="border-border/70 bg-card/80 overflow-hidden rounded-[22px] border">
-              <AudioPlayer.Timeline contentClassName="py-1.5 pr-3 pl-1" />
+    <>
+      <SessionSurface
+        header={
+          <OuterHeader
+            sessionId={sessionId}
+            currentView={currentView}
+            standaloneWindow={standaloneWindow}
+            title={
+              <NoteInputHeader
+                sessionId={sessionId}
+                editorTabs={editorTabs}
+                currentTab={currentView}
+                handleTabChange={handleTabChange}
+                isTranscribing={isTranscribing}
+              />
+            }
+          />
+        }
+        floatingButton={
+          <FloatingActionButton
+            allowListening={!standaloneWindow}
+            audioExists={audioExists}
+            currentView={currentView}
+            skipReason={skipReason}
+            tab={tab}
+          />
+        }
+      >
+        <div className="flex h-full min-h-0 flex-col">
+          {showTopAudioPlayer ? (
+            <div
+              data-session-top-audio-player
+              className="shrink-0 px-1 pt-1 pb-2"
+            >
+              <div className="border-border/70 bg-card/80 overflow-hidden rounded-[22px] border">
+                <AudioPlayer.Timeline contentClassName="py-1.5 pr-3 pl-1" />
+              </div>
             </div>
+          ) : null}
+          <div className="min-h-0 flex-1">
+            {contentHydrated ? (
+              <NoteInput
+                ref={noteInputRef}
+                tab={tab}
+                editorTabs={editorTabs}
+                currentTab={currentView}
+                handleTabChange={handleTabChange}
+                hideHeader
+              />
+            ) : (
+              <SessionContentLoading />
+            )}
           </div>
-        ) : null}
-        <div className="min-h-0 flex-1">
-          {contentHydrated ? (
-            <NoteInput
-              ref={noteInputRef}
-              tab={tab}
-              editorTabs={editorTabs}
-              currentTab={currentView}
-              handleTabChange={handleTabChange}
-              hideHeader
-            />
-          ) : (
-            <SessionContentLoading />
-          )}
         </div>
-      </div>
-    </SessionSurface>
+      </SessionSurface>
+    </>
   );
 }
 


### PR DESCRIPTION
Reuse derived session view state in floating actions and avoid broad content checks in the overflow menu upload gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of visibility logic with existing tests; behavior should match prior FAB/overflow rules if `currentView` stays in sync with the editor.
> 
> **Overview**
> **Reduces session UI render work** by passing the already-derived `currentView` from the session shell into `FloatingActionButton` instead of re-deriving the editor tab inside the FAB (via `useCurrentNoteTab`).
> 
> The FAB now **hoists Tinybase/AI subscriptions once** and drives listen/chat/summary/transcript visibility through **pure helpers** (`shouldShowChatFab`, `getGenerateSummaryNoteId`, `getTranscriptFloatingAction`) that take `currentView` plus fetched state.
> 
> The overflow menu **replaces the broad `useCurrentNoteHasContent` check** with `useUploadCurrentViewHasContent`, which only reads `raw_md`, enhanced `content`, or transcript presence for the **active** view when deciding whether upload actions appear.
> 
> Tests add a `renderFloatingActionButton` helper with an explicit `currentView` prop and mock store cells for overflow upload gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0838e9e9735da83432e64f74376a10b3eb486dd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->