### PR TITLE
Scope editor transaction plugins

### DIFF
--- a/packages/editor/src/plugins/autolink.ts
+++ b/packages/editor/src/plugins/autolink.ts
@@ -1,5 +1,6 @@
 import { Plugin, PluginKey, type Transaction } from "prosemirror-state";
 
+import { getChangedTextblockRanges } from "./changed-ranges";
 import { isValidUrl, normalizeUrlHref } from "./url";
 
 const URL_CANDIDATE_REGEX =
@@ -76,26 +77,33 @@ export function autolinkPlugin() {
 
       let tr: Transaction | null = null;
 
-      newState.doc.descendants((node, pos, parent) => {
-        if (!node.isText || !node.text || parent?.type.spec.code) {
-          return;
-        }
+      const changedTextblockRanges = getChangedTextblockRanges(
+        newState.doc,
+        transactions,
+      );
 
-        for (const match of findAutolinkMatches(node.text)) {
-          const from = pos + match.start;
-          const to = pos + match.end;
-          if (newState.doc.rangeHasMark(from, to, linkType)) {
-            continue;
+      for (const range of changedTextblockRanges) {
+        newState.doc.nodesBetween(range.from, range.to, (node, pos, parent) => {
+          if (!node.isText || !node.text || parent?.type.spec.code) {
+            return;
           }
 
-          if (!tr) tr = newState.tr;
-          tr.addMark(
-            from,
-            to,
-            linkType.create({ href: match.href, target: null }),
-          );
-        }
-      });
+          for (const match of findAutolinkMatches(node.text)) {
+            const from = pos + match.start;
+            const to = pos + match.end;
+            if (newState.doc.rangeHasMark(from, to, linkType)) {
+              continue;
+            }
+
+            if (!tr) tr = newState.tr;
+            tr.addMark(
+              from,
+              to,
+              linkType.create({ href: match.href, target: null }),
+            );
+          }
+        });
+      }
 
       return tr;
     },

--- a/packages/editor/src/plugins/changed-ranges.ts
+++ b/packages/editor/src/plugins/changed-ranges.ts
@@ -1,0 +1,150 @@
+import type { Node as PMNode } from "prosemirror-model";
+import type { Transaction } from "prosemirror-state";
+
+export type ChangedRange = {
+  from: number;
+  to: number;
+};
+
+export function getChangedRanges(transactions: readonly Transaction[]) {
+  const ranges: ChangedRange[] = [];
+
+  for (const transaction of transactions) {
+    if (!transaction.docChanged) continue;
+    transaction.mapping.maps.forEach((stepMap) => {
+      stepMap.forEach((_oldStart, _oldEnd, newStart, newEnd) => {
+        ranges.push({ from: newStart, to: newEnd });
+      });
+    });
+  }
+
+  return ranges;
+}
+
+export function hasChangedRange(
+  ranges: readonly ChangedRange[],
+  from: number,
+  to: number,
+) {
+  return ranges.some((range) =>
+    range.from === range.to
+      ? from <= range.from && range.from <= to
+      : range.from < to && from < range.to,
+  );
+}
+
+export function getChangedTextblockRanges(
+  doc: PMNode,
+  transactions: readonly Transaction[],
+) {
+  return mergeRanges(
+    getChangedRanges(transactions).flatMap((range) =>
+      getTextblockRangesForRange(doc, range),
+    ),
+  );
+}
+
+export function hasChangedNodeOfType(
+  doc: PMNode,
+  transactions: readonly Transaction[],
+  nodeTypeName: string,
+) {
+  return getChangedRanges(transactions).some((range) => {
+    if (
+      hasAncestorNodeOfType(doc, range.from, nodeTypeName) ||
+      hasAncestorNodeOfType(doc, range.to, nodeTypeName)
+    ) {
+      return true;
+    }
+
+    let found = false;
+    const from = clampPosition(range.from, doc.content.size);
+    const to = clampPosition(Math.max(range.to, range.from), doc.content.size);
+    doc.nodesBetween(from, to, (node) => {
+      if (node.type.name === nodeTypeName) {
+        found = true;
+        return false;
+      }
+
+      return !found;
+    });
+    return found;
+  });
+}
+
+function hasAncestorNodeOfType(doc: PMNode, pos: number, nodeTypeName: string) {
+  const resolved = doc.resolve(clampPosition(pos, doc.content.size));
+  for (let depth = resolved.depth; depth > 0; depth--) {
+    if (resolved.node(depth).type.name === nodeTypeName) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function getTextblockRangesForRange(doc: PMNode, range: ChangedRange) {
+  const ranges: ChangedRange[] = [];
+  const docSize = doc.content.size;
+  const from = clampPosition(range.from, docSize);
+  const to = clampPosition(Math.max(range.to, range.from), docSize);
+
+  addParentTextblockRange(doc, from, ranges);
+  addParentTextblockRange(doc, to, ranges);
+
+  if (from < to) {
+    doc.nodesBetween(from, to, (node, pos) => {
+      if (!node.isTextblock) {
+        return true;
+      }
+
+      ranges.push({
+        from: pos + 1,
+        to: pos + node.nodeSize - 1,
+      });
+      return false;
+    });
+  }
+
+  return ranges;
+}
+
+function addParentTextblockRange(
+  doc: PMNode,
+  pos: number,
+  ranges: ChangedRange[],
+) {
+  const resolved = doc.resolve(pos);
+  for (let depth = resolved.depth; depth > 0; depth--) {
+    const node = resolved.node(depth);
+    if (!node.isTextblock) {
+      continue;
+    }
+
+    ranges.push({ from: resolved.start(depth), to: resolved.end(depth) });
+    return;
+  }
+}
+
+function mergeRanges(ranges: ChangedRange[]) {
+  const sorted = ranges
+    .filter((range) => range.to >= range.from)
+    .sort((a, b) => a.from - b.from || a.to - b.to);
+  const merged: ChangedRange[] = [];
+
+  for (const range of sorted) {
+    const last = merged[merged.length - 1];
+    if (!last || range.from > last.to) {
+      merged.push({ ...range });
+      continue;
+    }
+
+    last.to = Math.max(last.to, range.to);
+  }
+
+  return merged;
+}
+
+function clampPosition(pos: number, docSize: number) {
+  return Math.max(0, Math.min(pos, docSize));
+}

--- a/packages/editor/src/plugins/hashtag.test.ts
+++ b/packages/editor/src/plugins/hashtag.test.ts
@@ -1,0 +1,48 @@
+import { EditorState } from "prosemirror-state";
+import { describe, expect, it } from "vitest";
+
+import { schema } from "../note/schema";
+import { hashtagPlugin, hashtagPluginKey } from "./hashtag";
+
+describe("hashtagPlugin", () => {
+  it("updates decorations for the changed block", () => {
+    let state = createState("#one #two");
+
+    expect(getHashtagDecorationCount(state)).toBe(2);
+
+    state = state.apply(state.tr.delete(1, 5));
+
+    expect(getHashtagDecorationCount(state)).toBe(1);
+  });
+
+  it("keeps decorations in unchanged blocks", () => {
+    let state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [schema.text("#one")]),
+        schema.node("paragraph", null, [schema.text("#two")]),
+      ]),
+      plugins: [hashtagPlugin()],
+    });
+
+    expect(getHashtagDecorationCount(state)).toBe(2);
+
+    state = state.apply(state.tr.insertText("!", state.doc.content.size - 1));
+
+    expect(getHashtagDecorationCount(state)).toBe(2);
+  });
+});
+
+function createState(text: string) {
+  return EditorState.create({
+    schema,
+    doc: schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text(text)]),
+    ]),
+    plugins: [hashtagPlugin()],
+  });
+}
+
+function getHashtagDecorationCount(state: EditorState) {
+  return hashtagPluginKey.getState(state).find().length;
+}

