### PR TITLE
Reduce start recording sidebar collapse cost

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -634,7 +634,7 @@ describe("ClassicMainBody", () => {
     expect(panels[1]?.dataset.minWidth).toBe("500");
   });
 
-  it("collapses the sidebar panel without unmounting the animated shell", () => {
+  it("collapses the sidebar panel and unmounts hidden timeline content", () => {
     mocks.leftsidebar.expanded = false;
 
     render(<ClassicMainBody />);
@@ -643,7 +643,7 @@ describe("ClassicMainBody", () => {
 
     expect(resizeHandle.dataset.className).toContain("pointer-events-none");
     expect(resizeHandle.dataset.className).toContain("w-0");
-    expect(screen.getByTestId("classic-main-sidebar")).toBeTruthy();
+    expect(screen.queryByTestId("classic-main-sidebar")).toBeNull();
 
     const panels = screen.getAllByTestId("panel");
     expect(panels).toHaveLength(2);

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -616,7 +616,6 @@ export function ClassicMainBody() {
                 ])}
               >
                 <ClassicMainSidebar
-                  forceMount
                   showIgnoredTimelineEvents={showIgnoredTimelineEvents}
                   onShowIgnoredTimelineEventsChange={
                     setShowIgnoredTimelineEvents

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -18,6 +18,7 @@ const {
   useConfigValueMock,
   useSTTConnectionMock,
   isSupportedLanguagesLiveMock,
+  leftSidebarExpanded,
   setLeftSidebarExpandedMock,
   settingsUseStoreMock,
   deleteProcessedAudioForRetentionMock,
@@ -36,6 +37,7 @@ const {
   useConfigValueMock: vi.fn(),
   useSTTConnectionMock: vi.fn(),
   isSupportedLanguagesLiveMock: vi.fn(),
+  leftSidebarExpanded: { value: true },
   setLeftSidebarExpandedMock: vi.fn(),
   settingsUseStoreMock: vi.fn(),
   deleteProcessedAudioForRetentionMock: vi.fn(),
@@ -95,6 +97,7 @@ vi.mock("~/services/audio-retention", () => ({
 vi.mock("~/contexts/shell", () => ({
   useShell: vi.fn(() => ({
     leftsidebar: {
+      expanded: leftSidebarExpanded.value,
       setExpanded: setLeftSidebarExpandedMock,
     },
   })),
@@ -195,6 +198,7 @@ describe("useStartListening", () => {
     useConfigValueMock.mockImplementation((key) =>
       key === "ai_language" ? "en" : [],
     );
+    leftSidebarExpanded.value = true;
     settingsUseStoreMock.mockReturnValue(settingsStoreMock);
     mainStoreMock.getCell.mockImplementation(() => "");
     mainStoreMock.forEachRow.mockImplementation(() => {});
@@ -216,6 +220,18 @@ describe("useStartListening", () => {
   });
 
   test("collapses the left sidebar after listening starts", async () => {
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(setLeftSidebarExpandedMock).toHaveBeenCalledWith(false);
+  });
+
+  test("sets the left sidebar collapsed after listening starts even if render state is stale", async () => {
+    leftSidebarExpanded.value = false;
+
     const { result } = renderHook(() => useStartListening("session-1"));
 
     await act(async () => {


### PR DESCRIPTION
Unmount hidden timeline content when the left sidebar collapses and skip redundant collapse updates when recording starts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly lifecycle and data-flow refactors with tests; the hydration gate slightly changes when default summaries are created.
> 
> **Overview**
> **Reduces work when the left sidebar collapses (especially at recording start)** by dropping `forceMount` on `ClassicMainSidebar`, so hidden timeline content unmounts instead of staying mounted behind the collapse animation.
> 
> **Moves session note UI state up to `TabContentNoteInner`** so editor tabs, current view, transcript-tab visibility, and tab changes are computed once and passed into `NoteInput` (with `createEditorTabs`, `getCanShowTranscript`, and `computeCurrentNoteTab` exported/shared for that path). `NoteInput` now either renders with those props or falls back to the old hook-driven wrapper.
> 
> **Default summary rows** are created via `useEnsureDefaultSummaryFromState` with `enabled: contentHydrated`, avoiding `ensureNote` before session content has loaded. Tests cover the disabled case and updated sidebar collapse expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b8a826435b611533c0ef07fe7f3c262075b4334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->