### PR TITLE
Reduce editor keydown plugin work

### DIFF
--- a/packages/editor/src/plugins/image-trailing-paragraph.test.ts
+++ b/packages/editor/src/plugins/image-trailing-paragraph.test.ts
@@ -69,6 +69,14 @@ describe("imageTrailingParagraphPlugin", () => {
     expect(state.doc.textContent).toBe("hello!world");
     expect(state.doc.childCount).toBe(2);
   });
+
+  it("handles edits at document boundaries", () => {
+    let state = createState([schema.node("paragraph")]);
+
+    state = state.applyTransaction(state.tr.insertText("x", 1)).state;
+
+    expect(state.doc.textContent).toBe("x");
+  });
 });
 
 function createState(content: Parameters<typeof schema.node>[2]) {

--- a/packages/editor/src/plugins/image-trailing-paragraph.test.ts
+++ b/packages/editor/src/plugins/image-trailing-paragraph.test.ts
@@ -1,0 +1,80 @@
+import { EditorState } from "prosemirror-state";
+import { describe, expect, it } from "vitest";
+
+import { schema } from "../note/schema";
+import { imageTrailingParagraphPlugin } from "./image-trailing-paragraph";
+
+describe("imageTrailingParagraphPlugin", () => {
+  it("adds a paragraph after an inserted image", () => {
+    const image = schema.nodes.image.create({ src: "image.png" });
+    let state = createState([schema.node("paragraph")]);
+
+    state = state.applyTransaction(state.tr.replaceWith(0, 2, image)).state;
+
+    expect(state.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "image",
+          attrs: {
+            src: "image.png",
+            alt: null,
+            title: null,
+            attachmentId: null,
+            editorWidth: 80,
+          },
+        },
+        { type: "paragraph" },
+      ],
+    });
+  });
+
+  it("restores a trailing paragraph when the one after an image is removed", () => {
+    const image = schema.nodes.image.create({ src: "image.png" });
+    let state = createState([image, schema.node("paragraph")]);
+
+    state = state.applyTransaction(
+      state.tr.delete(image.nodeSize, state.doc.content.size),
+    ).state;
+
+    expect(state.doc.childCount).toBe(2);
+    expect(state.doc.child(0).type).toBe(schema.nodes.image);
+    expect(state.doc.child(1).type).toBe(schema.nodes.paragraph);
+  });
+
+  it("adds paragraphs after multiple pasted images without shifting positions", () => {
+    const firstImage = schema.nodes.image.create({ src: "first.png" });
+    const secondImage = schema.nodes.image.create({ src: "second.png" });
+    let state = createState([schema.node("paragraph")]);
+
+    state = state.applyTransaction(
+      state.tr.replaceWith(0, 2, [firstImage, secondImage]),
+    ).state;
+
+    expect(state.doc.childCount).toBe(4);
+    expect(state.doc.child(0).type).toBe(schema.nodes.image);
+    expect(state.doc.child(1).type).toBe(schema.nodes.paragraph);
+    expect(state.doc.child(2).type).toBe(schema.nodes.image);
+    expect(state.doc.child(3).type).toBe(schema.nodes.paragraph);
+  });
+
+  it("does not change the document for normal text edits", () => {
+    let state = createState([
+      schema.node("paragraph", null, [schema.text("hello")]),
+      schema.node("paragraph", null, [schema.text("world")]),
+    ]);
+
+    state = state.applyTransaction(state.tr.insertText("!", 6)).state;
+
+    expect(state.doc.textContent).toBe("hello!world");
+    expect(state.doc.childCount).toBe(2);
+  });
+});
+
+function createState(content: Parameters<typeof schema.node>[2]) {
+  return EditorState.create({
+    schema,
+    doc: schema.node("doc", null, content),
+    plugins: [imageTrailingParagraphPlugin()],
+  });
+}

--- a/packages/editor/src/plugins/image-trailing-paragraph.ts
+++ b/packages/editor/src/plugins/image-trailing-paragraph.ts
@@ -1,4 +1,7 @@
+import type { Node as PMNode } from "prosemirror-model";
 import { Plugin, PluginKey } from "prosemirror-state";
+
+import { getChangedRanges, type ChangedRange } from "./changed-ranges";
 
 type JSONContent = {
   type?: string;
@@ -36,14 +39,10 @@ export function imageTrailingParagraphPlugin() {
       const paragraphType = schema.nodes.paragraph;
       if (!imageType || !paragraphType) return null;
 
-      const insertions: number[] = [];
-      doc.content.forEach((child, offset, index) => {
-        if (child.type !== imageType) return;
-        const next = doc.maybeChild(index + 1);
-        if (!next || next.type !== paragraphType) {
-          insertions.push(offset + child.nodeSize);
-        }
-      });
+      const insertions = getImageTrailingParagraphInsertions(
+        doc,
+        getChangedRanges(transactions),
+      );
 
       if (insertions.length === 0) return null;
 
@@ -54,4 +53,59 @@ export function imageTrailingParagraphPlugin() {
       return tr;
     },
   });