--- a/packages/editor/src/plugins/hashtag.ts
+++ b/packages/editor/src/plugins/hashtag.ts
@@ -2,6 +2,8 @@ import { type Node as PMNode } from "prosemirror-model";
 import { Plugin, PluginKey } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 
+import { getChangedTextblockRanges, type ChangedRange } from "./changed-ranges";
+
 const HASHTAG_REGEX = /#([\p{L}\p{N}_\p{Emoji}\p{Emoji_Component}]+)/gu;
 const LEADING_PUNCTUATION_REGEX = /^[([{<"'`]+/u;
 const HTTP_PREFIXES = ["http://", "https://", "www."];
@@ -77,24 +79,61 @@ export const hashtagPluginKey = new PluginKey("hashtagDecoration");
 export function hashtagPlugin() {
   return new Plugin({
     key: hashtagPluginKey,
+    state: {
+      init(_config, state) {
+        return buildHashtagDecorationSet(state.doc);
+      },
+      apply(tr, decorationSet) {
+        let next = decorationSet.map(tr.mapping, tr.doc);
+        if (!tr.docChanged) {
+          return next;
+        }
+
+        const changedTextblockRanges = getChangedTextblockRanges(tr.doc, [tr]);
+        for (const range of changedTextblockRanges) {
+          next = next.remove(next.find(range.from, range.to));
+        }
+
+        return next.add(
+          tr.doc,
+          buildHashtagDecorations(tr.doc, changedTextblockRanges),
+        );
+      },
+    },
     props: {
       decorations(state) {
-        const { doc } = state;
-        const decorations: Decoration[] = [];
-
-        doc.descendants((node: PMNode, pos: number) => {
-          if (!node.isText || !node.text) return;
-          for (const match of findHashtags(node.text)) {
-            decorations.push(
-              Decoration.inline(pos + match.start, pos + match.end, {
-                class: "hashtag",
-              }),
-            );
-          }
-        });
-
-        return DecorationSet.create(doc, decorations);
+        return hashtagPluginKey.getState(state);
       },
     },
   });
+}
+
+function buildHashtagDecorationSet(doc: PMNode) {
+  return DecorationSet.create(doc, buildHashtagDecorations(doc));
+}
+
+function buildHashtagDecorations(doc: PMNode, ranges?: ChangedRange[]) {
+  const decorations: Decoration[] = [];
+  const visitRange = (from: number, to: number) => {
+    doc.nodesBetween(from, to, (node: PMNode, pos: number) => {
+      if (!node.isText || !node.text) return;
+      for (const match of findHashtags(node.text)) {
+        decorations.push(
+          Decoration.inline(pos + match.start, pos + match.end, {
+            class: "hashtag",
+          }),
+        );
+      }
+    });
+  };
+
+  if (ranges) {
+    for (const range of ranges) {
+      visitRange(range.from, range.to);
+    }
+  } else {
+    visitRange(0, doc.content.size);
+  }
+
+  return decorations;
 }

--- a/packages/editor/src/plugins/link-boundary-guard.ts
+++ b/packages/editor/src/plugins/link-boundary-guard.ts
@@ -2,6 +2,11 @@ import type { Attrs } from "prosemirror-model";
 import { Plugin, PluginKey, type Transaction } from "prosemirror-state";
 
 import {
+  getChangedRanges,
+  getChangedTextblockRanges,
+  hasChangedRange,
+} from "./changed-ranges";
+import {
   isLinkTextForHref,
   isValidUrl,
   looksLikeUrlText,
@@ -26,117 +31,101 @@ export function linkBoundaryGuardPlugin() {
         href: string;
       } | null = null;
       const changedRanges = getChangedRanges(transactions);
+      const changedTextblockRanges = getChangedTextblockRanges(
+        newState.doc,
+        transactions,
+      );
 
-      newState.doc.descendants((node, pos) => {
-        if (!node.isText || !node.text) {
-          prevLink = null;
-          return;
-        }
-
-        const linkMark = node.marks.find((m) => m.type === linkType);
-
-        if (linkMark) {
-          const textLooksLikeUrl = looksLikeUrlText(node.text);
-          const href = linkMark.attrs.href;
-          const nodeTextChanged = hasChangedRange(
-            changedRanges,
-            pos,
-            pos + node.text.length,
-          );
-
-          if (typeof href !== "string") {
+      for (const range of changedTextblockRanges) {
+        prevLink = null;
+        newState.doc.nodesBetween(range.from, range.to, (node, pos) => {
+          if (!node.isText || !node.text) {
             prevLink = null;
             return;
           }
 
-          if (textLooksLikeUrl && !isValidUrl(node.text) && nodeTextChanged) {
-            if (!tr) tr = newState.tr;
-            tr.removeMark(pos, pos + node.text.length, linkType);
-            prevLink = null;
-          } else if (isLinkTextForHref(node.text, href)) {
-            prevLink = {
-              startPos: pos,
-              endPos: pos + node.text.length,
-              attrs: linkMark.attrs,
-              href,
-            };
-          } else if (textLooksLikeUrl && nodeTextChanged) {
-            const nextHref = normalizeUrlHref(node.text);
-            if (!tr) tr = newState.tr;
-            tr.removeMark(pos, pos + node.text.length, linkType);
-            tr.addMark(
+          const linkMark = node.marks.find((m) => m.type === linkType);
+
+          if (linkMark) {
+            const textLooksLikeUrl = looksLikeUrlText(node.text);
+            const href = linkMark.attrs.href;
+            const nodeTextChanged = hasChangedRange(
+              changedRanges,
               pos,
               pos + node.text.length,
-              linkType.create({ ...linkMark.attrs, href: nextHref }),
             );
-            prevLink = {
-              startPos: pos,
-              endPos: pos + node.text.length,
-              attrs: { ...linkMark.attrs, href: nextHref },
-              href: nextHref,
-            };
-          } else if (textLooksLikeUrl) {
-            prevLink = {
-              startPos: pos,
-              endPos: pos + node.text.length,
-              attrs: linkMark.attrs,
-              href,
-            };
+
+            if (typeof href !== "string") {
+              prevLink = null;
+              return;
+            }
+
+            if (textLooksLikeUrl && !isValidUrl(node.text) && nodeTextChanged) {
+              if (!tr) tr = newState.tr;
+              tr.removeMark(pos, pos + node.text.length, linkType);
+              prevLink = null;
+            } else if (isLinkTextForHref(node.text, href)) {
+              prevLink = {
+                startPos: pos,
+                endPos: pos + node.text.length,
+                attrs: linkMark.attrs,
+                href,
+              };
+            } else if (textLooksLikeUrl && nodeTextChanged) {
+              const nextHref = normalizeUrlHref(node.text);
+              if (!tr) tr = newState.tr;
+              tr.removeMark(pos, pos + node.text.length, linkType);
+              tr.addMark(
+                pos,
+                pos + node.text.length,
+                linkType.create({ ...linkMark.attrs, href: nextHref }),
+              );
+              prevLink = {
+                startPos: pos,
+                endPos: pos + node.text.length,
+                attrs: { ...linkMark.attrs, href: nextHref },
+                href: nextHref,
+              };
+            } else if (textLooksLikeUrl) {
+              prevLink = {
+                startPos: pos,
+                endPos: pos + node.text.length,
+                attrs: linkMark.attrs,
+                href,
+              };
+            } else {
+              prevLink = null;
+            }
+          } else if (prevLink && pos === prevLink.endPos && node.text) {
+            if (!/^\s/.test(node.text[0])) {
+              const wsIdx = node.text.search(/\s/);
+              const extendLen = wsIdx >= 0 ? wsIdx : node.text.length;
+              const extension = node.text.slice(0, extendLen);
+              const newHref = prevLink.href + extension;
+              if (
+                !STANDALONE_TRAILING_PUNCTUATION_REGEX.test(extension) &&
+                isValidUrl(newHref)
+              ) {
+                if (!tr) tr = newState.tr;
+                tr.removeMark(prevLink.startPos, prevLink.endPos, linkType);
+                tr.addMark(
+                  prevLink.startPos,
+                  pos + extendLen,
+                  linkType.create({
+                    ...prevLink.attrs,
+                    href: newHref,
+                  }),
+                );
+              }
+            }
+            prevLink = null;
           } else {
             prevLink = null;
           }
-        } else if (prevLink && pos === prevLink.endPos && node.text) {
-          if (!/^\s/.test(node.text[0])) {
-            const wsIdx = node.text.search(/\s/);
-            const extendLen = wsIdx >= 0 ? wsIdx : node.text.length;
-            const extension = node.text.slice(0, extendLen);
-            const newHref = prevLink.href + extension;
-            if (
-              !STANDALONE_TRAILING_PUNCTUATION_REGEX.test(extension) &&
-              isValidUrl(newHref)
-            ) {
-              if (!tr) tr = newState.tr;
-              tr.removeMark(prevLink.startPos, prevLink.endPos, linkType);
-              tr.addMark(
-                prevLink.startPos,
-                pos + extendLen,
-                linkType.create({
-                  ...prevLink.attrs,
-                  href: newHref,
-                }),
-              );
-            }
-          }
-          prevLink = null;
-        } else {
-          prevLink = null;
-        }
-      });
+        });
+      }
 
       return tr;
     },
   });
-}
-
-function getChangedRanges(transactions: readonly Transaction[]) {
-  const ranges: Array<{ from: number; to: number }> = [];
-
-  for (const transaction of transactions) {
-    if (!transaction.docChanged) continue;
-    transaction.mapping.maps.forEach((stepMap) => {
-      stepMap.forEach((_oldStart, _oldEnd, newStart, newEnd) => {
-        ranges.push({ from: newStart, to: newEnd });
-      });
-    });
-  }
-
-  return ranges;
-}
-
-function hasChangedRange(
-  ranges: Array<{ from: number; to: number }>,
-  from: number,
-  to: number,
-) {
-  return ranges.some((range) => range.from < to && from < range.to);
 }

--- a/packages/editor/src/plugins/task-identity.test.ts
+++ b/packages/editor/src/plugins/task-identity.test.ts
@@ -1,0 +1,44 @@
+import { EditorState } from "prosemirror-state";
+import { describe, expect, it } from "vitest";
+
+import { schema } from "../note/schema";
+import { taskIdentityPlugin } from "./task-identity";
+
+describe("taskIdentityPlugin", () => {
+  it("repairs duplicate task identities after unrelated document edits", () => {
+    const duplicateAttrs = {
+      status: "todo",
+      checked: false,
+      taskId: "task-1",
+      taskItemId: "task-item-1",
+    };
+    let state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [schema.text("intro")]),
+        schema.node("taskList", null, [
+          schema.node("taskItem", duplicateAttrs, [schema.node("paragraph")]),
+          schema.node("taskItem", duplicateAttrs, [schema.node("paragraph")]),
+        ]),
+      ]),
+      plugins: [taskIdentityPlugin()],
+    });
+
+    state = state.applyTransaction(state.tr.insertText("!", 1)).state;
+
+    const taskIds: string[] = [];
+    const taskItemIds: string[] = [];
+    state.doc.descendants((node) => {
+      if (node.type.name !== "taskItem") {
+        return true;
+      }
+
+      taskIds.push(node.attrs.taskId);
+      taskItemIds.push(node.attrs.taskItemId);
+      return false;
+    });
+
+    expect(new Set(taskIds).size).toBe(2);
+    expect(new Set(taskItemIds).size).toBe(2);
+  });
+});

