### PR TITLE
Reduce recording start editor renders

### DIFF
--- a/apps/desktop/src/audio-player/index.tsx
+++ b/apps/desktop/src/audio-player/index.tsx
@@ -1,3 +1,7 @@
-export { AudioPlayerProvider as Provider, useAudioPlayer } from "./provider";
+export {
+  AudioPlayerProvider as Provider,
+  useAudioExists,
+  useAudioPlayer,
+} from "./provider";
 export { Timeline } from "./timeline";
 export { TimelineMeta, TimelineShell } from "./timeline-shell";

--- a/apps/desktop/src/audio-player/provider.tsx
+++ b/apps/desktop/src/audio-player/provider.tsx
@@ -96,6 +96,21 @@ export function useAudioTime(): TimeSnapshot {
   return useSyncExternalStore(timeStore.subscribe, timeStore.getSnapshot);
 }
 
+export function useAudioExists(sessionId: string): boolean {
+  const audioExists = useQuery({
+    queryKey: ["audio", sessionId, "exist"],
+    queryFn: () => fsSyncCommands.audioExist(sessionId),
+    select: (result) => {
+      if (result.status === "error") {
+        throw new Error(result.error);
+      }
+      return result.data;
+    },
+  });
+
+  return audioExists.data ?? false;
+}
+
 export function AudioPlayerProvider({
   sessionId,
   url,
@@ -113,17 +128,7 @@ export function AudioPlayerProvider({
   const [playbackRate, setPlaybackRateState] = useState(1);
   const timeStoreRef = useRef(new TimeStore());
   const stopRequestedRef = useRef(false);
-
-  const audioExists = useQuery({
-    queryKey: ["audio", sessionId, "exist"],
-    queryFn: () => fsSyncCommands.audioExist(sessionId),
-    select: (result) => {
-      if (result.status === "error") {
-        throw new Error(result.error);
-      }
-      return result.data;
-    },
-  });
+  const audioExistsValue = useAudioExists(sessionId);
 
   const registerContainer = useCallback((el: HTMLDivElement | null) => {
     setContainer((prev) => (prev === el ? prev : el));
@@ -327,8 +332,6 @@ export function AudioPlayerProvider({
       });
     },
   });
-
-  const audioExistsValue = audioExists.data ?? false;
 
   const value = useMemo<AudioPlayerContextValue>(
     () => ({

--- a/apps/desktop/src/session/components/listen-action.tsx
+++ b/apps/desktop/src/session/components/listen-action.tsx
@@ -17,10 +17,46 @@ import { useStartListening } from "~/stt/useStartListening";
 export function ListenActionButton({ sessionId }: { sessionId: string }) {
   const { shouldRender, isDisabled, warningMessage } =
     useListenButtonState(sessionId);
-  const { loading, stop } = useListener((state) => ({
-    loading: state.live.loading && state.live.sessionId === sessionId,
-    stop: state.stop,
-  }));
+  const loading = useListener(
+    (state) => state.live.loading && state.live.sessionId === sessionId,
+  );
+
+  if (loading) {
+    return <StopListeningButton />;
+  }
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  return (
+    <StartListeningButton
+      sessionId={sessionId}
+      isDisabled={isDisabled}
+      warningMessage={warningMessage}
+    />
+  );
+}
+
+function StopListeningButton() {
+  const stop = useListener((state) => state.stop);
+
+  return (
+    <FloatingButton onClick={stop}>
+      <Spinner />
+    </FloatingButton>
+  );
+}
+
+function StartListeningButton({
+  sessionId,
+  isDisabled,
+  warningMessage,
+}: {
+  sessionId: string;
+  isDisabled: boolean;
+  warningMessage: string;
+}) {
   const startListening = useStartListening(sessionId);
   const openNew = useTabs((state) => state.openNew);
   const noteHasContent = useCurrentNoteHasContent(sessionId, { type: "raw" });
@@ -29,18 +65,6 @@ export function ListenActionButton({ sessionId }: { sessionId: string }) {
     startListening();
     openNew({ type: "settings", state: { tab: "transcription" } });
   }, [startListening, openNew]);
-
-  if (loading) {
-    return (
-      <FloatingButton onClick={stop}>
-        <Spinner />
-      </FloatingButton>
-    );
-  }
-
-  if (!shouldRender) {
-    return null;
-  }
 
   return (
     <div>

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -42,49 +42,7 @@ export function TabContentNote({
   tab: Extract<Tab, { type: "sessions" }>;
 }) {
   const sessionMode = useListener((state) => state.getSessionMode(tab.id));
-  const canStartLiveSession = useListener((state) =>
-    state.canStartLiveSession(tab.id),
-  );
-  const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
-  const { conn } = useSTTConnection();
-  const startListening = useStartListening(tab.id);
-  const hasAttemptedAutoStart = useRef(false);
-
-  useEffect(() => {
-    if (!tab.state.autoStart) {
-      hasAttemptedAutoStart.current = false;
-      return;
-    }
-
-    if (standaloneWindow) {
-      return;
-    }
-
-    if (hasAttemptedAutoStart.current) {
-      return;
-    }
-
-    if (!canStartLiveSession) {
-      return;
-    }
-
-    if (!conn) {
-      return;
-    }
-
-    hasAttemptedAutoStart.current = true;
-    startListening();
-    updateSessionTabState(tab, { ...tab.state, autoStart: null });
-  }, [
-    tab.id,
-    tab.state,
-    tab.state.autoStart,
-    standaloneWindow,
-    canStartLiveSession,
-    conn,
-    startListening,
-    updateSessionTabState,
-  ]);
+  const audioExists = AudioPlayer.useAudioExists(tab.id);
 
   const audioUrlQuery = useQuery({
     enabled: sessionMode !== "active" && sessionMode !== "finalizing",
@@ -101,12 +59,16 @@ export function TabContentNote({
 
   return (
     <CaretPositionProvider>
+      {tab.state.autoStart && !standaloneWindow ? (
+        <AutoStartListening tab={tab} />
+      ) : null}
       <SearchProvider>
         <AudioPlayer.Provider sessionId={tab.id} url={audioUrl ?? ""}>
           <TabContentNoteInner
             tab={tab}
             standaloneWindow={standaloneWindow}
             audioUrlReady={Boolean(audioUrl)}
+            audioExists={audioExists}
           />
         </AudioPlayer.Provider>
       </SearchProvider>
@@ -114,29 +76,126 @@ export function TabContentNote({
   );
 }
 
+function AutoStartListening({
+  tab,
+}: {
+  tab: Extract<Tab, { type: "sessions" }>;
+}) {
+  const canStartLiveSession = useListener((state) =>
+    state.canStartLiveSession(tab.id),
+  );
+  const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
+  const { conn } = useSTTConnection();
+  const startListening = useStartListening(tab.id);
+  const hasAttemptedAutoStart = useRef(false);
+
+  useEffect(() => {
+    if (hasAttemptedAutoStart.current) {
+      return;
+    }
+
+    if (!canStartLiveSession) {
+      return;
+    }
+
+    if (!conn) {
+      return;
+    }
+
+    hasAttemptedAutoStart.current = true;
+    startListening();
+    updateSessionTabState(tab, { ...tab.state, autoStart: null });
+  }, [
+    tab,
+    tab.state,
+    canStartLiveSession,
+    conn,
+    startListening,
+    updateSessionTabState,
+  ]);
+
+  return null;
+}
+
 function TabContentNoteInner({
   tab,
   standaloneWindow,
   audioUrlReady,
+  audioExists,
 }: {
   tab: Extract<Tab, { type: "sessions" }>;
   standaloneWindow: boolean;
   audioUrlReady: boolean;
+  audioExists: boolean;
 }) {
   const noteInputRef = React.useRef<NoteInputHandle>(null);
 
-  const { audioExists } = AudioPlayer.useAudioPlayer();
-  const editorTabs = useEditorTabs({ sessionId: tab.id, audioExists });
-  const currentView = useCurrentNoteTab(tab, { audioExists });
-  const contentHydrated = useHydrateSessionContent(tab.id);
+  const sessionId = tab.id;
+  usePendingUpload(sessionId);
+
+  const hasTranscript = useHasTranscript(sessionId);
+  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
+  const batchError = useListener((state) => state.batch[sessionId]?.error);
+  const hasLiveSegments = useListener(
+    (state) =>
+      state.live.sessionId === sessionId && state.liveSegments.length > 0,
+  );
+  const canShowTranscript = getCanShowTranscript({
+    audioExists,
+    batchError: Boolean(batchError),
+    hasLiveSegments,
+    hasTranscript,
+    sessionMode,
+  });
+  const canShowInsights = useCanShowInsights(sessionId);
+  const enhancedNoteIds =
+    main.UI.useSliceRowIds(
+      main.INDEXES.enhancedNotesBySession,
+      sessionId,
+      main.STORE_ID,
+    ) ?? [];
+  const firstEnhancedNoteId = enhancedNoteIds[0];
+  useEnsureDefaultSummaryFromState({
+    batchError: Boolean(batchError),
+    enhancedNoteCount: enhancedNoteIds.length,
+    hasTranscript,
+    sessionId,
+    sessionMode,
+  });
+  const contentHydrated = useHydrateSessionContent(sessionId);
   const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
 
-  const sessionId = tab.id;
   const { skipReason } = useAutoEnhance(tab);
-  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const isTranscribing = shouldShowTranscriptTabSpinner(sessionMode);
+  const isLiveSessionActive = sessionMode === "active";
+  const editorTabs = React.useMemo(
+    () =>
+      createEditorTabs({
+        enhancedNoteIds,
+        canShowInsights,
+        canShowTranscript,
+      }),
+    [enhancedNoteIds, canShowInsights, canShowTranscript],
+  );
+  const currentView = React.useMemo(() => {
+    if (tab.state.view?.type === "insights" && canShowInsights) {
+      return tab.state.view;
+    }
+
+    return computeCurrentNoteTab(
+      tab.state.view ?? null,
+      isLiveSessionActive,
+      firstEnhancedNoteId,
+      canShowTranscript,
+    );
+  }, [
+    tab.state.view,
+    isLiveSessionActive,
+    firstEnhancedNoteId,
+    canShowTranscript,
+    canShowInsights,
+  ]);
   useAutoFocusTitle({ sessionId, noteInputRef });
-  usePendingUpload(sessionId);
 
   const showTopAudioPlayer = shouldShowSessionTopAudioPlayer({
     audioExists,


### PR DESCRIPTION
Keep expensive recording-start hooks out of inactive render branches and read audio existence through a narrow query hook instead of the full playback context.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5903
- <kbd>&nbsp;1&nbsp;</kbd> #5902 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI performance refactors with equivalent behavior; session tab and timeline selection logic are moderately touched but not security- or data-critical paths.
> 
> **Overview**
> Cuts unnecessary React work when starting or viewing sessions by **narrowing subscriptions** and **splitting render branches**.
> 
> **Session note tab:** `useAudioExists` reads the same React Query cache as the player but without subscribing to WaveSurfer/playback context. Auto-start listening runs in a small `AutoStartListening` child instead of the main tab body. `TabContentNoteInner` builds editor tabs and the active view from explicit state (`createEditorTabs`, `computeCurrentNoteTab`, transcript/insights flags) instead of `useEditorTabs` / `useCurrentNoteTab`, which pulled in heavier hooks via the audio player context.
> 
> **Listen FAB:** While a session is connecting, only `StopListeningButton` mounts (stop action); start/configure hooks stay in `StartListeningButton` when idle.
> 
> **Sidebar timeline:** Timeline items receive a stable `getFlatItemKeys()` (ref-backed) for shift-range selection instead of a new `flatItemKeys` array each parent render. `ItemBase` is memoized with a custom props equality check to limit row re-renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ced4850ed025c213ea45ea76eb5db3b687c42251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->