+}
+
+function getImageTrailingParagraphInsertions(
+  doc: PMNode,
+  ranges: ChangedRange[],
+) {
+  const imageType = doc.type.schema.nodes.image;
+  const paragraphType = doc.type.schema.nodes.paragraph;
+  if (!imageType || !paragraphType) return [];
+
+  const insertions = new Set<number>();
+  const inspectImage = (
+    node: PMNode | null | undefined,
+    pos: number,
+    index: number,
+  ) => {
+    if (!node || node.type !== imageType) return;
+    const next = doc.maybeChild(index + 1);
+    if (!next || next.type !== paragraphType) {
+      insertions.add(pos + node.nodeSize);
+    }
+  };
+
+  const inspectAround = (pos: number) => {
+    const clamped = Math.max(0, Math.min(pos, doc.content.size));
+    const before = doc.childBefore(clamped);
+    if (before.node) {
+      inspectImage(before.node, before.offset, before.index);
+    }
+
+    const after = doc.childAfter(clamped);
+    if (after.node) {
+      inspectImage(after.node, after.offset, after.index);
+    }
+  };
+
+  for (const range of ranges) {
+    inspectAround(range.from);
+    inspectAround(range.to);
+
+    if (range.from >= range.to) {
+      continue;
+    }
+
+    doc.nodesBetween(range.from, range.to, (node, pos, parent, index) => {
+      if (parent !== doc || typeof index !== "number") {
+        return true;
+      }
+
+      inspectImage(node, pos, index);
+      return false;
+    });
+  }
+
+  return Array.from(insertions).sort((a, b) => a - b);
 }

--- a/packages/editor/src/plugins/placeholder.test.ts
+++ b/packages/editor/src/plugins/placeholder.test.ts
@@ -1,0 +1,121 @@
+import { GapCursor } from "prosemirror-gapcursor";
+import { EditorState, TextSelection } from "prosemirror-state";
+import { describe, expect, it } from "vitest";
+
+import { schema } from "../note/schema";
+import { placeholderPlugin } from "./placeholder";
+
+describe("placeholderPlugin", () => {
+  it("decorates only the selected empty top-level block", () => {
+    const plugin = placeholderPlugin(
+      ({ node }) => `${node.type.name} placeholder`,
+    );
+    let state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [schema.text("filled")]),
+        schema.node("paragraph"),
+      ]),
+      plugins: [plugin],
+    });
+
+    expect(plugin.props.decorations?.(state)?.find()).toHaveLength(0);
+
+    const emptyParagraphPos = state.doc.firstChild!.nodeSize;
+    state = state.apply(
+      state.tr.setSelection(
+        TextSelection.create(state.doc, emptyParagraphPos + 1),
+      ),
+    );
+
+    const decorations = plugin.props.decorations?.(state)?.find() ?? [];
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].from).toBe(emptyParagraphPos);
+    expect(decorations[0].to).toBe(emptyParagraphPos + 2);
+  });
+
+  it("does not decorate a sibling empty block when selection is in filled text", () => {
+    const plugin = placeholderPlugin(() => "Memo");
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph"),
+      schema.node("paragraph", null, [schema.text("filled")]),
+    ]);
+    const filledParagraphPos = doc.firstChild!.nodeSize;
+    const state = EditorState.create({
+      schema,
+      doc,
+      plugins: [plugin],
+    }).apply(
+      EditorState.create({ schema, doc }).tr.setSelection(
+        TextSelection.create(doc, filledParagraphPos + 2),
+      ),
+    );
+
+    expect(plugin.props.decorations?.(state)?.find()).toHaveLength(0);
+  });
+
+  it("adds the editor-empty class for an empty document", () => {
+    const plugin = placeholderPlugin(() => "Memo");
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [schema.node("paragraph")]),
+      plugins: [plugin],
+    });
+
+    const decorations = plugin.props.decorations?.(state)?.find() ?? [];
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].type.attrs.class).toContain("is-editor-empty");
+  });
+
+  it("decorates an empty block next to a gap cursor", () => {
+    const plugin = placeholderPlugin(() => "Memo");
+    const doc = schema.node("doc", null, [schema.node("paragraph")]);
+    const state = EditorState.create({
+      schema,
+      doc,
+      plugins: [plugin],
+    });
+    const gapCursorState = state.apply(
+      state.tr.setSelection(new GapCursor(doc.resolve(0))),
+    );
+
+    const decorations =
+      plugin.props.decorations?.(gapCursorState)?.find() ?? [];
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].from).toBe(0);
+  });
+
+  it("decorates the selected nested empty block", () => {
+    const plugin = placeholderPlugin(() => "Nested");
+    const doc = schema.node("doc", null, [
+      schema.node("taskList", null, [
+        schema.node(
+          "taskItem",
+          {
+            checked: false,
+            taskItemId: "task-item-1",
+            taskId: "task-1",
+            source: null,
+            status: "todo",
+          },
+          [schema.node("paragraph")],
+        ),
+      ]),
+    ]);
+    const state = EditorState.create({ schema, doc, plugins: [plugin] });
+    let emptyParagraphPos = 0;
+    doc.descendants((node, pos) => {
+      if (node.type === schema.nodes.paragraph) {
+        emptyParagraphPos = pos;
+        return false;
+      }
+    });
+    const nestedState = state.apply(
+      state.tr.setSelection(TextSelection.create(doc, emptyParagraphPos + 1)),
+    );
+
+    const decorations = plugin.props.decorations?.(nestedState)?.find() ?? [];
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].from).toBe(emptyParagraphPos);
+  });
+});