--- a/packages/editor/src/plugins/task-identity.ts
+++ b/packages/editor/src/plugins/task-identity.ts
@@ -1,11 +1,19 @@
+import type { Node as PMNode } from "prosemirror-model";
 import { Plugin } from "prosemirror-state";
 
 import { createTaskId, createTaskItemId } from "../tasks";
+import { hasChangedNodeOfType } from "./changed-ranges";
 
 export function taskIdentityPlugin() {
   return new Plugin({
     appendTransaction(transactions, _oldState, newState) {
       if (!transactions.some((transaction) => transaction.docChanged)) {
+        return null;
+      }
+      if (
+        !hasChangedNodeOfType(newState.doc, transactions, "taskItem") &&
+        !hasInvalidTaskIdentity(newState.doc)
+      ) {
         return null;
       }
 
@@ -74,4 +82,37 @@ export function taskIdentityPlugin() {
       return tr;
     },
   });
+}
+
+function hasInvalidTaskIdentity(doc: PMNode) {
+  const seenTaskIds = new Set<string>();
+  const seenTaskItemIds = new Set<string>();
+  let invalid = false;
+
+  doc.descendants((node) => {
+    if (invalid || node.type.name !== "taskItem") {
+      return !invalid;
+    }
+
+    const taskId =
+      typeof node.attrs.taskId === "string" && node.attrs.taskId.trim()
+        ? node.attrs.taskId
+        : "";
+    const taskItemId =
+      typeof node.attrs.taskItemId === "string" && node.attrs.taskItemId.trim()
+        ? node.attrs.taskItemId
+        : "";
+
+    invalid =
+      !taskId ||
+      !taskItemId ||
+      seenTaskIds.has(taskId) ||
+      seenTaskItemIds.has(taskItemId);
+    seenTaskIds.add(taskId);
+    seenTaskItemIds.add(taskItemId);
+
+    return !invalid;
+  });
+
+  return invalid;
 }


### PR DESCRIPTION
Process autolinks, link boundary checks, hashtag decorations, and task identity work from changed ranges so large notes avoid full-document plugin walks on each keypress.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core editing behavior (links, hashtags, task IDs); incorrect range expansion could miss updates in edge cases, though new tests cover hashtag scoping and duplicate task repair after unrelated edits.
> 
> **Overview**
> **Limits per-keystroke work** in the ProseMirror editor by introducing shared `changed-ranges` helpers and using them across autolink, link boundary guard, hashtag, and task-identity plugins instead of walking the whole document on every change.
> 
> **Autolink** and **link boundary guard** now run `nodesBetween` only inside merged **changed textblock** ranges derived from transaction mappings. **Link boundary guard** drops its local range helpers in favor of the shared module (including updated **zero-width** `hasChangedRange` behavior).
> 
> **Hashtag** moves from rebuilding all inline decorations on each `decorations` read to **plugin state**: map existing decorations, strip decorations in changed blocks, and re-scan hashtags only in those ranges—so edits in one paragraph leave others untouched.
> 
> **Task identity** **short-circuits** when no `taskItem` nodes were touched and identities are already valid; it still does a full-document repair pass when duplicates or missing IDs are detected (covered by new tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a97a8b02f2ed63ff9bdec6b8ea15ff747f85f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->