### PR TITLE
Stabilize timeline item renders

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -160,6 +160,9 @@ export const TimelineView = memo(function TimelineView({
     }
     return keys;
   }, [buckets]);
+  const flatItemKeysRef = useRef(flatItemKeys);
+  flatItemKeysRef.current = flatItemKeys;
+  const getFlatItemKeys = useCallback(() => flatItemKeysRef.current, []);
   const flatSessionItemKeys = useMemo(
     () => flatItemKeys.filter(isSessionItemKey),
     [flatItemKeys],
@@ -516,7 +519,7 @@ export const TimelineView = memo(function TimelineView({
                   suppressCurrentTimeIndicator={hasActiveVisibleSession}
                   timezone={timezone}
                   selectedIds={selectedIds}
-                  flatItemKeys={flatItemKeys}
+                  getFlatItemKeys={getFlatItemKeys}
                   upcomingItemKey={upcomingMeetingStatus?.itemKey}
                   upcomingItemLabel={upcomingMeetingStatus?.label}
                   upcomingItemNodeRef={setUpcomingMeetingNodeRef}
@@ -534,7 +537,7 @@ export const TimelineView = memo(function TimelineView({
                       selected={selected}
                       timezone={timezone}
                       multiSelected={selectedIds.includes(itemKey)}
-                      flatItemKeys={flatItemKeys}
+                      getFlatItemKeys={getFlatItemKeys}
                       selectedNodeRef={
                         selected ? scrollSelectedSessionIntoView : undefined
                       }
@@ -852,7 +855,7 @@ function TodayBucket({
   suppressCurrentTimeIndicator,
   timezone,
   selectedIds,
-  flatItemKeys,
+  getFlatItemKeys,
   upcomingItemKey,
   upcomingItemLabel,
   upcomingItemNodeRef,
@@ -865,7 +868,7 @@ function TodayBucket({
   suppressCurrentTimeIndicator: boolean;
   timezone?: string;
   selectedIds: string[];
-  flatItemKeys: string[];
+  getFlatItemKeys: () => string[];
   upcomingItemKey?: string;
   upcomingItemLabel?: string;
   upcomingItemNodeRef: RefCallback<HTMLDivElement>;
@@ -939,7 +942,7 @@ function TodayBucket({
           selected={selected}
           timezone={timezone}
           multiSelected={selectedIds.includes(itemKey)}
-          flatItemKeys={flatItemKeys}
+          getFlatItemKeys={getFlatItemKeys}
           selectedNodeRef={selected ? selectedNodeRef : undefined}
           itemNodeRef={
             itemKey === upcomingItemKey ? upcomingItemNodeRef : undefined
@@ -1009,7 +1012,7 @@ function TodayBucket({
     suppressCurrentTimeIndicator,
     timezone,
     selectedIds,
-    flatItemKeys,
+    getFlatItemKeys,
     upcomingItemKey,
     upcomingItemLabel,
     upcomingItemNodeRef,

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -37,87 +37,9 @@ import { useTabs } from "~/store/zustand/tabs";
 import { useTimelineSelection } from "~/store/zustand/timeline-selection";
 import { useListener } from "~/stt/contexts";
 
-export const TimelineItemComponent = memo(
-  ({
-    item,
-    precision,
-    selected,
-    timezone,
-    multiSelected,
-    flatItemKeys,
-    selectedNodeRef,
-    itemNodeRef,
-    isUpcoming,
-    upcomingLabel,
-  }: {
-    item: TimelineItem;
-    precision: TimelinePrecision;
-    selected: boolean;
-    timezone?: string;
-    multiSelected: boolean;
-    flatItemKeys: string[];
-    selectedNodeRef?: RefCallback<HTMLDivElement>;
-    itemNodeRef?: RefCallback<HTMLDivElement>;
-    isUpcoming?: boolean;
-    upcomingLabel?: string;
-  }) => {
-    if (item.type === "event") {
-      return (
-        <EventItem
-          item={item}
-          precision={precision}
-          selected={selected}
-          timezone={timezone}
-          multiSelected={multiSelected}
-          flatItemKeys={flatItemKeys}
-          selectedNodeRef={selectedNodeRef}
-          itemNodeRef={itemNodeRef}
-          isUpcoming={isUpcoming}
-          upcomingLabel={upcomingLabel}
-        />
-      );
-    }
-    return (
-      <SessionItem
-        item={item}
-        precision={precision}
-        selected={selected}
-        timezone={timezone}
-        multiSelected={multiSelected}
-        flatItemKeys={flatItemKeys}
-        selectedNodeRef={selectedNodeRef}
-        itemNodeRef={itemNodeRef}
-        isUpcoming={isUpcoming}
-        upcomingLabel={upcomingLabel}
-      />
-    );
-  },
-);
+const EMPTY_TIMELINE_ITEM_KEYS: string[] = [];
 
-function ItemBase({
-  title,
-  displayTime,
-  isLive,
-  amplitude,
-  showSpinner,
-  selected,
-  ignored,
-  muted,
-  multiSelected,
-  onClick,
-  onDoubleClick,
-  onCmdClick,
-  onShiftClick,
-  onStop,
-  onDragStart,
-  contextMenu,
-  draggable,
-  selectedNodeRef,
-  itemNodeRef,
-  timelineSessionId,
-  isUpcoming,
-  upcomingLabel,
-}: {
+type ItemBaseProps = {
   title: string;
   displayTime: string;
   isLive?: boolean;
@@ -140,7 +62,94 @@ function ItemBase({
   timelineSessionId?: string;
   isUpcoming?: boolean;
   upcomingLabel?: string;
-}) {
+};
+
+export const TimelineItemComponent = memo(
+  ({
+    item,
+    precision,
+    selected,
+    timezone,
+    multiSelected,
+    flatItemKeys,
+    getFlatItemKeys,
+    selectedNodeRef,
+    itemNodeRef,
+    isUpcoming,
+    upcomingLabel,
+  }: {
+    item: TimelineItem;
+    precision: TimelinePrecision;
+    selected: boolean;
+    timezone?: string;
+    multiSelected: boolean;
+    flatItemKeys?: string[];
+    getFlatItemKeys?: () => string[];
+    selectedNodeRef?: RefCallback<HTMLDivElement>;
+    itemNodeRef?: RefCallback<HTMLDivElement>;
+    isUpcoming?: boolean;
+    upcomingLabel?: string;
+  }) => {
+    const readFlatItemKeys =
+      getFlatItemKeys ?? (() => flatItemKeys ?? EMPTY_TIMELINE_ITEM_KEYS);
+
+    if (item.type === "event") {
+      return (
+        <EventItem
+          item={item}
+          precision={precision}
+          selected={selected}
+          timezone={timezone}
+          multiSelected={multiSelected}
+          getFlatItemKeys={readFlatItemKeys}
+          selectedNodeRef={selectedNodeRef}
+          itemNodeRef={itemNodeRef}
+          isUpcoming={isUpcoming}
+          upcomingLabel={upcomingLabel}
+        />
+      );
+    }
+    return (
+      <SessionItem
+        item={item}
+        precision={precision}
+        selected={selected}
+        timezone={timezone}
+        multiSelected={multiSelected}
+        getFlatItemKeys={readFlatItemKeys}
+        selectedNodeRef={selectedNodeRef}
+        itemNodeRef={itemNodeRef}
+        isUpcoming={isUpcoming}
+        upcomingLabel={upcomingLabel}
+      />
+    );
+  },
+);
+
+const ItemBase = memo(function ItemBase({
+  title,
+  displayTime,
+  isLive,
+  amplitude,
+  showSpinner,
+  selected,
+  ignored,
+  muted,
+  multiSelected,
+  onClick,
+  onDoubleClick,
+  onCmdClick,
+  onShiftClick,
+  onStop,
+  onDragStart,
+  contextMenu,
+  draggable,
+  selectedNodeRef,
+  itemNodeRef,
+  timelineSessionId,
+  isUpcoming,
+  upcomingLabel,
+}: ItemBaseProps) {
   const { t } = useLingui();
   const hasSelection = useTimelineSelection((s) => s.selectedIds.length > 0);
   const showLiveStop = isLive && onStop;
@@ -271,6 +280,33 @@ function ItemBase({
       ) : null}
     </div>
   );
+}, itemBasePropsAreEqual);
+
+function itemBasePropsAreEqual(prev: ItemBaseProps, next: ItemBaseProps) {
+  return (
+    prev.title === next.title &&
+    prev.displayTime === next.displayTime &&
+    prev.isLive === next.isLive &&
+    prev.amplitude === next.amplitude &&
+    prev.showSpinner === next.showSpinner &&
+    prev.selected === next.selected &&
+    prev.ignored === next.ignored &&
+    prev.muted === next.muted &&
+    prev.multiSelected === next.multiSelected &&
+    prev.onClick === next.onClick &&
+    prev.onDoubleClick === next.onDoubleClick &&
+    prev.onCmdClick === next.onCmdClick &&
+    prev.onShiftClick === next.onShiftClick &&
+    prev.onStop === next.onStop &&
+    prev.onDragStart === next.onDragStart &&
+    prev.contextMenu === next.contextMenu &&
+    prev.draggable === next.draggable &&
+    prev.selectedNodeRef === next.selectedNodeRef &&
+    prev.itemNodeRef === next.itemNodeRef &&
+    prev.timelineSessionId === next.timelineSessionId &&
+    prev.isUpcoming === next.isUpcoming &&
+    prev.upcomingLabel === next.upcomingLabel
+  );
 }
 
 const EventItem = memo(
@@ -280,7 +316,7 @@ const EventItem = memo(
     selected,
     timezone,
     multiSelected,
-    flatItemKeys,
+    getFlatItemKeys,
     selectedNodeRef,
     itemNodeRef,
     isUpcoming,
@@ -291,7 +327,7 @@ const EventItem = memo(
     selected: boolean;
     timezone?: string;
     multiSelected: boolean;
-    flatItemKeys: string[];
+    getFlatItemKeys: () => string[];
     selectedNodeRef?: RefCallback<HTMLDivElement>;
     itemNodeRef?: RefCallback<HTMLDivElement>;
     isUpcoming?: boolean;
@@ -343,8 +379,8 @@ const EventItem = memo(
     }, [itemKey]);
 
     const handleShiftClick = useCallback(() => {
-      useTimelineSelection.getState().selectRange(flatItemKeys, itemKey);
-    }, [flatItemKeys, itemKey]);
+      useTimelineSelection.getState().selectRange(getFlatItemKeys(), itemKey);
+    }, [getFlatItemKeys, itemKey]);
 
     const handleIgnore = useCallback(() => {
       if (!trackingIdEvent) return;
@@ -439,7 +475,7 @@ const SessionItem = memo(
     selected,
     timezone,
     multiSelected,
-    flatItemKeys,
+    getFlatItemKeys,
     selectedNodeRef,
     itemNodeRef,
     isUpcoming,
@@ -450,7 +486,7 @@ const SessionItem = memo(
     selected: boolean;
     timezone?: string;
     multiSelected: boolean;
-    flatItemKeys: string[];
+    getFlatItemKeys: () => string[];
     selectedNodeRef?: RefCallback<HTMLDivElement>;
     itemNodeRef?: RefCallback<HTMLDivElement>;
     isUpcoming?: boolean;
@@ -512,8 +548,8 @@ const SessionItem = memo(
     }, [itemKey]);
 
     const handleShiftClick = useCallback(() => {
-      useTimelineSelection.getState().selectRange(flatItemKeys, itemKey);
-    }, [flatItemKeys, itemKey]);
+      useTimelineSelection.getState().selectRange(getFlatItemKeys(), itemKey);
+    }, [getFlatItemKeys, itemKey]);
 
     const handleOpenStandaloneWindow = useCallback(() => {
       void openStandaloneNoteWindow(sessionId);


### PR DESCRIPTION
Keep shift-click range data behind a stable getter and memoize the timeline row shell so sidebar panel updates do not recreate every item action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Timeline selection and memoization affect multi-select UX and re-render behavior; editor plugins change placeholder visibility and when trailing paragraphs are inserted during edits.
> 
> **Overview**
> **Sidebar timeline** no longer passes the full `flatItemKeys` array into every row. A stable `getFlatItemKeys` reads the latest keys from a ref at **shift-click** time, and **`ItemBase`** is wrapped in **`memo`** with a custom props comparator so unrelated sidebar updates do not recreate row shells and click handlers.
> 
> **Note editor plugins** are tightened for correctness and cost: **`imageTrailingParagraphPlugin`** only inspects images in **transaction changed ranges** (including neighbors), with new Vitest coverage for insert, delete, multi-paste, and plain text edits. **`placeholderPlugin`** now applies a single decoration to the **selection’s empty block** (top-level, nested, or gap-cursor-adjacent) instead of walking the whole document, also covered by new tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37eb8cfd87482b4f2abc7795ab76938b5f7ceffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->