--- a/packages/editor/src/plugins/placeholder.ts
+++ b/packages/editor/src/plugins/placeholder.ts
@@ -1,4 +1,4 @@
-import { type Node as PMNode } from "prosemirror-model";
+import { type Node as PMNode, type ResolvedPos } from "prosemirror-model";
 import { Plugin, PluginKey } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 
@@ -10,46 +10,76 @@ export type PlaceholderFunction = (props: {
 
 export const placeholderPluginKey = new PluginKey("placeholder");
 
+function getPlaceholderTarget(doc: PMNode, $anchor: ResolvedPos) {
+  for (let depth = $anchor.depth; depth > 0; depth--) {
+    const node = $anchor.node(depth);
+    if (!node.isLeaf && node.content.size === 0) {
+      return {
+        pos: $anchor.before(depth),
+        node,
+      };
+    }
+  }
+
+  if ($anchor.depth > 0) {
+    return null;
+  }
+
+  const after = doc.childAfter($anchor.parentOffset);
+  if (after.node && !after.node.isLeaf && after.node.content.size === 0) {
+    return { pos: after.offset, node: after.node };
+  }
+
+  const before = doc.childBefore($anchor.parentOffset);
+  if (before.node && !before.node.isLeaf && before.node.content.size === 0) {
+    return { pos: before.offset, node: before.node };
+  }
+
+  return null;
+}
+
 export function placeholderPlugin(placeholder?: PlaceholderFunction) {
   return new Plugin({
     key: placeholderPluginKey,
     props: {
       decorations(state) {
         const { doc, selection } = state;
-        const { anchor } = selection;
-        const decorations: Decoration[] = [];
+        const { $anchor } = selection;
+
+        const target = getPlaceholderTarget(doc, $anchor);
+        if (!target) {
+          return DecorationSet.empty;
+        }
+
+        const { pos, node } = target;
+        const isEmpty = !node.isLeaf && node.content.size === 0;
+
+        if (!isEmpty) {
+          return DecorationSet.empty;
+        }
 
         const isEmptyDoc =
           doc.childCount === 1 &&
           doc.firstChild!.isTextblock &&
           doc.firstChild!.content.size === 0;
 
-        doc.descendants((node, pos) => {
-          const hasAnchor = anchor >= pos && anchor <= pos + node.nodeSize;
-          const isEmpty = !node.isLeaf && node.content.size === 0;
+        const classes = ["is-empty"];
+        if (isEmptyDoc) classes.push("is-editor-empty");
 
-          if (hasAnchor && isEmpty) {
-            const classes = ["is-empty"];
-            if (isEmptyDoc) classes.push("is-editor-empty");
+        const text = placeholder
+          ? placeholder({ node, pos, hasAnchor: true })
+          : "";
 
-            const text = placeholder
-              ? placeholder({ node, pos, hasAnchor })
-              : "";
+        if (!text) {
+          return DecorationSet.empty;
+        }
 
-            if (text) {
-              decorations.push(
-                Decoration.node(pos, pos + node.nodeSize, {
-                  class: classes.join(" "),
-                  "data-placeholder": text,
-                }),
-              );
-            }
-          }
-
-          return false;
-        });
-
-        return DecorationSet.create(doc, decorations);
+        return DecorationSet.create(doc, [
+          Decoration.node(pos, pos + node.nodeSize, {
+            class: classes.join(" "),
+            "data-placeholder": text,
+          }),
+        ]);
       },
     },
   });


### PR DESCRIPTION
Compute placeholder decorations from the selected block and limit image trailing paragraph repair to changed document ranges so large notes avoid document-wide plugin scans during typing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Placeholder and image-repair logic changed how empty blocks are targeted; behavior is covered by new tests but still affects all note editing UX.
> 
> **Overview**
> **Editor typing performance:** `placeholderPlugin` no longer walks the whole document with `doc.descendants`; it resolves a single empty block from the selection (including nested blocks and gap-cursor neighbors) and applies at most one decoration. **`imageTrailingParagraphPlugin`** only inspects images in transaction **changed ranges** (via `getChangedRanges`) instead of every top-level child on each edit.
> 
> **Desktop:** `ClassicMainBody` is wrapped in a memoized `ClassicMainBodyHost`, and **`TimelineView`** is exported as `memo(...)` so parents can skip redundant subtree work. Timeline tests pass explicit props on `rerender` where memo would otherwise leave stale UI.
> 
> **Tests:** New Vitest coverage for placeholder selection behavior and image trailing-paragraph insert/repair edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cc5fb234a1d7d7834bb00a5f15ddb4bcc567c4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->